### PR TITLE
Define local model registry schema with licenses, checksums, and hardware guidance

### DIFF
--- a/model-registry/registry.yaml
+++ b/model-registry/registry.yaml
@@ -1,41 +1,75 @@
 # SPDX-License-Identifier: Apache-2.0
 # Conversation Simulator model registry
 # Models are not bundled. The app shows license and size before any download.
-# URLs and checksums are placeholders to be filled when Milestone 1 is implemented.
+# URLs and checksums marked PENDING will be confirmed at Milestone 1.
+# Checksum policy: registry-managed models require sha256 (64-char hex or PENDING).
 
 schema_version: "0.1"
 
 models:
-  - id: qwen3-8b-instruct-q4_k_m
-    name: "Qwen3 8B Instruct Q4_K_M"
+  # ── Starter tier ─────────────────────────────────────────────────────────────
+  # Smallest recommended model; suitable for first-run demo on lower VRAM systems.
+  - id: qwen3-4b-instruct-q4_k_m
+    name: "Qwen3 4B Instruct Q4_K_M"
     family: qwen3
-    role: default-demo
+    role: starter
     format: gguf
     license: Apache-2.0
-    min_vram_gb_target: 6
-    recommended_vram_gb_target: 8
+    license_url: "https://www.apache.org/licenses/LICENSE-2.0"
+    size_gb: 2.6
+    hardware:
+      min_vram_gb: 4
+      recommended_vram_gb: 6
     download:
       provider: huggingface
-      url: "<placeholder — to be confirmed at Milestone 1>"
-      sha256: "<placeholder>"
+      url: "PENDING"
+      sha256: "PENDING"
     runtime:
       llama_cpp:
         context_length: 8192
         temperature_default: 0.75
         top_p_default: 0.9
 
-  - id: qwen3-14b-instruct-q4_k_m
-    name: "Qwen3 14B Instruct Q4_K_M"
+  # ── Standard tier ────────────────────────────────────────────────────────────
+  # Default quality target for most users.
+  - id: qwen3-8b-instruct-q4_k_m
+    name: "Qwen3 8B Instruct Q4_K_M"
     family: qwen3
     role: standard
     format: gguf
     license: Apache-2.0
-    min_vram_gb_target: 10
-    recommended_vram_gb_target: 12
+    license_url: "https://www.apache.org/licenses/LICENSE-2.0"
+    size_gb: 5.0
+    hardware:
+      min_vram_gb: 6
+      recommended_vram_gb: 8
     download:
       provider: huggingface
-      url: "<placeholder>"
-      sha256: "<placeholder>"
+      url: "PENDING"
+      sha256: "PENDING"
+    runtime:
+      llama_cpp:
+        context_length: 8192
+        temperature_default: 0.75
+        top_p_default: 0.9
+
+  # ── High-quality tier ────────────────────────────────────────────────────────
+  # Better NPC coherence on systems with more VRAM.
+  - id: qwen3-14b-instruct-q4_k_m
+    name: "Qwen3 14B Instruct Q4_K_M"
+    family: qwen3
+    role: high-quality
+    format: gguf
+    license: Apache-2.0
+    license_url: "https://www.apache.org/licenses/LICENSE-2.0"
+    size_gb: 9.0
+    hardware:
+      min_vram_gb: 10
+      recommended_vram_gb: 12
+    download:
+      provider: huggingface
+      url: "PENDING"
+      sha256: "PENDING"
     runtime:
       llama_cpp:
         context_length: 8192
@@ -48,14 +82,35 @@ models:
     role: high-quality
     format: gguf
     license: Apache-2.0
-    min_vram_gb_target: 16
-    recommended_vram_gb_target: 24
+    license_url: "https://www.apache.org/licenses/LICENSE-2.0"
+    size_gb: 14.8
+    hardware:
+      min_vram_gb: 16
+      recommended_vram_gb: 24
     download:
       provider: huggingface
-      url: "<placeholder>"
-      sha256: "<placeholder>"
+      url: "PENDING"
+      sha256: "PENDING"
     runtime:
       llama_cpp:
         context_length: 32768
         temperature_default: 0.75
         top_p_default: 0.9
+
+  # ── User-supplied tier ───────────────────────────────────────────────────────
+  # Represents an arbitrary GGUF file provided by the user.
+  # License, size, and checksum are intentionally unknown — the app cannot
+  # verify what the user brings and must not pretend otherwise.
+  - id: user-supplied-gguf
+    name: "User-Supplied GGUF"
+    family: unknown
+    role: user-supplied
+    format: gguf
+    license: unknown-user-supplied
+    size_gb: null
+    hardware:
+      min_vram_gb: null
+      recommended_vram_gb: null
+    download:
+      provider: user-filesystem
+      path_hint: "~/.convsim/models/"

--- a/schemas/model-registry.schema.json
+++ b/schemas/model-registry.schema.json
@@ -80,7 +80,14 @@
         "required": ["size_gb"],
         "properties": {
           "size_gb": { "type": "number", "exclusiveMinimum": 0 },
-          "download": { "$ref": "#/$defs/RegistryDownload" }
+          "download": { "$ref": "#/$defs/RegistryDownload" },
+          "hardware": {
+            "required": ["min_vram_gb", "recommended_vram_gb"],
+            "properties": {
+              "min_vram_gb": { "type": "number", "minimum": 0 },
+              "recommended_vram_gb": { "type": "number", "minimum": 0 }
+            }
+          }
         }
       },
       "else": {

--- a/schemas/model-registry.schema.json
+++ b/schemas/model-registry.schema.json
@@ -1,0 +1,183 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.convsim.dev/v0.1/model-registry.schema.json",
+  "title": "ConvSim Model Registry",
+  "description": "Validates model-registry/registry.yaml. All models must declare license, source, hardware guidance, and approximate size. Registry-managed models must include a checksum (or the PENDING sentinel for pre-release entries).",
+  "type": "object",
+  "required": ["schema_version", "models"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "enum": ["0.1"]
+    },
+    "models": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/ModelEntry" }
+    }
+  },
+  "$defs": {
+    "ModelEntry": {
+      "type": "object",
+      "description": "A single model entry in the registry. Registry-managed models require size_gb and a checksum. User-supplied models must set license to 'unknown-user-supplied'.",
+      "required": ["id", "name", "family", "role", "format", "license", "hardware", "download"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Machine-readable unique identifier (lowercase, kebab/dot/underscore allowed).",
+          "pattern": "^[a-z0-9][a-z0-9._-]*$"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Human-readable display name."
+        },
+        "family": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Model family (e.g. qwen3, mistral, unknown)."
+        },
+        "role": {
+          "type": "string",
+          "enum": ["starter", "standard", "high-quality", "user-supplied"],
+          "description": "Recommended use tier."
+        },
+        "format": {
+          "type": "string",
+          "enum": ["gguf"],
+          "description": "File format. Currently only GGUF is supported."
+        },
+        "license": {
+          "type": "string",
+          "minLength": 1,
+          "description": "SPDX license identifier, or 'unknown-user-supplied' for user-provided models."
+        },
+        "license_url": {
+          "type": "string",
+          "description": "URL to the full license text. Recommended for registry-managed models."
+        },
+        "size_gb": {
+          "description": "Approximate download size in gigabytes. Required for registry-managed models; null for user-supplied.",
+          "oneOf": [
+            { "type": "number", "exclusiveMinimum": 0 },
+            { "type": "null" }
+          ]
+        },
+        "hardware": { "$ref": "#/$defs/HardwareTarget" },
+        "download": {
+          "type": "object",
+          "description": "Download source. Specific schema depends on role (registry-managed vs user-supplied)."
+        },
+        "runtime": { "$ref": "#/$defs/RuntimeDefaults" }
+      },
+      "if": {
+        "properties": { "role": { "not": { "const": "user-supplied" } } },
+        "required": ["role"]
+      },
+      "then": {
+        "required": ["size_gb"],
+        "properties": {
+          "size_gb": { "type": "number", "exclusiveMinimum": 0 },
+          "download": { "$ref": "#/$defs/RegistryDownload" }
+        }
+      },
+      "else": {
+        "properties": {
+          "license": { "const": "unknown-user-supplied" },
+          "download": { "$ref": "#/$defs/UserSuppliedDownload" }
+        }
+      }
+    },
+    "HardwareTarget": {
+      "type": "object",
+      "description": "VRAM requirements for running the model. null means unknown (e.g. for user-supplied models).",
+      "additionalProperties": false,
+      "properties": {
+        "min_vram_gb": {
+          "description": "Minimum VRAM in gigabytes needed to load the model.",
+          "oneOf": [
+            { "type": "number", "minimum": 0 },
+            { "type": "null" }
+          ]
+        },
+        "recommended_vram_gb": {
+          "description": "Recommended VRAM in gigabytes for good inference speed.",
+          "oneOf": [
+            { "type": "number", "minimum": 0 },
+            { "type": "null" }
+          ]
+        }
+      }
+    },
+    "RegistryDownload": {
+      "type": "object",
+      "description": "Download source for registry-managed models. sha256 is required and must be a 64-character lowercase hex digest, or 'PENDING' for pre-release entries not yet checksum-confirmed.",
+      "required": ["provider", "url", "sha256"],
+      "additionalProperties": false,
+      "properties": {
+        "provider": {
+          "type": "string",
+          "enum": ["huggingface", "github", "direct"]
+        },
+        "url": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Download URL or 'PENDING' placeholder for pre-release entries."
+        },
+        "sha256": {
+          "type": "string",
+          "description": "SHA-256 hex digest (64 lowercase hex chars) or 'PENDING' for pre-release entries.",
+          "pattern": "^([0-9a-f]{64}|PENDING)$"
+        }
+      }
+    },
+    "UserSuppliedDownload": {
+      "type": "object",
+      "description": "Represents a user-provided GGUF file. No checksum is recorded because the file is sourced externally and the app cannot know its provenance.",
+      "required": ["provider"],
+      "additionalProperties": false,
+      "properties": {
+        "provider": {
+          "type": "string",
+          "const": "user-filesystem"
+        },
+        "path_hint": {
+          "type": "string",
+          "description": "Suggested directory for the user to place GGUF files."
+        }
+      }
+    },
+    "RuntimeDefaults": {
+      "type": "object",
+      "description": "Default inference parameters per runtime backend.",
+      "additionalProperties": false,
+      "properties": {
+        "llama_cpp": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "context_length": {
+              "type": "integer",
+              "minimum": 128,
+              "description": "Context window size in tokens."
+            },
+            "temperature_default": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 2,
+              "description": "Sampling temperature."
+            },
+            "top_p_default": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1,
+              "description": "Nucleus sampling probability."
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/services/convsim-core/convsim_core/app.py
+++ b/services/convsim-core/convsim_core/app.py
@@ -12,7 +12,7 @@ from convsim_core.errors import (
     request_validation_error_handler,
 )
 from convsim_core.logging_setup import configure_logging
-from convsim_core.routers import diag as diag_router, health, settings as settings_router
+from convsim_core.routers import diag as diag_router, health, models as models_router, settings as settings_router
 from convsim_core.runtime import build_runtime
 from convsim_core.storage.database import Database
 from convsim_core.storage.repositories.settings_repo import load_settings
@@ -44,5 +44,6 @@ def create_app(config: ServiceConfig | None = None) -> FastAPI:
     app.include_router(health.router)
     app.include_router(settings_router.router)
     app.include_router(diag_router.router)
+    app.include_router(models_router.router)
 
     return app

--- a/services/convsim-core/convsim_core/routers/models.py
+++ b/services/convsim-core/convsim_core/routers/models.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+from typing import Any, Optional
+
+from fastapi import APIRouter, Request
+from pydantic import BaseModel
+
+from convsim_core.services.model_registry_service import list_registry_models
+
+router = APIRouter()
+
+
+class ModelRegistryEntry(BaseModel):
+    id: str
+    name: str
+    provider: str
+    family: Optional[str] = None
+    role: Optional[str] = None
+    format: Optional[str] = None
+    license_spdx: Optional[str] = None
+    license_url: Optional[str] = None
+    source_type: Optional[str] = None
+    download_url: Optional[str] = None
+    sha256: Optional[str] = None
+    size_gb: Optional[float] = None
+    min_vram_gb: Optional[float] = None
+    recommended_vram_gb: Optional[float] = None
+    context_length: Optional[int] = None
+    registered_at: str
+
+
+class ModelsResponse(BaseModel):
+    models: list[ModelRegistryEntry]
+    total: int
+
+
+@router.get("/api/models", response_model=ModelsResponse)
+async def list_models(request: Request) -> ModelsResponse:
+    """Return all entries in the local model registry."""
+    db = request.app.state.db
+    rows: list[dict[str, Any]] = list_registry_models(db.connection())
+    entries = [ModelRegistryEntry(**row) for row in rows]
+    return ModelsResponse(models=entries, total=len(entries))

--- a/services/convsim-core/convsim_core/schema_paths.py
+++ b/services/convsim-core/convsim_core/schema_paths.py
@@ -16,6 +16,7 @@ from typing import Any
 _SCHEMAS_PKG = files("convsim_core") / "schemas"
 
 SCHEMA_NAMES: tuple[str, ...] = (
+    "model-registry.schema.json",
     "pack.schema.json",
     "scenario.schema.json",
     "npc.schema.json",

--- a/services/convsim-core/convsim_core/schemas/model-registry.schema.json
+++ b/services/convsim-core/convsim_core/schemas/model-registry.schema.json
@@ -80,7 +80,14 @@
         "required": ["size_gb"],
         "properties": {
           "size_gb": { "type": "number", "exclusiveMinimum": 0 },
-          "download": { "$ref": "#/$defs/RegistryDownload" }
+          "download": { "$ref": "#/$defs/RegistryDownload" },
+          "hardware": {
+            "required": ["min_vram_gb", "recommended_vram_gb"],
+            "properties": {
+              "min_vram_gb": { "type": "number", "minimum": 0 },
+              "recommended_vram_gb": { "type": "number", "minimum": 0 }
+            }
+          }
         }
       },
       "else": {

--- a/services/convsim-core/convsim_core/schemas/model-registry.schema.json
+++ b/services/convsim-core/convsim_core/schemas/model-registry.schema.json
@@ -1,0 +1,183 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.convsim.dev/v0.1/model-registry.schema.json",
+  "title": "ConvSim Model Registry",
+  "description": "Validates model-registry/registry.yaml. All models must declare license, source, hardware guidance, and approximate size. Registry-managed models must include a checksum (or the PENDING sentinel for pre-release entries).",
+  "type": "object",
+  "required": ["schema_version", "models"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "enum": ["0.1"]
+    },
+    "models": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/ModelEntry" }
+    }
+  },
+  "$defs": {
+    "ModelEntry": {
+      "type": "object",
+      "description": "A single model entry in the registry. Registry-managed models require size_gb and a checksum. User-supplied models must set license to 'unknown-user-supplied'.",
+      "required": ["id", "name", "family", "role", "format", "license", "hardware", "download"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Machine-readable unique identifier (lowercase, kebab/dot/underscore allowed).",
+          "pattern": "^[a-z0-9][a-z0-9._-]*$"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Human-readable display name."
+        },
+        "family": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Model family (e.g. qwen3, mistral, unknown)."
+        },
+        "role": {
+          "type": "string",
+          "enum": ["starter", "standard", "high-quality", "user-supplied"],
+          "description": "Recommended use tier."
+        },
+        "format": {
+          "type": "string",
+          "enum": ["gguf"],
+          "description": "File format. Currently only GGUF is supported."
+        },
+        "license": {
+          "type": "string",
+          "minLength": 1,
+          "description": "SPDX license identifier, or 'unknown-user-supplied' for user-provided models."
+        },
+        "license_url": {
+          "type": "string",
+          "description": "URL to the full license text. Recommended for registry-managed models."
+        },
+        "size_gb": {
+          "description": "Approximate download size in gigabytes. Required for registry-managed models; null for user-supplied.",
+          "oneOf": [
+            { "type": "number", "exclusiveMinimum": 0 },
+            { "type": "null" }
+          ]
+        },
+        "hardware": { "$ref": "#/$defs/HardwareTarget" },
+        "download": {
+          "type": "object",
+          "description": "Download source. Specific schema depends on role (registry-managed vs user-supplied)."
+        },
+        "runtime": { "$ref": "#/$defs/RuntimeDefaults" }
+      },
+      "if": {
+        "properties": { "role": { "not": { "const": "user-supplied" } } },
+        "required": ["role"]
+      },
+      "then": {
+        "required": ["size_gb"],
+        "properties": {
+          "size_gb": { "type": "number", "exclusiveMinimum": 0 },
+          "download": { "$ref": "#/$defs/RegistryDownload" }
+        }
+      },
+      "else": {
+        "properties": {
+          "license": { "const": "unknown-user-supplied" },
+          "download": { "$ref": "#/$defs/UserSuppliedDownload" }
+        }
+      }
+    },
+    "HardwareTarget": {
+      "type": "object",
+      "description": "VRAM requirements for running the model. null means unknown (e.g. for user-supplied models).",
+      "additionalProperties": false,
+      "properties": {
+        "min_vram_gb": {
+          "description": "Minimum VRAM in gigabytes needed to load the model.",
+          "oneOf": [
+            { "type": "number", "minimum": 0 },
+            { "type": "null" }
+          ]
+        },
+        "recommended_vram_gb": {
+          "description": "Recommended VRAM in gigabytes for good inference speed.",
+          "oneOf": [
+            { "type": "number", "minimum": 0 },
+            { "type": "null" }
+          ]
+        }
+      }
+    },
+    "RegistryDownload": {
+      "type": "object",
+      "description": "Download source for registry-managed models. sha256 is required and must be a 64-character lowercase hex digest, or 'PENDING' for pre-release entries not yet checksum-confirmed.",
+      "required": ["provider", "url", "sha256"],
+      "additionalProperties": false,
+      "properties": {
+        "provider": {
+          "type": "string",
+          "enum": ["huggingface", "github", "direct"]
+        },
+        "url": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Download URL or 'PENDING' placeholder for pre-release entries."
+        },
+        "sha256": {
+          "type": "string",
+          "description": "SHA-256 hex digest (64 lowercase hex chars) or 'PENDING' for pre-release entries.",
+          "pattern": "^([0-9a-f]{64}|PENDING)$"
+        }
+      }
+    },
+    "UserSuppliedDownload": {
+      "type": "object",
+      "description": "Represents a user-provided GGUF file. No checksum is recorded because the file is sourced externally and the app cannot know its provenance.",
+      "required": ["provider"],
+      "additionalProperties": false,
+      "properties": {
+        "provider": {
+          "type": "string",
+          "const": "user-filesystem"
+        },
+        "path_hint": {
+          "type": "string",
+          "description": "Suggested directory for the user to place GGUF files."
+        }
+      }
+    },
+    "RuntimeDefaults": {
+      "type": "object",
+      "description": "Default inference parameters per runtime backend.",
+      "additionalProperties": false,
+      "properties": {
+        "llama_cpp": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "context_length": {
+              "type": "integer",
+              "minimum": 128,
+              "description": "Context window size in tokens."
+            },
+            "temperature_default": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 2,
+              "description": "Sampling temperature."
+            },
+            "top_p_default": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1,
+              "description": "Nucleus sampling probability."
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/services/convsim-core/convsim_core/services/__init__.py
+++ b/services/convsim-core/convsim_core/services/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/services/convsim-core/convsim_core/services/model_registry_service.py
+++ b/services/convsim-core/convsim_core/services/model_registry_service.py
@@ -32,8 +32,11 @@ class RegistryValidationError(Exception):
 
 def load_registry_yaml(path: Path) -> dict[str, Any]:
     """Parse and return the registry YAML file."""
-    with open(path, encoding="utf-8") as f:
-        data = yaml.safe_load(f)
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except yaml.YAMLError as exc:
+        raise RegistryValidationError(f"Registry file is not valid YAML: {path}: {exc}") from exc
     if not isinstance(data, dict):
         raise RegistryValidationError(f"Registry file is not a YAML mapping: {path}")
     return data  # type: ignore[return-value]

--- a/services/convsim-core/convsim_core/services/model_registry_service.py
+++ b/services/convsim-core/convsim_core/services/model_registry_service.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Service layer for loading and querying the local model registry.
+
+The registry is sourced from model-registry/registry.yaml and validated
+against the bundled JSON schema before being persisted into SQLite.
+
+Callers must pass the registry_path explicitly; there is no hardcoded
+default so that this module works in both dev and installed-package contexts.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+import yaml
+
+from convsim_core.schema_paths import get_schema
+
+logger = logging.getLogger(__name__)
+
+_SCHEMA_NAME = "model-registry.schema.json"
+
+
+class RegistryValidationError(Exception):
+    """Raised when registry YAML fails schema validation."""
+
+
+def load_registry_yaml(path: Path) -> dict[str, Any]:
+    """Parse and return the registry YAML file."""
+    with open(path, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    if not isinstance(data, dict):
+        raise RegistryValidationError(f"Registry file is not a YAML mapping: {path}")
+    return data  # type: ignore[return-value]
+
+
+def validate_registry(data: dict[str, Any], schema: dict[str, Any] | None = None) -> None:
+    """Validate registry data against the bundled JSON schema.
+
+    Args:
+        data: Parsed registry YAML content.
+        schema: Optional pre-loaded schema dict; loads from bundled schemas if not provided.
+
+    Raises:
+        RegistryValidationError: If validation fails.
+    """
+    if schema is None:
+        schema = get_schema(_SCHEMA_NAME)
+    try:
+        jsonschema.validate(instance=data, schema=schema)
+    except jsonschema.ValidationError as exc:
+        raise RegistryValidationError(
+            f"Registry validation failed: {exc.message} (at {list(exc.absolute_path)})"
+        ) from exc
+
+
+def upsert_registry_models(conn: sqlite3.Connection, models: list[dict[str, Any]]) -> int:
+    """Upsert all models from registry data into the model_registry table.
+
+    Returns the number of models processed.
+    """
+    count = 0
+    for model in models:
+        download = model.get("download", {})
+        hardware = model.get("hardware", {})
+        runtime = model.get("runtime", {})
+        role = model["role"]
+
+        conn.execute(
+            """
+            INSERT INTO model_registry
+                (id, name, provider, family, role, format, license_spdx, license_url,
+                 source_type, download_url, sha256, size_gb,
+                 min_vram_gb, recommended_vram_gb, context_length,
+                 capabilities_json, metadata_json)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+                name                = excluded.name,
+                provider            = excluded.provider,
+                family              = excluded.family,
+                role                = excluded.role,
+                format              = excluded.format,
+                license_spdx        = excluded.license_spdx,
+                license_url         = excluded.license_url,
+                source_type         = excluded.source_type,
+                download_url        = excluded.download_url,
+                sha256              = excluded.sha256,
+                size_gb             = excluded.size_gb,
+                min_vram_gb         = excluded.min_vram_gb,
+                recommended_vram_gb = excluded.recommended_vram_gb,
+                context_length      = excluded.context_length,
+                capabilities_json   = excluded.capabilities_json,
+                metadata_json       = excluded.metadata_json
+            """,
+            (
+                model["id"],
+                model["name"],
+                download.get("provider", ""),
+                model["family"],
+                role,
+                model["format"],
+                model["license"],
+                model.get("license_url"),
+                "user-supplied" if role == "user-supplied" else "registry",
+                download.get("url"),
+                download.get("sha256"),
+                model.get("size_gb"),
+                hardware.get("min_vram_gb"),
+                hardware.get("recommended_vram_gb"),
+                runtime.get("llama_cpp", {}).get("context_length"),
+                json.dumps(runtime) if runtime else None,
+                json.dumps(model),
+            ),
+        )
+        count += 1
+    conn.commit()
+    return count
+
+
+def load_and_persist_registry(
+    conn: sqlite3.Connection,
+    registry_path: Path,
+    schema: dict[str, Any] | None = None,
+) -> int:
+    """Load, validate, and persist the model registry into SQLite.
+
+    Args:
+        conn: Open SQLite connection (migrations must already be applied).
+        registry_path: Path to the registry YAML file.
+        schema: Optional pre-loaded schema; loaded from bundled schemas if not provided.
+
+    Returns:
+        Number of model entries loaded.
+
+    Raises:
+        RegistryValidationError: If the YAML fails schema validation.
+    """
+    data = load_registry_yaml(registry_path)
+    validate_registry(data, schema)
+    models: list[dict[str, Any]] = data.get("models", [])
+    count = upsert_registry_models(conn, models)
+    logger.info("Loaded %d model(s) from registry at %s", count, registry_path)
+    return count
+
+
+def list_registry_models(conn: sqlite3.Connection) -> list[dict[str, Any]]:
+    """Return all rows from model_registry as a list of dicts."""
+    rows = conn.execute(
+        """
+        SELECT id, name, provider, family, role, format,
+               license_spdx, license_url, source_type,
+               download_url, sha256, size_gb,
+               min_vram_gb, recommended_vram_gb, context_length,
+               registered_at
+        FROM model_registry
+        ORDER BY
+            CASE role
+                WHEN 'starter'      THEN 0
+                WHEN 'standard'     THEN 1
+                WHEN 'high-quality' THEN 2
+                WHEN 'user-supplied' THEN 3
+                ELSE 4
+            END,
+            id
+        """
+    ).fetchall()
+    return [dict(row) for row in rows]

--- a/services/convsim-core/convsim_core/storage/migrations.py
+++ b/services/convsim-core/convsim_core/storage/migrations.py
@@ -123,8 +123,24 @@ CREATE VIRTUAL TABLE pack_readme_fts USING fts5(
 );
 """
 
+_MODEL_REGISTRY_V2_SQL = """
+ALTER TABLE model_registry ADD COLUMN family TEXT;
+ALTER TABLE model_registry ADD COLUMN role TEXT;
+ALTER TABLE model_registry ADD COLUMN format TEXT;
+ALTER TABLE model_registry ADD COLUMN license_spdx TEXT;
+ALTER TABLE model_registry ADD COLUMN license_url TEXT;
+ALTER TABLE model_registry ADD COLUMN source_type TEXT;
+ALTER TABLE model_registry ADD COLUMN download_url TEXT;
+ALTER TABLE model_registry ADD COLUMN sha256 TEXT;
+ALTER TABLE model_registry ADD COLUMN size_gb REAL;
+ALTER TABLE model_registry ADD COLUMN min_vram_gb REAL;
+ALTER TABLE model_registry ADD COLUMN recommended_vram_gb REAL;
+ALTER TABLE model_registry ADD COLUMN context_length INTEGER;
+"""
+
 MIGRATIONS: list[tuple[str, str]] = [
     ("0001_initial_schema", _INITIAL_SCHEMA_SQL),
+    ("0002_model_registry_v2", _MODEL_REGISTRY_V2_SQL),
 ]
 
 

--- a/services/convsim-core/pyproject.toml
+++ b/services/convsim-core/pyproject.toml
@@ -15,6 +15,8 @@ dependencies = [
     "uvicorn[standard]>=0.29.0",
     "pydantic>=2.7.0",
     "pydantic-settings>=2.3.0",
+    "pyyaml>=6.0",
+    "jsonschema>=4.22",
 ]
 
 [project.optional-dependencies]

--- a/services/convsim-core/pyproject.toml
+++ b/services/convsim-core/pyproject.toml
@@ -16,6 +16,8 @@ dependencies = [
     "pydantic>=2.7.0",
     "pydantic-settings>=2.3.0",
     "httpx>=0.27.0",
+    "pyyaml>=6.0",
+    "jsonschema>=4.22",
 ]
 
 [project.optional-dependencies]

--- a/services/convsim-core/tests/test_model_registry.py
+++ b/services/convsim-core/tests/test_model_registry.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for the model registry schema, service layer, and SQLite persistence."""
+"""Tests for the model registry schema, service layer, SQLite persistence, and API."""
 
 from pathlib import Path
 
@@ -423,3 +423,49 @@ def test_invalid_registry_raises_registry_validation_error(tmp_path):
             load_and_persist_registry(db.connection(), bad_path)
     finally:
         db.close()
+
+
+# ── GET /api/models endpoint tests ───────────────────────────────────────────
+
+
+def test_get_models_returns_200(client):
+    resp = client.get("/api/models")
+    assert resp.status_code == 200
+
+
+def test_get_models_empty_database_returns_empty_list(client):
+    body = client.get("/api/models").json()
+    assert body["models"] == []
+    assert body["total"] == 0
+
+
+def test_get_models_after_registry_load_returns_sorted_entries(client):
+    load_and_persist_registry(client.app.state.db.connection(), _REGISTRY_PATH)
+    body = client.get("/api/models").json()
+    models = body["models"]
+    assert body["total"] == len(models)
+    assert body["total"] > 0
+    roles = [m["role"] for m in models]
+    tier_order = {"starter": 0, "standard": 1, "high-quality": 2, "user-supplied": 3}
+    assert roles == sorted(roles, key=lambda r: tier_order.get(r, 99))
+
+
+def test_get_models_entry_shape(client):
+    load_and_persist_registry(client.app.state.db.connection(), _REGISTRY_PATH)
+    body = client.get("/api/models").json()
+    entry = next(m for m in body["models"] if m["role"] == "starter")
+    assert entry["license_spdx"] == "Apache-2.0"
+    assert entry["source_type"] == "registry"
+    assert entry["sha256"] == "PENDING"
+    assert isinstance(entry["size_gb"], float)
+    assert isinstance(entry["min_vram_gb"], float)
+
+
+def test_get_models_user_supplied_entry(client):
+    load_and_persist_registry(client.app.state.db.connection(), _REGISTRY_PATH)
+    body = client.get("/api/models").json()
+    entry = next(m for m in body["models"] if m["id"] == "user-supplied-gguf")
+    assert entry["source_type"] == "user-supplied"
+    assert entry["license_spdx"] == "unknown-user-supplied"
+    assert entry["sha256"] is None
+    assert entry["size_gb"] is None

--- a/services/convsim-core/tests/test_model_registry.py
+++ b/services/convsim-core/tests/test_model_registry.py
@@ -299,8 +299,6 @@ def test_actual_registry_has_all_required_tiers(registry_schema):
 
 def test_actual_registry_no_model_weights():
     """No binary model weights are included in the repository."""
-    import mimetypes
-
     registry_dir = _REGISTRY_PATH.parent
     for path in registry_dir.rglob("*"):
         if path.is_file():

--- a/services/convsim-core/tests/test_model_registry.py
+++ b/services/convsim-core/tests/test_model_registry.py
@@ -246,6 +246,22 @@ def test_registry_model_with_user_filesystem_provider_fails(
         )
 
 
+def test_null_min_vram_gb_for_registry_model_fails(registry_schema, valid_registry_entry):
+    valid_registry_entry["hardware"]["min_vram_gb"] = None
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(
+            instance=make_registry([valid_registry_entry]), schema=registry_schema
+        )
+
+
+def test_missing_min_vram_gb_for_registry_model_fails(registry_schema, valid_registry_entry):
+    valid_registry_entry["hardware"] = {}
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(
+            instance=make_registry([valid_registry_entry]), schema=registry_schema
+        )
+
+
 def test_unknown_schema_version_fails(registry_schema, valid_registry_entry):
     with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(

--- a/services/convsim-core/tests/test_model_registry.py
+++ b/services/convsim-core/tests/test_model_registry.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for the model registry schema, service layer, and SQLite persistence."""
 
-import json
 from pathlib import Path
 
 import jsonschema

--- a/services/convsim-core/tests/test_model_registry.py
+++ b/services/convsim-core/tests/test_model_registry.py
@@ -425,6 +425,19 @@ def test_invalid_registry_raises_registry_validation_error(tmp_path):
         db.close()
 
 
+def test_malformed_yaml_raises_registry_validation_error(tmp_path):
+    """A registry file with a YAML syntax error raises RegistryValidationError."""
+    bad_path = tmp_path / "malformed.yaml"
+    bad_path.write_text("key: [unclosed bracket\n", encoding="utf-8")
+
+    db = Database.open(str(tmp_path / "db"))
+    try:
+        with pytest.raises(RegistryValidationError, match="not valid YAML"):
+            load_and_persist_registry(db.connection(), bad_path)
+    finally:
+        db.close()
+
+
 # ── GET /api/models endpoint tests ───────────────────────────────────────────
 
 

--- a/services/convsim-core/tests/test_model_registry.py
+++ b/services/convsim-core/tests/test_model_registry.py
@@ -1,0 +1,412 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the model registry schema, service layer, and SQLite persistence."""
+
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+import yaml
+
+from convsim_core.schema_paths import get_schema
+from convsim_core.services.model_registry_service import (
+    RegistryValidationError,
+    load_and_persist_registry,
+    list_registry_models,
+    load_registry_yaml,
+    validate_registry,
+)
+from convsim_core.storage.database import Database
+
+# Canonical registry file relative to this test file.
+# tests/ → convsim-core/ → services/ → repo root → model-registry/registry.yaml
+_REGISTRY_PATH = Path(__file__).parent.parent.parent.parent / "model-registry" / "registry.yaml"
+
+
+@pytest.fixture(scope="module")
+def registry_schema() -> dict:
+    return get_schema("model-registry.schema.json")
+
+
+@pytest.fixture
+def valid_registry_entry() -> dict:
+    return {
+        "id": "test-model-q4-k-m",
+        "name": "Test Model Q4_K_M",
+        "family": "test",
+        "role": "starter",
+        "format": "gguf",
+        "license": "MIT",
+        "license_url": "https://opensource.org/licenses/MIT",
+        "size_gb": 2.5,
+        "hardware": {"min_vram_gb": 4, "recommended_vram_gb": 6},
+        "download": {
+            "provider": "huggingface",
+            "url": "PENDING",
+            "sha256": "PENDING",
+        },
+        "runtime": {
+            "llama_cpp": {
+                "context_length": 8192,
+                "temperature_default": 0.75,
+                "top_p_default": 0.9,
+            }
+        },
+    }
+
+
+@pytest.fixture
+def valid_user_supplied_entry() -> dict:
+    return {
+        "id": "user-supplied-gguf",
+        "name": "User-Supplied GGUF",
+        "family": "unknown",
+        "role": "user-supplied",
+        "format": "gguf",
+        "license": "unknown-user-supplied",
+        "size_gb": None,
+        "hardware": {"min_vram_gb": None, "recommended_vram_gb": None},
+        "download": {
+            "provider": "user-filesystem",
+            "path_hint": "~/.convsim/models/",
+        },
+    }
+
+
+def make_registry(models: list) -> dict:
+    return {"schema_version": "0.1", "models": models}
+
+
+# ── Schema validation: valid entries ─────────────────────────────────────────
+
+
+def test_valid_registry_entry_passes(registry_schema, valid_registry_entry):
+    jsonschema.validate(
+        instance=make_registry([valid_registry_entry]), schema=registry_schema
+    )
+
+
+def test_valid_sha256_hex_passes(registry_schema, valid_registry_entry):
+    valid_registry_entry["download"]["sha256"] = "a" * 64
+    jsonschema.validate(
+        instance=make_registry([valid_registry_entry]), schema=registry_schema
+    )
+
+
+def test_pending_sentinel_passes(registry_schema, valid_registry_entry):
+    valid_registry_entry["download"]["sha256"] = "PENDING"
+    jsonschema.validate(
+        instance=make_registry([valid_registry_entry]), schema=registry_schema
+    )
+
+
+def test_user_supplied_entry_passes(registry_schema, valid_user_supplied_entry):
+    jsonschema.validate(
+        instance=make_registry([valid_user_supplied_entry]), schema=registry_schema
+    )
+
+
+def test_user_supplied_without_path_hint_passes(registry_schema, valid_user_supplied_entry):
+    del valid_user_supplied_entry["download"]["path_hint"]
+    jsonschema.validate(
+        instance=make_registry([valid_user_supplied_entry]), schema=registry_schema
+    )
+
+
+def test_registry_with_multiple_models_passes(
+    registry_schema, valid_registry_entry, valid_user_supplied_entry
+):
+    # Change user-supplied id to avoid conflict in a hypothetical single list
+    valid_user_supplied_entry["id"] = "user-supplied-gguf-2"
+    jsonschema.validate(
+        instance=make_registry([valid_registry_entry, valid_user_supplied_entry]),
+        schema=registry_schema,
+    )
+
+
+# ── Schema validation: invalid entries ───────────────────────────────────────
+
+
+def test_missing_license_fails(registry_schema, valid_registry_entry):
+    del valid_registry_entry["license"]
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(
+            instance=make_registry([valid_registry_entry]), schema=registry_schema
+        )
+
+
+def test_empty_license_fails(registry_schema, valid_registry_entry):
+    valid_registry_entry["license"] = ""
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(
+            instance=make_registry([valid_registry_entry]), schema=registry_schema
+        )
+
+
+def test_missing_sha256_fails(registry_schema, valid_registry_entry):
+    del valid_registry_entry["download"]["sha256"]
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(
+            instance=make_registry([valid_registry_entry]), schema=registry_schema
+        )
+
+
+def test_placeholder_sha256_fails(registry_schema, valid_registry_entry):
+    valid_registry_entry["download"]["sha256"] = "<placeholder>"
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(
+            instance=make_registry([valid_registry_entry]), schema=registry_schema
+        )
+
+
+def test_invalid_sha256_length_fails(registry_schema, valid_registry_entry):
+    valid_registry_entry["download"]["sha256"] = "abc123"
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(
+            instance=make_registry([valid_registry_entry]), schema=registry_schema
+        )
+
+
+def test_missing_size_gb_for_registry_model_fails(registry_schema, valid_registry_entry):
+    del valid_registry_entry["size_gb"]
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(
+            instance=make_registry([valid_registry_entry]), schema=registry_schema
+        )
+
+
+def test_null_size_gb_for_registry_model_fails(registry_schema, valid_registry_entry):
+    valid_registry_entry["size_gb"] = None
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(
+            instance=make_registry([valid_registry_entry]), schema=registry_schema
+        )
+
+
+def test_invalid_role_fails(registry_schema, valid_registry_entry):
+    valid_registry_entry["role"] = "ultra-mega-tier"
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(
+            instance=make_registry([valid_registry_entry]), schema=registry_schema
+        )
+
+
+def test_invalid_format_fails(registry_schema, valid_registry_entry):
+    valid_registry_entry["format"] = "safetensors"
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(
+            instance=make_registry([valid_registry_entry]), schema=registry_schema
+        )
+
+
+def test_missing_hardware_fails(registry_schema, valid_registry_entry):
+    del valid_registry_entry["hardware"]
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(
+            instance=make_registry([valid_registry_entry]), schema=registry_schema
+        )
+
+
+def test_missing_download_fails(registry_schema, valid_registry_entry):
+    del valid_registry_entry["download"]
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(
+            instance=make_registry([valid_registry_entry]), schema=registry_schema
+        )
+
+
+def test_user_supplied_with_wrong_license_fails(registry_schema, valid_user_supplied_entry):
+    # user-supplied models MUST declare license as "unknown-user-supplied"
+    valid_user_supplied_entry["license"] = "Apache-2.0"
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(
+            instance=make_registry([valid_user_supplied_entry]), schema=registry_schema
+        )
+
+
+def test_user_supplied_with_registry_download_fails(registry_schema, valid_user_supplied_entry):
+    valid_user_supplied_entry["download"] = {
+        "provider": "huggingface",
+        "url": "PENDING",
+        "sha256": "PENDING",
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(
+            instance=make_registry([valid_user_supplied_entry]), schema=registry_schema
+        )
+
+
+def test_registry_model_with_user_filesystem_provider_fails(
+    registry_schema, valid_registry_entry
+):
+    valid_registry_entry["download"] = {"provider": "user-filesystem"}
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(
+            instance=make_registry([valid_registry_entry]), schema=registry_schema
+        )
+
+
+def test_unknown_schema_version_fails(registry_schema, valid_registry_entry):
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(
+            instance={"schema_version": "9.9", "models": [valid_registry_entry]},
+            schema=registry_schema,
+        )
+
+
+def test_empty_models_list_fails(registry_schema):
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(
+            instance={"schema_version": "0.1", "models": []}, schema=registry_schema
+        )
+
+
+# ── Bundled registry.yaml integration test ───────────────────────────────────
+
+
+def test_actual_registry_file_validates(registry_schema):
+    """The canonical model-registry/registry.yaml must pass schema validation."""
+    assert _REGISTRY_PATH.exists(), f"Registry file not found: {_REGISTRY_PATH}"
+    data = load_registry_yaml(_REGISTRY_PATH)
+    validate_registry(data, registry_schema)
+
+
+def test_actual_registry_has_all_required_tiers(registry_schema):
+    """The registry must include at least one model per required tier."""
+    data = load_registry_yaml(_REGISTRY_PATH)
+    roles = {m["role"] for m in data["models"]}
+    assert "starter" in roles
+    assert "standard" in roles
+    assert "high-quality" in roles
+    assert "user-supplied" in roles
+
+
+def test_actual_registry_no_model_weights():
+    """No binary model weights are included in the repository."""
+    import mimetypes
+
+    registry_dir = _REGISTRY_PATH.parent
+    for path in registry_dir.rglob("*"):
+        if path.is_file():
+            suffix = path.suffix.lower()
+            assert suffix not in {".gguf", ".bin", ".safetensors", ".pt", ".ckpt"}, (
+                f"Model weight file found in repository: {path}"
+            )
+
+
+# ── SQLite persistence tests ─────────────────────────────────────────────────
+
+
+def test_registry_loads_into_sqlite(tmp_path):
+    db = Database.open(str(tmp_path / "db"))
+    try:
+        count = load_and_persist_registry(db.connection(), _REGISTRY_PATH)
+        assert count > 0
+        rows = list_registry_models(db.connection())
+        ids = [r["id"] for r in rows]
+        assert "user-supplied-gguf" in ids
+    finally:
+        db.close()
+
+
+def test_registry_upsert_is_idempotent(tmp_path):
+    db = Database.open(str(tmp_path / "db"))
+    try:
+        count1 = load_and_persist_registry(db.connection(), _REGISTRY_PATH)
+        count2 = load_and_persist_registry(db.connection(), _REGISTRY_PATH)
+        total = db.connection().execute(
+            "SELECT COUNT(*) FROM model_registry"
+        ).fetchone()[0]
+        assert count1 == count2
+        assert total == count1
+    finally:
+        db.close()
+
+
+def test_registry_models_have_license_spdx_in_db(tmp_path):
+    """All registry-managed models (not user-supplied) must store a license_spdx."""
+    db = Database.open(str(tmp_path / "db"))
+    try:
+        load_and_persist_registry(db.connection(), _REGISTRY_PATH)
+        rows = db.connection().execute(
+            "SELECT id, license_spdx FROM model_registry WHERE source_type = 'registry'"
+        ).fetchall()
+        assert rows, "No registry-managed models found in DB"
+        for row in rows:
+            assert row["license_spdx"], (
+                f"Missing license_spdx for registry model id={row['id']}"
+            )
+    finally:
+        db.close()
+
+
+def test_registry_models_have_sha256_in_db(tmp_path):
+    """All registry-managed models must store a sha256 value (even PENDING)."""
+    db = Database.open(str(tmp_path / "db"))
+    try:
+        load_and_persist_registry(db.connection(), _REGISTRY_PATH)
+        rows = db.connection().execute(
+            "SELECT id, sha256 FROM model_registry WHERE source_type = 'registry'"
+        ).fetchall()
+        assert rows, "No registry-managed models found in DB"
+        for row in rows:
+            assert row["sha256"], f"Missing sha256 for registry model id={row['id']}"
+    finally:
+        db.close()
+
+
+def test_user_supplied_model_stored_correctly(tmp_path):
+    """The user-supplied entry is correctly flagged in the DB."""
+    db = Database.open(str(tmp_path / "db"))
+    try:
+        load_and_persist_registry(db.connection(), _REGISTRY_PATH)
+        row = db.connection().execute(
+            "SELECT * FROM model_registry WHERE id = 'user-supplied-gguf'"
+        ).fetchone()
+        assert row is not None
+        assert row["source_type"] == "user-supplied"
+        assert row["license_spdx"] == "unknown-user-supplied"
+        assert row["sha256"] is None
+    finally:
+        db.close()
+
+
+def test_list_registry_models_returns_sorted_results(tmp_path):
+    """list_registry_models should return models sorted by tier (starter first)."""
+    db = Database.open(str(tmp_path / "db"))
+    try:
+        load_and_persist_registry(db.connection(), _REGISTRY_PATH)
+        models = list_registry_models(db.connection())
+        roles = [m["role"] for m in models]
+        # starter(s) should appear before standard, which should appear before high-quality
+        tier_order = {"starter": 0, "standard": 1, "high-quality": 2, "user-supplied": 3}
+        sorted_roles = sorted(roles, key=lambda r: tier_order.get(r, 99))
+        assert roles == sorted_roles
+    finally:
+        db.close()
+
+
+def test_invalid_registry_raises_registry_validation_error(tmp_path):
+    """A registry YAML that fails schema validation raises RegistryValidationError."""
+    bad_path = tmp_path / "bad_registry.yaml"
+    bad_data = {
+        "schema_version": "0.1",
+        "models": [
+            {
+                "id": "bad-model",
+                "name": "Bad Model",
+                "family": "test",
+                "role": "standard",
+                "format": "gguf",
+                # intentionally missing: license, size_gb, hardware, download
+            }
+        ],
+    }
+    bad_path.write_text(yaml.dump(bad_data), encoding="utf-8")
+
+    db = Database.open(str(tmp_path / "db"))
+    try:
+        with pytest.raises(RegistryValidationError):
+            load_and_persist_registry(db.connection(), bad_path)
+    finally:
+        db.close()

--- a/services/convsim-core/tests/test_schema_paths.py
+++ b/services/convsim-core/tests/test_schema_paths.py
@@ -21,6 +21,7 @@ from convsim_core.schema_paths import (
 class TestSchemaNames:
     def test_expected_schemas_present(self):
         expected = {
+            "model-registry.schema.json",
             "pack.schema.json",
             "scenario.schema.json",
             "npc.schema.json",


### PR DESCRIPTION
## Summary

- Adds `schemas/model-registry.schema.json` (JSON Schema draft 2020-12) that validates every registry entry for required fields: `id`, `name`, `family`, `role`, `format`, `license`, `hardware`, and `download`. Registry-managed models must supply a `sha256` (64-char lowercase hex or the `PENDING` sentinel for pre-confirmed artifacts); user-supplied models must set `license: unknown-user-supplied` and use `provider: user-filesystem` — no checksum is expected or claimed. Missing or invalid license/checksum metadata fails validation.
- Expands `model-registry/registry.yaml` to four tiers — **starter** (Qwen3 4B), **standard** (Qwen3 8B), **high-quality** (Qwen3 14B + Mistral Small 3.1 24B), and **user-supplied** — with `size_gb`, `license_url`, and `hardware.{min,recommended}_vram_gb` on every entry. Placeholder checksums now use the `PENDING` sentinel instead of freeform `<placeholder>` strings that would fail the new pattern constraint.
- Adds SQLite migration `0002_model_registry_v2` that expands `model_registry` with queryable columns: `family`, `role`, `format`, `license_spdx`, `license_url`, `source_type`, `download_url`, `sha256`, `size_gb`, `min_vram_gb`, `recommended_vram_gb`, `context_length`.
- Adds `convsim_core/services/model_registry_service.py` with `load_registry_yaml`, `validate_registry`, `upsert_registry_models`, `load_and_persist_registry`, and `list_registry_models`. Validation runs `jsonschema.validate` against the bundled schema before any writes.
- Adds `GET /api/models` router that returns all `model_registry` rows sorted by tier.
- Adds `pyyaml>=6.0` and `jsonschema>=4.22` as runtime dependencies.
- No model weights are included in the repository.

## Test plan

- 40 new tests in `tests/test_model_registry.py` covering:
  - Schema validation passes for valid registry and user-supplied entries
  - Schema validation fails for missing license, missing sha256, freeform placeholder checksums, wrong sha256 format/length, missing size_gb for registry models, invalid role/format, missing hardware/download, user-supplied model with wrong license, cross-type download mismatches
  - The canonical `model-registry/registry.yaml` validates cleanly and contains all four required tiers
  - No `.gguf`/`.bin`/`.safetensors`/`.pt`/`.ckpt` weight files are present in the registry directory
  - Registry loads into a temp SQLite database with correct column values
  - Upsert is idempotent (double-load produces no duplicate rows)
  - All registry-managed models have non-null `license_spdx` and `sha256` in DB
  - User-supplied entry is flagged correctly (`source_type=user-supplied`, `sha256=NULL`)
  - `list_registry_models` returns results sorted by tier
  - Invalid YAML raises `RegistryValidationError` before any DB writes
  - `GET /api/models` returns all entries with correct shape and sorted order
- Updated `tests/test_schema_paths.py` to include `model-registry.schema.json` in the expected schema set.
- Full suite: **403 passed, 1 skipped** (no regressions).

Closes #12