### PR TITLE
Define ChatRuntime abstraction and runtime capability model

### DIFF
--- a/packages/shared-types/src/runtime.ts
+++ b/packages/shared-types/src/runtime.ts
@@ -1,11 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /** Overall health status of a local model runtime. */
-export type RuntimeStatus = "ok" | "degraded" | "unavailable";
+export type RuntimeStatus =
+  | "unavailable"
+  | "starting"
+  | "ready"
+  | "degraded"
+  | "error";
 
 /** Health snapshot returned by the /health API and the ChatRuntime.health() method. */
 export interface RuntimeHealth {
-  /** Unique runtime identifier (e.g. "llama_cpp", "ollama"). */
+  /** Unique runtime identifier (e.g. "llama_cpp", "fake"). */
   runtime_id: string;
   /** Human-readable display name. */
   runtime_name: string;
@@ -15,7 +20,7 @@ export interface RuntimeHealth {
   model_id?: string;
   /** Observed round-trip latency in milliseconds, if measured. */
   latency_ms?: number;
-  /** Human-readable status message (error description when status != "ok"). */
+  /** Human-readable status message (error description when status != "ready"). */
   message?: string;
   /** ISO 8601 timestamp of when this health snapshot was taken. */
   checked_at: string;
@@ -38,3 +43,38 @@ export interface ModelInfo {
   size_category?: "small" | "medium" | "large";
   context_length?: number;
 }
+
+/** A single message in a chat conversation. */
+export interface ChatMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+}
+
+/** Request sent to a ChatRuntime chat stream. */
+export interface ChatRequest {
+  messages: ChatMessage[];
+  model_id?: string;
+  max_tokens?: number;
+  temperature?: number;
+  json_schema?: Record<string, unknown>;
+}
+
+/** A single streamed text chunk from a ChatRuntime. */
+export interface ChatToken {
+  type: "token";
+  text: string;
+}
+
+/** Final completion result streamed by a ChatRuntime. */
+export interface ChatFinal {
+  type: "final";
+  text: string;
+  model_id: string;
+  input_tokens: number;
+  output_tokens: number;
+  /** Parsed structured output when json_schema was supplied in the request. */
+  structured?: Record<string, unknown>;
+}
+
+/** Union type for items emitted by a ChatRuntime stream. */
+export type ChatStreamChunk = ChatToken | ChatFinal;

--- a/services/convsim-core/convsim_core/app.py
+++ b/services/convsim-core/convsim_core/app.py
@@ -13,6 +13,7 @@ from convsim_core.errors import (
 )
 from convsim_core.logging_setup import configure_logging
 from convsim_core.routers import diag as diag_router, health, settings as settings_router
+from convsim_core.runtime import build_runtime
 from convsim_core.storage.database import Database
 from convsim_core.storage.repositories.settings_repo import load_settings
 

--- a/services/convsim-core/convsim_core/app.py
+++ b/services/convsim-core/convsim_core/app.py
@@ -13,6 +13,7 @@ from convsim_core.errors import (
 )
 from convsim_core.logging_setup import configure_logging
 from convsim_core.routers import health, settings as settings_router
+from convsim_core.runtime import build_runtime
 from convsim_core.storage.database import Database
 from convsim_core.storage.repositories.settings_repo import load_settings
 
@@ -30,6 +31,7 @@ def create_app(config: ServiceConfig | None = None) -> FastAPI:
         app.state.service_config = config
         app.state.db = db
         app.state.app_settings = load_settings(db.connection(), config.data_dir, config.log_dir)
+        app.state.runtime = build_runtime(config.runtime_id)
         yield
         db.close()
 

--- a/services/convsim-core/convsim_core/config.py
+++ b/services/convsim-core/convsim_core/config.py
@@ -31,6 +31,7 @@ class ServiceConfig(BaseSettings):
     log_dir: str = _DEFAULT_LOG_DIR
     db_dir: str = _DEFAULT_DB_DIR
     lan_access_enabled: bool = False
+    runtime_id: str = "fake"
 
     @model_validator(mode="after")
     def _reject_wildcard_bind(self) -> "ServiceConfig":

--- a/services/convsim-core/convsim_core/config.py
+++ b/services/convsim-core/convsim_core/config.py
@@ -31,6 +31,7 @@ class ServiceConfig(BaseSettings):
     log_dir: str = _DEFAULT_LOG_DIR
     db_dir: str = _DEFAULT_DB_DIR
     lan_access_enabled: bool = False
+    runtime_id: str = "fake"
     # Set CONVSIM_DEV_DEBUG=true to enable DEBUG-level logging.
     # Even in debug mode callers must use convsim_core.redaction helpers
     # before logging any value derived from conversation content.

--- a/services/convsim-core/convsim_core/routers/health.py
+++ b/services/convsim-core/convsim_core/routers/health.py
@@ -18,12 +18,6 @@ class _DatabaseStatus(BaseModel):
     message: Optional[str] = None
 
 
-class _RuntimeReadiness(BaseModel):
-    llm_ready: bool = False
-    stt_ready: bool = False
-    tts_ready: bool = False
-
-
 class _PrivacyPosture(BaseModel):
     """Current privacy-relevant settings, safe to expose publicly."""
 
@@ -39,7 +33,7 @@ class HealthResponse(BaseModel):
     pid: int
     config_path: str
     database: _DatabaseStatus
-    runtime: _RuntimeReadiness
+    runtime: RuntimeHealth
     privacy: _PrivacyPosture
 
 
@@ -58,7 +52,7 @@ async def health(request: Request) -> HealthResponse:
             path=db.path,
             migrations_applied=db.migrations_applied,
         ),
-        runtime=_RuntimeReadiness(),
+        runtime=await request.app.state.runtime.health(),
         privacy=_PrivacyPosture(
             telemetry_enabled=app_settings.telemetry_enabled,
             save_transcripts=app_settings.save_transcripts,

--- a/services/convsim-core/convsim_core/routers/health.py
+++ b/services/convsim-core/convsim_core/routers/health.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Request
 from pydantic import BaseModel
 
 from convsim_core import __version__
+from convsim_core.runtime.types import RuntimeHealth
 
 router = APIRouter()
 
@@ -17,25 +18,21 @@ class _DatabaseStatus(BaseModel):
     message: Optional[str] = None
 
 
-class _RuntimeReadiness(BaseModel):
-    llm_ready: bool = False
-    stt_ready: bool = False
-    tts_ready: bool = False
-
-
 class HealthResponse(BaseModel):
     status: str
     version: str
     pid: int
     config_path: str
     database: _DatabaseStatus
-    runtime: _RuntimeReadiness
+    runtime: RuntimeHealth
 
 
 @router.get("/api/health", response_model=HealthResponse)
 async def health(request: Request) -> HealthResponse:
     config = request.app.state.service_config
     db = request.app.state.db
+    runtime = request.app.state.runtime
+    runtime_health = await runtime.health()
     return HealthResponse(
         status="ok",
         version=__version__,
@@ -46,5 +43,5 @@ async def health(request: Request) -> HealthResponse:
             path=db.path,
             migrations_applied=db.migrations_applied,
         ),
-        runtime=_RuntimeReadiness(),
+        runtime=runtime_health,
     )

--- a/services/convsim-core/convsim_core/runtime/__init__.py
+++ b/services/convsim-core/convsim_core/runtime/__init__.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+"""ChatRuntime abstraction and built-in runtime implementations.
+
+Import this package to ensure all built-in runtimes are registered before
+calling build_runtime().
+"""
+
+from convsim_core.runtime.base import ChatRuntime
+from convsim_core.runtime.registry import build_runtime, list_runtime_ids, register
+from convsim_core.runtime.types import (
+    ChatFinal,
+    ChatMessage,
+    ChatRequest,
+    ChatToken,
+    ModelInfo,
+    RuntimeCapabilities,
+    RuntimeHealth,
+    RuntimeStatus,
+)
+
+# Import built-in adapters to trigger their @register() decorators.
+import convsim_core.runtime.fake  # noqa: F401, E402
+
+__all__ = [
+    "ChatRuntime",
+    "ChatFinal",
+    "ChatMessage",
+    "ChatRequest",
+    "ChatToken",
+    "ModelInfo",
+    "RuntimeCapabilities",
+    "RuntimeHealth",
+    "RuntimeStatus",
+    "build_runtime",
+    "list_runtime_ids",
+    "register",
+]

--- a/services/convsim-core/convsim_core/runtime/base.py
+++ b/services/convsim-core/convsim_core/runtime/base.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import AsyncIterator
+
+from convsim_core.runtime.types import (
+    ChatFinal,
+    ChatRequest,
+    ChatToken,
+    ModelInfo,
+    RuntimeCapabilities,
+    RuntimeHealth,
+)
+
+
+class ChatRuntime(ABC):
+    """Provider-agnostic interface for a local chat model runtime.
+
+    The scenario engine depends only on this interface; concrete adapters
+    (llama_cpp, ollama, …) are registered separately and never imported
+    by scenario-engine code.
+    """
+
+    @property
+    @abstractmethod
+    def id(self) -> str:
+        """Stable machine-readable identifier (e.g. "llama_cpp", "fake")."""
+
+    @property
+    @abstractmethod
+    def display_name(self) -> str:
+        """Human-readable name shown in the UI."""
+
+    @property
+    @abstractmethod
+    def capabilities(self) -> RuntimeCapabilities:
+        """Feature flags advertised by this runtime."""
+
+    @abstractmethod
+    async def list_models(self) -> list[ModelInfo]:
+        """Return models available through this runtime."""
+
+    @abstractmethod
+    def chat_stream(self, request: ChatRequest) -> AsyncIterator[ChatToken | ChatFinal]:
+        """Return an async iterator that yields ChatToken chunks then a single ChatFinal."""
+
+    @abstractmethod
+    async def health(self) -> RuntimeHealth:
+        """Return a point-in-time health snapshot for this runtime."""

--- a/services/convsim-core/convsim_core/runtime/fake.py
+++ b/services/convsim-core/convsim_core/runtime/fake.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, timezone
+from typing import AsyncGenerator
+
+from convsim_core.runtime.base import ChatRuntime
+from convsim_core.runtime.registry import register
+from convsim_core.runtime.types import (
+    ChatFinal,
+    ChatRequest,
+    ChatToken,
+    ModelInfo,
+    RuntimeCapabilities,
+    RuntimeHealth,
+    RuntimeStatus,
+)
+
+_MODELS = [
+    ModelInfo(id="fake-small", name="Fake Small", size_category="small", context_length=4096),
+    ModelInfo(id="fake-large", name="Fake Large", size_category="large", context_length=32768),
+]
+
+_PLAIN_RESPONSE = "This is a fake response for testing and demo purposes."
+
+_STRUCTURED_RESPONSE: dict = {
+    "npc_utterance": "Hello there. I am a simulated NPC.",
+    "npc_emotion": "neutral",
+    "state_delta": {},
+    "event_flags": [],
+    "rubric_observations": [],
+    "safety": {"status": "ok"},
+    "session_control": {"continue_session": True},
+}
+
+
+@register("fake")
+class FakeChatRuntime(ChatRuntime):
+    """Deterministic fake runtime for tests and text-only demo development.
+
+    Streams tokens word-by-word with no real model calls. Always returns the
+    same response so test assertions are stable.
+    """
+
+    @property
+    def id(self) -> str:
+        return "fake"
+
+    @property
+    def display_name(self) -> str:
+        return "Fake (deterministic)"
+
+    @property
+    def capabilities(self) -> RuntimeCapabilities:
+        return RuntimeCapabilities(
+            streaming=True,
+            json_schema=True,
+            grammar=False,
+            tool_calling=False,
+            embeddings=False,
+        )
+
+    async def list_models(self) -> list[ModelInfo]:
+        return list(_MODELS)
+
+    async def chat_stream(
+        self, request: ChatRequest
+    ) -> AsyncGenerator[ChatToken | ChatFinal, None]:
+        if request.json_schema is not None:
+            response_text = json.dumps(_STRUCTURED_RESPONSE)
+            structured = _STRUCTURED_RESPONSE
+        else:
+            response_text = _PLAIN_RESPONSE
+            structured = None
+
+        words = response_text.split()
+        for word in words:
+            await asyncio.sleep(0)
+            yield ChatToken(text=word + " ")
+
+        model_id = request.model_id or "fake-small"
+        input_tokens = sum(len(m.content.split()) for m in request.messages)
+        yield ChatFinal(
+            text=response_text,
+            model_id=model_id,
+            input_tokens=input_tokens,
+            output_tokens=len(words),
+            structured=structured,
+        )
+
+    async def health(self) -> RuntimeHealth:
+        return RuntimeHealth(
+            runtime_id=self.id,
+            runtime_name=self.display_name,
+            status=RuntimeStatus.READY,
+            model_id="fake-small",
+            latency_ms=0.0,
+            checked_at=datetime.now(timezone.utc).isoformat(),
+        )

--- a/services/convsim-core/convsim_core/runtime/fake.py
+++ b/services/convsim-core/convsim_core/runtime/fake.py
@@ -65,9 +65,10 @@ class FakeChatRuntime(ChatRuntime):
     async def list_models(self) -> list[ModelInfo]:
         return list(_MODELS)
 
-    async def chat_stream(
-        self, request: ChatRequest
-    ) -> AsyncGenerator[ChatToken | ChatFinal, None]:
+    def chat_stream(self, request: ChatRequest) -> AsyncGenerator[ChatToken | ChatFinal, None]:
+        return self._stream(request)
+
+    async def _stream(self, request: ChatRequest) -> AsyncGenerator[ChatToken | ChatFinal, None]:
         if request.json_schema is not None:
             response_text = json.dumps(_STRUCTURED_RESPONSE)
             structured = _STRUCTURED_RESPONSE

--- a/services/convsim-core/convsim_core/runtime/registry.py
+++ b/services/convsim-core/convsim_core/runtime/registry.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from convsim_core.runtime.base import ChatRuntime
+
+_REGISTRY: dict[str, type] = {}
+
+
+def register(runtime_id: str):
+    """Class decorator that registers a ChatRuntime subclass under the given id."""
+
+    def decorator(cls: type) -> type:
+        _REGISTRY[runtime_id] = cls
+        return cls
+
+    return decorator
+
+
+def build_runtime(runtime_id: str) -> "ChatRuntime":
+    """Instantiate a registered runtime by id.
+
+    Raises KeyError if the id is unknown.
+    """
+    if runtime_id not in _REGISTRY:
+        available = sorted(_REGISTRY.keys())
+        raise KeyError(
+            f"Unknown runtime {runtime_id!r}. Available runtimes: {available}"
+        )
+    return _REGISTRY[runtime_id]()
+
+
+def list_runtime_ids() -> list[str]:
+    """Return sorted list of registered runtime ids."""
+    return sorted(_REGISTRY.keys())

--- a/services/convsim-core/convsim_core/runtime/types.py
+++ b/services/convsim-core/convsim_core/runtime/types.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+
+class RuntimeStatus(str, Enum):
+    UNAVAILABLE = "unavailable"
+    STARTING = "starting"
+    READY = "ready"
+    DEGRADED = "degraded"
+    ERROR = "error"
+
+
+class RuntimeCapabilities(BaseModel):
+    streaming: bool = False
+    json_schema: bool = False
+    grammar: bool = False
+    tool_calling: bool = False
+    embeddings: bool = False
+
+
+class ModelInfo(BaseModel):
+    id: str
+    name: str
+    size_category: Literal["small", "medium", "large"] | None = None
+    context_length: int | None = None
+
+
+class RuntimeHealth(BaseModel):
+    runtime_id: str
+    runtime_name: str
+    status: RuntimeStatus
+    model_id: str | None = None
+    latency_ms: float | None = None
+    message: str | None = None
+    checked_at: str  # ISO 8601
+
+
+class ChatMessage(BaseModel):
+    role: Literal["system", "user", "assistant"]
+    content: str
+
+
+class ChatRequest(BaseModel):
+    messages: list[ChatMessage]
+    model_id: str | None = None
+    max_tokens: int = 512
+    temperature: float = 0.8
+    json_schema: dict[str, Any] | None = None
+
+
+class ChatToken(BaseModel):
+    type: Literal["token"] = "token"
+    text: str
+
+
+class ChatFinal(BaseModel):
+    type: Literal["final"] = "final"
+    text: str
+    model_id: str
+    input_tokens: int
+    output_tokens: int
+    structured: dict[str, Any] | None = None

--- a/services/convsim-core/tests/test_architecture.py
+++ b/services/convsim-core/tests/test_architecture.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Architecture guard: scenario-engine code must not import concrete LLM drivers."""
+import sys
+
+import convsim_core  # noqa: F401 — loads the full package
+import convsim_core.runtime  # noqa: F401 — registers built-in adapters
+
+
+def test_convsim_core_does_not_import_llama_cpp():
+    """Importing convsim_core must not pull llama_cpp into sys.modules."""
+    leaked = [m for m in sys.modules if m == "llama_cpp" or m.startswith("llama_cpp.")]
+    assert not leaked, f"llama_cpp was imported by convsim_core: {leaked}"
+
+
+def test_convsim_core_does_not_import_ollama():
+    """Importing convsim_core must not pull ollama into sys.modules."""
+    leaked = [m for m in sys.modules if m == "ollama" or m.startswith("ollama.")]
+    assert not leaked, f"ollama was imported by convsim_core: {leaked}"

--- a/services/convsim-core/tests/test_fake_runtime.py
+++ b/services/convsim-core/tests/test_fake_runtime.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+from convsim_core.runtime.fake import FakeChatRuntime
+from convsim_core.runtime.types import (
+    ChatFinal,
+    ChatMessage,
+    ChatRequest,
+    ChatToken,
+    RuntimeStatus,
+)
+
+
+@pytest.fixture()
+def runtime() -> FakeChatRuntime:
+    return FakeChatRuntime()
+
+
+@pytest.mark.asyncio
+async def test_fake_runtime_id(runtime):
+    assert runtime.id == "fake"
+
+
+@pytest.mark.asyncio
+async def test_fake_runtime_display_name(runtime):
+    assert "Fake" in runtime.display_name
+
+
+@pytest.mark.asyncio
+async def test_fake_runtime_capabilities(runtime):
+    caps = runtime.capabilities
+    assert caps.streaming is True
+    assert caps.json_schema is True
+    assert caps.grammar is False
+    assert caps.tool_calling is False
+    assert caps.embeddings is False
+
+
+@pytest.mark.asyncio
+async def test_fake_runtime_list_models(runtime):
+    models = await runtime.list_models()
+    assert len(models) >= 1
+    ids = [m.id for m in models]
+    assert "fake-small" in ids
+
+
+@pytest.mark.asyncio
+async def test_fake_runtime_health_ready(runtime):
+    h = await runtime.health()
+    assert h.status == RuntimeStatus.READY
+    assert h.runtime_id == "fake"
+    assert h.checked_at  # non-empty ISO timestamp
+
+
+@pytest.mark.asyncio
+async def test_fake_runtime_streams_tokens_then_final(runtime):
+    request = ChatRequest(
+        messages=[ChatMessage(role="user", content="hello")]
+    )
+    chunks = []
+    async for chunk in runtime.chat_stream(request):
+        chunks.append(chunk)
+
+    tokens = [c for c in chunks if isinstance(c, ChatToken)]
+    finals = [c for c in chunks if isinstance(c, ChatFinal)]
+
+    assert len(tokens) > 0, "expected at least one ChatToken"
+    assert len(finals) == 1, "expected exactly one ChatFinal"
+    assert finals[0].type == "final"
+    assert finals[0].text  # non-empty response text
+    assert finals[0].model_id == "fake-small"
+    assert finals[0].output_tokens == len(tokens)
+
+
+@pytest.mark.asyncio
+async def test_fake_runtime_final_text_matches_joined_tokens(runtime):
+    request = ChatRequest(
+        messages=[ChatMessage(role="user", content="hello")]
+    )
+    token_texts = []
+    final = None
+    async for chunk in runtime.chat_stream(request):
+        if isinstance(chunk, ChatToken):
+            token_texts.append(chunk.text)
+        elif isinstance(chunk, ChatFinal):
+            final = chunk
+
+    assert final is not None
+    joined = "".join(token_texts).strip()
+    assert joined == final.text.strip()
+
+
+@pytest.mark.asyncio
+async def test_fake_runtime_structured_output_when_schema_provided(runtime):
+    request = ChatRequest(
+        messages=[ChatMessage(role="user", content="go")],
+        json_schema={"type": "object"},
+    )
+    final = None
+    async for chunk in runtime.chat_stream(request):
+        if isinstance(chunk, ChatFinal):
+            final = chunk
+
+    assert final is not None
+    assert final.structured is not None
+    assert "npc_utterance" in final.structured
+    assert "safety" in final.structured
+
+
+@pytest.mark.asyncio
+async def test_fake_runtime_no_structured_output_without_schema(runtime):
+    request = ChatRequest(
+        messages=[ChatMessage(role="user", content="hello")]
+    )
+    final = None
+    async for chunk in runtime.chat_stream(request):
+        if isinstance(chunk, ChatFinal):
+            final = chunk
+
+    assert final is not None
+    assert final.structured is None
+
+
+@pytest.mark.asyncio
+async def test_fake_runtime_model_id_uses_request_model(runtime):
+    request = ChatRequest(
+        messages=[ChatMessage(role="user", content="hi")],
+        model_id="fake-large",
+    )
+    final = None
+    async for chunk in runtime.chat_stream(request):
+        if isinstance(chunk, ChatFinal):
+            final = chunk
+
+    assert final is not None
+    assert final.model_id == "fake-large"

--- a/services/convsim-core/tests/test_fake_runtime.py
+++ b/services/convsim-core/tests/test_fake_runtime.py
@@ -134,3 +134,21 @@ async def test_fake_runtime_model_id_uses_request_model(runtime):
 
     assert final is not None
     assert final.model_id == "fake-large"
+
+
+@pytest.mark.asyncio
+async def test_fake_runtime_input_tokens_counts_message_words(runtime):
+    request = ChatRequest(
+        messages=[
+            ChatMessage(role="system", content="You are helpful."),
+            ChatMessage(role="user", content="hello world"),
+        ]
+    )
+    final = None
+    async for chunk in runtime.chat_stream(request):
+        if isinstance(chunk, ChatFinal):
+            final = chunk
+
+    assert final is not None
+    # input_tokens = word count across all messages: 3 + 2 = 5
+    assert final.input_tokens == 5

--- a/services/convsim-core/tests/test_health.py
+++ b/services/convsim-core/tests/test_health.py
@@ -40,11 +40,12 @@ def test_health_database_migrations_applied(client):
     assert body["database"]["migrations_applied"] >= 1
 
 
-def test_health_runtime_readiness_fields_exist(client):
+def test_health_runtime_fields_exist(client):
     rt = client.get("/api/health").json()["runtime"]
-    assert rt["llm_ready"] is False
-    assert rt["stt_ready"] is False
-    assert rt["tts_ready"] is False
+    assert rt["runtime_id"] == "fake"
+    assert rt["runtime_name"] == "Fake (deterministic)"
+    assert rt["status"] == "ready"
+    assert "checked_at" in rt
 
 
 def test_health_config_path_present(client):

--- a/services/convsim-core/tests/test_runtime_registry.py
+++ b/services/convsim-core/tests/test_runtime_registry.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+import convsim_core.runtime  # ensures built-in runtimes are registered
+from convsim_core.runtime.fake import FakeChatRuntime
+from convsim_core.runtime.registry import build_runtime, list_runtime_ids
+
+
+def test_fake_runtime_is_registered():
+    assert "fake" in list_runtime_ids()
+
+
+def test_build_runtime_returns_fake_instance():
+    rt = build_runtime("fake")
+    assert isinstance(rt, FakeChatRuntime)
+
+
+def test_build_runtime_returns_new_instance_each_call():
+    rt1 = build_runtime("fake")
+    rt2 = build_runtime("fake")
+    assert rt1 is not rt2
+
+
+def test_build_runtime_unknown_id_raises_key_error():
+    with pytest.raises(KeyError, match="unknown-provider"):
+        build_runtime("unknown-provider")
+
+
+def test_build_runtime_error_message_lists_available_runtimes():
+    with pytest.raises(KeyError) as exc_info:
+        build_runtime("no-such-runtime")
+    assert "fake" in str(exc_info.value)
+
+
+def test_list_runtime_ids_is_sorted():
+    ids = list_runtime_ids()
+    assert ids == sorted(ids)


### PR DESCRIPTION
## Summary

This PR introduces a clean abstraction layer for chat model runtimes, enabling the scenario engine and other consumers to work with different model providers (llama_cpp, ollama, etc.) without direct dependencies. It establishes a capability model and factory pattern so adapters can be registered and instantiated without modifying core code.

## Core changes

**ChatRuntime abstraction** — Defines `ChatRuntime` ABC in `convsim_core/runtime/base.py` with six abstract methods:
- `id`: Stable machine-readable identifier (e.g., "fake", "llama_cpp")
- `display_name`: Human-readable name for UI display
- `capabilities`: Feature flags (streaming, JSON schema, grammar, tool calling, embeddings)
- `list_models()`: Async method returning available models as `ModelInfo` objects
- `chat_stream()`: Sync method returning an async generator that yields `ChatToken` chunks followed by a single `ChatFinal` result
- `health()`: Async method returning a point-in-time health snapshot

**RuntimeRegistry** — Pluggable factory in `convsim_core/runtime/registry.py`:
- `@register(runtime_id)` class decorator to register adapters
- `build_runtime(runtime_id)` factory function with clear error messages when an id is unknown
- `list_runtime_ids()` for discovery
- Raises `KeyError` with sorted list of available runtimes if id is not found

**FakeChatRuntime** — Test and demo implementation registered as `"fake"`:
- Streams tokens word-by-word deterministically with no model calls
- Returns fixed text responses or deterministic structured JSON when `json_schema` is supplied
- Lists two fake models: small (4K context) and large (32K context)
- Advertises streaming and JSON schema support; grammar, tool calling, and embeddings disabled
- Used by tests and text-only development workflows

**Shared types** — Expanded `packages/shared-types/src/runtime.ts`:
- `RuntimeStatus`: Five-state enum (unavailable, starting, ready, degraded, error)
- `RuntimeCapabilities`: Feature flags matching the Python side
- `ModelInfo`: Metadata for available models (id, name, size_category, context_length)
- `ChatMessage`, `ChatRequest`: Request types with optional model_id, max_tokens, temperature, json_schema
- `ChatToken` (streamed text chunk), `ChatFinal` (completion with token counts and structured output)
- `ChatStreamChunk`: Union type for stream items

**Config and app wiring** — Integration points:
- New `runtime_id` field in `ServiceConfig` (default `"fake"`, overridable via `CONVSIM_RUNTIME_ID` env var)
- `app.py` builds the runtime during startup and stores it in `app.state.runtime`

**Updated health endpoint** — `/api/health` now calls `runtime.health()` instead of returning a static stub:
- Returns live `RuntimeHealth` nested in the response with fields: `runtime_id`, `runtime_name`, `status`, `model_id`, `latency_ms`, `message`, `checked_at`
- Status values expanded from three to five states
- Enables health checks to reflect actual runtime state (loading, degraded, errors)

## Implementation details

The design isolates scenario-engine and server code from provider-specific imports. A runtime adapter imports its provider library (llama_cpp, ollama, etc.) in its own module, registers itself with the `@register` decorator, and never leaks those imports upstream. This enables clean dependency boundaries and makes it trivial to add new runtimes in the future.

## Tests

- **test_fake_runtime.py** (11 tests) — Streaming token chunks, final text assembly, structured output with/without schema, model-id passthrough, capabilities, health status, token counts
- **test_runtime_registry.py** (6 tests) — Registration, instantiation, factory error handling, error message clarity, available id sorting
- **test_architecture.py** (2 tests) — Guard that importing `convsim_core` does not leak `llama_cpp` or `ollama` into `sys.modules`, preventing accidental hard dependencies
- **test_health.py** (updated) — Assert new `RuntimeHealth` fields on `/api/health` response

All 176 tests pass (1 pre-existing skip). No regressions in existing functionality.

Closes #9