### PR TITLE
Add NPC turn output parser, repair retry, and safe fallback to prevent session corruption from model drift

### DIFF
--- a/packages/prompt-composer/src/convsim_prompt/__init__.py
+++ b/packages/prompt-composer/src/convsim_prompt/__init__.py
@@ -3,6 +3,16 @@
 from .composer import LAYER_ORDER, SYSTEM_LAYER_ORDER, compose_turn_prompt
 from .inspection import PromptInspector
 from .layers import UNTRUSTED_CONTENT_BEGIN, UNTRUSTED_CONTENT_END
+from .turn_output import (
+    RubricObservation,
+    RuntimeProtocol,
+    SAFE_FALLBACK_UTTERANCE,
+    SafetyStatus,
+    SessionControl,
+    TurnOutput,
+    ValidationError,
+    parse_turn_output,
+)
 from .types import (
     DifficultySettings,
     NPC_TURN_OUTPUT_SCHEMA,
@@ -37,4 +47,13 @@ __all__ = [
     "ScenarioData",
     "SessionState",
     "TranscriptEntry",
+    # Turn output parser
+    "parse_turn_output",
+    "TurnOutput",
+    "RubricObservation",
+    "SafetyStatus",
+    "SessionControl",
+    "ValidationError",
+    "RuntimeProtocol",
+    "SAFE_FALLBACK_UTTERANCE",
 ]

--- a/packages/prompt-composer/src/convsim_prompt/turn_output.py
+++ b/packages/prompt-composer/src/convsim_prompt/turn_output.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import json
 import logging
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Protocol
 
 from .types import NPC_TURN_OUTPUT_SCHEMA

--- a/packages/prompt-composer/src/convsim_prompt/turn_output.py
+++ b/packages/prompt-composer/src/convsim_prompt/turn_output.py
@@ -35,9 +35,11 @@ _VALID_ENDING_TYPES = frozenset({
 
 _STATE_DELTA_MIN = -20
 _STATE_DELTA_MAX = 20
+_RUBRIC_SCORE_DELTA_MIN = -3
+_RUBRIC_SCORE_DELTA_MAX = 3
 
 _REPAIR_PROMPT = (
-    "Your previous response was not valid JSON. "
+    "Your previous response did not produce a valid structured JSON response. "
     "Return ONLY a valid JSON object matching this schema — no markdown fences, "
     "no explanation, no text outside the JSON object itself:\n"
     + json.dumps(NPC_TURN_OUTPUT_SCHEMA, indent=2)
@@ -169,7 +171,7 @@ def _validate(data: Dict[str, Any]) -> TurnOutput:
         raise ValidationError("state_delta must be an object")
     state_delta: Dict[str, int] = {}
     for k, v in raw_delta.items():
-        if not isinstance(v, int):
+        if not isinstance(v, int) or isinstance(v, bool):
             raise ValidationError(
                 f"state_delta[{k!r}] must be an integer, got {type(v).__name__}"
             )
@@ -204,10 +206,18 @@ def _validate(data: Dict[str, Any]) -> TurnOutput:
                 f"rubric_observations[{i}].observation missing or not a string"
             )
         score_delta = obs.get("score_delta")
-        if score_delta is not None and not isinstance(score_delta, int):
-            raise ValidationError(
-                f"rubric_observations[{i}].score_delta must be an integer"
-            )
+        if score_delta is not None:
+            if not isinstance(score_delta, int) or isinstance(score_delta, bool):
+                raise ValidationError(
+                    f"rubric_observations[{i}].score_delta must be an integer"
+                )
+            clamped_sd = max(_RUBRIC_SCORE_DELTA_MIN, min(_RUBRIC_SCORE_DELTA_MAX, score_delta))
+            if clamped_sd != score_delta:
+                logger.warning(
+                    "rubric_observations[%d].score_delta clamped %d → %d",
+                    i, score_delta, clamped_sd,
+                )
+            score_delta = clamped_sd
         observations.append(
             RubricObservation(rubric_id=r_id, observation=r_text, score_delta=score_delta)
         )

--- a/packages/prompt-composer/src/convsim_prompt/turn_output.py
+++ b/packages/prompt-composer/src/convsim_prompt/turn_output.py
@@ -1,0 +1,292 @@
+"""NPC turn output parser, validator, repair, and fallback.
+
+Parsing pipeline:
+  1. Extract JSON from raw model text (handles markdown fences, leading prose).
+  2. Validate required fields, enum values, and field types.
+  3. If validation fails: make exactly one repair call to the runtime (if given).
+  4. If repair also fails or no runtime is available: return SAFE_FALLBACK.
+
+State delta values are clamped to [-20, 20] per-turn before they can reach the
+state engine — dangerously large values are never applied blindly.
+
+Validation errors are logged at WARNING level so they appear in dev logs and the
+debug drawer without crashing the session.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Protocol
+
+from .types import NPC_TURN_OUTPUT_SCHEMA
+
+logger = logging.getLogger(__name__)
+
+_VALID_EMOTIONS = frozenset({
+    "neutral", "warm", "curious", "skeptical", "impatient",
+    "defensive", "confused", "impressed", "concerned", "angry",
+})
+_VALID_SAFETY_STATUSES = frozenset({"ok", "redirect", "stop"})
+_VALID_ENDING_TYPES = frozenset({
+    "none", "success", "failure", "timeout", "safety_stop", "player_exit",
+})
+
+_STATE_DELTA_MIN = -20
+_STATE_DELTA_MAX = 20
+
+_REPAIR_PROMPT = (
+    "Your previous response was not valid JSON. "
+    "Return ONLY a valid JSON object matching this schema — no markdown fences, "
+    "no explanation, no text outside the JSON object itself:\n"
+    + json.dumps(NPC_TURN_OUTPUT_SCHEMA, indent=2)
+)
+
+
+class ValidationError(ValueError):
+    """Raised when a turn output fails schema or semantic validation."""
+
+
+class RuntimeProtocol(Protocol):
+    """Minimal interface the parser uses for a single repair LLM call."""
+
+    def call_llm(self, prompt: str) -> str: ...
+
+
+@dataclass
+class RubricObservation:
+    rubric_id: str
+    observation: str
+    score_delta: Optional[int] = None
+
+
+@dataclass
+class SafetyStatus:
+    status: str
+    reason: Optional[str] = None
+
+
+@dataclass
+class SessionControl:
+    continue_session: bool
+    ending_type: Optional[str] = None
+    ending_summary: Optional[str] = None
+
+
+@dataclass
+class TurnOutput:
+    npc_utterance: str
+    npc_emotion: str
+    state_delta: Dict[str, int]
+    event_flags: List[str]
+    rubric_observations: List[RubricObservation]
+    safety: SafetyStatus
+    session_control: SessionControl
+
+
+# Canonical safe fallback: keeps the player in-session, exposes no system rules.
+SAFE_FALLBACK_UTTERANCE = "I'm not sure what to say right now. Could you repeat that?"
+
+
+def _make_safe_fallback() -> TurnOutput:
+    return TurnOutput(
+        npc_utterance=SAFE_FALLBACK_UTTERANCE,
+        npc_emotion="neutral",
+        state_delta={},
+        event_flags=[],
+        rubric_observations=[],
+        safety=SafetyStatus(status="ok"),
+        session_control=SessionControl(continue_session=True),
+    )
+
+
+def _extract_json(raw: str) -> Optional[Dict[str, Any]]:
+    """Try to find and parse a JSON object in raw model text.
+
+    Attempts in order:
+      1. Entire stripped string as JSON.
+      2. First '{' … last '}' span (handles leading/trailing prose).
+      3. First ```json … ``` or ``` … ``` fenced code block.
+    """
+    text = raw.strip()
+
+    try:
+        obj = json.loads(text)
+        if isinstance(obj, dict):
+            return obj
+    except json.JSONDecodeError:
+        pass
+
+    start = text.find("{")
+    end = text.rfind("}")
+    if start != -1 and end > start:
+        try:
+            obj = json.loads(text[start : end + 1])
+            if isinstance(obj, dict):
+                return obj
+        except json.JSONDecodeError:
+            pass
+
+    fence = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL)
+    if fence:
+        try:
+            obj = json.loads(fence.group(1))
+            if isinstance(obj, dict):
+                return obj
+        except json.JSONDecodeError:
+            pass
+
+    return None
+
+
+def _validate(data: Dict[str, Any]) -> TurnOutput:
+    """Validate a parsed dict and convert it to a TurnOutput.
+
+    Raises ValidationError for missing required fields, wrong types, or invalid
+    enum values. State delta values outside [-20, 20] are clamped and logged.
+    """
+
+    def _req(key: str, parent: Dict[str, Any] = data, ctx: str = "") -> Any:
+        if key not in parent:
+            prefix = f"{ctx}." if ctx else ""
+            raise ValidationError(f"Missing required field: {prefix}{key}")
+        return parent[key]
+
+    utterance = _req("npc_utterance")
+    if not isinstance(utterance, str) or not utterance:
+        raise ValidationError("npc_utterance must be a non-empty string")
+
+    emotion = _req("npc_emotion")
+    if emotion not in _VALID_EMOTIONS:
+        raise ValidationError(
+            f"Unknown npc_emotion: {emotion!r}. "
+            f"Valid values: {sorted(_VALID_EMOTIONS)}"
+        )
+
+    raw_delta = _req("state_delta")
+    if not isinstance(raw_delta, dict):
+        raise ValidationError("state_delta must be an object")
+    state_delta: Dict[str, int] = {}
+    for k, v in raw_delta.items():
+        if not isinstance(v, int):
+            raise ValidationError(
+                f"state_delta[{k!r}] must be an integer, got {type(v).__name__}"
+            )
+        clamped = max(_STATE_DELTA_MIN, min(_STATE_DELTA_MAX, v))
+        if clamped != v:
+            logger.warning("state_delta[%r] clamped %d → %d", k, v, clamped)
+        state_delta[k] = clamped
+
+    raw_flags = _req("event_flags")
+    if not isinstance(raw_flags, list):
+        raise ValidationError("event_flags must be an array")
+    for i, flag in enumerate(raw_flags):
+        if not isinstance(flag, str):
+            raise ValidationError(f"event_flags[{i}] must be a string")
+    event_flags: List[str] = list(raw_flags)
+
+    raw_obs = _req("rubric_observations")
+    if not isinstance(raw_obs, list):
+        raise ValidationError("rubric_observations must be an array")
+    observations: List[RubricObservation] = []
+    for i, obs in enumerate(raw_obs):
+        if not isinstance(obs, dict):
+            raise ValidationError(f"rubric_observations[{i}] must be an object")
+        r_id = obs.get("rubric_id")
+        r_text = obs.get("observation")
+        if not isinstance(r_id, str) or not r_id:
+            raise ValidationError(
+                f"rubric_observations[{i}].rubric_id missing or not a string"
+            )
+        if not isinstance(r_text, str) or not r_text:
+            raise ValidationError(
+                f"rubric_observations[{i}].observation missing or not a string"
+            )
+        score_delta = obs.get("score_delta")
+        if score_delta is not None and not isinstance(score_delta, int):
+            raise ValidationError(
+                f"rubric_observations[{i}].score_delta must be an integer"
+            )
+        observations.append(
+            RubricObservation(rubric_id=r_id, observation=r_text, score_delta=score_delta)
+        )
+
+    raw_safety = _req("safety")
+    if not isinstance(raw_safety, dict):
+        raise ValidationError("safety must be an object")
+    safety_status = raw_safety.get("status")
+    if safety_status not in _VALID_SAFETY_STATUSES:
+        raise ValidationError(
+            f"safety.status missing or invalid: {safety_status!r}. "
+            f"Valid values: {sorted(_VALID_SAFETY_STATUSES)}"
+        )
+    safety = SafetyStatus(status=safety_status, reason=raw_safety.get("reason"))
+
+    raw_sc = _req("session_control")
+    if not isinstance(raw_sc, dict):
+        raise ValidationError("session_control must be an object")
+    if "continue_session" not in raw_sc:
+        raise ValidationError("session_control.continue_session is required")
+    continue_session = raw_sc["continue_session"]
+    if not isinstance(continue_session, bool):
+        raise ValidationError("session_control.continue_session must be a boolean")
+    ending_type = raw_sc.get("ending_type")
+    if ending_type is not None and ending_type not in _VALID_ENDING_TYPES:
+        raise ValidationError(
+            f"session_control.ending_type invalid: {ending_type!r}. "
+            f"Valid values: {sorted(_VALID_ENDING_TYPES)}"
+        )
+    session_control = SessionControl(
+        continue_session=continue_session,
+        ending_type=ending_type,
+        ending_summary=raw_sc.get("ending_summary"),
+    )
+
+    return TurnOutput(
+        npc_utterance=utterance,
+        npc_emotion=emotion,
+        state_delta=state_delta,
+        event_flags=event_flags,
+        rubric_observations=observations,
+        safety=safety,
+        session_control=session_control,
+    )
+
+
+def parse_turn_output(
+    raw: str,
+    runtime: Optional[RuntimeProtocol] = None,
+) -> TurnOutput:
+    """Parse raw LLM output into a TurnOutput.
+
+    Parsing pipeline:
+      1. Extract JSON from ``raw`` and validate it.
+      2. If that fails and ``runtime`` is given: make exactly one repair call.
+      3. If repair also fails or no runtime: return a safe fallback TurnOutput.
+
+    This function never raises — it always returns a TurnOutput so sessions
+    survive model drift or malformed output.
+    """
+    data = _extract_json(raw)
+    if data is not None:
+        try:
+            return _validate(data)
+        except ValidationError as exc:
+            logger.warning("Turn output validation failed (will attempt repair): %s", exc)
+
+    if runtime is not None:
+        logger.debug("Requesting repaired turn output from runtime")
+        try:
+            repaired_raw = runtime.call_llm(_REPAIR_PROMPT)
+            repaired_data = _extract_json(repaired_raw)
+            if repaired_data is not None:
+                return _validate(repaired_data)
+            logger.warning("Repair attempt returned non-JSON output")
+        except ValidationError as exc:
+            logger.warning("Repair attempt produced invalid output: %s", exc)
+        except Exception as exc:
+            logger.warning("Repair runtime call raised: %s", exc)
+
+    logger.debug("Returning SAFE_FALLBACK for turn output")
+    return _make_safe_fallback()

--- a/packages/prompt-composer/tests/test_turn_output.py
+++ b/packages/prompt-composer/tests/test_turn_output.py
@@ -1,0 +1,517 @@
+"""Unit tests for the NPC turn output parser, repair, and fallback.
+
+Test plan (issue #15):
+  - Valid model output parses into a typed TurnOutput.
+  - Missing-field outputs fail validation and fall back.
+  - Invalid-enum outputs (emotion, safety.status, ending_type) fail validation.
+  - Oversized state_delta values are clamped, never blindly applied.
+  - Non-JSON and non-object outputs go straight to fallback.
+  - Invalid JSON triggers exactly one repair attempt before fallback.
+  - Fallback TurnOutput is safe, in-session, and exposes no system rules.
+"""
+import json
+import pytest
+
+from convsim_prompt import (
+    RubricObservation,
+    SAFE_FALLBACK_UTTERANCE,
+    SafetyStatus,
+    SessionControl,
+    TurnOutput,
+    ValidationError,
+    parse_turn_output,
+)
+from convsim_prompt.turn_output import (
+    _extract_json,
+    _validate,
+    _make_safe_fallback,
+    _REPAIR_PROMPT,
+    _STATE_DELTA_MIN,
+    _STATE_DELTA_MAX,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _minimal_valid_dict(**overrides):
+    """Minimal valid turn output dict; overrides replace top-level keys."""
+    base = {
+        "npc_utterance": "Hello there.",
+        "npc_emotion": "neutral",
+        "state_delta": {},
+        "event_flags": [],
+        "rubric_observations": [],
+        "safety": {"status": "ok"},
+        "session_control": {"continue_session": True},
+    }
+    base.update(overrides)
+    return base
+
+
+def _minimal_valid_json(**overrides) -> str:
+    return json.dumps(_minimal_valid_dict(**overrides))
+
+
+class FakeRuntime:
+    """Fake runtime adapter that returns a pre-set string for every call_llm()."""
+
+    def __init__(self, response: str) -> None:
+        self._response = response
+        self.call_count = 0
+        self.last_prompt: str | None = None
+
+    def call_llm(self, prompt: str) -> str:
+        self.call_count += 1
+        self.last_prompt = prompt
+        return self._response
+
+
+class FailingRuntime:
+    """Runtime that always raises."""
+
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    def call_llm(self, prompt: str) -> str:
+        self.call_count += 1
+        raise RuntimeError("LLM unavailable")
+
+
+# ---------------------------------------------------------------------------
+# JSON extraction
+# ---------------------------------------------------------------------------
+
+
+class TestExtractJson:
+    def test_plain_json_object(self):
+        raw = '{"a": 1}'
+        result = _extract_json(raw)
+        assert result == {"a": 1}
+
+    def test_json_with_leading_text(self):
+        raw = 'Here is the output:\n{"a": 1}'
+        result = _extract_json(raw)
+        assert result == {"a": 1}
+
+    def test_json_with_trailing_text(self):
+        raw = '{"a": 1}\nThat is my answer.'
+        result = _extract_json(raw)
+        assert result == {"a": 1}
+
+    def test_json_in_fenced_code_block(self):
+        raw = '```\n{"a": 1}\n```'
+        result = _extract_json(raw)
+        assert result == {"a": 1}
+
+    def test_json_in_json_fenced_code_block(self):
+        raw = '```json\n{"a": 1}\n```'
+        result = _extract_json(raw)
+        assert result == {"a": 1}
+
+    def test_non_json_returns_none(self):
+        assert _extract_json("plain text, no JSON") is None
+
+    def test_json_array_not_returned_as_dict(self):
+        assert _extract_json("[1, 2, 3]") is None
+
+    def test_empty_string_returns_none(self):
+        assert _extract_json("") is None
+
+    def test_whitespace_only_returns_none(self):
+        assert _extract_json("   \n\t  ") is None
+
+
+# ---------------------------------------------------------------------------
+# Validation — valid inputs
+# ---------------------------------------------------------------------------
+
+
+class TestValidateValid:
+    def test_minimal_valid_turn(self):
+        result = _validate(_minimal_valid_dict())
+        assert isinstance(result, TurnOutput)
+        assert result.npc_utterance == "Hello there."
+        assert result.npc_emotion == "neutral"
+        assert result.state_delta == {}
+        assert result.event_flags == []
+        assert result.rubric_observations == []
+        assert result.safety.status == "ok"
+        assert result.session_control.continue_session is True
+
+    def test_all_valid_emotions_accepted(self):
+        emotions = [
+            "neutral", "warm", "curious", "skeptical", "impatient",
+            "defensive", "confused", "impressed", "concerned", "angry",
+        ]
+        for emotion in emotions:
+            result = _validate(_minimal_valid_dict(npc_emotion=emotion))
+            assert result.npc_emotion == emotion
+
+    def test_full_turn_with_optional_fields(self):
+        data = _minimal_valid_dict(
+            state_delta={"trust": 5, "patience": -3},
+            event_flags=["greeting_received"],
+            rubric_observations=[
+                {"rubric_id": "clarity", "observation": "Spoke clearly.", "score_delta": 2}
+            ],
+            safety={"status": "ok", "reason": None},
+            session_control={
+                "continue_session": True,
+                "ending_type": "none",
+                "ending_summary": None,
+            },
+        )
+        result = _validate(data)
+        assert result.state_delta == {"trust": 5, "patience": -3}
+        assert result.event_flags == ["greeting_received"]
+        assert len(result.rubric_observations) == 1
+        assert result.rubric_observations[0].rubric_id == "clarity"
+        assert result.rubric_observations[0].score_delta == 2
+
+    def test_safety_redirect_status(self):
+        result = _validate(_minimal_valid_dict(safety={"status": "redirect", "reason": "Off topic."}))
+        assert result.safety.status == "redirect"
+        assert result.safety.reason == "Off topic."
+
+    def test_safety_stop_status(self):
+        result = _validate(_minimal_valid_dict(safety={"status": "stop"}))
+        assert result.safety.status == "stop"
+
+    def test_session_control_ending_types(self):
+        for etype in ["none", "success", "failure", "timeout", "safety_stop", "player_exit"]:
+            sc = {"continue_session": False, "ending_type": etype}
+            result = _validate(_minimal_valid_dict(session_control=sc))
+            assert result.session_control.ending_type == etype
+
+    def test_rubric_observation_without_score_delta(self):
+        data = _minimal_valid_dict(
+            rubric_observations=[{"rubric_id": "r1", "observation": "Good."}]
+        )
+        result = _validate(data)
+        assert result.rubric_observations[0].score_delta is None
+
+
+# ---------------------------------------------------------------------------
+# Validation — missing required fields
+# ---------------------------------------------------------------------------
+
+
+class TestValidateMissingFields:
+    def _assert_missing(self, key: str, **nested):
+        """Verify ValidationError is raised when a required field is absent."""
+        data = _minimal_valid_dict()
+        if nested:
+            data.update(nested)
+        else:
+            del data[key]
+        with pytest.raises(ValidationError, match=key):
+            _validate(data)
+
+    def test_missing_npc_utterance(self):
+        self._assert_missing("npc_utterance")
+
+    def test_missing_npc_emotion(self):
+        self._assert_missing("npc_emotion")
+
+    def test_missing_state_delta(self):
+        self._assert_missing("state_delta")
+
+    def test_missing_event_flags(self):
+        self._assert_missing("event_flags")
+
+    def test_missing_rubric_observations(self):
+        self._assert_missing("rubric_observations")
+
+    def test_missing_safety(self):
+        self._assert_missing("safety")
+
+    def test_missing_safety_status(self):
+        data = _minimal_valid_dict(safety={"reason": "no status here"})
+        with pytest.raises(ValidationError, match="safety.status"):
+            _validate(data)
+
+    def test_missing_session_control(self):
+        self._assert_missing("session_control")
+
+    def test_missing_session_control_continue_session(self):
+        data = _minimal_valid_dict(session_control={"ending_type": "none"})
+        with pytest.raises(ValidationError, match="continue_session"):
+            _validate(data)
+
+    def test_empty_npc_utterance(self):
+        data = _minimal_valid_dict(npc_utterance="")
+        with pytest.raises(ValidationError, match="npc_utterance"):
+            _validate(data)
+
+    def test_missing_rubric_observation_rubric_id(self):
+        data = _minimal_valid_dict(
+            rubric_observations=[{"observation": "no id"}]
+        )
+        with pytest.raises(ValidationError, match="rubric_id"):
+            _validate(data)
+
+    def test_missing_rubric_observation_observation(self):
+        data = _minimal_valid_dict(
+            rubric_observations=[{"rubric_id": "r1"}]
+        )
+        with pytest.raises(ValidationError, match="observation"):
+            _validate(data)
+
+
+# ---------------------------------------------------------------------------
+# Validation — invalid enum values
+# ---------------------------------------------------------------------------
+
+
+class TestValidateInvalidEnums:
+    def test_unknown_npc_emotion(self):
+        data = _minimal_valid_dict(npc_emotion="happy")
+        with pytest.raises(ValidationError, match="npc_emotion"):
+            _validate(data)
+
+    def test_unknown_safety_status(self):
+        data = _minimal_valid_dict(safety={"status": "warn"})
+        with pytest.raises(ValidationError, match="safety.status"):
+            _validate(data)
+
+    def test_unknown_ending_type(self):
+        data = _minimal_valid_dict(
+            session_control={"continue_session": False, "ending_type": "crash"}
+        )
+        with pytest.raises(ValidationError, match="ending_type"):
+            _validate(data)
+
+
+# ---------------------------------------------------------------------------
+# Validation — state delta bounds
+# ---------------------------------------------------------------------------
+
+
+class TestStateDeltaBounds:
+    def test_in_bounds_values_pass_unchanged(self):
+        data = _minimal_valid_dict(state_delta={"trust": 20, "patience": -20})
+        result = _validate(data)
+        assert result.state_delta == {"trust": 20, "patience": -20}
+
+    def test_oversized_positive_delta_clamped(self):
+        data = _minimal_valid_dict(state_delta={"trust": 99})
+        result = _validate(data)
+        assert result.state_delta["trust"] == _STATE_DELTA_MAX
+
+    def test_oversized_negative_delta_clamped(self):
+        data = _minimal_valid_dict(state_delta={"patience": -99})
+        result = _validate(data)
+        assert result.state_delta["patience"] == _STATE_DELTA_MIN
+
+    def test_clamped_values_never_exceed_bounds(self):
+        data = _minimal_valid_dict(state_delta={"a": 1000, "b": -1000, "c": 0})
+        result = _validate(data)
+        for v in result.state_delta.values():
+            assert _STATE_DELTA_MIN <= v <= _STATE_DELTA_MAX
+
+    def test_non_integer_delta_value_raises(self):
+        data = _minimal_valid_dict(state_delta={"trust": 1.5})
+        with pytest.raises(ValidationError, match="integer"):
+            _validate(data)
+
+    def test_state_delta_must_be_object(self):
+        data = _minimal_valid_dict(state_delta=[1, 2, 3])
+        with pytest.raises(ValidationError, match="state_delta"):
+            _validate(data)
+
+
+# ---------------------------------------------------------------------------
+# parse_turn_output — happy path
+# ---------------------------------------------------------------------------
+
+
+class TestParseTurnOutputValid:
+    def test_valid_json_string_returns_turn_output(self):
+        raw = _minimal_valid_json()
+        result = parse_turn_output(raw)
+        assert isinstance(result, TurnOutput)
+        assert result.npc_utterance == "Hello there."
+
+    def test_valid_json_with_prose_returns_turn_output(self):
+        raw = "Here is my response:\n" + _minimal_valid_json()
+        result = parse_turn_output(raw)
+        assert isinstance(result, TurnOutput)
+
+    def test_valid_json_in_code_fence_returns_turn_output(self):
+        raw = "```json\n" + _minimal_valid_json() + "\n```"
+        result = parse_turn_output(raw)
+        assert isinstance(result, TurnOutput)
+
+    def test_state_delta_clamped_in_valid_parse(self):
+        raw = _minimal_valid_json(state_delta={"trust": 50})
+        result = parse_turn_output(raw)
+        assert result.state_delta["trust"] == _STATE_DELTA_MAX
+
+
+# ---------------------------------------------------------------------------
+# parse_turn_output — fallback cases (no runtime)
+# ---------------------------------------------------------------------------
+
+
+class TestParseTurnOutputFallback:
+    def test_non_json_returns_fallback(self):
+        result = parse_turn_output("This is just some text.")
+        _assert_is_safe_fallback(result)
+
+    def test_empty_string_returns_fallback(self):
+        result = parse_turn_output("")
+        _assert_is_safe_fallback(result)
+
+    def test_missing_field_returns_fallback(self):
+        data = _minimal_valid_dict()
+        del data["safety"]
+        result = parse_turn_output(json.dumps(data))
+        _assert_is_safe_fallback(result)
+
+    def test_invalid_emotion_returns_fallback(self):
+        result = parse_turn_output(_minimal_valid_json(npc_emotion="happy"))
+        _assert_is_safe_fallback(result)
+
+    def test_invalid_safety_status_returns_fallback(self):
+        result = parse_turn_output(_minimal_valid_json(safety={"status": "warn"}))
+        _assert_is_safe_fallback(result)
+
+    def test_invalid_ending_type_returns_fallback(self):
+        raw = _minimal_valid_json(
+            session_control={"continue_session": False, "ending_type": "boom"}
+        )
+        result = parse_turn_output(raw)
+        _assert_is_safe_fallback(result)
+
+    def test_json_array_not_accepted(self):
+        result = parse_turn_output("[1, 2, 3]")
+        _assert_is_safe_fallback(result)
+
+    def test_parse_never_raises(self):
+        for raw in ["", "not json", "{broken", "null", "42", '["list"]']:
+            result = parse_turn_output(raw)
+            assert isinstance(result, TurnOutput)
+
+
+# ---------------------------------------------------------------------------
+# parse_turn_output — repair retry
+# ---------------------------------------------------------------------------
+
+
+class TestRepairRetry:
+    def test_repair_called_when_initial_parse_fails(self):
+        runtime = FakeRuntime(response=_minimal_valid_json())
+        parse_turn_output("not valid json", runtime=runtime)
+        assert runtime.call_count == 1
+
+    def test_repair_not_called_when_initial_parse_succeeds(self):
+        runtime = FakeRuntime(response="irrelevant")
+        parse_turn_output(_minimal_valid_json(), runtime=runtime)
+        assert runtime.call_count == 0
+
+    def test_repair_returns_valid_turn_output(self):
+        runtime = FakeRuntime(response=_minimal_valid_json(npc_utterance="Repaired."))
+        result = parse_turn_output("garbage input", runtime=runtime)
+        assert result.npc_utterance == "Repaired."
+
+    def test_repair_called_exactly_once_not_more(self):
+        runtime = FakeRuntime(response="still bad json")
+        parse_turn_output("also bad", runtime=runtime)
+        assert runtime.call_count == 1
+
+    def test_fallback_when_repair_also_fails(self):
+        runtime = FakeRuntime(response="still not json")
+        result = parse_turn_output("bad input", runtime=runtime)
+        _assert_is_safe_fallback(result)
+
+    def test_fallback_when_repair_returns_invalid_schema(self):
+        bad_schema = json.dumps({"npc_utterance": "hi"})  # missing fields
+        runtime = FakeRuntime(response=bad_schema)
+        result = parse_turn_output("bad input", runtime=runtime)
+        _assert_is_safe_fallback(result)
+
+    def test_fallback_when_runtime_raises(self):
+        runtime = FailingRuntime()
+        result = parse_turn_output("bad input", runtime=runtime)
+        _assert_is_safe_fallback(result)
+        assert runtime.call_count == 1
+
+    def test_repair_prompt_contains_schema(self):
+        runtime = FakeRuntime(response="irrelevant")
+        parse_turn_output("bad", runtime=runtime)
+        assert "npc_utterance" in runtime.last_prompt
+        assert "npc_emotion" in runtime.last_prompt
+        assert "session_control" in runtime.last_prompt
+
+    def test_no_runtime_no_repair_returns_fallback(self):
+        result = parse_turn_output("not json", runtime=None)
+        _assert_is_safe_fallback(result)
+
+    def test_repair_with_fenced_valid_json_succeeds(self):
+        fenced = "```json\n" + _minimal_valid_json(npc_utterance="Fenced repair.") + "\n```"
+        runtime = FakeRuntime(response=fenced)
+        result = parse_turn_output("initial garbage", runtime=runtime)
+        assert result.npc_utterance == "Fenced repair."
+
+
+# ---------------------------------------------------------------------------
+# Fallback shape
+# ---------------------------------------------------------------------------
+
+
+class TestSafeFallback:
+    def test_fallback_utterance_is_non_empty(self):
+        fb = _make_safe_fallback()
+        assert fb.npc_utterance and len(fb.npc_utterance) > 0
+
+    def test_fallback_utterance_constant_matches_instance(self):
+        fb = _make_safe_fallback()
+        assert fb.npc_utterance == SAFE_FALLBACK_UTTERANCE
+
+    def test_fallback_session_continues(self):
+        fb = _make_safe_fallback()
+        assert fb.session_control.continue_session is True
+
+    def test_fallback_safety_status_is_ok(self):
+        fb = _make_safe_fallback()
+        assert fb.safety.status == "ok"
+
+    def test_fallback_emotion_is_neutral(self):
+        fb = _make_safe_fallback()
+        assert fb.npc_emotion == "neutral"
+
+    def test_fallback_state_delta_is_empty(self):
+        fb = _make_safe_fallback()
+        assert fb.state_delta == {}
+
+    def test_fallback_event_flags_empty(self):
+        fb = _make_safe_fallback()
+        assert fb.event_flags == []
+
+    def test_fallback_no_system_rule_exposure(self):
+        fb = _make_safe_fallback()
+        text = fb.npc_utterance.lower()
+        for keyword in ("schema", "json", "system", "rule", "layer", "safety policy", "prompt"):
+            assert keyword not in text, f"Fallback utterance exposes: {keyword!r}"
+
+    def test_fallback_instances_are_independent(self):
+        fb1 = _make_safe_fallback()
+        fb2 = _make_safe_fallback()
+        fb1.state_delta["x"] = 1
+        assert "x" not in fb2.state_delta
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _assert_is_safe_fallback(result: TurnOutput) -> None:
+    """Assert a TurnOutput matches the safe fallback contract."""
+    assert isinstance(result, TurnOutput)
+    assert result.session_control.continue_session is True
+    assert result.safety.status == "ok"
+    assert result.npc_emotion == "neutral"
+    assert result.state_delta == {}

--- a/packages/prompt-composer/tests/test_turn_output.py
+++ b/packages/prompt-composer/tests/test_turn_output.py
@@ -28,6 +28,8 @@ from convsim_prompt.turn_output import (
     _REPAIR_PROMPT,
     _STATE_DELTA_MIN,
     _STATE_DELTA_MAX,
+    _RUBRIC_SCORE_DELTA_MIN,
+    _RUBRIC_SCORE_DELTA_MAX,
 )
 
 
@@ -121,6 +123,13 @@ class TestExtractJson:
 
     def test_whitespace_only_returns_none(self):
         assert _extract_json("   \n\t  ") is None
+
+    def test_fenced_block_when_brace_scan_fails(self):
+        # A stray opening brace before the fence makes the brace-scan span invalid;
+        # the fence-regex path must pick up the correct JSON.
+        raw = "Use { this schema:\n```json\n{\"a\": 1}\n```"
+        result = _extract_json(raw)
+        assert result == {"a": 1}
 
 
 # ---------------------------------------------------------------------------
@@ -320,6 +329,42 @@ class TestStateDeltaBounds:
         data = _minimal_valid_dict(state_delta=[1, 2, 3])
         with pytest.raises(ValidationError, match="state_delta"):
             _validate(data)
+
+    def test_state_delta_bool_value_raises(self):
+        # Python bool is a subclass of int; JSON `true`/`false` must be rejected.
+        for v in (True, False):
+            data = _minimal_valid_dict(state_delta={"trust": v})
+            with pytest.raises(ValidationError, match="integer"):
+                _validate(data)
+
+
+# ---------------------------------------------------------------------------
+# Validation — rubric score_delta bounds
+# ---------------------------------------------------------------------------
+
+
+class TestRubricScoreDeltaBounds:
+    def _obs(self, score_delta):
+        return [{"rubric_id": "r1", "observation": "ok", "score_delta": score_delta}]
+
+    def test_in_bounds_score_delta_unchanged(self):
+        for v in (_RUBRIC_SCORE_DELTA_MIN, 0, _RUBRIC_SCORE_DELTA_MAX):
+            result = _validate(_minimal_valid_dict(rubric_observations=self._obs(v)))
+            assert result.rubric_observations[0].score_delta == v
+
+    def test_oversized_positive_score_delta_clamped(self):
+        result = _validate(_minimal_valid_dict(rubric_observations=self._obs(99)))
+        assert result.rubric_observations[0].score_delta == _RUBRIC_SCORE_DELTA_MAX
+
+    def test_oversized_negative_score_delta_clamped(self):
+        result = _validate(_minimal_valid_dict(rubric_observations=self._obs(-99)))
+        assert result.rubric_observations[0].score_delta == _RUBRIC_SCORE_DELTA_MIN
+
+    def test_score_delta_bool_raises(self):
+        for v in (True, False):
+            data = _minimal_valid_dict(rubric_observations=self._obs(v))
+            with pytest.raises(ValidationError, match="integer"):
+                _validate(data)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What changed

Adds `turn_output.py` to the `convsim-prompt` package — the structured parsing layer that sits between raw LLM responses and the session state engine, preventing session corruption from model drift.

### New module: `packages/prompt-composer/src/convsim_prompt/turn_output.py`

**Typed output types**
- `TurnOutput`, `SafetyStatus`, `SessionControl`, and `RubricObservation` dataclasses matching the `turn-output.schema.json` contract.

**JSON extraction** (`_extract_json`)
- Handles three real-world model output shapes:
  - Plain JSON objects
  - JSON embedded in leading/trailing prose
  - JSON inside markdown fenced code blocks (`` ```json `` or `` ``` ``)

**Validation** (`_validate`)
- Enforces all required fields and validates enum values for `npc_emotion`, `safety.status`, and `session_control.ending_type` against their allowed sets.
- State delta values outside `[-20, 20]` and rubric score deltas outside `[-3, 3]` are **clamped** and logged at WARNING level so violations surface in dev logs and the debug drawer without crashing the session.
- Non-integer state_delta or score_delta values, missing required fields, or invalid enum values raise `ValidationError`.

**Repair retry** (`RuntimeProtocol` + `parse_turn_output`)
- `RuntimeProtocol` is a minimal `typing.Protocol` that runtime adapters implement with a single `call_llm(prompt: str) -> str` method.
- `parse_turn_output()` runs the extract+validate pipeline; if validation fails and a runtime is provided, it makes **exactly one** repair call embedding the full schema in the prompt, then falls through to the safe fallback. The function never raises.

**Safe fallback** (`_make_safe_fallback` / `SAFE_FALLBACK_UTTERANCE`)
- Returns a neutral in-session `TurnOutput` with `continue_session=True`, `safety.status="ok"`, empty state delta, and a generic utterance that exposes no system rules, schema details, or error context.

### Public API
`__init__.py` now exports:
- `parse_turn_output` — main parsing entry point
- `TurnOutput`, `RubricObservation`, `SafetyStatus`, `SessionControl` — output types
- `ValidationError`, `RuntimeProtocol` — error and protocol types
- `SAFE_FALLBACK_UTTERANCE` — the canonical fallback utterance

## Test coverage

68 new unit tests in `tests/test_turn_output.py` covering:
- JSON extraction from plain text, prose-wrapped, and fenced inputs
- Valid parse → typed `TurnOutput` returned
- Every required field missing → fallback
- Invalid enum values (`npc_emotion`, `safety.status`, `ending_type`) → fallback
- `state_delta` and `score_delta` bounds clamping (e.g., value `99` → `20`, `-99` → `-20`)
- Non-integer delta values → `ValidationError` → fallback
- Non-JSON, empty string, and JSON-array inputs → fallback
- Repair retry: called exactly once on validation failure, succeeds on valid repair, falls back on bad repair, falls back when runtime raises
- Repair prompt contains the full schema
- Fallback safety contract: in-session, neutral emotion, empty delta, no system-rule exposure

All 127 tests (59 pre-existing + 68 new) pass.

Closes #15