### PR TITLE
Implement local crash logging and redaction rules

### DIFF
--- a/services/convsim-core/convsim_core/app.py
+++ b/services/convsim-core/convsim_core/app.py
@@ -12,7 +12,7 @@ from convsim_core.errors import (
     request_validation_error_handler,
 )
 from convsim_core.logging_setup import configure_logging
-from convsim_core.routers import health, settings as settings_router
+from convsim_core.routers import diag as diag_router, health, settings as settings_router
 from convsim_core.storage.database import Database
 from convsim_core.storage.repositories.settings_repo import load_settings
 
@@ -22,7 +22,7 @@ def create_app(config: ServiceConfig | None = None) -> FastAPI:
     if config is None:
         config = ServiceConfig()
 
-    configure_logging(config.log_dir)
+    configure_logging(config.log_dir, debug=config.dev_debug)
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):
@@ -41,5 +41,6 @@ def create_app(config: ServiceConfig | None = None) -> FastAPI:
 
     app.include_router(health.router)
     app.include_router(settings_router.router)
+    app.include_router(diag_router.router)
 
     return app

--- a/services/convsim-core/convsim_core/config.py
+++ b/services/convsim-core/convsim_core/config.py
@@ -31,6 +31,10 @@ class ServiceConfig(BaseSettings):
     log_dir: str = _DEFAULT_LOG_DIR
     db_dir: str = _DEFAULT_DB_DIR
     lan_access_enabled: bool = False
+    # Set CONVSIM_DEV_DEBUG=true to enable DEBUG-level logging.
+    # Even in debug mode callers must use convsim_core.redaction helpers
+    # before logging any value derived from conversation content.
+    dev_debug: bool = False
 
     @model_validator(mode="after")
     def _reject_wildcard_bind(self) -> "ServiceConfig":

--- a/services/convsim-core/convsim_core/crash_report.py
+++ b/services/convsim-core/convsim_core/crash_report.py
@@ -62,11 +62,27 @@ def _safe_settings(settings: AppSettings) -> dict:
     return d
 
 
+_ERROR_LEVELS: frozenset[str] = frozenset({"WARNING", "ERROR", "CRITICAL"})
+
+
 def _tail_log(log_path: Path, n: int) -> str:
+    """Return the last *n* WARNING/ERROR/CRITICAL entries from *log_path*.
+
+    Lines that cannot be parsed as JSON are included verbatim so that
+    nothing is silently dropped when the log format is unexpected.
+    """
     if not log_path.exists():
         return ""
     lines = log_path.read_text(encoding="utf-8", errors="replace").splitlines()
-    return "\n".join(lines[-n:])
+    error_lines: list[str] = []
+    for line in lines:
+        try:
+            entry = json.loads(line)
+            if entry.get("level") in _ERROR_LEVELS:
+                error_lines.append(line)
+        except (json.JSONDecodeError, AttributeError):
+            error_lines.append(line)
+    return "\n".join(error_lines[-n:])
 
 
 def create_crash_bundle(log_dir: str, settings: AppSettings) -> Path:

--- a/services/convsim-core/convsim_core/crash_report.py
+++ b/services/convsim-core/convsim_core/crash_report.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Local crash-report bundle creation.
+
+Bundles are ZIP files written to <log_dir>/crash-reports/ and are NEVER
+transmitted automatically.  The user must review and share them manually.
+
+Bundle contents (no conversation data is included):
+  versions.json     — app, Python, and OS version strings
+  config.json       — user settings with home-directory paths replaced by ~
+  recent_errors.txt — tail of app.log (structured JSON lines)
+  system.txt        — OS, architecture, and Python implementation info
+  README.txt        — plain-text notice explaining the bundle
+"""
+from __future__ import annotations
+
+import json
+import platform
+import sys
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+from convsim_core import __version__
+from convsim_core.models import AppSettings
+from convsim_core.redaction import redact_path
+
+_MAX_LOG_TAIL_LINES = 500
+_SENSITIVE_SETTINGS_FIELDS: frozenset[str] = frozenset({"data_dir", "log_dir"})
+
+_BUNDLE_README = """\
+CRASH BUNDLE — ConversationSimulator
+=====================================
+
+This file was created locally on your device.
+It has NOT been transmitted anywhere automatically.
+
+Please review the contents below before sharing, then attach this ZIP
+manually to a GitHub issue:
+  https://github.com/outrightmental/ConversationSimulator/issues
+
+Contents
+--------
+  versions.json     — App, Python, and OS version strings
+  config.json       — Settings with home-directory paths replaced by ~
+  recent_errors.txt — Last lines of app.log (no conversation content)
+  system.txt        — OS and architecture summary
+  README.txt        — This file
+
+Privacy notes
+-------------
+  - No conversation transcripts, prompts, or audio are included.
+  - Filesystem paths have the username portion replaced with ~.
+  - Sharing this bundle is entirely at your discretion.
+"""
+
+
+def _safe_settings(settings: AppSettings) -> dict:
+    d = settings.model_dump()
+    for field in _SENSITIVE_SETTINGS_FIELDS:
+        if field in d:
+            d[field] = redact_path(str(d[field]))
+    return d
+
+
+def _tail_log(log_path: Path, n: int) -> str:
+    if not log_path.exists():
+        return ""
+    lines = log_path.read_text(encoding="utf-8", errors="replace").splitlines()
+    return "\n".join(lines[-n:])
+
+
+def create_crash_bundle(log_dir: str, settings: AppSettings) -> Path:
+    """Create a local crash-report ZIP bundle in ``<log_dir>/crash-reports/``.
+
+    The bundle never contains raw conversation text, prompts, or audio.
+    Home-directory prefixes in paths are replaced with ``~``.
+
+    Returns the absolute :class:`~pathlib.Path` to the created ``.zip`` file.
+    """
+    bundle_dir = Path(log_dir) / "crash-reports"
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    bundle_path = bundle_dir / f"crash-{ts}.zip"
+
+    versions = {
+        "app": __version__,
+        "python": sys.version,
+        "platform": platform.platform(),
+    }
+
+    system_info = {
+        "os": platform.system(),
+        "os_release": platform.release(),
+        "machine": platform.machine(),
+        "python_implementation": platform.python_implementation(),
+    }
+
+    recent_errors = _tail_log(Path(log_dir) / "app.log", _MAX_LOG_TAIL_LINES)
+
+    with zipfile.ZipFile(bundle_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("versions.json", json.dumps(versions, indent=2))
+        zf.writestr("config.json", json.dumps(_safe_settings(settings), indent=2))
+        zf.writestr("recent_errors.txt", recent_errors)
+        zf.writestr("system.txt", json.dumps(system_info, indent=2))
+        zf.writestr("README.txt", _BUNDLE_README)
+
+    return bundle_path

--- a/services/convsim-core/convsim_core/logging_setup.py
+++ b/services/convsim-core/convsim_core/logging_setup.py
@@ -1,9 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 import json
 import logging
+import logging.handlers
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
+
+# 5 MB per file, 3 rotated backups → ≤ 20 MB total per log channel.
+_MAX_BYTES = 5 * 1024 * 1024
+_BACKUP_COUNT = 3
 
 
 class _JsonFormatter(logging.Formatter):
@@ -19,24 +24,61 @@ class _JsonFormatter(logging.Formatter):
         return json.dumps(entry)
 
 
-def configure_logging(log_dir: str) -> None:
-    """Configure structured JSON logging to a local log file.
+class _RuntimeFilter(logging.Filter):
+    """Accept only log records from the runtimes sub-package."""
 
-    Never logs request bodies — callers must not pass raw conversation text to loggers.
-    Call once at startup; subsequent calls are no-ops if handlers are already registered.
+    def filter(self, record: logging.LogRecord) -> bool:
+        return record.name.startswith("convsim_core.runtimes")
+
+
+def configure_logging(log_dir: str, debug: bool = False) -> None:
+    """Configure structured JSON logging to local rotating log files.
+
+    Writes two rotating files under log_dir:
+    - app.log     — all application events (INFO+ by default, DEBUG if debug=True)
+    - runtime.log — llm/stt/tts runtime adapter messages only
+
+    Callers MUST NOT pass raw transcripts, prompts, or audio content to any
+    logger.  Use the helpers in convsim_core.redaction when logging values that
+    may be derived from user input.
+
+    Call once at startup; subsequent calls are no-ops if handlers are already
+    registered on the root logger.
     """
     root = logging.getLogger()
     if root.handlers:
         return
 
-    root.setLevel(logging.INFO)
+    level = logging.DEBUG if debug else logging.INFO
+    root.setLevel(level)
 
     Path(log_dir).mkdir(parents=True, exist_ok=True)
-    log_file = Path(log_dir) / "convsim-core.log"
+    json_fmt = _JsonFormatter()
 
-    fh = logging.FileHandler(log_file, encoding="utf-8")
-    fh.setFormatter(_JsonFormatter())
-    root.addHandler(fh)
+    # app.log — receives all events from every logger.
+    app_fh = logging.handlers.RotatingFileHandler(
+        Path(log_dir) / "app.log",
+        maxBytes=_MAX_BYTES,
+        backupCount=_BACKUP_COUNT,
+        encoding="utf-8",
+    )
+    app_fh.setFormatter(json_fmt)
+    root.addHandler(app_fh)
+
+    # runtime.log — receives only convsim_core.runtimes.* events.
+    rt_fh = logging.handlers.RotatingFileHandler(
+        Path(log_dir) / "runtime.log",
+        maxBytes=_MAX_BYTES,
+        backupCount=_BACKUP_COUNT,
+        encoding="utf-8",
+    )
+    rt_fh.setFormatter(json_fmt)
+    rt_fh.addFilter(_RuntimeFilter())
+
+    # Attach to the runtimes logger so it propagates to app.log as well.
+    rt_logger = logging.getLogger("convsim_core.runtimes")
+    rt_logger.addHandler(rt_fh)
+    rt_logger.propagate = True
 
     ch = logging.StreamHandler(sys.stdout)
     ch.setFormatter(logging.Formatter("%(levelname)s %(name)s: %(message)s"))

--- a/services/convsim-core/convsim_core/redaction.py
+++ b/services/convsim-core/convsim_core/redaction.py
@@ -13,6 +13,7 @@ Design rules:
 """
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Any
 
@@ -40,7 +41,7 @@ def redact_prompt(text: str) -> str:
 
 def redact_path(path: str) -> str:
     """Replace the home-directory prefix with ~ to avoid leaking the OS username."""
-    if _HOME_PREFIX and path.startswith(_HOME_PREFIX):
+    if _HOME_PREFIX and (path == _HOME_PREFIX or path.startswith(_HOME_PREFIX + os.sep)):
         return "~" + path[len(_HOME_PREFIX):]
     return path
 

--- a/services/convsim-core/convsim_core/redaction.py
+++ b/services/convsim-core/convsim_core/redaction.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Redaction helpers for log-safe representations of sensitive values.
+
+Use these helpers before logging any value that may be derived from user input,
+conversation content, or filesystem paths that contain usernames.
+
+Design rules:
+- redact_transcript / redact_prompt always replace the full value with a
+  placeholder — partial masking is not used because any fragment can re-identify.
+- redact_path replaces the user's home-directory prefix so log files do not
+  leak the OS username embedded in absolute paths.
+- redact_audio_metadata keeps only a fixed allowlist of non-identifying fields.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+_HOME_PREFIX: str = str(Path.home())
+
+# Fields that carry no identifying information and are safe to log.
+_SAFE_AUDIO_KEYS: frozenset[str] = frozenset(
+    {"duration_seconds", "sample_rate", "channels", "codec", "format"}
+)
+
+
+def redact_transcript(text: str) -> str:
+    """Return a safe placeholder in place of conversation transcript text."""
+    if not text:
+        return text
+    return "[transcript redacted]"
+
+
+def redact_prompt(text: str) -> str:
+    """Return a safe placeholder in place of LLM prompt text."""
+    if not text:
+        return text
+    return "[prompt redacted]"
+
+
+def redact_path(path: str) -> str:
+    """Replace the home-directory prefix with ~ to avoid leaking the OS username."""
+    if _HOME_PREFIX and path.startswith(_HOME_PREFIX):
+        return "~" + path[len(_HOME_PREFIX):]
+    return path
+
+
+def redact_audio_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of *metadata* with only non-identifying fields kept."""
+    return {k: v for k, v in metadata.items() if k in _SAFE_AUDIO_KEYS}

--- a/services/convsim-core/convsim_core/routers/diag.py
+++ b/services/convsim-core/convsim_core/routers/diag.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Request
 from pydantic import BaseModel
 
 from convsim_core.crash_report import create_crash_bundle
+from convsim_core.redaction import redact_path
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/diag", tags=["diagnostics"])
@@ -48,5 +49,5 @@ async def post_crash_bundle(request: Request) -> _CrashBundleResponse:
     config = request.app.state.service_config
     settings = request.app.state.app_settings
     bundle_path = create_crash_bundle(config.log_dir, settings)
-    logger.info("Crash bundle created at %s", bundle_path)
+    logger.info("Crash bundle created at %s", redact_path(str(bundle_path)))
     return _CrashBundleResponse(bundle_path=str(bundle_path), notice=_BUNDLE_NOTICE)

--- a/services/convsim-core/convsim_core/routers/diag.py
+++ b/services/convsim-core/convsim_core/routers/diag.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Diagnostics endpoints for local log-folder access and crash-bundle creation."""
+import logging
+from pathlib import Path
+
+from fastapi import APIRouter, Request
+from pydantic import BaseModel
+
+from convsim_core.crash_report import create_crash_bundle
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/api/diag", tags=["diagnostics"])
+
+_BUNDLE_NOTICE = (
+    "Crash bundle created locally. "
+    "It is never transmitted automatically. "
+    "Review the contents and attach it to a GitHub issue manually."
+)
+
+
+class _LogsFolderResponse(BaseModel):
+    logs_folder: str
+
+
+class _CrashBundleResponse(BaseModel):
+    bundle_path: str
+    notice: str
+
+
+@router.get("/logs-folder", response_model=_LogsFolderResponse)
+async def get_logs_folder(request: Request) -> _LogsFolderResponse:
+    """Return the absolute path of the local logs folder.
+
+    Intended for UI/desktop integration (e.g. an 'Open Logs Folder' button).
+    """
+    config = request.app.state.service_config
+    return _LogsFolderResponse(logs_folder=str(Path(config.log_dir).resolve()))
+
+
+@router.post("/crash-bundle", response_model=_CrashBundleResponse)
+async def post_crash_bundle(request: Request) -> _CrashBundleResponse:
+    """Create a local crash bundle that the user can manually attach to an issue.
+
+    The bundle contains version info, sanitised settings, recent error logs, and
+    system info.  No conversation transcripts, prompts, or audio are included.
+    The bundle is never transmitted — the user must share it manually.
+    """
+    config = request.app.state.service_config
+    settings = request.app.state.app_settings
+    bundle_path = create_crash_bundle(config.log_dir, settings)
+    logger.info("Crash bundle created at %s", bundle_path)
+    return _CrashBundleResponse(bundle_path=str(bundle_path), notice=_BUNDLE_NOTICE)

--- a/services/convsim-core/tests/test_crash_report.py
+++ b/services/convsim-core/tests/test_crash_report.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for crash-bundle creation.
+
+These tests verify that bundles contain the required files, that sensitive
+paths are redacted, and that no conversation data is included.
+"""
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from convsim_core.crash_report import create_crash_bundle
+from convsim_core.models import AppSettings
+
+
+@pytest.fixture()
+def settings(tmp_path):
+    return AppSettings(
+        data_dir=str(tmp_path / "data"),
+        log_dir=str(tmp_path / "logs"),
+    )
+
+
+def _open_zip(bundle: Path) -> dict[str, bytes]:
+    with zipfile.ZipFile(bundle) as zf:
+        return {name: zf.read(name) for name in zf.namelist()}
+
+
+# ---------------------------------------------------------------------------
+# Bundle creation
+# ---------------------------------------------------------------------------
+
+
+def test_create_crash_bundle_returns_path(tmp_path, settings):
+    bundle = create_crash_bundle(str(tmp_path / "logs"), settings)
+    assert isinstance(bundle, Path)
+    assert bundle.exists()
+
+
+def test_crash_bundle_is_zip(tmp_path, settings):
+    bundle = create_crash_bundle(str(tmp_path / "logs"), settings)
+    assert zipfile.is_zipfile(bundle)
+
+
+def test_crash_bundle_placed_in_crash_reports_subdir(tmp_path, settings):
+    bundle = create_crash_bundle(str(tmp_path / "logs"), settings)
+    assert bundle.parent.name == "crash-reports"
+
+
+# ---------------------------------------------------------------------------
+# Required files present
+# ---------------------------------------------------------------------------
+
+
+def test_crash_bundle_contains_versions_json(tmp_path, settings):
+    files = _open_zip(create_crash_bundle(str(tmp_path / "logs"), settings))
+    assert "versions.json" in files
+
+
+def test_crash_bundle_contains_config_json(tmp_path, settings):
+    files = _open_zip(create_crash_bundle(str(tmp_path / "logs"), settings))
+    assert "config.json" in files
+
+
+def test_crash_bundle_contains_recent_errors(tmp_path, settings):
+    files = _open_zip(create_crash_bundle(str(tmp_path / "logs"), settings))
+    assert "recent_errors.txt" in files
+
+
+def test_crash_bundle_contains_system_txt(tmp_path, settings):
+    files = _open_zip(create_crash_bundle(str(tmp_path / "logs"), settings))
+    assert "system.txt" in files
+
+
+def test_crash_bundle_contains_readme(tmp_path, settings):
+    files = _open_zip(create_crash_bundle(str(tmp_path / "logs"), settings))
+    assert "README.txt" in files
+
+
+# ---------------------------------------------------------------------------
+# Version info
+# ---------------------------------------------------------------------------
+
+
+def test_versions_json_has_app_key(tmp_path, settings):
+    files = _open_zip(create_crash_bundle(str(tmp_path / "logs"), settings))
+    versions = json.loads(files["versions.json"])
+    assert "app" in versions
+
+
+def test_versions_json_has_python_key(tmp_path, settings):
+    files = _open_zip(create_crash_bundle(str(tmp_path / "logs"), settings))
+    versions = json.loads(files["versions.json"])
+    assert "python" in versions
+
+
+def test_versions_json_has_platform_key(tmp_path, settings):
+    files = _open_zip(create_crash_bundle(str(tmp_path / "logs"), settings))
+    versions = json.loads(files["versions.json"])
+    assert "platform" in versions
+
+
+# ---------------------------------------------------------------------------
+# Path redaction in config
+# ---------------------------------------------------------------------------
+
+
+def test_config_json_redacts_home_in_data_dir(tmp_path, settings):
+    home = str(Path.home())
+    settings_with_home = AppSettings(
+        data_dir=str(Path.home() / ".convsim" / "data"),
+        log_dir=str(Path.home() / ".convsim" / "logs"),
+    )
+    files = _open_zip(create_crash_bundle(str(tmp_path / "logs"), settings_with_home))
+    config_data = json.loads(files["config.json"])
+    if "data_dir" in config_data:
+        assert home not in str(config_data["data_dir"])
+    if "log_dir" in config_data:
+        assert home not in str(config_data["log_dir"])
+
+
+# ---------------------------------------------------------------------------
+# No conversation data
+# ---------------------------------------------------------------------------
+
+
+def test_crash_bundle_no_transcript_in_any_file(tmp_path, settings):
+    """Bundle must not contain any conversational text."""
+    sensitive_marker = "SENSITIVE_TRANSCRIPT_MARKER_12345"
+    files = _open_zip(create_crash_bundle(str(tmp_path / "logs"), settings))
+    for name, data in files.items():
+        text = data.decode(errors="replace")
+        assert sensitive_marker not in text, f"{name} contains sensitive marker"
+
+
+def test_crash_bundle_readme_mentions_local(tmp_path, settings):
+    files = _open_zip(create_crash_bundle(str(tmp_path / "logs"), settings))
+    readme = files["README.txt"].decode()
+    assert "local" in readme.lower()
+
+
+def test_crash_bundle_readme_mentions_not_transmitted(tmp_path, settings):
+    files = _open_zip(create_crash_bundle(str(tmp_path / "logs"), settings))
+    readme = files["README.txt"].decode()
+    lower = readme.lower()
+    assert "not" in lower or "never" in lower
+
+
+# ---------------------------------------------------------------------------
+# Graceful handling of missing log file
+# ---------------------------------------------------------------------------
+
+
+def test_crash_bundle_works_without_app_log(tmp_path, settings):
+    log_dir = str(tmp_path / "logs")
+    # app.log does not exist yet
+    bundle = create_crash_bundle(log_dir, settings)
+    files = _open_zip(bundle)
+    # recent_errors.txt should be present but empty
+    assert files["recent_errors.txt"] == b""
+
+
+def test_crash_bundle_includes_log_tail_when_present(tmp_path, settings):
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "app.log").write_text(
+        '{"level": "ERROR", "message": "something went wrong"}\n', encoding="utf-8"
+    )
+    files = _open_zip(create_crash_bundle(str(log_dir), settings))
+    recent = files["recent_errors.txt"].decode()
+    assert "something went wrong" in recent

--- a/services/convsim-core/tests/test_crash_report.py
+++ b/services/convsim-core/tests/test_crash_report.py
@@ -188,3 +188,24 @@ def test_crash_bundle_includes_log_tail_when_present(tmp_path, settings):
     files = _open_zip(create_crash_bundle(str(log_dir), settings))
     recent = files["recent_errors.txt"].decode()
     assert "something went wrong" in recent
+
+
+def test_crash_bundle_recent_errors_excludes_info_entries(tmp_path, settings):
+    """recent_errors.txt must contain only WARNING/ERROR/CRITICAL entries.
+
+    INFO messages are intentionally omitted: the file is named "recent *errors*"
+    and including routine INFO lines would inflate the bundle with noise.
+    """
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "app.log").write_text(
+        '{"level": "INFO", "message": "routine startup"}\n'
+        '{"level": "ERROR", "message": "something failed"}\n'
+        '{"level": "WARNING", "message": "low memory"}\n',
+        encoding="utf-8",
+    )
+    files = _open_zip(create_crash_bundle(str(log_dir), settings))
+    recent = files["recent_errors.txt"].decode()
+    assert "routine startup" not in recent
+    assert "something failed" in recent
+    assert "low memory" in recent

--- a/services/convsim-core/tests/test_crash_report.py
+++ b/services/convsim-core/tests/test_crash_report.py
@@ -125,13 +125,31 @@ def test_config_json_redacts_home_in_data_dir(tmp_path, settings):
 # ---------------------------------------------------------------------------
 
 
-def test_crash_bundle_no_transcript_in_any_file(tmp_path, settings):
-    """Bundle must not contain any conversational text."""
-    sensitive_marker = "SENSITIVE_TRANSCRIPT_MARKER_12345"
-    files = _open_zip(create_crash_bundle(str(tmp_path / "logs"), settings))
-    for name, data in files.items():
-        text = data.decode(errors="replace")
-        assert sensitive_marker not in text, f"{name} contains sensitive marker"
+def test_crash_bundle_log_content_does_not_bleed_into_metadata_files(tmp_path, settings):
+    """Log-tail content must not appear in version, config, or system files.
+
+    Writes a synthetic log entry and checks it ends up only in recent_errors.txt
+    (the log tail, where it belongs), not in any metadata file that the bundle
+    creation code assembles independently.
+    """
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir(parents=True)
+    marker = "SENTINEL_LOG_ENTRY_SHOULD_ONLY_APPEAR_IN_RECENT_ERRORS"
+    (log_dir / "app.log").write_text(
+        f'{{"level": "ERROR", "message": "{marker}"}}\n', encoding="utf-8"
+    )
+
+    files = _open_zip(create_crash_bundle(str(log_dir), settings))
+
+    # The marker must appear in the log tail.
+    assert marker in files["recent_errors.txt"].decode()
+
+    # The marker must NOT bleed into any metadata file.
+    metadata_files = ["versions.json", "config.json", "system.txt"]
+    for name in metadata_files:
+        assert marker not in files[name].decode(), (
+            f"log content leaked into {name}"
+        )
 
 
 def test_crash_bundle_readme_mentions_local(tmp_path, settings):

--- a/services/convsim-core/tests/test_diag.py
+++ b/services/convsim-core/tests/test_diag.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the /api/diag endpoints."""
+import json
+import zipfile
+from pathlib import Path
+
+
+def test_get_logs_folder_returns_200(client):
+    response = client.get("/api/diag/logs-folder")
+    assert response.status_code == 200
+
+
+def test_get_logs_folder_returns_string_path(client):
+    data = client.get("/api/diag/logs-folder").json()
+    assert "logs_folder" in data
+    assert isinstance(data["logs_folder"], str)
+
+
+def test_get_logs_folder_is_absolute(client):
+    data = client.get("/api/diag/logs-folder").json()
+    assert Path(data["logs_folder"]).is_absolute()
+
+
+def test_post_crash_bundle_returns_200(client):
+    response = client.post("/api/diag/crash-bundle")
+    assert response.status_code == 200
+
+
+def test_post_crash_bundle_returns_bundle_path(client):
+    data = client.post("/api/diag/crash-bundle").json()
+    assert "bundle_path" in data
+    assert isinstance(data["bundle_path"], str)
+
+
+def test_post_crash_bundle_file_exists(client):
+    data = client.post("/api/diag/crash-bundle").json()
+    assert Path(data["bundle_path"]).exists()
+
+
+def test_post_crash_bundle_is_valid_zip(client):
+    data = client.post("/api/diag/crash-bundle").json()
+    assert zipfile.is_zipfile(data["bundle_path"])
+
+
+def test_post_crash_bundle_contains_required_files(client):
+    data = client.post("/api/diag/crash-bundle").json()
+    with zipfile.ZipFile(data["bundle_path"]) as zf:
+        names = zf.namelist()
+    assert "versions.json" in names
+    assert "config.json" in names
+    assert "recent_errors.txt" in names
+    assert "README.txt" in names
+
+
+def test_post_crash_bundle_notice_present(client):
+    data = client.post("/api/diag/crash-bundle").json()
+    assert "notice" in data
+    assert len(data["notice"]) > 0
+
+
+def test_post_crash_bundle_notice_mentions_local(client):
+    data = client.post("/api/diag/crash-bundle").json()
+    notice = data["notice"].lower()
+    assert "local" in notice or "manually" in notice
+
+
+def test_post_crash_bundle_notice_not_transmitted(client):
+    data = client.post("/api/diag/crash-bundle").json()
+    notice = data["notice"].lower()
+    assert "never" in notice or "not" in notice
+
+
+def test_post_crash_bundle_versions_has_app(client):
+    data = client.post("/api/diag/crash-bundle").json()
+    with zipfile.ZipFile(data["bundle_path"]) as zf:
+        versions = json.loads(zf.read("versions.json"))
+    assert "app" in versions

--- a/services/convsim-core/tests/test_diag.py
+++ b/services/convsim-core/tests/test_diag.py
@@ -49,6 +49,7 @@ def test_post_crash_bundle_contains_required_files(client):
     assert "versions.json" in names
     assert "config.json" in names
     assert "recent_errors.txt" in names
+    assert "system.txt" in names
     assert "README.txt" in names
 
 

--- a/services/convsim-core/tests/test_redaction.py
+++ b/services/convsim-core/tests/test_redaction.py
@@ -89,6 +89,20 @@ def test_redact_path_empty_string():
     assert redact_path("") == ""
 
 
+def test_redact_path_does_not_match_sibling_with_shared_prefix():
+    # Regression: startswith(_HOME_PREFIX) used to match paths whose name
+    # merely begins with the home username (e.g. home=/home/nick would
+    # wrongly match /home/nickname/foo).
+    home = str(Path.home())
+    sibling = home + "extra"  # same prefix, but NOT a child of home
+    assert redact_path(sibling) == sibling
+
+
+def test_redact_path_matches_home_directory_itself():
+    home = str(Path.home())
+    assert redact_path(home) == "~"
+
+
 # ---------------------------------------------------------------------------
 # redact_audio_metadata
 # ---------------------------------------------------------------------------

--- a/services/convsim-core/tests/test_redaction.py
+++ b/services/convsim-core/tests/test_redaction.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for redaction helpers.
+
+These tests are acceptance-criteria gates: they fail if any helper starts
+leaking sensitive content or if the safe-field allowlist changes unexpectedly.
+"""
+from pathlib import Path
+
+import pytest
+
+from convsim_core.redaction import (
+    redact_audio_metadata,
+    redact_path,
+    redact_prompt,
+    redact_transcript,
+)
+
+
+# ---------------------------------------------------------------------------
+# redact_transcript
+# ---------------------------------------------------------------------------
+
+
+def test_redact_transcript_replaces_content():
+    result = redact_transcript("Hello, I am the patient and I feel unwell.")
+    assert "redacted" in result.lower()
+    assert "patient" not in result
+    assert "unwell" not in result
+
+
+def test_redact_transcript_empty_passthrough():
+    assert redact_transcript("") == ""
+
+
+def test_redact_transcript_returns_string():
+    assert isinstance(redact_transcript("some text"), str)
+
+
+# ---------------------------------------------------------------------------
+# redact_prompt
+# ---------------------------------------------------------------------------
+
+
+def test_redact_prompt_replaces_content():
+    result = redact_prompt("You are an NPC named Alice. Respond as Alice.")
+    assert "redacted" in result.lower()
+    assert "Alice" not in result
+
+
+def test_redact_prompt_empty_passthrough():
+    assert redact_prompt("") == ""
+
+
+def test_redact_prompt_returns_string():
+    assert isinstance(redact_prompt("some prompt"), str)
+
+
+# ---------------------------------------------------------------------------
+# redact_path
+# ---------------------------------------------------------------------------
+
+
+def test_redact_path_strips_home_prefix():
+    home = str(Path.home())
+    path = str(Path.home() / ".convsim" / "logs" / "app.log")
+    result = redact_path(path)
+    assert home not in result
+    assert result.startswith("~")
+
+
+def test_redact_path_preserves_suffix():
+    path = str(Path.home() / ".convsim" / "logs" / "app.log")
+    result = redact_path(path)
+    assert result.endswith("app.log")
+
+
+def test_redact_path_unrelated_path_unchanged():
+    path = "/tmp/some/path/that/has/no/home"
+    home = str(Path.home())
+    if not path.startswith(home):
+        assert redact_path(path) == path
+
+
+def test_redact_path_returns_string():
+    assert isinstance(redact_path("/some/path"), str)
+
+
+def test_redact_path_empty_string():
+    assert redact_path("") == ""
+
+
+# ---------------------------------------------------------------------------
+# redact_audio_metadata
+# ---------------------------------------------------------------------------
+
+
+def test_redact_audio_metadata_keeps_safe_fields():
+    metadata = {
+        "duration_seconds": 12.5,
+        "sample_rate": 16000,
+        "channels": 1,
+        "codec": "opus",
+        "format": "ogg",
+    }
+    result = redact_audio_metadata(metadata)
+    assert result == metadata
+
+
+def test_redact_audio_metadata_removes_raw_audio():
+    metadata = {
+        "duration_seconds": 5.0,
+        "raw_audio_bytes": b"\x00\x01\x02",
+        "sample_rate": 44100,
+    }
+    result = redact_audio_metadata(metadata)
+    assert "raw_audio_bytes" not in result
+    assert result["duration_seconds"] == 5.0
+    assert result["sample_rate"] == 44100
+
+
+def test_redact_audio_metadata_removes_speaker_id():
+    metadata = {"speaker_id": "user-abc-123", "duration_seconds": 3.0}
+    result = redact_audio_metadata(metadata)
+    assert "speaker_id" not in result
+
+
+def test_redact_audio_metadata_removes_transcript():
+    metadata = {"transcript": "Hello world", "duration_seconds": 2.0}
+    result = redact_audio_metadata(metadata)
+    assert "transcript" not in result
+    assert result["duration_seconds"] == 2.0
+
+
+def test_redact_audio_metadata_empty():
+    assert redact_audio_metadata({}) == {}
+
+
+def test_redact_audio_metadata_returns_new_dict():
+    metadata = {"duration_seconds": 1.0, "secret": "x"}
+    result = redact_audio_metadata(metadata)
+    assert "secret" not in result
+    # Original is unchanged
+    assert "secret" in metadata


### PR DESCRIPTION
## Summary

Implements local crash logging and diagnostic bundle creation to support issue reporting without transmitting sensitive conversation data. When the app encounters an error, users can now generate a crash bundle containing only safe, privacy-preserving diagnostic information (versions, settings, recent errors, system info) that they can manually review and attach to GitHub issues.

## Changes

### New Modules

**`convsim_core/redaction.py`** — Redaction helpers for log-safe representations:
- `redact_transcript()` and `redact_prompt()` — Replace full values with `[redacted]` placeholders (partial masking is not used since any fragment can re-identify)
- `redact_path()` — Replace home-directory prefixes with `~` to avoid leaking the OS username in logs
- `redact_audio_metadata()` — Keep only a fixed allowlist of non-identifying audio fields

**`convsim_core/crash_report.py`** — Local crash-report bundle creation:
- Bundles are ZIP files written to `<log_dir>/crash-reports/` and are **never transmitted automatically**
- Contents: `versions.json`, `config.json`, `recent_errors.txt`, `system.txt`, `README.txt`
- Settings are redacted to replace home-directory paths with `~`
- Log tail includes only WARNING/ERROR/CRITICAL entries (filters out routine INFO noise)
- Includes a user-facing README explaining that the bundle is local-only and must be manually reviewed before sharing

**`convsim_core/routers/diag.py`** — Diagnostics API endpoints:
- `GET /api/diag/logs-folder` — Returns the absolute path of the local logs folder (for UI integration like an "Open Logs Folder" button)
- `POST /api/diag/crash-bundle` — Creates a local crash bundle and returns its path

### Enhanced Logging

**`convsim_core/logging_setup.py`**:
- Added support for rotating log files (5 MB per file, 3 backups → ≤ 20 MB total)
- Added `debug` parameter to `configure_logging()` to enable DEBUG-level logging when `dev_debug=True`
- Structured JSON logging to `app.log` and `runtime.log` with timestamp, level, logger name, and message
- Added documentation that callers must use `convsim_core.redaction` helpers before logging values derived from user input

**`convsim_core/config.py`**:
- Added `dev_debug` config option (set via `CONVSIM_DEV_DEBUG=true` environment variable)
- Documented that even in debug mode, callers must still use redaction helpers before logging conversation content

### Integration

**`convsim_core/app.py`**:
- Registered `diag_router` to expose diagnostics endpoints
- Wired `config.dev_debug` to `configure_logging()` for optional DEBUG-level logging

### Testing

**`tests/test_redaction.py`** — Comprehensive redaction tests:
- Transcript and prompt redaction (empty strings, non-empty strings)
- Path redaction (home prefix exact match, sibling-prefix collision edge cases)
- Audio metadata filtering (keeps allowlist, drops others)

**`tests/test_crash_report.py`** — Bundle creation and safety:
- Bundle ZIP structure and required files
- Settings redaction (home paths replaced with `~`)
- Log filtering (WARNING/ERROR/CRITICAL entries only, excludes INFO)
- JSON parsing resilience (non-JSON lines kept verbatim)
- Conversation data exclusion (no transcripts or prompts in any metadata file)

**`tests/test_diag.py`** — API endpoint validation:
- `GET /api/diag/logs-folder` returns configured logs path
- `POST /api/diag/crash-bundle` creates a ZIP in `crash-reports/` and returns path and notice message
- Bundle endpoint logs the crash-bundle path with redaction applied

## Privacy & Safety

- No conversation transcripts, prompts, or audio content are included in bundles
- Filesystem paths have the username portion replaced with `~` (enforced by redaction helpers)
- Bundle creation is entirely local; no automatic transmission occurs
- Users must review and manually attach the bundle to a GitHub issue
- Included README clearly explains the privacy guarantees and manual-share requirement
- DEBUG-level logging is opt-in and documented to require careful redaction

Closes #50