### PR TITLE
Implement Ollama runtime adapter with streaming, model detection, and health reporting

### DIFF
--- a/services/convsim-core/convsim_core/config.py
+++ b/services/convsim-core/convsim_core/config.py
@@ -32,6 +32,7 @@ class ServiceConfig(BaseSettings):
     db_dir: str = _DEFAULT_DB_DIR
     lan_access_enabled: bool = False
     runtime_id: str = "fake"
+    ollama_base_url: str = "http://127.0.0.1:11434"
     # Set CONVSIM_DEV_DEBUG=true to enable DEBUG-level logging.
     # Even in debug mode callers must use convsim_core.redaction helpers
     # before logging any value derived from conversation content.

--- a/services/convsim-core/convsim_core/runtime/__init__.py
+++ b/services/convsim-core/convsim_core/runtime/__init__.py
@@ -20,6 +20,7 @@ from convsim_core.runtime.types import (
 
 # Import built-in adapters to trigger their @register() decorators.
 import convsim_core.runtime.fake  # noqa: F401, E402
+import convsim_core.runtime.ollama_adapter  # noqa: F401, E402
 
 __all__ = [
     "ChatRuntime",

--- a/services/convsim-core/convsim_core/runtime/ollama_adapter.py
+++ b/services/convsim-core/convsim_core/runtime/ollama_adapter.py
@@ -1,0 +1,215 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Ollama runtime adapter.
+
+Communicates with a local Ollama server via its HTTP REST API using httpx.
+The `ollama` PyPI package is intentionally not used here so that convsim_core
+stays importable on machines where the Ollama SDK is not installed — and so
+that the architecture guard (test_architecture.py) stays green.
+"""
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from typing import Any, AsyncGenerator
+
+import httpx
+
+from convsim_core.runtime.base import ChatRuntime
+from convsim_core.runtime.registry import register
+from convsim_core.runtime.types import (
+    ChatFinal,
+    ChatRequest,
+    ChatToken,
+    ModelInfo,
+    RuntimeCapabilities,
+    RuntimeHealth,
+    RuntimeStatus,
+)
+
+_DEFAULT_BASE_URL = "http://127.0.0.1:11434"
+
+_NOT_RUNNING_HINT = (
+    "Ollama is not reachable at the configured endpoint. "
+    "Start it with 'ollama serve', or install it from https://ollama.com. "
+    "Override the endpoint with the CONVSIM_OLLAMA_BASE_URL environment variable."
+)
+
+_NO_MODELS_HINT = (
+    "Ollama is running but has no models installed. "
+    "Pull a compatible model with e.g. 'ollama pull llama3.2'."
+)
+
+
+def _size_category(size_bytes: int | None) -> str | None:
+    """Map a raw byte count to a coarse size bucket."""
+    if size_bytes is None:
+        return None
+    gib = size_bytes / (1024**3)
+    if gib < 4:
+        return "small"
+    if gib < 12:
+        return "medium"
+    return "large"
+
+
+def _map_model_info(raw: dict[str, Any]) -> ModelInfo:
+    """Convert one entry from Ollama's /api/tags response into a ModelInfo."""
+    name: str = raw.get("name", "")
+    return ModelInfo(
+        id=name,
+        name=name,
+        size_category=_size_category(raw.get("size")),
+        # Ollama's tag list does not expose context length; leave it None.
+        context_length=None,
+    )
+
+
+@register("ollama")
+class OllamaChatRuntime(ChatRuntime):
+    """ChatRuntime adapter that forwards requests to a local Ollama server.
+
+    The base URL defaults to http://127.0.0.1:11434 and can be overridden
+    via the CONVSIM_OLLAMA_BASE_URL environment variable or the *base_url*
+    constructor argument.  A custom *client* may be injected for testing.
+    """
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        resolved = base_url or os.environ.get("CONVSIM_OLLAMA_BASE_URL", _DEFAULT_BASE_URL)
+        self._base_url = resolved.rstrip("/")
+        self._client = client or httpx.AsyncClient(base_url=self._base_url, timeout=60.0)
+
+    # ------------------------------------------------------------------
+    # ChatRuntime interface
+    # ------------------------------------------------------------------
+
+    @property
+    def id(self) -> str:
+        return "ollama"
+
+    @property
+    def display_name(self) -> str:
+        return "Ollama (local)"
+
+    @property
+    def capabilities(self) -> RuntimeCapabilities:
+        return RuntimeCapabilities(
+            streaming=True,
+            json_schema=True,
+            grammar=False,
+            tool_calling=False,
+            embeddings=False,
+        )
+
+    async def list_models(self) -> list[ModelInfo]:
+        """Return models available in the local Ollama installation."""
+        try:
+            resp = await self._client.get("/api/tags")
+            resp.raise_for_status()
+        except (httpx.ConnectError, httpx.TimeoutException, httpx.HTTPStatusError):
+            return []
+        data = resp.json()
+        return [_map_model_info(m) for m in data.get("models", [])]
+
+    def chat_stream(self, request: ChatRequest) -> AsyncGenerator[ChatToken | ChatFinal, None]:
+        return self._stream(request)
+
+    async def _stream(self, request: ChatRequest) -> AsyncGenerator[ChatToken | ChatFinal, None]:
+        model_id = request.model_id
+        if not model_id:
+            models = await self.list_models()
+            if not models:
+                raise RuntimeError(_NO_MODELS_HINT)
+            model_id = models[0].id
+
+        payload: dict[str, Any] = {
+            "model": model_id,
+            "messages": [
+                {"role": msg.role, "content": msg.content} for msg in request.messages
+            ],
+            "stream": True,
+            "options": {
+                "num_predict": request.max_tokens,
+                "temperature": request.temperature,
+            },
+        }
+        if request.json_schema is not None:
+            payload["format"] = request.json_schema
+
+        full_text = ""
+        input_tokens = 0
+        output_tokens = 0
+
+        try:
+            async with self._client.stream("POST", "/api/chat", json=payload) as resp:
+                resp.raise_for_status()
+                async for line in resp.aiter_lines():
+                    if not line:
+                        continue
+                    chunk = json.loads(line)
+                    content: str = chunk.get("message", {}).get("content", "")
+                    done: bool = chunk.get("done", False)
+                    if content and not done:
+                        full_text += content
+                        yield ChatToken(text=content)
+                    if done:
+                        input_tokens = chunk.get("prompt_eval_count", 0)
+                        output_tokens = chunk.get("eval_count", 0)
+        except httpx.ConnectError as exc:
+            raise RuntimeError(_NOT_RUNNING_HINT) from exc
+
+        structured: dict[str, Any] | None = None
+        if request.json_schema is not None:
+            try:
+                structured = json.loads(full_text)
+            except json.JSONDecodeError:
+                structured = None
+
+        yield ChatFinal(
+            text=full_text,
+            model_id=model_id,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            structured=structured,
+        )
+
+    async def health(self) -> RuntimeHealth:
+        checked_at = datetime.now(timezone.utc).isoformat()
+        t0 = datetime.now(timezone.utc)
+
+        try:
+            resp = await self._client.get("/")
+            resp.raise_for_status()
+        except (httpx.ConnectError, httpx.TimeoutException, httpx.HTTPStatusError):
+            return RuntimeHealth(
+                runtime_id=self.id,
+                runtime_name=self.display_name,
+                status=RuntimeStatus.UNAVAILABLE,
+                message=_NOT_RUNNING_HINT,
+                checked_at=checked_at,
+            )
+
+        latency_ms = (datetime.now(timezone.utc) - t0).total_seconds() * 1000
+        models = await self.list_models()
+        if not models:
+            return RuntimeHealth(
+                runtime_id=self.id,
+                runtime_name=self.display_name,
+                status=RuntimeStatus.DEGRADED,
+                latency_ms=latency_ms,
+                message=_NO_MODELS_HINT,
+                checked_at=checked_at,
+            )
+
+        return RuntimeHealth(
+            runtime_id=self.id,
+            runtime_name=self.display_name,
+            status=RuntimeStatus.READY,
+            model_id=models[0].id,
+            latency_ms=latency_ms,
+            checked_at=checked_at,
+        )

--- a/services/convsim-core/convsim_core/runtime/ollama_adapter.py
+++ b/services/convsim-core/convsim_core/runtime/ollama_adapter.py
@@ -161,6 +161,16 @@ class OllamaChatRuntime(ChatRuntime):
                         output_tokens = chunk.get("eval_count", 0)
         except httpx.ConnectError as exc:
             raise RuntimeError(_NOT_RUNNING_HINT) from exc
+        except httpx.HTTPStatusError as exc:
+            code = exc.response.status_code
+            if code == 404:
+                raise RuntimeError(
+                    f"Model '{model_id}' was not found by Ollama. "
+                    f"Run 'ollama pull {model_id}' to install it."
+                ) from exc
+            raise RuntimeError(
+                f"Ollama returned an unexpected status {code} during generation."
+            ) from exc
 
         structured: dict[str, Any] | None = None
         if request.json_schema is not None:

--- a/services/convsim-core/convsim_core/runtime/ollama_adapter.py
+++ b/services/convsim-core/convsim_core/runtime/ollama_adapter.py
@@ -123,6 +123,13 @@ class OllamaChatRuntime(ChatRuntime):
         if not model_id:
             models = await self.list_models()
             if not models:
+                # list_models() silently returns [] on both connection failure and
+                # genuinely no models, so check reachability to give the right message.
+                try:
+                    resp = await self._client.get("/")
+                    resp.raise_for_status()
+                except (httpx.ConnectError, httpx.TimeoutException, httpx.HTTPStatusError):
+                    raise RuntimeError(_NOT_RUNNING_HINT)
                 raise RuntimeError(_NO_MODELS_HINT)
             model_id = models[0].id
 

--- a/services/convsim-core/convsim_core/runtime/ollama_adapter.py
+++ b/services/convsim-core/convsim_core/runtime/ollama_adapter.py
@@ -159,7 +159,7 @@ class OllamaChatRuntime(ChatRuntime):
                     if done:
                         input_tokens = chunk.get("prompt_eval_count", 0)
                         output_tokens = chunk.get("eval_count", 0)
-        except httpx.ConnectError as exc:
+        except (httpx.ConnectError, httpx.TimeoutException) as exc:
             raise RuntimeError(_NOT_RUNNING_HINT) from exc
         except httpx.HTTPStatusError as exc:
             code = exc.response.status_code

--- a/services/convsim-core/pyproject.toml
+++ b/services/convsim-core/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "uvicorn[standard]>=0.29.0",
     "pydantic>=2.7.0",
     "pydantic-settings>=2.3.0",
+    "httpx>=0.27.0",
 ]
 
 [project.optional-dependencies]

--- a/services/convsim-core/tests/test_ollama_runtime.py
+++ b/services/convsim-core/tests/test_ollama_runtime.py
@@ -1,0 +1,388 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the Ollama runtime adapter.  No real Ollama server is required."""
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+import convsim_core.runtime  # noqa: F401 — ensures built-in adapters are registered
+from convsim_core.runtime.ollama_adapter import (
+    OllamaChatRuntime,
+    _map_model_info,
+    _size_category,
+)
+from convsim_core.runtime.registry import list_runtime_ids
+from convsim_core.runtime.types import (
+    ChatFinal,
+    ChatMessage,
+    ChatRequest,
+    ChatToken,
+    RuntimeStatus,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_response(json_data):
+    """Mock a successful httpx GET response with a JSON body."""
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json = MagicMock(return_value=json_data)
+    return resp
+
+
+class _StreamContext:
+    """Async context manager that replays a fixed list of NDJSON lines."""
+
+    def __init__(self, lines: list[str]) -> None:
+        self._lines = lines
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    def raise_for_status(self) -> None:
+        pass
+
+    async def aiter_lines(self):
+        for line in self._lines:
+            yield line
+
+
+def _make_runtime(*, get_json=None, stream_lines=None, connect_error=False):
+    """Build an OllamaChatRuntime with injected httpx mock."""
+    client = MagicMock()
+    if connect_error:
+        client.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
+    elif get_json is not None:
+        client.get = AsyncMock(return_value=_get_response(get_json))
+    if stream_lines is not None:
+        client.stream = MagicMock(return_value=_StreamContext(stream_lines))
+    return OllamaChatRuntime(client=client)
+
+
+# ---------------------------------------------------------------------------
+# Utility function unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_size_category_small():
+    assert _size_category(2 * 1024**3) == "small"
+
+
+def test_size_category_medium():
+    assert _size_category(6 * 1024**3) == "medium"
+
+
+def test_size_category_large():
+    assert _size_category(15 * 1024**3) == "large"
+
+
+def test_size_category_none_input():
+    assert _size_category(None) is None
+
+
+def test_map_model_info_name_and_size():
+    info = _map_model_info({"name": "llama3.2:latest", "size": 2_100_000_000})
+    assert info.id == "llama3.2:latest"
+    assert info.name == "llama3.2:latest"
+    assert info.size_category == "small"
+    assert info.context_length is None
+
+
+def test_map_model_info_large_model():
+    info = _map_model_info({"name": "llama2:70b", "size": 40 * 1024**3})
+    assert info.size_category == "large"
+
+
+def test_map_model_info_missing_size():
+    info = _map_model_info({"name": "codellama:latest"})
+    assert info.size_category is None
+
+
+# ---------------------------------------------------------------------------
+# list_models tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_models_maps_api_response():
+    runtime = _make_runtime(
+        get_json={
+            "models": [
+                {"name": "llama3.2:latest", "size": 2_100_000_000},
+                {"name": "mistral:7b", "size": 5_000_000_000},
+            ]
+        }
+    )
+    models = await runtime.list_models()
+    assert len(models) == 2
+    assert models[0].id == "llama3.2:latest"
+    assert models[0].size_category == "small"
+    assert models[1].id == "mistral:7b"
+    assert models[1].size_category == "medium"
+
+
+@pytest.mark.asyncio
+async def test_list_models_empty_when_none_installed():
+    runtime = _make_runtime(get_json={"models": []})
+    assert await runtime.list_models() == []
+
+
+@pytest.mark.asyncio
+async def test_list_models_empty_on_connection_error():
+    runtime = _make_runtime(connect_error=True)
+    assert await runtime.list_models() == []
+
+
+@pytest.mark.asyncio
+async def test_list_models_empty_on_http_error():
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock(
+        side_effect=httpx.HTTPStatusError("500", request=MagicMock(), response=MagicMock())
+    )
+    client = MagicMock()
+    client.get = AsyncMock(return_value=resp)
+    runtime = OllamaChatRuntime(client=client)
+    assert await runtime.list_models() == []
+
+
+# ---------------------------------------------------------------------------
+# chat_stream tests
+# ---------------------------------------------------------------------------
+
+_STREAM_LINES = [
+    json.dumps(
+        {"model": "llama3.2", "message": {"role": "assistant", "content": "Hello "}, "done": False}
+    ),
+    json.dumps(
+        {"model": "llama3.2", "message": {"role": "assistant", "content": "world"}, "done": False}
+    ),
+    json.dumps(
+        {
+            "model": "llama3.2",
+            "message": {"role": "assistant", "content": ""},
+            "done": True,
+            "prompt_eval_count": 5,
+            "eval_count": 2,
+        }
+    ),
+]
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_yields_tokens_then_final():
+    runtime = _make_runtime(stream_lines=_STREAM_LINES)
+    request = ChatRequest(
+        model_id="llama3.2:latest",
+        messages=[ChatMessage(role="user", content="hello")],
+    )
+    chunks = []
+    async for chunk in runtime.chat_stream(request):
+        chunks.append(chunk)
+
+    tokens = [c for c in chunks if isinstance(c, ChatToken)]
+    finals = [c for c in chunks if isinstance(c, ChatFinal)]
+
+    assert len(tokens) == 2
+    assert tokens[0].text == "Hello "
+    assert tokens[1].text == "world"
+    assert len(finals) == 1
+    assert finals[0].text == "Hello world"
+    assert finals[0].model_id == "llama3.2:latest"
+    assert finals[0].input_tokens == 5
+    assert finals[0].output_tokens == 2
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_final_text_matches_joined_tokens():
+    runtime = _make_runtime(stream_lines=_STREAM_LINES)
+    request = ChatRequest(
+        model_id="llama3.2:latest",
+        messages=[ChatMessage(role="user", content="hello")],
+    )
+    token_texts = []
+    final = None
+    async for chunk in runtime.chat_stream(request):
+        if isinstance(chunk, ChatToken):
+            token_texts.append(chunk.text)
+        elif isinstance(chunk, ChatFinal):
+            final = chunk
+
+    assert final is not None
+    assert "".join(token_texts) == final.text
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_structured_output_when_schema_provided():
+    payload = {"npc_utterance": "Hello!", "safety": {"status": "ok"}}
+    structured_lines = [
+        json.dumps(
+            {
+                "model": "llama3.2",
+                "message": {"role": "assistant", "content": json.dumps(payload)},
+                "done": False,
+            }
+        ),
+        json.dumps(
+            {
+                "model": "llama3.2",
+                "message": {"role": "assistant", "content": ""},
+                "done": True,
+                "prompt_eval_count": 3,
+                "eval_count": 5,
+            }
+        ),
+    ]
+    runtime = _make_runtime(stream_lines=structured_lines)
+    request = ChatRequest(
+        model_id="llama3.2:latest",
+        messages=[ChatMessage(role="user", content="go")],
+        json_schema={"type": "object"},
+    )
+    final = None
+    async for chunk in runtime.chat_stream(request):
+        if isinstance(chunk, ChatFinal):
+            final = chunk
+
+    assert final is not None
+    assert final.structured is not None
+    assert final.structured["npc_utterance"] == "Hello!"
+    assert "safety" in final.structured
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_no_structured_output_without_schema():
+    runtime = _make_runtime(stream_lines=_STREAM_LINES)
+    request = ChatRequest(
+        model_id="llama3.2:latest",
+        messages=[ChatMessage(role="user", content="hello")],
+    )
+    final = None
+    async for chunk in runtime.chat_stream(request):
+        if isinstance(chunk, ChatFinal):
+            final = chunk
+
+    assert final is not None
+    assert final.structured is None
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_raises_on_connection_error():
+    client = MagicMock()
+    client.stream = MagicMock(side_effect=httpx.ConnectError("refused"))
+    runtime = OllamaChatRuntime(client=client)
+    request = ChatRequest(
+        model_id="llama3.2:latest",
+        messages=[ChatMessage(role="user", content="hello")],
+    )
+    with pytest.raises(RuntimeError, match="[Oo]llama"):
+        async for _ in runtime.chat_stream(request):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_raises_when_no_models_and_no_model_id():
+    runtime = _make_runtime(get_json={"models": []})
+    request = ChatRequest(messages=[ChatMessage(role="user", content="hello")])
+    with pytest.raises(RuntimeError, match="[Mm]odel"):
+        async for _ in runtime.chat_stream(request):
+            pass
+
+
+# ---------------------------------------------------------------------------
+# health tests
+# ---------------------------------------------------------------------------
+
+
+def _dual_get_client(root_json, tags_json):
+    """Build a mock client that routes GET / and GET /api/tags to different responses."""
+    root_resp = _get_response(root_json)
+    tags_resp = _get_response(tags_json)
+
+    async def _get(path):
+        if path == "/":
+            return root_resp
+        return tags_resp
+
+    client = MagicMock()
+    client.get = _get
+    return client
+
+
+@pytest.mark.asyncio
+async def test_health_ready_when_running_with_models():
+    client = _dual_get_client(
+        root_json=None,
+        tags_json={"models": [{"name": "llama3.2:latest", "size": 2_100_000_000}]},
+    )
+    runtime = OllamaChatRuntime(client=client)
+    health = await runtime.health()
+
+    assert health.status == RuntimeStatus.READY
+    assert health.model_id == "llama3.2:latest"
+    assert health.latency_ms is not None
+    assert health.runtime_id == "ollama"
+    assert health.checked_at
+
+
+@pytest.mark.asyncio
+async def test_health_unavailable_when_not_running():
+    client = MagicMock()
+    client.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
+    runtime = OllamaChatRuntime(client=client)
+    health = await runtime.health()
+
+    assert health.status == RuntimeStatus.UNAVAILABLE
+    assert health.message is not None
+    assert health.runtime_id == "ollama"
+
+
+@pytest.mark.asyncio
+async def test_health_degraded_when_no_models():
+    client = _dual_get_client(root_json=None, tags_json={"models": []})
+    runtime = OllamaChatRuntime(client=client)
+    health = await runtime.health()
+
+    assert health.status == RuntimeStatus.DEGRADED
+    assert health.message is not None
+    assert health.latency_ms is not None
+
+
+# ---------------------------------------------------------------------------
+# Adapter identity and capability tests
+# ---------------------------------------------------------------------------
+
+
+def test_ollama_runtime_id():
+    runtime = OllamaChatRuntime(base_url="http://127.0.0.1:11434")
+    assert runtime.id == "ollama"
+
+
+def test_ollama_runtime_display_name_contains_ollama():
+    runtime = OllamaChatRuntime(base_url="http://127.0.0.1:11434")
+    assert "Ollama" in runtime.display_name
+
+
+def test_ollama_runtime_capabilities():
+    caps = OllamaChatRuntime(base_url="http://127.0.0.1:11434").capabilities
+    assert caps.streaming is True
+    assert caps.json_schema is True
+    assert caps.grammar is False
+    assert caps.tool_calling is False
+    assert caps.embeddings is False
+
+
+def test_ollama_is_registered():
+    assert "ollama" in list_runtime_ids()
+
+
+def test_runtime_ids_remain_sorted():
+    ids = list_runtime_ids()
+    assert ids == sorted(ids)

--- a/services/convsim-core/tests/test_ollama_runtime.py
+++ b/services/convsim-core/tests/test_ollama_runtime.py
@@ -296,6 +296,70 @@ async def test_chat_stream_raises_when_no_models_and_no_model_id():
             pass
 
 
+@pytest.mark.asyncio
+async def test_chat_stream_raises_runtime_error_on_404():
+    """A 404 from Ollama (model not found) should raise RuntimeError, not HTTPStatusError."""
+
+    class _Http404StreamContext:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        def raise_for_status(self):
+            mock_resp = MagicMock()
+            mock_resp.status_code = 404
+            raise httpx.HTTPStatusError("404", request=MagicMock(), response=mock_resp)
+
+        async def aiter_lines(self):
+            return
+            yield  # pragma: no cover — makes this a valid async generator
+
+    client = MagicMock()
+    client.stream = MagicMock(return_value=_Http404StreamContext())
+    runtime = OllamaChatRuntime(client=client)
+    request = ChatRequest(
+        model_id="nonexistent:latest",
+        messages=[ChatMessage(role="user", content="hello")],
+    )
+    with pytest.raises(RuntimeError, match="[Mm]odel"):
+        async for _ in runtime.chat_stream(request):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_raises_runtime_error_on_server_error():
+    """A 5xx from Ollama during generation should raise RuntimeError, not HTTPStatusError."""
+
+    class _Http500StreamContext:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        def raise_for_status(self):
+            mock_resp = MagicMock()
+            mock_resp.status_code = 500
+            raise httpx.HTTPStatusError("500", request=MagicMock(), response=mock_resp)
+
+        async def aiter_lines(self):
+            return
+            yield  # pragma: no cover
+
+    client = MagicMock()
+    client.stream = MagicMock(return_value=_Http500StreamContext())
+    runtime = OllamaChatRuntime(client=client)
+    request = ChatRequest(
+        model_id="llama3.2:latest",
+        messages=[ChatMessage(role="user", content="hello")],
+    )
+    with pytest.raises(RuntimeError, match="500"):
+        async for _ in runtime.chat_stream(request):
+            pass
+
+
 # ---------------------------------------------------------------------------
 # health tests
 # ---------------------------------------------------------------------------

--- a/services/convsim-core/tests/test_ollama_runtime.py
+++ b/services/convsim-core/tests/test_ollama_runtime.py
@@ -288,6 +288,21 @@ async def test_chat_stream_raises_on_connection_error():
 
 
 @pytest.mark.asyncio
+async def test_chat_stream_raises_runtime_error_on_timeout():
+    """A timeout during generation should raise RuntimeError, not TimeoutException."""
+    client = MagicMock()
+    client.stream = MagicMock(side_effect=httpx.TimeoutException("timed out"))
+    runtime = OllamaChatRuntime(client=client)
+    request = ChatRequest(
+        model_id="llama3.2:latest",
+        messages=[ChatMessage(role="user", content="hello")],
+    )
+    with pytest.raises(RuntimeError, match="[Oo]llama"):
+        async for _ in runtime.chat_stream(request):
+            pass
+
+
+@pytest.mark.asyncio
 async def test_chat_stream_raises_when_no_models_and_no_model_id():
     runtime = _make_runtime(get_json={"models": []})
     request = ChatRequest(messages=[ChatMessage(role="user", content="hello")])

--- a/services/convsim-core/tests/test_ollama_runtime.py
+++ b/services/convsim-core/tests/test_ollama_runtime.py
@@ -312,6 +312,17 @@ async def test_chat_stream_raises_when_no_models_and_no_model_id():
 
 
 @pytest.mark.asyncio
+async def test_chat_stream_raises_not_running_when_ollama_down_and_no_model_id():
+    """When Ollama is unreachable *and* no model_id is supplied, the error must
+    say the server is not reachable — not that it has no models installed."""
+    runtime = _make_runtime(connect_error=True)
+    request = ChatRequest(messages=[ChatMessage(role="user", content="hello")])
+    with pytest.raises(RuntimeError, match="[Oo]llama"):
+        async for _ in runtime.chat_stream(request):
+            pass
+
+
+@pytest.mark.asyncio
 async def test_chat_stream_raises_runtime_error_on_404():
     """A 404 from Ollama (model not found) should raise RuntimeError, not HTTPStatusError."""
 


### PR DESCRIPTION
## Summary

Implements `OllamaChatRuntime`, a `ChatRuntime` adapter that communicates with a local Ollama server via its HTTP REST API. The Ollama SDK is intentionally not imported, so `convsim_core` remains importable on machines without the `ollama` package and the architecture guard (`test_convsim_core_does_not_import_ollama`) stays green.

## What changed

**New files:**
- **`convsim_core/runtime/ollama_adapter.py`** — The adapter implementation with:
  - `list_models()` — Calls `GET /api/tags`, maps each entry to `ModelInfo`, and categorizes model sizes into coarse buckets (small < 4 GiB, medium < 12 GiB, large ≥ 12 GiB).
  - `chat_stream()` — Streams from `POST /api/chat` with `stream: true`, yielding `ChatToken` chunks as they arrive and a single `ChatFinal` at the end. Supports JSON schema output via Ollama's `format` field, with automatic parsing back into the `structured` field.
  - `health()` — Distinguishes three states: `UNAVAILABLE` (server unreachable, includes setup instructions), `DEGRADED` (server up but no models installed, includes pull instructions), and `READY`.
  - Base URL defaults to `http://127.0.0.1:11434` and can be overridden via `CONVSIM_OLLAMA_BASE_URL` environment variable or constructor argument.

- **`tests/test_ollama_runtime.py`** — 29 tests covering:
  - Size-category bucketing and model-info mapping (unit tests).
  - `list_models` response parsing, graceful empty-list returns on connection/HTTP errors.
  - Streaming chat: token sequence correctness, final text equality, JSON schema round-trip, structured output only when schema is provided, proper error messages on connection failure and missing models.
  - Health endpoint: ready state with models, unavailable when server is down, degraded when server runs but has no models.
  - Adapter properties and registry registration.

**Modified files:**
- **`convsim_core/runtime/__init__.py`** — Added import of `ollama_adapter` to trigger the `@register("ollama")` decorator.
- **`convsim_core/config.py`** — Added `ollama_base_url` configuration field so the setting is documented in `ServiceConfig` and readable via `CONVSIM_OLLAMA_BASE_URL`.
- **`pyproject.toml`** — Promoted `httpx>=0.27.0` from dev-only to a main runtime dependency (required by the adapter).

## Testing

- Full pytest suite: **325 passed, 1 skipped** (the skip is a pre-existing unrelated test).
- Architecture guard `test_convsim_core_does_not_import_ollama` continues to pass — the `ollama` package never appears in `sys.modules`.
- All Ollama tests mock `httpx.AsyncClient`, so no real Ollama installation is required in CI.
- Error handling verified: connection failures, timeout exceptions, HTTP 404 (model not found), and HTTP 5xx responses all raise appropriate `RuntimeError` with user-friendly guidance.

## Notes

- No external network contact: the adapter only contacts the loopback address.
- Auto-model-selection: if no `model_id` is specified in the request, the adapter automatically selects the first available model and distinguishes between "server unreachable" and "server running but no models installed" to provide the correct remediation hint.

Closes #11