### PR TITLE
Add CI jobs for backend, frontend, schemas, and pack validation placeholder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [main]
 
+# Minimal permissions — jobs declare no additional scopes.
+permissions:
+  contents: read
+
 jobs:
   smoke-check:
     name: Smoke check
@@ -14,7 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Verify monorepo structure
-        run: bash scripts/smoke-check.sh
+        run: |
+          echo "Local: bash scripts/smoke-check.sh"
+          bash scripts/smoke-check.sh
 
   shellcheck:
     name: Shellcheck
@@ -24,4 +30,91 @@ jobs:
       - name: Install shellcheck
         run: sudo apt-get install -y shellcheck
       - name: Lint shell scripts
-        run: shellcheck scripts/*.sh
+        run: |
+          echo "Local: shellcheck scripts/*.sh"
+          shellcheck scripts/*.sh
+
+  backend:
+    name: Backend tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: |
+            services/convsim-core/pyproject.toml
+            packages/prompt-composer/pyproject.toml
+      - name: Install convsim-core
+        run: pip install -e "services/convsim-core[dev]"
+      - name: Test convsim-core
+        working-directory: services/convsim-core
+        run: |
+          echo "Local: cd services/convsim-core && python -m pytest"
+          python -m pytest
+      - name: Install prompt-composer
+        run: pip install -e "packages/prompt-composer[dev]"
+      - name: Test prompt-composer
+        working-directory: packages/prompt-composer
+        run: |
+          echo "Local: cd packages/prompt-composer && python -m pytest"
+          python -m pytest
+
+  frontend:
+    name: Frontend typecheck and tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build shared TypeScript packages
+        run: |
+          pnpm --filter @convsim/shared-types build
+          pnpm --filter @convsim/scenario-schema build
+      - name: Typecheck packages
+        run: |
+          echo "Local: pnpm test:types"
+          pnpm test:types
+      - name: Typecheck web app
+        run: |
+          echo "Local: pnpm --filter @convsim/web typecheck"
+          pnpm --filter @convsim/web typecheck
+      - name: Run web tests
+        run: |
+          echo "Local: pnpm --filter @convsim/web test"
+          pnpm --filter @convsim/web test
+
+  schemas:
+    name: Schema load tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Run schema load tests
+        run: |
+          echo "Local: node packages/scenario-schema/tests/load-schemas.js"
+          node packages/scenario-schema/tests/load-schemas.js
+
+  pack-validation:
+    name: Pack validation (placeholder)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate packs
+        # No pack validator exists yet. When one is implemented, replace the
+        # echo below with the validator invocation.
+        # Local: <pack-validator-command> packs/official
+        run: |
+          echo "Pack validation placeholder — no pack validator installed yet."
+          echo "Future quality gate: validate all scenario packs under packs/official/"
+          echo "Local: <pack-validator-command> packs/official"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,76 @@
 <!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Contributing to Conversation Simulator
 
-> **Status:** Placeholder. Contribution guidelines will be written once the
-> first implementation milestone is complete and the codebase is open for
-> external contribution.
+> **Status:** Early-stage. The skeleton is in place and CI is running.
+> Broader contribution guidelines will be written once the first simulation
+> milestone lands and the codebase is open for external contribution.
+
+## Running CI locally
+
+Every CI job has an equivalent local command. Run these before pushing to
+catch failures without waiting for GitHub Actions.
+
+### Smoke check — verify monorepo structure
+
+```sh
+bash scripts/smoke-check.sh
+```
+
+### Shell script linting
+
+```sh
+shellcheck scripts/*.sh
+```
+
+### Backend tests — convsim-core (FastAPI service)
+
+```sh
+pip install -e "services/convsim-core[dev]"
+cd services/convsim-core && python -m pytest
+```
+
+### Backend tests — prompt-composer
+
+```sh
+pip install -e "packages/prompt-composer[dev]"
+cd packages/prompt-composer && python -m pytest
+```
+
+### Frontend — typecheck shared packages
+
+```sh
+pnpm install
+pnpm test:types
+```
+
+### Frontend — typecheck web app
+
+```sh
+pnpm install
+pnpm --filter @convsim/shared-types build
+pnpm --filter @convsim/scenario-schema build
+pnpm --filter @convsim/web typecheck
+```
+
+### Frontend — run web tests
+
+```sh
+pnpm install
+pnpm --filter @convsim/web test
+```
+
+### Schema load tests
+
+```sh
+node packages/scenario-schema/tests/load-schemas.js
+```
+
+### Pack validation
+
+No pack validator exists yet. This CI job is a placeholder for the quality
+gate that will validate scenario packs once a validator is implemented.
+
+---
 
 ## For now
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "setup": "./scripts/setup.sh",
     "dev": "./scripts/dev.sh",
     "test:schemas": "node packages/scenario-schema/tests/load-schemas.js",
-    "test:types": "node_modules/.bin/tsc --noEmit -p packages/shared-types/tsconfig.json && node_modules/.bin/tsc --noEmit -p packages/scenario-schema/tsconfig.json"
+    "test:types": "pnpm --filter @convsim/shared-types check && pnpm --filter @convsim/scenario-schema check"
   },
   "engines": {
     "node": ">=18"

--- a/packages/prompt-composer/pyproject.toml
+++ b/packages/prompt-composer/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools>=68"]
-build-backend = "setuptools.backends.legacy:build"
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "convsim-prompt"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,9 +80,17 @@ importers:
         specifier: ^2.1.9
         version: 2.1.9(@types/node@22.20.0)(@vitest/ui@2.1.9)(jsdom@25.0.1)
 
-  packages/scenario-schema: {}
+  packages/scenario-schema:
+    devDependencies:
+      typescript:
+        specifier: ^5.5.0
+        version: 5.6.3
 
-  packages/shared-types: {}
+  packages/shared-types:
+    devDependencies:
+      typescript:
+        specifier: ^5.5.0
+        version: 5.6.3
 
   packages/ui:
     dependencies:


### PR DESCRIPTION
## Summary

Expands the existing two-job CI workflow into a full quality gate covering all layers of the monorepo, as specified in issue #6.

### New jobs

- **backend** — installs `convsim-core[dev]` and `prompt-composer[dev]` with pip, runs `pytest` for each; pip downloads are cached keyed to both `pyproject.toml` hashes.
- **frontend** — installs pnpm dependencies (store cached via `setup-node cache: pnpm`), builds the shared TypeScript packages (`shared-types`, `scenario-schema`), typechecks all packages (`pnpm test:types`) and the web app (`pnpm --filter @convsim/web typecheck`), then runs Vitest.
- **schemas** — runs `node packages/scenario-schema/tests/load-schemas.js` directly; no npm install needed since the test suite uses only Node.js stdlib.
- **pack-validation** — placeholder job that no-ops with an explanatory message until a pack validator is implemented; wired so contributors see the intended quality gate without it blocking PRs.

### Changes to existing jobs

- **smoke-check** and **shellcheck** — each key step now echoes its local repro command before running, so CI failure logs point users to the right command.

### Other

- `permissions: contents: read` added at workflow level (minimal permissions).
- `CONTRIBUTING.md` updated with a _Running CI locally_ section documenting the exact commands that mirror each CI job.
- `packages/prompt-composer/pyproject.toml` — changed build-backend to `setuptools.build_meta` (the universally-supported path); legacy backend was unavailable in CI environment and caused `BackendUnavailable` on editable install. Added wheel to build requirements.
- `pnpm-lock.yaml` — regenerated to reflect TypeScript 5.5+ dependency added by scenario-schema; stale lockfile was causing `ERR_PNPM_OUTDATED_LOCKFILE` and blocking frozen-lockfile install.
- `package.json` — corrected `test:types` script to use `pnpm --filter` instead of bare `node_modules/.bin/tsc`, since pnpm does not hoist TypeScript to the root when it is only a package devDependency.

## Test plan

- [ ] Open a PR against main and confirm all six jobs appear and pass.
- [ ] Introduce a deliberate lint or type error on a branch; confirm the right job fails and the log shows the local repro command.
- [ ] Inspect the Actions run to verify no model files are downloaded.
- [ ] Check that the pack-validation job shows the placeholder message and exits 0.

Closes #6