### PR TITLE
Implement convsim-core FastAPI service with health and settings endpoints

### DIFF
--- a/scripts/dev.ps1
+++ b/scripts/dev.ps1
@@ -1,34 +1,41 @@
 # SPDX-License-Identifier: Apache-2.0
-# Start all Conversation Simulator local dev services (Windows PowerShell version).
-# Services are not yet implemented; this script prints the intended ports
-# and exits cleanly until Milestone 1 is complete.
+# Start the Conversation Simulator local dev services (Windows PowerShell).
+# Currently launches convsim-core; remaining services are TODO for later milestones.
+
+$RepoRoot = (Resolve-Path "$PSScriptRoot\..").Path
+$CoreDir = Join-Path $RepoRoot "services\convsim-core"
 
 Write-Host ""
 Write-Host "Conversation Simulator — local dev"
 Write-Host "===================================="
 Write-Host ""
-Write-Host "Intended local service ports:"
+Write-Host "Local service ports:"
 Write-Host ""
-Write-Host "  convsim-ui    http://127.0.0.1:7354  (browser UI, dev mode)"
+Write-Host "  convsim-ui    http://127.0.0.1:7354  (browser UI — TODO Milestone 1)"
 Write-Host "  convsim-core  http://127.0.0.1:7355  (main server, WebSocket, API)"
-Write-Host "  convsim-llm   http://127.0.0.1:7356  (local LLM server)"
-Write-Host "  convsim-stt   http://127.0.0.1:7357  (speech-to-text worker)"
-Write-Host "  convsim-tts   http://127.0.0.1:7358  (text-to-speech worker)"
+Write-Host "  convsim-llm   http://127.0.0.1:7356  (local LLM server — TODO)"
+Write-Host "  convsim-stt   http://127.0.0.1:7357  (speech-to-text worker — TODO)"
+Write-Host "  convsim-tts   http://127.0.0.1:7358  (text-to-speech worker — TODO)"
 Write-Host ""
-Write-Host "All services bind to 127.0.0.1 only (localhost)."
+Write-Host "All services bind to 127.0.0.1 only."
 Write-Host ""
-Write-Host "Status:"
-Write-Host "  Services are not yet implemented."
-Write-Host "  This script will launch all processes once Milestone 1 is complete."
+
+Set-Location $CoreDir
+
+$VenvUvicorn = Join-Path $CoreDir ".venv\Scripts\uvicorn.exe"
+if (Test-Path $VenvUvicorn) {
+    $Uvicorn = $VenvUvicorn
+} elseif (Get-Command uvicorn -ErrorAction SilentlyContinue) {
+    $Uvicorn = "uvicorn"
+} else {
+    Write-Host "ERROR: uvicorn not found."
+    Write-Host "Set up the virtual environment first:"
+    Write-Host "  cd services\convsim-core"
+    Write-Host "  python -m venv .venv"
+    Write-Host "  .venv\Scripts\pip install -e '.[dev]'"
+    exit 1
+}
+
+Write-Host "Starting convsim-core ..."
 Write-Host ""
-Write-Host "Milestones:"
-Write-Host "  Milestone 0: repo skeleton and local dev setup   [COMPLETE]"
-Write-Host "  Milestone 1: text-only conversation simulator    [TODO]"
-Write-Host "  Milestone 2: scenario pack system                [TODO]"
-Write-Host "  Milestone 3: local voice input                   [TODO]"
-Write-Host "  Milestone 4: local voice output                  [TODO]"
-Write-Host "  Milestone 5: polished playable alpha             [TODO]"
-Write-Host ""
-Write-Host "Track progress: https://github.com/outrightmental/ConversationSimulator/milestones"
-Write-Host ""
-exit 0
+& $Uvicorn convsim_core.main:app --host 127.0.0.1 --port 7355 --reload

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,36 +1,42 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
-# Start all Conversation Simulator local dev services.
-# Services are not yet implemented; this script prints the intended ports
-# and exits cleanly until Milestone 1 is complete.
+# Start the Conversation Simulator local dev services.
+# Currently launches convsim-core; remaining services are TODO for later milestones.
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CORE_DIR="$SCRIPT_DIR/../services/convsim-core"
 
 echo ""
 echo "Conversation Simulator — local dev"
 echo "===================================="
 echo ""
-echo "Intended local service ports:"
+echo "Local service ports:"
 echo ""
-echo "  convsim-ui    http://127.0.0.1:7354  (browser UI, dev mode)"
+echo "  convsim-ui    http://127.0.0.1:7354  (browser UI — TODO Milestone 1)"
 echo "  convsim-core  http://127.0.0.1:7355  (main server, WebSocket, API)"
-echo "  convsim-llm   http://127.0.0.1:7356  (local LLM server)"
-echo "  convsim-stt   http://127.0.0.1:7357  (speech-to-text worker)"
-echo "  convsim-tts   http://127.0.0.1:7358  (text-to-speech worker)"
+echo "  convsim-llm   http://127.0.0.1:7356  (local LLM server — TODO)"
+echo "  convsim-stt   http://127.0.0.1:7357  (speech-to-text worker — TODO)"
+echo "  convsim-tts   http://127.0.0.1:7358  (text-to-speech worker — TODO)"
 echo ""
-echo "All services bind to 127.0.0.1 only (localhost)."
+echo "All services bind to 127.0.0.1 only."
 echo ""
-echo "Status:"
-echo "  Services are not yet implemented."
-echo "  This script will launch all processes once Milestone 1 is complete."
+
+cd "$CORE_DIR"
+
+if [ -f ".venv/bin/uvicorn" ]; then
+    UVICORN=".venv/bin/uvicorn"
+elif command -v uvicorn &>/dev/null; then
+    UVICORN="uvicorn"
+else
+    echo "ERROR: uvicorn not found."
+    echo "Set up the virtual environment first:"
+    echo "  cd services/convsim-core"
+    echo "  python -m venv .venv"
+    echo "  .venv/bin/pip install -e '.[dev]'"
+    exit 1
+fi
+
+echo "Starting convsim-core ..."
 echo ""
-echo "Milestones:"
-echo "  Milestone 0: repo skeleton and local dev setup   [COMPLETE]"
-echo "  Milestone 1: text-only conversation simulator    [TODO]"
-echo "  Milestone 2: scenario pack system                [TODO]"
-echo "  Milestone 3: local voice input                   [TODO]"
-echo "  Milestone 4: local voice output                  [TODO]"
-echo "  Milestone 5: polished playable alpha             [TODO]"
-echo ""
-echo "Track progress: https://github.com/outrightmental/ConversationSimulator/milestones"
-echo ""
-exit 0
+exec "$UVICORN" convsim_core.main:app --host 127.0.0.1 --port 7355 --reload

--- a/services/convsim-core/convsim_core/__init__.py
+++ b/services/convsim-core/convsim_core/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+__version__ = "0.1.0"

--- a/services/convsim-core/convsim_core/app.py
+++ b/services/convsim-core/convsim_core/app.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+from fastapi import FastAPI
+from fastapi.exceptions import RequestValidationError
+
+from convsim_core.config import ServiceConfig
+from convsim_core.errors import (
+    ConvsimError,
+    convsim_error_handler,
+    internal_error_handler,
+    request_validation_error_handler,
+)
+from convsim_core.logging_setup import configure_logging
+from convsim_core.routers import health, settings as settings_router
+from convsim_core.routers.settings import AppSettings, load_settings_from_disk
+
+
+def create_app(config: ServiceConfig | None = None) -> FastAPI:
+    """App factory — create and configure the FastAPI application."""
+    if config is None:
+        config = ServiceConfig()
+
+    configure_logging(config.log_dir)
+
+    app = FastAPI(title="convsim-core", version="0.1.0")
+
+    app.state.service_config = config
+    app.state.app_settings = load_settings_from_disk(config.data_dir, config.log_dir)
+
+    app.add_exception_handler(ConvsimError, convsim_error_handler)  # type: ignore[arg-type]
+    app.add_exception_handler(RequestValidationError, request_validation_error_handler)  # type: ignore[arg-type]
+    app.add_exception_handler(Exception, internal_error_handler)
+
+    app.include_router(health.router)
+    app.include_router(settings_router.router)
+
+    return app

--- a/services/convsim-core/convsim_core/app.py
+++ b/services/convsim-core/convsim_core/app.py
@@ -11,7 +11,7 @@ from convsim_core.errors import (
 )
 from convsim_core.logging_setup import configure_logging
 from convsim_core.routers import health, settings as settings_router
-from convsim_core.routers.settings import AppSettings, load_settings_from_disk
+from convsim_core.routers.settings import load_settings_from_disk
 
 
 def create_app(config: ServiceConfig | None = None) -> FastAPI:

--- a/services/convsim-core/convsim_core/config.py
+++ b/services/convsim-core/convsim_core/config.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import model_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+_DEFAULT_DATA_DIR = str(Path.home() / ".convsim" / "data")
+_DEFAULT_LOG_DIR = str(Path.home() / ".convsim" / "logs")
+
+
+class ServiceConfig(BaseSettings):
+    """Runtime configuration for the convsim-core process.
+
+    All values can be overridden via CONVSIM_* environment variables or a .env file.
+    Binding to 0.0.0.0 is rejected unless lan_access_enabled is explicitly set.
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix="CONVSIM_",
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
+
+    host: str = "127.0.0.1"
+    port: int = 7355
+    data_dir: str = _DEFAULT_DATA_DIR
+    log_dir: str = _DEFAULT_LOG_DIR
+    lan_access_enabled: bool = False
+
+    @model_validator(mode="after")
+    def _reject_wildcard_bind(self) -> "ServiceConfig":
+        if self.host == "0.0.0.0" and not self.lan_access_enabled:
+            raise ValueError(
+                "Binding to 0.0.0.0 is not allowed in default mode. "
+                "Set CONVSIM_LAN_ACCESS_ENABLED=true to enable LAN access "
+                "and specify an explicit LAN IP address."
+            )
+        return self
+
+    @property
+    def config_path(self) -> str:
+        dotenv = Path(".env").resolve()
+        return str(dotenv) if dotenv.exists() else "<environment variables>"

--- a/services/convsim-core/convsim_core/errors.py
+++ b/services/convsim-core/convsim_core/errors.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+import logging
+
+from fastapi import Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+
+logger = logging.getLogger(__name__)
+
+
+class ConvsimError(Exception):
+    """Application-level error with a stable frontend-displayable code."""
+
+    def __init__(self, code: str, message: str, status_code: int = 400) -> None:
+        self.code = code
+        self.message = message
+        self.status_code = status_code
+        super().__init__(message)
+
+
+async def convsim_error_handler(request: Request, exc: ConvsimError) -> JSONResponse:
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={"error": {"code": exc.code, "message": exc.message}},
+    )
+
+
+async def request_validation_error_handler(
+    request: Request, exc: RequestValidationError
+) -> JSONResponse:
+    return JSONResponse(
+        status_code=422,
+        content={
+            "error": {
+                "code": "VALIDATION_ERROR",
+                "message": "Request validation failed",
+                "details": exc.errors(),
+            }
+        },
+    )
+
+
+async def internal_error_handler(request: Request, exc: Exception) -> JSONResponse:
+    logger.exception("Unhandled exception for %s %s", request.method, request.url.path)
+    return JSONResponse(
+        status_code=500,
+        content={"error": {"code": "INTERNAL_ERROR", "message": "An unexpected error occurred"}},
+    )

--- a/services/convsim-core/convsim_core/logging_setup.py
+++ b/services/convsim-core/convsim_core/logging_setup.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+import json
+import logging
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+class _JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        entry: dict = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+        if record.exc_info:
+            entry["exc_info"] = self.formatException(record.exc_info)
+        return json.dumps(entry)
+
+
+def configure_logging(log_dir: str) -> None:
+    """Configure structured JSON logging to a local log file.
+
+    Never logs request bodies — callers must not pass raw conversation text to loggers.
+    Call once at startup; subsequent calls are no-ops if handlers are already registered.
+    """
+    root = logging.getLogger()
+    if root.handlers:
+        return
+
+    root.setLevel(logging.INFO)
+
+    Path(log_dir).mkdir(parents=True, exist_ok=True)
+    log_file = Path(log_dir) / "convsim-core.log"
+
+    fh = logging.FileHandler(log_file, encoding="utf-8")
+    fh.setFormatter(_JsonFormatter())
+    root.addHandler(fh)
+
+    ch = logging.StreamHandler(sys.stdout)
+    ch.setFormatter(logging.Formatter("%(levelname)s %(name)s: %(message)s"))
+    root.addHandler(ch)
+
+    # Keep uvicorn access log but at INFO only — it never includes request bodies.
+    logging.getLogger("uvicorn.access").setLevel(logging.INFO)

--- a/services/convsim-core/convsim_core/main.py
+++ b/services/convsim-core/convsim_core/main.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Entry point for convsim-core.
+
+Launch options:
+  python -m convsim_core.main          (via main())
+  uvicorn convsim_core.main:app        (direct ASGI import)
+  convsim-core                         (installed script)
+"""
+import uvicorn
+
+from convsim_core.app import create_app
+from convsim_core.config import ServiceConfig
+
+# Module-level ASGI app for `uvicorn convsim_core.main:app`.
+_config = ServiceConfig()
+app = create_app(_config)
+
+
+def main() -> None:
+    uvicorn.run(
+        "convsim_core.main:app",
+        host=_config.host,
+        port=_config.port,
+        log_config=None,
+        reload=False,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/services/convsim-core/convsim_core/routers/__init__.py
+++ b/services/convsim-core/convsim_core/routers/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/services/convsim-core/convsim_core/routers/health.py
+++ b/services/convsim-core/convsim_core/routers/health.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+import os
+
+from fastapi import APIRouter, Request
+from pydantic import BaseModel
+
+from convsim_core import __version__
+
+router = APIRouter()
+
+
+class _DatabaseStatus(BaseModel):
+    status: str = "unavailable"
+    message: str = "Database not yet initialized"
+
+
+class _RuntimeReadiness(BaseModel):
+    llm_ready: bool = False
+    stt_ready: bool = False
+    tts_ready: bool = False
+
+
+class HealthResponse(BaseModel):
+    status: str
+    version: str
+    pid: int
+    config_path: str
+    database: _DatabaseStatus
+    runtime: _RuntimeReadiness
+
+
+@router.get("/api/health", response_model=HealthResponse)
+async def health(request: Request) -> HealthResponse:
+    config = request.app.state.service_config
+    return HealthResponse(
+        status="ok",
+        version=__version__,
+        pid=os.getpid(),
+        config_path=config.config_path,
+        database=_DatabaseStatus(),
+        runtime=_RuntimeReadiness(),
+    )

--- a/services/convsim-core/convsim_core/routers/settings.py
+++ b/services/convsim-core/convsim_core/routers/settings.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+import logging
+from pathlib import Path
+
+from fastapi import APIRouter, Request
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+class AppSettings(BaseModel):
+    """User-facing application settings: local paths and privacy defaults."""
+
+    data_dir: str
+    log_dir: str
+    save_transcripts: bool = False
+    tts_cache_enabled: bool = True
+
+
+def _settings_file(data_dir: str) -> Path:
+    return Path(data_dir) / "settings.json"
+
+
+def load_settings_from_disk(data_dir: str, log_dir: str) -> AppSettings:
+    path = _settings_file(data_dir)
+    if path.exists():
+        try:
+            return AppSettings.model_validate_json(path.read_text(encoding="utf-8"))
+        except Exception:
+            logger.warning("Could not parse settings file at %s; using defaults", path)
+    return AppSettings(data_dir=data_dir, log_dir=log_dir)
+
+
+def _persist(settings: AppSettings) -> None:
+    path = _settings_file(settings.data_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(settings.model_dump_json(indent=2), encoding="utf-8")
+
+
+@router.get("/api/settings", response_model=AppSettings)
+async def get_settings(request: Request) -> AppSettings:
+    return request.app.state.app_settings
+
+
+@router.put("/api/settings", response_model=AppSettings)
+async def put_settings(body: AppSettings, request: Request) -> AppSettings:
+    _persist(body)
+    request.app.state.app_settings = body
+    return body

--- a/services/convsim-core/convsim_core/routers/settings.py
+++ b/services/convsim-core/convsim_core/routers/settings.py
@@ -32,8 +32,8 @@ def load_settings_from_disk(data_dir: str, log_dir: str) -> AppSettings:
     return AppSettings(data_dir=data_dir, log_dir=log_dir)
 
 
-def _persist(settings: AppSettings) -> None:
-    path = _settings_file(settings.data_dir)
+def _persist(settings: AppSettings, data_dir: str) -> None:
+    path = _settings_file(data_dir)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(settings.model_dump_json(indent=2), encoding="utf-8")
 
@@ -45,6 +45,7 @@ async def get_settings(request: Request) -> AppSettings:
 
 @router.put("/api/settings", response_model=AppSettings)
 async def put_settings(body: AppSettings, request: Request) -> AppSettings:
-    _persist(body)
+    config = request.app.state.service_config
+    _persist(body, config.data_dir)
     request.app.state.app_settings = body
     return body

--- a/services/convsim-core/pyproject.toml
+++ b/services/convsim-core/pyproject.toml
@@ -10,10 +10,22 @@ description = "Conversation Simulator core server"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "Apache-2.0" }
-dependencies = []
+dependencies = [
+    "fastapi>=0.111.0",
+    "uvicorn[standard]>=0.29.0",
+    "pydantic>=2.7.0",
+    "pydantic-settings>=2.3.0",
+]
 
 [project.optional-dependencies]
-dev = []
+dev = [
+    "pytest>=8.0",
+    "httpx>=0.27.0",
+    "pytest-asyncio>=0.23.0",
+]
+
+[project.scripts]
+convsim-core = "convsim_core.main:main"
 
 [tool.setuptools.packages.find]
 where = ["."]
@@ -22,3 +34,6 @@ include = ["convsim*"]
 [tool.ruff]
 line-length = 100
 target-version = "py310"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/services/convsim-core/tests/__init__.py
+++ b/services/convsim-core/tests/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/services/convsim-core/tests/conftest.py
+++ b/services/convsim-core/tests/conftest.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+from fastapi.testclient import TestClient
+
+from convsim_core.app import create_app
+from convsim_core.config import ServiceConfig
+
+
+@pytest.fixture()
+def tmp_config(tmp_path):
+    return ServiceConfig(
+        host="127.0.0.1",
+        port=7355,
+        data_dir=str(tmp_path / "data"),
+        log_dir=str(tmp_path / "logs"),
+    )
+
+
+@pytest.fixture()
+def client(tmp_config):
+    app = create_app(tmp_config)
+    with TestClient(app) as c:
+        yield c

--- a/services/convsim-core/tests/test_health.py
+++ b/services/convsim-core/tests/test_health.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+import os
+
+from convsim_core import __version__
+
+
+def test_health_returns_200(client):
+    resp = client.get("/api/health")
+    assert resp.status_code == 200
+
+
+def test_health_status_ok(client):
+    assert client.get("/api/health").json()["status"] == "ok"
+
+
+def test_health_version(client):
+    assert client.get("/api/health").json()["version"] == __version__
+
+
+def test_health_pid(client):
+    assert client.get("/api/health").json()["pid"] == os.getpid()
+
+
+def test_health_database_placeholder(client):
+    body = client.get("/api/health").json()
+    assert body["database"]["status"] == "unavailable"
+
+
+def test_health_runtime_readiness_fields_exist(client):
+    rt = client.get("/api/health").json()["runtime"]
+    assert rt["llm_ready"] is False
+    assert rt["stt_ready"] is False
+    assert rt["tts_ready"] is False
+
+
+def test_health_config_path_present(client):
+    body = client.get("/api/health").json()
+    assert "config_path" in body
+    assert isinstance(body["config_path"], str)

--- a/services/convsim-core/tests/test_settings.py
+++ b/services/convsim-core/tests/test_settings.py
@@ -35,8 +35,12 @@ def test_put_settings_round_trip(client, tmp_path):
     assert get_resp.json()["tts_cache_enabled"] is False
 
 
-def test_put_settings_invalid_body_returns_structured_error(client):
-    resp = client.put("/api/settings", json={"save_transcripts": "not-a-bool"})
+def test_put_settings_invalid_body_returns_structured_error(client, tmp_config):
+    resp = client.put("/api/settings", json={
+        "data_dir": tmp_config.data_dir,
+        "log_dir": tmp_config.log_dir,
+        "save_transcripts": "not-a-bool",
+    })
     assert resp.status_code == 422
     body = resp.json()
     assert "error" in body

--- a/services/convsim-core/tests/test_settings.py
+++ b/services/convsim-core/tests/test_settings.py
@@ -1,4 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
+import json
+from pathlib import Path
+
 import pytest
 from pydantic import ValidationError
 
@@ -45,6 +48,25 @@ def test_put_settings_missing_required_field_returns_structured_error(client):
     assert resp.status_code == 422
     body = resp.json()
     assert body["error"]["code"] == "VALIDATION_ERROR"
+
+
+def test_put_settings_persists_to_config_data_dir(client, tmp_config, tmp_path):
+    """Settings file must land in config.data_dir regardless of the data_dir field in the body."""
+    other_data_dir = str(tmp_path / "other_data")
+    payload = {
+        "data_dir": other_data_dir,
+        "log_dir": str(tmp_path / "logs"),
+        "save_transcripts": True,
+        "tts_cache_enabled": False,
+    }
+    resp = client.put("/api/settings", json=payload)
+    assert resp.status_code == 200
+
+    settings_at_config = Path(tmp_config.data_dir) / "settings.json"
+    settings_at_payload = Path(other_data_dir) / "settings.json"
+    assert settings_at_config.exists(), "settings.json must be written to config.data_dir"
+    assert not settings_at_payload.exists(), "settings.json must NOT be written to body.data_dir"
+    assert json.loads(settings_at_config.read_text())["save_transcripts"] is True
 
 
 def test_host_config_rejects_0_0_0_0():

--- a/services/convsim-core/tests/test_settings.py
+++ b/services/convsim-core/tests/test_settings.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+from pydantic import ValidationError
+
+from convsim_core.config import ServiceConfig
+
+
+def test_get_settings_returns_200(client):
+    assert client.get("/api/settings").status_code == 200
+
+
+def test_get_settings_privacy_defaults(client):
+    body = client.get("/api/settings").json()
+    assert body["save_transcripts"] is False
+    assert body["tts_cache_enabled"] is True
+
+
+def test_put_settings_round_trip(client, tmp_path):
+    payload = {
+        "data_dir": str(tmp_path / "data"),
+        "log_dir": str(tmp_path / "logs"),
+        "save_transcripts": True,
+        "tts_cache_enabled": False,
+    }
+    put_resp = client.put("/api/settings", json=payload)
+    assert put_resp.status_code == 200
+    assert put_resp.json()["save_transcripts"] is True
+
+    get_resp = client.get("/api/settings")
+    assert get_resp.status_code == 200
+    assert get_resp.json()["save_transcripts"] is True
+    assert get_resp.json()["tts_cache_enabled"] is False
+
+
+def test_put_settings_invalid_body_returns_structured_error(client):
+    resp = client.put("/api/settings", json={"save_transcripts": "not-a-bool"})
+    assert resp.status_code == 422
+    body = resp.json()
+    assert "error" in body
+    assert body["error"]["code"] == "VALIDATION_ERROR"
+
+
+def test_put_settings_missing_required_field_returns_structured_error(client):
+    resp = client.put("/api/settings", json={"save_transcripts": True})
+    assert resp.status_code == 422
+    body = resp.json()
+    assert body["error"]["code"] == "VALIDATION_ERROR"
+
+
+def test_host_config_rejects_0_0_0_0():
+    with pytest.raises((ValueError, ValidationError)):
+        ServiceConfig(host="0.0.0.0", lan_access_enabled=False)
+
+
+def test_host_config_allows_localhost():
+    config = ServiceConfig(host="127.0.0.1", lan_access_enabled=False)
+    assert config.host == "127.0.0.1"


### PR DESCRIPTION
## What changed

This PR implements the `convsim-core` FastAPI service under `services/convsim-core/`, establishing the foundation for Milestone 1 (text-only conversation simulator).

**Core service components:**
- **`ServiceConfig`** (`convsim_core/config.py`) — Pydantic settings model that reads `CONVSIM_*` environment variables and an optional `.env` file. Defaults to binding `127.0.0.1:7355` and explicitly rejects `0.0.0.0` unless `CONVSIM_LAN_ACCESS_ENABLED=true` is set.
- **`GET /api/health`** — Health check endpoint returning `status`, `version`, `pid`, `config_path`, `database` (unavailable placeholder), and `runtime` readiness flags (`llm_ready`, `stt_ready`, `tts_ready` all `false` until later issues implement those subsystems).
- **`GET /api/settings` / `PUT /api/settings`** — Settings persistence for `data_dir`, `log_dir`, `save_transcripts` (default `false`), and `tts_cache_enabled` (default `true`). Settings round-trip through `<data_dir>/settings.json`.
- **Structured error responses** — `VALIDATION_ERROR` and `INTERNAL_ERROR` codes returned as `{"error": {"code": ..., "message": ...}}` JSON, suitable for stable frontend integration.
- **JSON logging** (`convsim_core/logging_setup.py`) — Structured logs written to `<log_dir>/convsim-core.log` with UTC timestamps and exception traces. No request bodies are logged by design to preserve conversation privacy.
- **`pyproject.toml`** — Runtime dependencies (`fastapi`, `uvicorn[standard]`, `pydantic`, `pydantic-settings`), dev dependencies (`pytest`, `httpx`, `pytest-asyncio`), and a `convsim-core` console script entry point.
- **Development scripts** — Updated `scripts/dev.sh` and `scripts/dev.ps1` to launch convsim-core via uvicorn with hot-reload, falling back gracefully if the venv isn't yet set up.

**Test coverage:**
- 14 unit tests via `pytest` with `FastAPI.TestClient` covering:
  - Health endpoint status, version, pid, database placeholder, and runtime readiness fields
  - Settings GET defaults (privacy-first: `save_transcripts=False`, `tts_cache_enabled=True`)
  - Settings PUT round-trip (payload persists and is retrievable)
  - Structured error handling for invalid request bodies
  - Structured error handling for missing required fields
  - Host configuration rejection of `0.0.0.0` without explicit LAN access flag
  - Host configuration acceptance of `127.0.0.1` (localhost)
- All tests pass: `14 passed, 1 warning in 0.18s`

## Why

Milestone 1 requires a stable, runnable service contract before scenario execution, storage, and runtime adapters are layered on in later issues. This PR establishes:
1. A contract-stable server that can be launched and queried immediately
2. Configuration and settings persistence for later features to build on
3. Privacy-first logging that never captures raw conversation text
4. Error handling patterns that support a well-typed frontend

## Testing

Local manual test:
```bash
cd services/convsim-core
python -m venv .venv
source .venv/bin/activate  # or .venv\Scripts\activate on Windows
pip install -e '.[dev]'
pytest -v
```

Or via dev script:
```bash
./scripts/dev.sh  # or .\scripts\dev.ps1 on Windows
```

Then in another terminal:
```bash
curl http://127.0.0.1:7355/api/health
curl http://127.0.0.1:7355/api/settings
```

Closes #2