### PR TITLE
Implement scenario state variables, bounded deltas, events, and endings

### DIFF
--- a/schemas/scenario.schema.json
+++ b/schemas/scenario.schema.json
@@ -307,7 +307,37 @@
           ]
         },
         "timeout": {
-          "type": "object",
+          "oneOf": [
+            {
+              "type": "object",
+              "required": ["type", "variable", "threshold"],
+              "additionalProperties": false,
+              "properties": {
+                "type": { "type": "string", "enum": ["variable_above"] },
+                "variable": { "type": "string" },
+                "threshold": { "type": "integer" }
+              }
+            },
+            {
+              "type": "object",
+              "required": ["type", "variable", "threshold"],
+              "additionalProperties": false,
+              "properties": {
+                "type": { "type": "string", "enum": ["variable_below"] },
+                "variable": { "type": "string" },
+                "threshold": { "type": "integer" }
+              }
+            },
+            {
+              "type": "object",
+              "required": ["type", "value"],
+              "additionalProperties": false,
+              "properties": {
+                "type": { "type": "string", "enum": ["max_turns"] },
+                "value": { "type": "integer", "minimum": 1 }
+              }
+            }
+          ],
           "description": "Optional explicit timeout condition (turn-count-based timeout is always enforced via duration.max_turns)."
         }
       }

--- a/schemas/scenario.schema.json
+++ b/schemas/scenario.schema.json
@@ -119,10 +119,37 @@
       "properties": {
         "variables": {
           "type": "object",
+          "description": "Override or extend baseline variables. Each key is a variable name. Value may be a simple integer (sets the default) or a rich object with min/max/default/visibility/max_delta_per_turn.",
           "additionalProperties": {
-            "type": "integer",
-            "minimum": 0,
-            "maximum": 100
+            "oneOf": [
+              {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 100,
+                "description": "Shorthand: sets the default value for a baseline variable."
+              },
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "description": "Full variable definition.",
+                "properties": {
+                  "min": { "type": "integer", "default": 0 },
+                  "max": { "type": "integer", "default": 100 },
+                  "default": { "type": "integer" },
+                  "visibility": {
+                    "type": "string",
+                    "enum": ["visible", "hidden"],
+                    "default": "visible"
+                  },
+                  "max_delta_per_turn": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 100,
+                    "default": 20
+                  }
+                }
+              }
+            ]
           }
         }
       }
@@ -158,8 +185,54 @@
         "additionalProperties": false,
         "properties": {
           "id": { "type": "string", "pattern": "^[a-z0-9_]+$" },
-          "when": { "type": "object" },
-          "npc_instruction": { "type": "string" }
+          "when": {
+            "oneOf": [
+              {
+                "type": "object",
+                "required": ["type", "variable", "threshold"],
+                "additionalProperties": false,
+                "properties": {
+                  "type": { "type": "string", "enum": ["variable_above"] },
+                  "variable": { "type": "string" },
+                  "threshold": { "type": "integer" }
+                }
+              },
+              {
+                "type": "object",
+                "required": ["type", "variable", "threshold"],
+                "additionalProperties": false,
+                "properties": {
+                  "type": { "type": "string", "enum": ["variable_below"] },
+                  "variable": { "type": "string" },
+                  "threshold": { "type": "integer" }
+                }
+              },
+              {
+                "type": "object",
+                "required": ["type", "value"],
+                "additionalProperties": false,
+                "properties": {
+                  "type": { "type": "string", "enum": ["max_turns"] },
+                  "value": { "type": "integer", "minimum": 1 }
+                }
+              },
+              {
+                "type": "object",
+                "required": ["type", "flag_id"],
+                "additionalProperties": false,
+                "properties": {
+                  "type": { "type": "string", "enum": ["flag"] },
+                  "flag_id": { "type": "string", "pattern": "^[a-z0-9_]+$" }
+                }
+              }
+            ]
+          },
+          "npc_instruction": { "type": "string" },
+          "repeat": {
+            "type": "boolean",
+            "default": false,
+            "description": "If true, the event may fire on every turn the condition is met. If false (default), fires at most once per session."
+          }
         }
       }
     },
@@ -167,9 +240,76 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "success": { "type": "object" },
-        "failure": { "type": "object" },
-        "timeout": { "type": "object" }
+        "success": {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": ["type", "variable", "threshold"],
+              "additionalProperties": false,
+              "properties": {
+                "type": { "type": "string", "enum": ["variable_above"] },
+                "variable": { "type": "string" },
+                "threshold": { "type": "integer" }
+              }
+            },
+            {
+              "type": "object",
+              "required": ["type", "variable", "threshold"],
+              "additionalProperties": false,
+              "properties": {
+                "type": { "type": "string", "enum": ["variable_below"] },
+                "variable": { "type": "string" },
+                "threshold": { "type": "integer" }
+              }
+            },
+            {
+              "type": "object",
+              "required": ["type", "value"],
+              "additionalProperties": false,
+              "properties": {
+                "type": { "type": "string", "enum": ["max_turns"] },
+                "value": { "type": "integer", "minimum": 1 }
+              }
+            }
+          ]
+        },
+        "failure": {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": ["type", "variable", "threshold"],
+              "additionalProperties": false,
+              "properties": {
+                "type": { "type": "string", "enum": ["variable_above"] },
+                "variable": { "type": "string" },
+                "threshold": { "type": "integer" }
+              }
+            },
+            {
+              "type": "object",
+              "required": ["type", "variable", "threshold"],
+              "additionalProperties": false,
+              "properties": {
+                "type": { "type": "string", "enum": ["variable_below"] },
+                "variable": { "type": "string" },
+                "threshold": { "type": "integer" }
+              }
+            },
+            {
+              "type": "object",
+              "required": ["type", "value"],
+              "additionalProperties": false,
+              "properties": {
+                "type": { "type": "string", "enum": ["max_turns"] },
+                "value": { "type": "integer", "minimum": 1 }
+              }
+            }
+          ]
+        },
+        "timeout": {
+          "type": "object",
+          "description": "Optional explicit timeout condition (turn-count-based timeout is always enforced via duration.max_turns)."
+        }
       }
     }
   }

--- a/services/convsim-core/convsim_core/scenario_state.py
+++ b/services/convsim-core/convsim_core/scenario_state.py
@@ -77,7 +77,15 @@ def build_variable_defs(
         if isinstance(spec, int):
             # Legacy simple format: name → default_value (0-100 integer).
             if name in defs:
-                defs[name] = ScenarioVariableDef(name=name, default=spec)
+                existing = defs[name]
+                defs[name] = ScenarioVariableDef(
+                    name=name,
+                    min=existing.min,
+                    max=existing.max,
+                    default=spec,
+                    visibility=existing.visibility,
+                    max_delta_per_turn=existing.max_delta_per_turn,
+                )
             else:
                 defs[name] = ScenarioVariableDef(name=name, default=spec)
         elif isinstance(spec, dict):

--- a/services/convsim-core/convsim_core/scenario_state.py
+++ b/services/convsim-core/convsim_core/scenario_state.py
@@ -108,8 +108,11 @@ def build_variable_defs(
 def initialize_state(
     variable_defs: Dict[str, ScenarioVariableDef],
 ) -> Dict[str, int]:
-    """Return initial state dict from variable defaults."""
-    return {name: defn.default for name, defn in variable_defs.items()}
+    """Return initial state dict from variable defaults, clamped to [min, max]."""
+    return {
+        name: max(defn.min, min(defn.max, defn.default))
+        for name, defn in variable_defs.items()
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/services/convsim-core/convsim_core/scenario_state.py
+++ b/services/convsim-core/convsim_core/scenario_state.py
@@ -243,6 +243,7 @@ def evaluate_event_triggers(
 # Ending condition evaluation
 # ---------------------------------------------------------------------------
 
+
 def evaluate_ending_condition(
     state: Dict[str, int],
     turn_number: int,

--- a/services/convsim-core/convsim_core/scenario_state.py
+++ b/services/convsim-core/convsim_core/scenario_state.py
@@ -1,0 +1,334 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Scenario state variable engine: clamping, event triggers, and ending conditions.
+
+Responsibilities:
+  - Initialize state from baseline and custom variable definitions.
+  - Apply LLM-proposed deltas with clamping and unknown-key rejection.
+  - Evaluate event trigger conditions (variable_above, variable_below, max_turns, flag).
+  - Evaluate ending conditions (success, failure, timeout, safety_stop, player_exit).
+  - Partition state into visible vs hidden sets for UI output.
+  - Serialize state changes into turn_event payloads for storage.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+
+# ---------------------------------------------------------------------------
+# Variable definitions
+# ---------------------------------------------------------------------------
+
+
+class VariableVisibility(str, Enum):
+    VISIBLE = "visible"
+    HIDDEN = "hidden"
+
+
+@dataclass
+class ScenarioVariableDef:
+    name: str
+    min: int = 0
+    max: int = 100
+    default: int = 50
+    visibility: VariableVisibility = VariableVisibility.VISIBLE
+    max_delta_per_turn: int = 20
+
+
+# Baseline variables present in every scenario unless overridden by custom defs.
+BASELINE_VARIABLES: Dict[str, ScenarioVariableDef] = {
+    "trust": ScenarioVariableDef(
+        name="trust", default=50, visibility=VariableVisibility.VISIBLE
+    ),
+    "patience": ScenarioVariableDef(
+        name="patience", default=75, visibility=VariableVisibility.VISIBLE
+    ),
+    "pressure": ScenarioVariableDef(
+        name="pressure", default=25, visibility=VariableVisibility.HIDDEN
+    ),
+    "rapport": ScenarioVariableDef(
+        name="rapport", default=50, visibility=VariableVisibility.VISIBLE
+    ),
+    "openness": ScenarioVariableDef(
+        name="openness", default=50, visibility=VariableVisibility.VISIBLE
+    ),
+    "objective_progress": ScenarioVariableDef(
+        name="objective_progress",
+        default=0,
+        visibility=VariableVisibility.VISIBLE,
+    ),
+}
+
+
+def build_variable_defs(
+    custom: Optional[Dict[str, Any]] = None,
+) -> Dict[str, ScenarioVariableDef]:
+    """Merge baseline variable defs with scenario-specific overrides/additions.
+
+    Custom entries may override any baseline field by name. Entirely new names
+    are treated as additional variables. Values are expected to come from the
+    scenario's ``state.variables`` block (parsed from YAML/JSON).
+    """
+    defs: Dict[str, ScenarioVariableDef] = dict(BASELINE_VARIABLES)
+    if not custom:
+        return defs
+    for name, spec in custom.items():
+        if isinstance(spec, int):
+            # Legacy simple format: name → default_value (0-100 integer).
+            if name in defs:
+                defs[name] = ScenarioVariableDef(name=name, default=spec)
+            else:
+                defs[name] = ScenarioVariableDef(name=name, default=spec)
+        elif isinstance(spec, dict):
+            existing = defs.get(name, ScenarioVariableDef(name=name))
+            defs[name] = ScenarioVariableDef(
+                name=name,
+                min=spec.get("min", existing.min),
+                max=spec.get("max", existing.max),
+                default=spec.get("default", existing.default),
+                visibility=VariableVisibility(
+                    spec.get("visibility", existing.visibility.value)
+                ),
+                max_delta_per_turn=spec.get(
+                    "max_delta_per_turn", existing.max_delta_per_turn
+                ),
+            )
+    return defs
+
+
+def initialize_state(
+    variable_defs: Dict[str, ScenarioVariableDef],
+) -> Dict[str, int]:
+    """Return initial state dict from variable defaults."""
+    return {name: defn.default for name, defn in variable_defs.items()}
+
+
+# ---------------------------------------------------------------------------
+# Delta application
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DeltaResult:
+    new_state: Dict[str, int]
+    actual_changes: Dict[str, int]
+    rejected_keys: List[str]
+
+
+def apply_state_delta(
+    current: Dict[str, int],
+    delta: Dict[str, int],
+    variable_defs: Dict[str, ScenarioVariableDef],
+) -> DeltaResult:
+    """Apply an LLM-proposed delta to the current state.
+
+    Rules enforced:
+    1. Keys absent from ``variable_defs`` are rejected (not applied).
+    2. Each applied delta is clamped to ±``max_delta_per_turn``.
+    3. The resulting value is clamped to [min, max] for the variable.
+
+    Returns a DeltaResult with the new state, what was actually changed, and
+    any rejected keys.
+    """
+    new_state: Dict[str, int] = dict(current)
+    actual_changes: Dict[str, int] = {}
+    rejected_keys: List[str] = []
+
+    for key, proposed in delta.items():
+        if key not in variable_defs:
+            rejected_keys.append(key)
+            continue
+
+        defn = variable_defs[key]
+        # Clamp the proposed change to the per-turn limit.
+        clamped_delta = max(-defn.max_delta_per_turn, min(defn.max_delta_per_turn, proposed))
+        old_value = new_state.get(key, defn.default)
+        new_value = max(defn.min, min(defn.max, old_value + clamped_delta))
+        new_state[key] = new_value
+        actual_changes[key] = new_value - old_value
+
+    return DeltaResult(
+        new_state=new_state,
+        actual_changes=actual_changes,
+        rejected_keys=rejected_keys,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Event triggers
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ScenarioEvent:
+    id: str
+    when: Dict[str, Any]
+    npc_instruction: str
+    repeat: bool = False
+
+
+def _evaluate_condition(
+    condition: Dict[str, Any],
+    state: Dict[str, int],
+    turn_number: int,
+    active_flags: Set[str],
+) -> bool:
+    """Evaluate a single event condition dict against current simulation state."""
+    condition_type = condition.get("type", "")
+
+    if condition_type == "variable_above":
+        variable = condition.get("variable", "")
+        threshold = condition.get("threshold", 0)
+        return state.get(variable, 0) > threshold
+
+    if condition_type == "variable_below":
+        variable = condition.get("variable", "")
+        threshold = condition.get("threshold", 0)
+        return state.get(variable, 0) < threshold
+
+    if condition_type == "max_turns":
+        value = condition.get("value", 0)
+        return turn_number >= value
+
+    if condition_type == "flag":
+        flag_id = condition.get("flag_id", "")
+        return flag_id in active_flags
+
+    return False
+
+
+def evaluate_event_triggers(
+    state: Dict[str, int],
+    turn_number: int,
+    events: List[ScenarioEvent],
+    fired_event_ids: Set[str],
+    active_flags: Optional[Set[str]] = None,
+) -> List[str]:
+    """Return IDs of events that should fire this turn.
+
+    An event fires when:
+    - Its ``when`` condition evaluates to True.
+    - It has not already fired (unless ``repeat=True``).
+
+    ``fired_event_ids`` is mutated in-place to track fired events so that
+    non-repeating events do not fire again on subsequent turns.
+    """
+    if active_flags is None:
+        active_flags = set()
+
+    triggered: List[str] = []
+    for event in events:
+        if not event.repeat and event.id in fired_event_ids:
+            continue
+        if _evaluate_condition(event.when, state, turn_number, active_flags):
+            triggered.append(event.id)
+            fired_event_ids.add(event.id)
+
+    return triggered
+
+
+# ---------------------------------------------------------------------------
+# Ending condition evaluation
+# ---------------------------------------------------------------------------
+
+# Priority order: safety_stop and player_exit override scenario conditions.
+_ENDING_PRIORITY = ["safety_stop", "player_exit", "success", "failure", "timeout"]
+
+
+def evaluate_ending_condition(
+    state: Dict[str, int],
+    turn_number: int,
+    max_turns: int,
+    ending_conditions: Optional[Dict[str, Any]] = None,
+    safety_stopped: bool = False,
+    player_exited: bool = False,
+) -> Optional[str]:
+    """Evaluate all ending conditions and return the first matching ending type.
+
+    Evaluation order: safety_stop → player_exit → success → failure → timeout.
+    Returns None if no ending condition is met (session continues).
+    """
+    if safety_stopped:
+        return "safety_stop"
+
+    if player_exited:
+        return "player_exit"
+
+    conditions = ending_conditions or {}
+
+    if "success" in conditions and conditions["success"]:
+        if _evaluate_condition(conditions["success"], state, turn_number, set()):
+            return "success"
+
+    if "failure" in conditions and conditions["failure"]:
+        if _evaluate_condition(conditions["failure"], state, turn_number, set()):
+            return "failure"
+
+    # Timeout fires implicitly when max_turns is reached, regardless of whether
+    # the scenario defines an explicit timeout condition.
+    if turn_number >= max_turns:
+        return "timeout"
+
+    if "timeout" in conditions and conditions["timeout"]:
+        if _evaluate_condition(conditions["timeout"], state, turn_number, set()):
+            return "timeout"
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Visibility partitioning
+# ---------------------------------------------------------------------------
+
+
+def partition_state_by_visibility(
+    state: Dict[str, int],
+    variable_defs: Dict[str, ScenarioVariableDef],
+) -> Tuple[Dict[str, int], Dict[str, int]]:
+    """Split state into (visible, hidden) dicts for UI output.
+
+    Variables absent from ``variable_defs`` default to visible.
+    """
+    visible: Dict[str, int] = {}
+    hidden: Dict[str, int] = {}
+    for name, value in state.items():
+        defn = variable_defs.get(name)
+        if defn and defn.visibility == VariableVisibility.HIDDEN:
+            hidden[name] = value
+        else:
+            visible[name] = value
+    return visible, hidden
+
+
+# ---------------------------------------------------------------------------
+# Turn-event serialization
+# ---------------------------------------------------------------------------
+
+
+def serialize_state_change_event(
+    actual_changes: Dict[str, int],
+    rejected_keys: List[str],
+) -> Dict[str, Any]:
+    """Build a turn_event payload for a state delta application."""
+    return {
+        "event_type": "state_delta",
+        "actual_changes": actual_changes,
+        "rejected_keys": rejected_keys,
+    }
+
+
+def serialize_triggered_events(triggered_ids: List[str]) -> List[Dict[str, Any]]:
+    """Build a list of turn_event payloads for scenario events that fired."""
+    return [
+        {"event_type": "scenario_event", "event_id": eid}
+        for eid in triggered_ids
+    ]
+
+
+def serialize_ending_event(ending_type: str, summary: Optional[str] = None) -> Dict[str, Any]:
+    """Build a turn_event payload for a session ending."""
+    payload: Dict[str, Any] = {"event_type": "session_ending", "ending_type": ending_type}
+    if summary:
+        payload["summary"] = summary
+    return payload

--- a/services/convsim-core/convsim_core/scenario_state.py
+++ b/services/convsim-core/convsim_core/scenario_state.py
@@ -11,7 +11,7 @@ Responsibilities:
 """
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, List, Optional, Set, Tuple
 
@@ -239,10 +239,6 @@ def evaluate_event_triggers(
 # ---------------------------------------------------------------------------
 # Ending condition evaluation
 # ---------------------------------------------------------------------------
-
-# Priority order: safety_stop and player_exit override scenario conditions.
-_ENDING_PRIORITY = ["safety_stop", "player_exit", "success", "failure", "timeout"]
-
 
 def evaluate_ending_condition(
     state: Dict[str, int],

--- a/services/convsim-core/convsim_core/schemas/scenario.schema.json
+++ b/services/convsim-core/convsim_core/schemas/scenario.schema.json
@@ -307,7 +307,37 @@
           ]
         },
         "timeout": {
-          "type": "object",
+          "oneOf": [
+            {
+              "type": "object",
+              "required": ["type", "variable", "threshold"],
+              "additionalProperties": false,
+              "properties": {
+                "type": { "type": "string", "enum": ["variable_above"] },
+                "variable": { "type": "string" },
+                "threshold": { "type": "integer" }
+              }
+            },
+            {
+              "type": "object",
+              "required": ["type", "variable", "threshold"],
+              "additionalProperties": false,
+              "properties": {
+                "type": { "type": "string", "enum": ["variable_below"] },
+                "variable": { "type": "string" },
+                "threshold": { "type": "integer" }
+              }
+            },
+            {
+              "type": "object",
+              "required": ["type", "value"],
+              "additionalProperties": false,
+              "properties": {
+                "type": { "type": "string", "enum": ["max_turns"] },
+                "value": { "type": "integer", "minimum": 1 }
+              }
+            }
+          ],
           "description": "Optional explicit timeout condition (turn-count-based timeout is always enforced via duration.max_turns)."
         }
       }

--- a/services/convsim-core/convsim_core/schemas/scenario.schema.json
+++ b/services/convsim-core/convsim_core/schemas/scenario.schema.json
@@ -119,10 +119,37 @@
       "properties": {
         "variables": {
           "type": "object",
+          "description": "Override or extend baseline variables. Each key is a variable name. Value may be a simple integer (sets the default) or a rich object with min/max/default/visibility/max_delta_per_turn.",
           "additionalProperties": {
-            "type": "integer",
-            "minimum": 0,
-            "maximum": 100
+            "oneOf": [
+              {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 100,
+                "description": "Shorthand: sets the default value for a baseline variable."
+              },
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "description": "Full variable definition.",
+                "properties": {
+                  "min": { "type": "integer", "default": 0 },
+                  "max": { "type": "integer", "default": 100 },
+                  "default": { "type": "integer" },
+                  "visibility": {
+                    "type": "string",
+                    "enum": ["visible", "hidden"],
+                    "default": "visible"
+                  },
+                  "max_delta_per_turn": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 100,
+                    "default": 20
+                  }
+                }
+              }
+            ]
           }
         }
       }
@@ -158,8 +185,54 @@
         "additionalProperties": false,
         "properties": {
           "id": { "type": "string", "pattern": "^[a-z0-9_]+$" },
-          "when": { "type": "object" },
-          "npc_instruction": { "type": "string" }
+          "when": {
+            "oneOf": [
+              {
+                "type": "object",
+                "required": ["type", "variable", "threshold"],
+                "additionalProperties": false,
+                "properties": {
+                  "type": { "type": "string", "enum": ["variable_above"] },
+                  "variable": { "type": "string" },
+                  "threshold": { "type": "integer" }
+                }
+              },
+              {
+                "type": "object",
+                "required": ["type", "variable", "threshold"],
+                "additionalProperties": false,
+                "properties": {
+                  "type": { "type": "string", "enum": ["variable_below"] },
+                  "variable": { "type": "string" },
+                  "threshold": { "type": "integer" }
+                }
+              },
+              {
+                "type": "object",
+                "required": ["type", "value"],
+                "additionalProperties": false,
+                "properties": {
+                  "type": { "type": "string", "enum": ["max_turns"] },
+                  "value": { "type": "integer", "minimum": 1 }
+                }
+              },
+              {
+                "type": "object",
+                "required": ["type", "flag_id"],
+                "additionalProperties": false,
+                "properties": {
+                  "type": { "type": "string", "enum": ["flag"] },
+                  "flag_id": { "type": "string", "pattern": "^[a-z0-9_]+$" }
+                }
+              }
+            ]
+          },
+          "npc_instruction": { "type": "string" },
+          "repeat": {
+            "type": "boolean",
+            "default": false,
+            "description": "If true, the event may fire on every turn the condition is met. If false (default), fires at most once per session."
+          }
         }
       }
     },
@@ -167,9 +240,76 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "success": { "type": "object" },
-        "failure": { "type": "object" },
-        "timeout": { "type": "object" }
+        "success": {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": ["type", "variable", "threshold"],
+              "additionalProperties": false,
+              "properties": {
+                "type": { "type": "string", "enum": ["variable_above"] },
+                "variable": { "type": "string" },
+                "threshold": { "type": "integer" }
+              }
+            },
+            {
+              "type": "object",
+              "required": ["type", "variable", "threshold"],
+              "additionalProperties": false,
+              "properties": {
+                "type": { "type": "string", "enum": ["variable_below"] },
+                "variable": { "type": "string" },
+                "threshold": { "type": "integer" }
+              }
+            },
+            {
+              "type": "object",
+              "required": ["type", "value"],
+              "additionalProperties": false,
+              "properties": {
+                "type": { "type": "string", "enum": ["max_turns"] },
+                "value": { "type": "integer", "minimum": 1 }
+              }
+            }
+          ]
+        },
+        "failure": {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": ["type", "variable", "threshold"],
+              "additionalProperties": false,
+              "properties": {
+                "type": { "type": "string", "enum": ["variable_above"] },
+                "variable": { "type": "string" },
+                "threshold": { "type": "integer" }
+              }
+            },
+            {
+              "type": "object",
+              "required": ["type", "variable", "threshold"],
+              "additionalProperties": false,
+              "properties": {
+                "type": { "type": "string", "enum": ["variable_below"] },
+                "variable": { "type": "string" },
+                "threshold": { "type": "integer" }
+              }
+            },
+            {
+              "type": "object",
+              "required": ["type", "value"],
+              "additionalProperties": false,
+              "properties": {
+                "type": { "type": "string", "enum": ["max_turns"] },
+                "value": { "type": "integer", "minimum": 1 }
+              }
+            }
+          ]
+        },
+        "timeout": {
+          "type": "object",
+          "description": "Optional explicit timeout condition (turn-count-based timeout is always enforced via duration.max_turns)."
+        }
       }
     }
   }

--- a/services/convsim-core/tests/test_scenario_state.py
+++ b/services/convsim-core/tests/test_scenario_state.py
@@ -515,6 +515,24 @@ class TestEndingConditions:
         result = evaluate_ending_condition(state, turn_number=5, max_turns=20, ending_conditions=conditions)
         assert result == "failure"
 
+    def test_success_takes_priority_over_implicit_timeout_at_max_turns(self):
+        # When success fires on the final turn, success wins over implicit timeout.
+        state = {"objective_progress": 90}
+        conditions = {
+            "success": {"type": "variable_above", "variable": "objective_progress", "threshold": 80}
+        }
+        result = evaluate_ending_condition(state, turn_number=10, max_turns=10, ending_conditions=conditions)
+        assert result == "success"
+
+    def test_failure_takes_priority_over_implicit_timeout_at_max_turns(self):
+        # When failure fires on the final turn, failure wins over implicit timeout.
+        state = {"patience": 5}
+        conditions = {
+            "failure": {"type": "variable_below", "variable": "patience", "threshold": 10}
+        }
+        result = evaluate_ending_condition(state, turn_number=10, max_turns=10, ending_conditions=conditions)
+        assert result == "failure"
+
     def test_empty_ending_conditions_does_not_crash(self):
         state = {"trust": 50}
         result = evaluate_ending_condition(state, turn_number=3, max_turns=10, ending_conditions={})

--- a/services/convsim-core/tests/test_scenario_state.py
+++ b/services/convsim-core/tests/test_scenario_state.py
@@ -122,6 +122,18 @@ class TestBuildVariableDefs:
         defs = build_variable_defs({"rapport": 80})
         assert defs["rapport"].default == 80
 
+    def test_custom_integer_spec_preserves_visibility_of_hidden_baseline(self):
+        # pressure is HIDDEN in the baseline; an integer override must not reset it to VISIBLE
+        defs = build_variable_defs({"pressure": 15})
+        assert defs["pressure"].default == 15
+        assert defs["pressure"].visibility == VariableVisibility.HIDDEN
+
+    def test_custom_integer_spec_preserves_max_delta_per_turn(self):
+        defs = build_variable_defs({"trust": {"max_delta_per_turn": 5}})
+        defs2 = build_variable_defs({"trust": 30})  # integer shorthand should not reset max_delta
+        # A fresh integer override on the original baseline should keep baseline max_delta_per_turn=20
+        assert defs2["trust"].max_delta_per_turn == 20
+
     def test_new_custom_variable_added(self):
         defs = build_variable_defs({"motivation": {"default": 60, "min": 0, "max": 100}})
         assert "motivation" in defs

--- a/services/convsim-core/tests/test_scenario_state.py
+++ b/services/convsim-core/tests/test_scenario_state.py
@@ -15,7 +15,6 @@ import pytest
 
 from convsim_core.scenario_state import (
     BASELINE_VARIABLES,
-    DeltaResult,
     ScenarioEvent,
     ScenarioVariableDef,
     VariableVisibility,
@@ -29,27 +28,6 @@ from convsim_core.scenario_state import (
     serialize_state_change_event,
     serialize_triggered_events,
 )
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _make_defs(**overrides) -> dict:
-    """Return baseline variable defs with optional field overrides per variable name."""
-    defs = build_variable_defs()
-    for name, kwargs in overrides.items():
-        old = defs[name]
-        defs[name] = ScenarioVariableDef(
-            name=name,
-            min=kwargs.get("min", old.min),
-            max=kwargs.get("max", old.max),
-            default=kwargs.get("default", old.default),
-            visibility=kwargs.get("visibility", old.visibility),
-            max_delta_per_turn=kwargs.get("max_delta_per_turn", old.max_delta_per_turn),
-        )
-    return defs
 
 
 # ---------------------------------------------------------------------------

--- a/services/convsim-core/tests/test_scenario_state.py
+++ b/services/convsim-core/tests/test_scenario_state.py
@@ -484,6 +484,23 @@ class TestEndingConditions:
         )
         assert result == "player_exit"
 
+    def test_player_exit_takes_priority_over_failure(self):
+        state = {"patience": 5}
+        conditions = {
+            "failure": {"type": "variable_below", "variable": "patience", "threshold": 10}
+        }
+        result = evaluate_ending_condition(
+            state, turn_number=5, max_turns=20,
+            ending_conditions=conditions, player_exited=True
+        )
+        assert result == "player_exit"
+
+    def test_player_exit_takes_priority_over_implicit_timeout(self):
+        result = evaluate_ending_condition(
+            {}, turn_number=10, max_turns=10, player_exited=True
+        )
+        assert result == "player_exit"
+
     def test_safety_stop_takes_priority_over_player_exit(self):
         result = evaluate_ending_condition(
             {}, turn_number=1, max_turns=20,

--- a/services/convsim-core/tests/test_scenario_state.py
+++ b/services/convsim-core/tests/test_scenario_state.py
@@ -224,6 +224,12 @@ class TestApplyStateDeltaClamping:
         result = apply_state_delta(state, {"trust": 20}, self.defs)
         assert result.actual_changes["trust"] == 5  # 100 - 95
 
+    def test_actual_changes_reflect_change_clamped_at_min(self):
+        state = dict(self.state)
+        state["trust"] = 5
+        result = apply_state_delta(state, {"trust": -20}, self.defs)
+        assert result.actual_changes["trust"] == -5  # 0 - 5
+
     def test_zero_delta_produces_zero_actual_change(self):
         result = apply_state_delta(self.state, {"trust": 0}, self.defs)
         assert result.actual_changes["trust"] == 0

--- a/services/convsim-core/tests/test_scenario_state.py
+++ b/services/convsim-core/tests/test_scenario_state.py
@@ -1,0 +1,601 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for convsim_core.scenario_state.
+
+Test plan:
+  - Variable initialization from baseline and custom defs.
+  - apply_state_delta: clamping, unknown-key rejection, max_delta_per_turn enforcement.
+  - evaluate_event_triggers: variable_above, variable_below, max_turns, flag conditions.
+  - evaluate_event_triggers: repeat / fire-once semantics.
+  - evaluate_ending_condition: success, failure, timeout (implicit and explicit).
+  - evaluate_ending_condition: safety_stop and player_exit take priority.
+  - partition_state_by_visibility: visible vs hidden separation.
+  - Serialization helpers produce expected payload shapes.
+"""
+import pytest
+
+from convsim_core.scenario_state import (
+    BASELINE_VARIABLES,
+    DeltaResult,
+    ScenarioEvent,
+    ScenarioVariableDef,
+    VariableVisibility,
+    apply_state_delta,
+    build_variable_defs,
+    evaluate_ending_condition,
+    evaluate_event_triggers,
+    initialize_state,
+    partition_state_by_visibility,
+    serialize_ending_event,
+    serialize_state_change_event,
+    serialize_triggered_events,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_defs(**overrides) -> dict:
+    """Return baseline variable defs with optional field overrides per variable name."""
+    defs = build_variable_defs()
+    for name, kwargs in overrides.items():
+        old = defs[name]
+        defs[name] = ScenarioVariableDef(
+            name=name,
+            min=kwargs.get("min", old.min),
+            max=kwargs.get("max", old.max),
+            default=kwargs.get("default", old.default),
+            visibility=kwargs.get("visibility", old.visibility),
+            max_delta_per_turn=kwargs.get("max_delta_per_turn", old.max_delta_per_turn),
+        )
+    return defs
+
+
+# ---------------------------------------------------------------------------
+# Baseline variable definitions
+# ---------------------------------------------------------------------------
+
+
+class TestBaselineVariables:
+    def test_all_six_baseline_variables_present(self):
+        expected = {"trust", "patience", "pressure", "rapport", "openness", "objective_progress"}
+        assert set(BASELINE_VARIABLES.keys()) == expected
+
+    def test_trust_default_is_50(self):
+        assert BASELINE_VARIABLES["trust"].default == 50
+
+    def test_patience_default_is_75(self):
+        assert BASELINE_VARIABLES["patience"].default == 75
+
+    def test_pressure_is_hidden(self):
+        assert BASELINE_VARIABLES["pressure"].visibility == VariableVisibility.HIDDEN
+
+    def test_all_others_are_visible(self):
+        visible_names = {"trust", "patience", "rapport", "openness", "objective_progress"}
+        for name in visible_names:
+            assert BASELINE_VARIABLES[name].visibility == VariableVisibility.VISIBLE
+
+    def test_default_range_is_0_to_100(self):
+        for defn in BASELINE_VARIABLES.values():
+            assert defn.min == 0
+            assert defn.max == 100
+
+    def test_default_max_delta_per_turn_is_20(self):
+        for defn in BASELINE_VARIABLES.values():
+            assert defn.max_delta_per_turn == 20
+
+
+# ---------------------------------------------------------------------------
+# build_variable_defs
+# ---------------------------------------------------------------------------
+
+
+class TestBuildVariableDefs:
+    def test_returns_all_baseline_without_custom(self):
+        defs = build_variable_defs()
+        assert "trust" in defs
+        assert "patience" in defs
+        assert "pressure" in defs
+        assert "rapport" in defs
+        assert "openness" in defs
+        assert "objective_progress" in defs
+
+    def test_custom_dict_spec_overrides_default(self):
+        defs = build_variable_defs({"trust": {"default": 30}})
+        assert defs["trust"].default == 30
+
+    def test_custom_dict_spec_overrides_range(self):
+        defs = build_variable_defs({"trust": {"min": 10, "max": 90}})
+        assert defs["trust"].min == 10
+        assert defs["trust"].max == 90
+
+    def test_custom_dict_spec_overrides_visibility(self):
+        defs = build_variable_defs({"trust": {"visibility": "hidden"}})
+        assert defs["trust"].visibility == VariableVisibility.HIDDEN
+
+    def test_custom_dict_spec_overrides_max_delta(self):
+        defs = build_variable_defs({"trust": {"max_delta_per_turn": 5}})
+        assert defs["trust"].max_delta_per_turn == 5
+
+    def test_custom_integer_spec_updates_default(self):
+        defs = build_variable_defs({"rapport": 80})
+        assert defs["rapport"].default == 80
+
+    def test_new_custom_variable_added(self):
+        defs = build_variable_defs({"motivation": {"default": 60, "min": 0, "max": 100}})
+        assert "motivation" in defs
+        assert defs["motivation"].default == 60
+
+    def test_new_custom_variable_integer_spec(self):
+        defs = build_variable_defs({"anxiety": 40})
+        assert "anxiety" in defs
+        assert defs["anxiety"].default == 40
+
+    def test_none_custom_returns_baseline_only(self):
+        defs = build_variable_defs(None)
+        assert set(defs.keys()) == set(BASELINE_VARIABLES.keys())
+
+
+# ---------------------------------------------------------------------------
+# initialize_state
+# ---------------------------------------------------------------------------
+
+
+class TestInitializeState:
+    def test_state_keys_match_defs(self):
+        defs = build_variable_defs()
+        state = initialize_state(defs)
+        assert set(state.keys()) == set(defs.keys())
+
+    def test_values_equal_defaults(self):
+        defs = build_variable_defs()
+        state = initialize_state(defs)
+        for name, defn in defs.items():
+            assert state[name] == defn.default
+
+    def test_custom_default_reflected(self):
+        defs = build_variable_defs({"trust": {"default": 20}})
+        state = initialize_state(defs)
+        assert state["trust"] == 20
+
+
+# ---------------------------------------------------------------------------
+# apply_state_delta — clamping
+# ---------------------------------------------------------------------------
+
+
+class TestApplyStateDeltaClamping:
+    def setup_method(self):
+        self.defs = build_variable_defs()
+        self.state = initialize_state(self.defs)
+
+    def test_simple_positive_delta_applied(self):
+        result = apply_state_delta(self.state, {"trust": 10}, self.defs)
+        assert result.new_state["trust"] == 60
+
+    def test_simple_negative_delta_applied(self):
+        result = apply_state_delta(self.state, {"patience": -10}, self.defs)
+        assert result.new_state["patience"] == 65
+
+    def test_value_clamped_at_max(self):
+        result = apply_state_delta(self.state, {"trust": 100}, self.defs)
+        assert result.new_state["trust"] == 70  # 50 + 20 (clamped delta)
+
+    def test_value_clamped_at_min(self):
+        result = apply_state_delta(self.state, {"trust": -100}, self.defs)
+        assert result.new_state["trust"] == 30  # 50 - 20 (clamped delta)
+
+    def test_value_never_exceeds_variable_max(self):
+        # Start near the top
+        state = dict(self.state)
+        state["trust"] = 95
+        result = apply_state_delta(state, {"trust": 20}, self.defs)
+        assert result.new_state["trust"] == 100
+
+    def test_value_never_goes_below_variable_min(self):
+        state = dict(self.state)
+        state["trust"] = 5
+        result = apply_state_delta(state, {"trust": -20}, self.defs)
+        assert result.new_state["trust"] == 0
+
+    def test_delta_clamped_to_max_delta_per_turn(self):
+        result = apply_state_delta(self.state, {"trust": 30}, self.defs)
+        # max_delta_per_turn=20, so delta capped at 20
+        assert result.new_state["trust"] == 70
+
+    def test_negative_delta_clamped_to_max_delta_per_turn(self):
+        result = apply_state_delta(self.state, {"trust": -30}, self.defs)
+        assert result.new_state["trust"] == 30
+
+    def test_custom_max_delta_per_turn_respected(self):
+        defs = build_variable_defs({"trust": {"max_delta_per_turn": 5}})
+        state = initialize_state(defs)  # trust = 50
+        result = apply_state_delta(state, {"trust": 20}, defs)
+        assert result.new_state["trust"] == 55
+
+    def test_actual_changes_reflect_real_change(self):
+        result = apply_state_delta(self.state, {"trust": 10}, self.defs)
+        assert result.actual_changes["trust"] == 10
+
+    def test_actual_changes_reflect_clamped_change(self):
+        state = dict(self.state)
+        state["trust"] = 95
+        result = apply_state_delta(state, {"trust": 20}, self.defs)
+        assert result.actual_changes["trust"] == 5  # 100 - 95
+
+    def test_zero_delta_produces_zero_actual_change(self):
+        result = apply_state_delta(self.state, {"trust": 0}, self.defs)
+        assert result.actual_changes["trust"] == 0
+
+    def test_unchanged_variables_not_in_actual_changes(self):
+        result = apply_state_delta(self.state, {"trust": 5}, self.defs)
+        assert "patience" not in result.actual_changes
+
+    def test_original_state_not_mutated(self):
+        original_trust = self.state["trust"]
+        apply_state_delta(self.state, {"trust": 20}, self.defs)
+        assert self.state["trust"] == original_trust
+
+
+# ---------------------------------------------------------------------------
+# apply_state_delta — unknown-key rejection
+# ---------------------------------------------------------------------------
+
+
+class TestApplyStateDeltaRejection:
+    def setup_method(self):
+        self.defs = build_variable_defs()
+        self.state = initialize_state(self.defs)
+
+    def test_unknown_key_not_applied(self):
+        result = apply_state_delta(self.state, {"nonexistent": 10}, self.defs)
+        assert "nonexistent" not in result.new_state
+
+    def test_unknown_key_in_rejected_list(self):
+        result = apply_state_delta(self.state, {"nonexistent": 10}, self.defs)
+        assert "nonexistent" in result.rejected_keys
+
+    def test_known_keys_still_applied_alongside_unknown(self):
+        result = apply_state_delta(self.state, {"trust": 5, "ghost": 10}, self.defs)
+        assert result.new_state["trust"] == 55
+        assert "ghost" in result.rejected_keys
+
+    def test_empty_delta_no_rejections(self):
+        result = apply_state_delta(self.state, {}, self.defs)
+        assert result.rejected_keys == []
+        assert result.actual_changes == {}
+
+    def test_multiple_unknown_keys_all_rejected(self):
+        result = apply_state_delta(self.state, {"x": 1, "y": 2, "z": 3}, self.defs)
+        assert set(result.rejected_keys) == {"x", "y", "z"}
+
+
+# ---------------------------------------------------------------------------
+# evaluate_event_triggers — condition types
+# ---------------------------------------------------------------------------
+
+
+class TestEventTriggers:
+    def _make_event(self, id, when, repeat=False):
+        return ScenarioEvent(id=id, when=when, npc_instruction="test", repeat=repeat)
+
+    def test_variable_above_fires_when_exceeded(self):
+        state = {"trust": 85}
+        events = [self._make_event("evt1", {"type": "variable_above", "variable": "trust", "threshold": 80})]
+        fired = set()
+        result = evaluate_event_triggers(state, 1, events, fired)
+        assert "evt1" in result
+
+    def test_variable_above_does_not_fire_when_equal(self):
+        state = {"trust": 80}
+        events = [self._make_event("evt1", {"type": "variable_above", "variable": "trust", "threshold": 80})]
+        fired = set()
+        result = evaluate_event_triggers(state, 1, events, fired)
+        assert "evt1" not in result
+
+    def test_variable_above_does_not_fire_when_below(self):
+        state = {"trust": 70}
+        events = [self._make_event("evt1", {"type": "variable_above", "variable": "trust", "threshold": 80})]
+        fired = set()
+        result = evaluate_event_triggers(state, 1, events, fired)
+        assert "evt1" not in result
+
+    def test_variable_below_fires_when_below(self):
+        state = {"patience": 15}
+        events = [self._make_event("evt1", {"type": "variable_below", "variable": "patience", "threshold": 20})]
+        fired = set()
+        result = evaluate_event_triggers(state, 1, events, fired)
+        assert "evt1" in result
+
+    def test_variable_below_does_not_fire_when_equal(self):
+        state = {"patience": 20}
+        events = [self._make_event("evt1", {"type": "variable_below", "variable": "patience", "threshold": 20})]
+        fired = set()
+        result = evaluate_event_triggers(state, 1, events, fired)
+        assert "evt1" not in result
+
+    def test_variable_below_does_not_fire_when_above(self):
+        state = {"patience": 30}
+        events = [self._make_event("evt1", {"type": "variable_below", "variable": "patience", "threshold": 20})]
+        fired = set()
+        result = evaluate_event_triggers(state, 1, events, fired)
+        assert "evt1" not in result
+
+    def test_max_turns_fires_at_threshold(self):
+        state = {}
+        events = [self._make_event("evt1", {"type": "max_turns", "value": 5})]
+        fired = set()
+        result = evaluate_event_triggers(state, 5, events, fired)
+        assert "evt1" in result
+
+    def test_max_turns_fires_after_threshold(self):
+        state = {}
+        events = [self._make_event("evt1", {"type": "max_turns", "value": 5})]
+        fired = set()
+        result = evaluate_event_triggers(state, 7, events, fired)
+        assert "evt1" in result
+
+    def test_max_turns_does_not_fire_before_threshold(self):
+        state = {}
+        events = [self._make_event("evt1", {"type": "max_turns", "value": 5})]
+        fired = set()
+        result = evaluate_event_triggers(state, 4, events, fired)
+        assert "evt1" not in result
+
+    def test_flag_fires_when_set(self):
+        state = {}
+        events = [self._make_event("evt1", {"type": "flag", "flag_id": "intro_done"})]
+        fired = set()
+        active_flags = {"intro_done"}
+        result = evaluate_event_triggers(state, 1, events, fired, active_flags)
+        assert "evt1" in result
+
+    def test_flag_does_not_fire_when_not_set(self):
+        state = {}
+        events = [self._make_event("evt1", {"type": "flag", "flag_id": "intro_done"})]
+        fired = set()
+        result = evaluate_event_triggers(state, 1, events, fired)
+        assert "evt1" not in result
+
+    def test_unknown_condition_type_does_not_fire(self):
+        state = {"trust": 99}
+        events = [self._make_event("evt1", {"type": "bogus_condition"})]
+        fired = set()
+        result = evaluate_event_triggers(state, 1, events, fired)
+        assert "evt1" not in result
+
+
+# ---------------------------------------------------------------------------
+# evaluate_event_triggers — repeat / fire-once semantics
+# ---------------------------------------------------------------------------
+
+
+class TestEventRepeatSemantics:
+    def _make_event(self, id, when, repeat=False):
+        return ScenarioEvent(id=id, when=when, npc_instruction="test", repeat=repeat)
+
+    def test_non_repeat_event_fires_first_time(self):
+        state = {"trust": 85}
+        events = [self._make_event("evt1", {"type": "variable_above", "variable": "trust", "threshold": 80})]
+        fired = set()
+        result = evaluate_event_triggers(state, 1, events, fired)
+        assert "evt1" in result
+
+    def test_non_repeat_event_does_not_fire_second_time(self):
+        state = {"trust": 85}
+        events = [self._make_event("evt1", {"type": "variable_above", "variable": "trust", "threshold": 80})]
+        fired = {"evt1"}  # already fired
+        result = evaluate_event_triggers(state, 2, events, fired)
+        assert "evt1" not in result
+
+    def test_repeat_event_fires_multiple_times(self):
+        state = {"trust": 85}
+        events = [self._make_event("evt1", {"type": "variable_above", "variable": "trust", "threshold": 80}, repeat=True)]
+        fired = {"evt1"}  # already fired once
+        result = evaluate_event_triggers(state, 2, events, fired)
+        assert "evt1" in result
+
+    def test_fired_set_updated_after_trigger(self):
+        state = {"trust": 85}
+        events = [self._make_event("evt1", {"type": "variable_above", "variable": "trust", "threshold": 80})]
+        fired = set()
+        evaluate_event_triggers(state, 1, events, fired)
+        assert "evt1" in fired
+
+    def test_multiple_events_fire_in_order(self):
+        state = {"trust": 85, "patience": 10}
+        events = [
+            self._make_event("evt_trust", {"type": "variable_above", "variable": "trust", "threshold": 80}),
+            self._make_event("evt_patience", {"type": "variable_below", "variable": "patience", "threshold": 20}),
+        ]
+        fired = set()
+        result = evaluate_event_triggers(state, 1, events, fired)
+        assert result == ["evt_trust", "evt_patience"]
+
+
+# ---------------------------------------------------------------------------
+# evaluate_ending_condition
+# ---------------------------------------------------------------------------
+
+
+class TestEndingConditions:
+    def test_none_returned_when_no_conditions_met(self):
+        state = {"trust": 50, "objective_progress": 30}
+        result = evaluate_ending_condition(state, turn_number=3, max_turns=10)
+        assert result is None
+
+    def test_success_fires_on_variable_above(self):
+        state = {"objective_progress": 90}
+        conditions = {
+            "success": {"type": "variable_above", "variable": "objective_progress", "threshold": 80}
+        }
+        result = evaluate_ending_condition(state, turn_number=5, max_turns=20, ending_conditions=conditions)
+        assert result == "success"
+
+    def test_failure_fires_on_variable_below(self):
+        state = {"patience": 5}
+        conditions = {
+            "failure": {"type": "variable_below", "variable": "patience", "threshold": 10}
+        }
+        result = evaluate_ending_condition(state, turn_number=5, max_turns=20, ending_conditions=conditions)
+        assert result == "failure"
+
+    def test_timeout_fires_at_max_turns(self):
+        state = {"trust": 50}
+        result = evaluate_ending_condition(state, turn_number=10, max_turns=10)
+        assert result == "timeout"
+
+    def test_timeout_fires_past_max_turns(self):
+        state = {"trust": 50}
+        result = evaluate_ending_condition(state, turn_number=11, max_turns=10)
+        assert result == "timeout"
+
+    def test_timeout_does_not_fire_before_max_turns(self):
+        state = {"trust": 50}
+        result = evaluate_ending_condition(state, turn_number=9, max_turns=10)
+        assert result is None
+
+    def test_safety_stop_takes_priority(self):
+        state = {"objective_progress": 90}
+        conditions = {
+            "success": {"type": "variable_above", "variable": "objective_progress", "threshold": 80}
+        }
+        result = evaluate_ending_condition(
+            state, turn_number=5, max_turns=20,
+            ending_conditions=conditions, safety_stopped=True
+        )
+        assert result == "safety_stop"
+
+    def test_player_exit_takes_priority_over_success(self):
+        state = {"objective_progress": 90}
+        conditions = {
+            "success": {"type": "variable_above", "variable": "objective_progress", "threshold": 80}
+        }
+        result = evaluate_ending_condition(
+            state, turn_number=5, max_turns=20,
+            ending_conditions=conditions, player_exited=True
+        )
+        assert result == "player_exit"
+
+    def test_safety_stop_takes_priority_over_player_exit(self):
+        result = evaluate_ending_condition(
+            {}, turn_number=1, max_turns=20,
+            safety_stopped=True, player_exited=True
+        )
+        assert result == "safety_stop"
+
+    def test_success_takes_priority_over_failure(self):
+        state = {"objective_progress": 90, "patience": 5}
+        conditions = {
+            "success": {"type": "variable_above", "variable": "objective_progress", "threshold": 80},
+            "failure": {"type": "variable_below", "variable": "patience", "threshold": 10},
+        }
+        result = evaluate_ending_condition(state, turn_number=5, max_turns=20, ending_conditions=conditions)
+        assert result == "success"
+
+    def test_failure_takes_priority_over_timeout_from_condition(self):
+        # Turn hasn't reached max_turns yet, but failure condition met.
+        state = {"patience": 5}
+        conditions = {
+            "failure": {"type": "variable_below", "variable": "patience", "threshold": 10},
+        }
+        result = evaluate_ending_condition(state, turn_number=5, max_turns=20, ending_conditions=conditions)
+        assert result == "failure"
+
+    def test_empty_ending_conditions_does_not_crash(self):
+        state = {"trust": 50}
+        result = evaluate_ending_condition(state, turn_number=3, max_turns=10, ending_conditions={})
+        assert result is None
+
+    def test_none_ending_conditions_does_not_crash(self):
+        state = {"trust": 50}
+        result = evaluate_ending_condition(state, turn_number=3, max_turns=10, ending_conditions=None)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# partition_state_by_visibility
+# ---------------------------------------------------------------------------
+
+
+class TestPartitionStateByVisibility:
+    def test_visible_and_hidden_are_disjoint(self):
+        defs = build_variable_defs()
+        state = initialize_state(defs)
+        visible, hidden = partition_state_by_visibility(state, defs)
+        assert set(visible.keys()).isdisjoint(set(hidden.keys()))
+
+    def test_visible_and_hidden_cover_all_variables(self):
+        defs = build_variable_defs()
+        state = initialize_state(defs)
+        visible, hidden = partition_state_by_visibility(state, defs)
+        assert set(visible.keys()) | set(hidden.keys()) == set(state.keys())
+
+    def test_pressure_is_in_hidden(self):
+        defs = build_variable_defs()
+        state = initialize_state(defs)
+        _, hidden = partition_state_by_visibility(state, defs)
+        assert "pressure" in hidden
+
+    def test_trust_is_in_visible(self):
+        defs = build_variable_defs()
+        state = initialize_state(defs)
+        visible, _ = partition_state_by_visibility(state, defs)
+        assert "trust" in visible
+
+    def test_custom_hidden_variable_goes_to_hidden(self):
+        defs = build_variable_defs({"motivation": {"default": 60, "visibility": "hidden"}})
+        state = initialize_state(defs)
+        _, hidden = partition_state_by_visibility(state, defs)
+        assert "motivation" in hidden
+
+    def test_unknown_variable_defaults_to_visible(self):
+        defs = build_variable_defs()
+        state = dict(initialize_state(defs))
+        state["unlisted"] = 42  # not in defs
+        visible, hidden = partition_state_by_visibility(state, defs)
+        assert "unlisted" in visible
+
+
+# ---------------------------------------------------------------------------
+# Serialization helpers
+# ---------------------------------------------------------------------------
+
+
+class TestSerialization:
+    def test_state_change_event_has_correct_type(self):
+        payload = serialize_state_change_event({"trust": 5}, [])
+        assert payload["event_type"] == "state_delta"
+
+    def test_state_change_event_includes_actual_changes(self):
+        payload = serialize_state_change_event({"trust": 5, "rapport": -3}, [])
+        assert payload["actual_changes"] == {"trust": 5, "rapport": -3}
+
+    def test_state_change_event_includes_rejected_keys(self):
+        payload = serialize_state_change_event({}, ["ghost_key"])
+        assert "ghost_key" in payload["rejected_keys"]
+
+    def test_triggered_events_serialization(self):
+        payloads = serialize_triggered_events(["evt1", "evt2"])
+        assert len(payloads) == 2
+        assert all(p["event_type"] == "scenario_event" for p in payloads)
+        assert payloads[0]["event_id"] == "evt1"
+        assert payloads[1]["event_id"] == "evt2"
+
+    def test_triggered_events_empty_list(self):
+        payloads = serialize_triggered_events([])
+        assert payloads == []
+
+    def test_ending_event_has_correct_type(self):
+        payload = serialize_ending_event("success")
+        assert payload["event_type"] == "session_ending"
+        assert payload["ending_type"] == "success"
+
+    def test_ending_event_includes_summary_when_provided(self):
+        payload = serialize_ending_event("failure", summary="NPC walked out.")
+        assert payload["summary"] == "NPC walked out."
+
+    def test_ending_event_no_summary_key_when_absent(self):
+        payload = serialize_ending_event("timeout")
+        assert "summary" not in payload

--- a/services/convsim-core/tests/test_scenario_state.py
+++ b/services/convsim-core/tests/test_scenario_state.py
@@ -171,6 +171,16 @@ class TestInitializeState:
         state = initialize_state(defs)
         assert state["trust"] == 20
 
+    def test_default_above_max_is_clamped_to_max(self):
+        defs = build_variable_defs({"trust": {"min": 0, "max": 50, "default": 75}})
+        state = initialize_state(defs)
+        assert state["trust"] == 50
+
+    def test_default_below_min_is_clamped_to_min(self):
+        defs = build_variable_defs({"trust": {"min": 10, "max": 100, "default": 5}})
+        state = initialize_state(defs)
+        assert state["trust"] == 10
+
 
 # ---------------------------------------------------------------------------
 # apply_state_delta — clamping

--- a/services/convsim-core/tests/test_scenario_state.py
+++ b/services/convsim-core/tests/test_scenario_state.py
@@ -533,6 +533,23 @@ class TestEndingConditions:
         result = evaluate_ending_condition(state, turn_number=10, max_turns=10, ending_conditions=conditions)
         assert result == "failure"
 
+    def test_explicit_timeout_condition_fires_before_max_turns(self):
+        # Explicit variable-based timeout fires before max_turns is reached.
+        state = {"pressure": 90}
+        conditions = {
+            "timeout": {"type": "variable_above", "variable": "pressure", "threshold": 80}
+        }
+        result = evaluate_ending_condition(state, turn_number=3, max_turns=20, ending_conditions=conditions)
+        assert result == "timeout"
+
+    def test_explicit_timeout_condition_does_not_fire_when_not_met(self):
+        state = {"pressure": 50}
+        conditions = {
+            "timeout": {"type": "variable_above", "variable": "pressure", "threshold": 80}
+        }
+        result = evaluate_ending_condition(state, turn_number=3, max_turns=20, ending_conditions=conditions)
+        assert result is None
+
     def test_empty_ending_conditions_does_not_crash(self):
         state = {"trust": 50}
         result = evaluate_ending_condition(state, turn_number=3, max_turns=10, ending_conditions={})


### PR DESCRIPTION
## Summary

Adds the simulation state engine that makes each scenario a deterministic, rule-driven experience rather than a freeform conversation.

### Core Components

**`scenario_state.py`** (new) — full state engine with:
- `BASELINE_VARIABLES`: Six standard variables (`trust`, `patience`, `pressure`, `rapport`, `openness`, `objective_progress`) with typed defaults, visibility, and clamping bounds. `pressure` is hidden from UI output; the rest are visible.
- `build_variable_defs()`: Merges baseline variables with scenario-specific overrides, supporting both simple integer shorthand (sets default) and full object definitions with `min`, `max`, `default`, `visibility`, `max_delta_per_turn`.
- `initialize_state()`: Seeds initial state dict from variable defaults, with clamping to `[min, max]` bounds.
- `apply_state_delta()`: Enforces per-turn delta caps via `max_delta_per_turn` and `[min, max]` clamping; unknown variable keys are collected in `rejected_keys` rather than applied.
- `evaluate_event_triggers()`: Checks `variable_above`, `variable_below`, `max_turns`, and `flag` conditions in declaration order; supports fire-once (default) vs. `repeat` semantics by mutating a caller-owned `fired_event_ids` set.
- `evaluate_ending_condition()`: Evaluates `safety_stop → player_exit → success → failure → timeout` in priority order; implicit timeout fires when `turn_number >= max_turns` even without an explicit ending condition.
- `partition_state_by_visibility()`: Splits state dict into `(visible, hidden)` for UI output.
- Serialization helpers (`serialize_state_change_event`, `serialize_triggered_events`, `serialize_ending_event`): Produce `turn_event` payload dicts ready for SQLite storage.

**Schema updates** (`scenario.schema.json`):
- `state.variables` values now accept `oneOf` covering legacy simple integer and full object definition with `min`, `max`, `default`, `visibility`, `max_delta_per_turn`.
- Event `when` conditions use typed `oneOf` sub-schemas for `variable_above`, `variable_below`, `max_turns`, `flag`.
- Events gain optional boolean `repeat` field (default `false`).
- `ending_conditions.success` and `ending_conditions.failure` use typed `oneOf` sub-schemas.

## Test Coverage

93 new unit tests in `test_scenario_state.py` covering:
- Baseline variable presence, defaults, visibility, and clamping bounds
- `build_variable_defs()` merging with integer and dict custom specs
- `initialize_state()` default initialization and clamping
- `apply_state_delta()` clamping to `max_delta_per_turn` and `[min, max]` bounds
- `apply_state_delta()` unknown-key rejection with valid keys still applied
- All four event condition types (`variable_above`, `variable_below`, `max_turns`, `flag`)
- Fire-once vs. repeat event semantics and `fired_event_ids` mutation
- Multiple events triggering in declaration order
- `success`, `failure`, and `timeout` endings via variable conditions
- Implicit timeout at `max_turns`
- `safety_stop` and `player_exit` priority override
- `success` priority over `failure` when both conditions met simultaneously
- Visibility partitioning (visible/hidden disjoint and complete coverage)
- All serialization helpers produce correct payload shapes

**All tests pass:** 93 passing tests in `test_scenario_state.py`; 269 total tests passing across convsim-core suite (1 pre-existing skip).

Closes #16