### PR TITLE
Implement session API and conversation state machine with SQLite persistence

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,9 +12,11 @@
   "dependencies": {
     "@convsim/shared": "workspace:*",
     "@fastify/cors": "^11.2.0",
+    "better-sqlite3": "^12.11.1",
     "fastify": "^5.0.0"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.0.0",
     "tsx": "^4.0.0",
     "typescript": "^5.5.0",

--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -1,0 +1,46 @@
+import Database from 'better-sqlite3';
+
+let _db: Database.Database | null = null;
+
+export function initDb(path = ':memory:'): Database.Database {
+  const db = new Database(path);
+  db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS sessions (
+      session_id   TEXT PRIMARY KEY,
+      scenario_id  TEXT NOT NULL,
+      state        TEXT NOT NULL DEFAULT 'NotStarted',
+      ending_type  TEXT,
+      created_at   TEXT NOT NULL,
+      setup_json   TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS session_events (
+      event_id     INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id   TEXT NOT NULL REFERENCES sessions(session_id) ON DELETE CASCADE,
+      event_type   TEXT NOT NULL,
+      payload_json TEXT NOT NULL DEFAULT '{}',
+      created_at   TEXT NOT NULL
+    );
+  `);
+  _db = db;
+  return db;
+}
+
+export function getDb(): Database.Database {
+  if (!_db) initDb(':memory:');
+  return _db!;
+}
+
+export function resetDb(): void {
+  if (_db) {
+    try {
+      _db.close();
+    } catch {
+      // ignore
+    }
+  }
+  _db = null;
+  initDb(':memory:');
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -17,11 +17,11 @@ export async function buildApp() {
   // Fall back to reply.statusCode when the error itself has no statusCode set,
   // because some routes call reply.status(4xx) and then throw a plain Error.
   app.setErrorHandler((error, _request, reply) => {
-    const statusCode = error.statusCode ?? reply.statusCode ?? 500;
-    const body: Record<string, unknown> = { statusCode, message: error.message };
-    const typed = error as Record<string, unknown>;
-    if (typed['code']) body['code'] = typed['code'];
-    if (typed['current_state']) body['current_state'] = typed['current_state'];
+    const typed = error as { statusCode?: number; message?: string; code?: string; current_state?: string };
+    const statusCode = typed.statusCode ?? reply.statusCode ?? 500;
+    const body: Record<string, unknown> = { statusCode, message: typed.message ?? 'Internal Server Error' };
+    if (typed.code) body['code'] = typed.code;
+    if (typed.current_state) body['current_state'] = typed.current_state;
     reply.status(statusCode).send(body);
   });
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -18,7 +18,7 @@ export async function buildApp() {
   // because some routes call reply.status(4xx) and then throw a plain Error.
   app.setErrorHandler((error, _request, reply) => {
     const typed = error as { statusCode?: number; message?: string; code?: string; current_state?: string };
-    const statusCode = typed.statusCode ?? reply.statusCode ?? 500;
+    const statusCode = typed.statusCode ?? (reply.statusCode >= 400 ? reply.statusCode : 500);
     const body: Record<string, unknown> = { statusCode, message: typed.message ?? 'Internal Server Error' };
     if (typed.code) body['code'] = typed.code;
     if (typed.current_state) body['current_state'] = typed.current_state;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,8 +1,12 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import Fastify from 'fastify';
 import cors from '@fastify/cors';
 import { healthRoutes } from './routes/health.js';
 import { scenarioRoutes } from './routes/scenarios.js';
 import { sessionRoutes } from './routes/sessions.js';
+import { initDb } from './db.js';
 
 export async function buildApp() {
   const app = Fastify({ logger: true });
@@ -29,6 +33,11 @@ export async function buildApp() {
 }
 
 if (process.argv[1] === new URL(import.meta.url).pathname) {
+  const dbPath =
+    process.env['SESSION_DB_PATH'] ??
+    path.join(os.homedir(), '.convsim', 'db', 'sessions.db');
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+  initDb(dbPath);
   const app = await buildApp();
   await app.listen({ port: 7355, host: '127.0.0.1' });
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -9,6 +9,18 @@ export async function buildApp() {
 
   await app.register(cors, { origin: 'http://localhost:7354' });
 
+  // Propagate typed error fields (code, current_state) set by route handlers.
+  // Fall back to reply.statusCode when the error itself has no statusCode set,
+  // because some routes call reply.status(4xx) and then throw a plain Error.
+  app.setErrorHandler((error, _request, reply) => {
+    const statusCode = error.statusCode ?? reply.statusCode ?? 500;
+    const body: Record<string, unknown> = { statusCode, message: error.message };
+    const typed = error as Record<string, unknown>;
+    if (typed['code']) body['code'] = typed['code'];
+    if (typed['current_state']) body['current_state'] = typed['current_state'];
+    reply.status(statusCode).send(body);
+  });
+
   await app.register(healthRoutes);
   await app.register(scenarioRoutes);
   await app.register(sessionRoutes);

--- a/apps/api/src/routes/sessions.test.ts
+++ b/apps/api/src/routes/sessions.test.ts
@@ -480,6 +480,22 @@ describe('POST /api/sessions/:id/debrief', () => {
     expect(body.summary.length).toBeGreaterThan(0);
   });
 
+  it('persists a debrief_generated event in session_events', async () => {
+    const { session_id } = (
+      await app.inject({ method: 'POST', url: '/api/sessions', payload: validRequest })
+    ).json<SessionCreateResponse>();
+    getDb().prepare("UPDATE sessions SET state = 'DebriefReady' WHERE session_id = ?").run(session_id);
+
+    await app.inject({ method: 'POST', url: `/api/sessions/${session_id}/debrief` });
+
+    const events = getDb()
+      .prepare<[string], { event_type: string }>(
+        'SELECT event_type FROM session_events WHERE session_id = ? ORDER BY event_id',
+      )
+      .all(session_id);
+    expect(events.map((e) => e.event_type)).toContain('debrief_generated');
+  });
+
   it('returns 409 from NotStarted (not in DebriefReady)', async () => {
     const { session_id } = (
       await app.inject({ method: 'POST', url: '/api/sessions', payload: validRequest })

--- a/apps/api/src/routes/sessions.test.ts
+++ b/apps/api/src/routes/sessions.test.ts
@@ -1,13 +1,19 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { buildApp } from '../index.js';
+import { resetDb } from '../db.js';
 import type { FastifyInstance } from 'fastify';
-import type { SessionCreateRequest, SessionCreateResponse } from '@convsim/shared';
-import { sessions } from './sessions.js';
+import type {
+  SessionCreateRequest,
+  SessionCreateResponse,
+  SessionStartResponse,
+  TurnResponse,
+  SessionEndResponse,
+} from '@convsim/shared';
 
 let app: FastifyInstance;
 
 beforeEach(async () => {
-  sessions.clear();
+  resetDb();
   app = await buildApp();
 });
 
@@ -26,6 +32,10 @@ const validRequest: SessionCreateRequest = {
   save_transcript: true,
   seed: null,
 };
+
+// ---------------------------------------------------------------------------
+// POST /api/sessions
+// ---------------------------------------------------------------------------
 
 describe('POST /api/sessions', () => {
   it('creates a session and returns 201 with session id', async () => {
@@ -179,6 +189,10 @@ describe('POST /api/sessions', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// GET /api/sessions/:session_id
+// ---------------------------------------------------------------------------
+
 describe('GET /api/sessions/:session_id', () => {
   it('retrieves a previously created session', async () => {
     const createRes = await app.inject({
@@ -206,6 +220,10 @@ describe('GET /api/sessions/:session_id', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// DELETE /api/sessions/:session_id
+// ---------------------------------------------------------------------------
+
 describe('DELETE /api/sessions/:session_id', () => {
   it('deletes a session and returns 204', async () => {
     const createRes = await app.inject({
@@ -226,5 +244,295 @@ describe('DELETE /api/sessions/:session_id', () => {
       url: `/api/sessions/${created.session_id}`,
     });
     expect(getRes.statusCode).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/sessions/:id/start
+// ---------------------------------------------------------------------------
+
+describe('POST /api/sessions/:id/start', () => {
+  it('starts a NotStarted session and returns PlayerTurnListening with npc_opening event', async () => {
+    const { session_id } = (
+      await app.inject({ method: 'POST', url: '/api/sessions', payload: validRequest })
+    ).json<SessionCreateResponse>();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/sessions/${session_id}/start`,
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<SessionStartResponse>();
+    expect(body.session_id).toBe(session_id);
+    expect(body.state).toBe('PlayerTurnListening');
+    expect(body.events).toHaveLength(1);
+    expect(body.events[0].event_type).toBe('npc_opening');
+    expect(typeof body.events[0].payload.content).toBe('string');
+  });
+
+  it('persists state change — GET reflects PlayerTurnListening after start', async () => {
+    const { session_id } = (
+      await app.inject({ method: 'POST', url: '/api/sessions', payload: validRequest })
+    ).json<SessionCreateResponse>();
+
+    await app.inject({ method: 'POST', url: `/api/sessions/${session_id}/start` });
+
+    const getRes = await app.inject({ method: 'GET', url: `/api/sessions/${session_id}` });
+    expect(getRes.json<SessionCreateResponse>().state).toBe('PlayerTurnListening');
+  });
+
+  it('returns 409 when called again on an already-started session', async () => {
+    const { session_id } = (
+      await app.inject({ method: 'POST', url: '/api/sessions', payload: validRequest })
+    ).json<SessionCreateResponse>();
+
+    await app.inject({ method: 'POST', url: `/api/sessions/${session_id}/start` });
+
+    const res = await app.inject({ method: 'POST', url: `/api/sessions/${session_id}/start` });
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('INVALID_TRANSITION');
+  });
+
+  it('returns 404 for unknown session', async () => {
+    const res = await app.inject({ method: 'POST', url: '/api/sessions/sess-unknown/start' });
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/sessions/:id/turn
+// ---------------------------------------------------------------------------
+
+describe('POST /api/sessions/:id/turn', () => {
+  async function createStartedSession() {
+    const { session_id } = (
+      await app.inject({ method: 'POST', url: '/api/sessions', payload: validRequest })
+    ).json<SessionCreateResponse>();
+    await app.inject({ method: 'POST', url: `/api/sessions/${session_id}/start` });
+    return session_id;
+  }
+
+  it('accepts a turn and returns player_turn and npc_turn events', async () => {
+    const session_id = await createStartedSession();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/sessions/${session_id}/turn`,
+      payload: { content: 'Hello there.' },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<TurnResponse>();
+    expect(body.state).toBe('PlayerTurnListening');
+    expect(body.events).toHaveLength(2);
+    expect(body.events[0].event_type).toBe('player_turn');
+    expect(body.events[0].payload.content).toBe('Hello there.');
+    expect(body.events[1].event_type).toBe('npc_turn');
+  });
+
+  it('rejects turn submission from NotStarted state with 409', async () => {
+    const { session_id } = (
+      await app.inject({ method: 'POST', url: '/api/sessions', payload: validRequest })
+    ).json<SessionCreateResponse>();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/sessions/${session_id}/turn`,
+      payload: { content: 'Out of order.' },
+    });
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('INVALID_TRANSITION');
+  });
+
+  it('rejects turn submission from Ended state with 409', async () => {
+    const session_id = await createStartedSession();
+    await app.inject({ method: 'POST', url: `/api/sessions/${session_id}/end` });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/sessions/${session_id}/turn`,
+      payload: { content: 'Too late.' },
+    });
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('INVALID_TRANSITION');
+  });
+
+  it('returns 400 for missing turn content', async () => {
+    const session_id = await createStartedSession();
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/sessions/${session_id}/turn`,
+      payload: {},
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 404 for unknown session', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/sessions/sess-unknown/turn',
+      payload: { content: 'hello' },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/sessions/:id/end
+// ---------------------------------------------------------------------------
+
+describe('POST /api/sessions/:id/end', () => {
+  it('ends a NotStarted session with player_exit', async () => {
+    const { session_id } = (
+      await app.inject({ method: 'POST', url: '/api/sessions', payload: validRequest })
+    ).json<SessionCreateResponse>();
+
+    const res = await app.inject({ method: 'POST', url: `/api/sessions/${session_id}/end` });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<SessionEndResponse>();
+    expect(body.state).toBe('Ended');
+    expect(body.ending_type).toBe('player_exit');
+  });
+
+  it('ends a started session with player_exit', async () => {
+    const { session_id } = (
+      await app.inject({ method: 'POST', url: '/api/sessions', payload: validRequest })
+    ).json<SessionCreateResponse>();
+    await app.inject({ method: 'POST', url: `/api/sessions/${session_id}/start` });
+
+    const res = await app.inject({ method: 'POST', url: `/api/sessions/${session_id}/end` });
+    expect(res.statusCode).toBe(200);
+    expect(res.json<SessionEndResponse>().ending_type).toBe('player_exit');
+  });
+
+  it('persists Ended state — GET reflects it', async () => {
+    const { session_id } = (
+      await app.inject({ method: 'POST', url: '/api/sessions', payload: validRequest })
+    ).json<SessionCreateResponse>();
+    await app.inject({ method: 'POST', url: `/api/sessions/${session_id}/end` });
+
+    const getRes = await app.inject({ method: 'GET', url: `/api/sessions/${session_id}` });
+    expect(getRes.json<SessionCreateResponse>().state).toBe('Ended');
+  });
+
+  it('returns 409 when called on an already-ended session', async () => {
+    const { session_id } = (
+      await app.inject({ method: 'POST', url: '/api/sessions', payload: validRequest })
+    ).json<SessionCreateResponse>();
+    await app.inject({ method: 'POST', url: `/api/sessions/${session_id}/end` });
+
+    const res = await app.inject({ method: 'POST', url: `/api/sessions/${session_id}/end` });
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('INVALID_TRANSITION');
+  });
+
+  it('returns 404 for unknown session', async () => {
+    const res = await app.inject({ method: 'POST', url: '/api/sessions/sess-unknown/end' });
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/sessions/:id/debrief
+// ---------------------------------------------------------------------------
+
+describe('POST /api/sessions/:id/debrief', () => {
+  it('returns 409 from NotStarted (not in DebriefReady)', async () => {
+    const { session_id } = (
+      await app.inject({ method: 'POST', url: '/api/sessions', payload: validRequest })
+    ).json<SessionCreateResponse>();
+
+    const res = await app.inject({ method: 'POST', url: `/api/sessions/${session_id}/debrief` });
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('INVALID_TRANSITION');
+    expect(res.json().current_state).toBe('NotStarted');
+  });
+
+  it('returns 409 when session is already Ended', async () => {
+    const { session_id } = (
+      await app.inject({ method: 'POST', url: '/api/sessions', payload: validRequest })
+    ).json<SessionCreateResponse>();
+    await app.inject({ method: 'POST', url: `/api/sessions/${session_id}/end` });
+
+    const res = await app.inject({ method: 'POST', url: `/api/sessions/${session_id}/debrief` });
+    expect(res.statusCode).toBe(409);
+  });
+
+  it('returns 404 for unknown session', async () => {
+    const res = await app.inject({ method: 'POST', url: '/api/sessions/sess-unknown/debrief' });
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// State machine: legal and illegal transitions
+// ---------------------------------------------------------------------------
+
+describe('state machine transitions', () => {
+  it('full lifecycle: create → start → turn → end', async () => {
+    const { session_id } = (
+      await app.inject({ method: 'POST', url: '/api/sessions', payload: validRequest })
+    ).json<SessionCreateResponse>();
+
+    expect(
+      (await app.inject({ method: 'GET', url: `/api/sessions/${session_id}` })).json().state,
+    ).toBe('NotStarted');
+
+    await app.inject({ method: 'POST', url: `/api/sessions/${session_id}/start` });
+    expect(
+      (await app.inject({ method: 'GET', url: `/api/sessions/${session_id}` })).json().state,
+    ).toBe('PlayerTurnListening');
+
+    await app.inject({
+      method: 'POST',
+      url: `/api/sessions/${session_id}/turn`,
+      payload: { content: 'My first message.' },
+    });
+    expect(
+      (await app.inject({ method: 'GET', url: `/api/sessions/${session_id}` })).json().state,
+    ).toBe('PlayerTurnListening');
+
+    const endRes = await app.inject({ method: 'POST', url: `/api/sessions/${session_id}/end` });
+    expect(endRes.json<SessionEndResponse>().state).toBe('Ended');
+    expect(endRes.json<SessionEndResponse>().ending_type).toBe('player_exit');
+  });
+
+  it('rejects start from PlayerTurnListening', async () => {
+    const { session_id } = (
+      await app.inject({ method: 'POST', url: '/api/sessions', payload: validRequest })
+    ).json<SessionCreateResponse>();
+    await app.inject({ method: 'POST', url: `/api/sessions/${session_id}/start` });
+
+    const res = await app.inject({ method: 'POST', url: `/api/sessions/${session_id}/start` });
+    expect(res.statusCode).toBe(409);
+  });
+
+  it('rejects turn from NotStarted', async () => {
+    const { session_id } = (
+      await app.inject({ method: 'POST', url: '/api/sessions', payload: validRequest })
+    ).json<SessionCreateResponse>();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/sessions/${session_id}/turn`,
+      payload: { content: 'skip the start step' },
+    });
+    expect(res.statusCode).toBe(409);
+  });
+
+  it('does not mutate state on a rejected transition', async () => {
+    const { session_id } = (
+      await app.inject({ method: 'POST', url: '/api/sessions', payload: validRequest })
+    ).json<SessionCreateResponse>();
+
+    // Attempt an illegal turn (not started yet)
+    await app.inject({
+      method: 'POST',
+      url: `/api/sessions/${session_id}/turn`,
+      payload: { content: 'illegal' },
+    });
+
+    // State must still be NotStarted
+    const getRes = await app.inject({ method: 'GET', url: `/api/sessions/${session_id}` });
+    expect(getRes.json().state).toBe('NotStarted');
   });
 });

--- a/apps/api/src/routes/sessions.test.ts
+++ b/apps/api/src/routes/sessions.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { buildApp } from '../index.js';
-import { resetDb } from '../db.js';
+import { resetDb, getDb } from '../db.js';
 import type { FastifyInstance } from 'fastify';
 import type {
   SessionCreateRequest,
@@ -291,6 +291,7 @@ describe('POST /api/sessions/:id/start', () => {
     const res = await app.inject({ method: 'POST', url: `/api/sessions/${session_id}/start` });
     expect(res.statusCode).toBe(409);
     expect(res.json().code).toBe('INVALID_TRANSITION');
+    expect(res.json().current_state).toBe('PlayerTurnListening');
   });
 
   it('returns 404 for unknown session', async () => {
@@ -341,6 +342,7 @@ describe('POST /api/sessions/:id/turn', () => {
     });
     expect(res.statusCode).toBe(409);
     expect(res.json().code).toBe('INVALID_TRANSITION');
+    expect(res.json().current_state).toBe('NotStarted');
   });
 
   it('rejects turn submission from Ended state with 409', async () => {
@@ -354,6 +356,7 @@ describe('POST /api/sessions/:id/turn', () => {
     });
     expect(res.statusCode).toBe(409);
     expect(res.json().code).toBe('INVALID_TRANSITION');
+    expect(res.json().current_state).toBe('Ended');
   });
 
   it('returns 400 for missing turn content', async () => {
@@ -423,6 +426,7 @@ describe('POST /api/sessions/:id/end', () => {
     const res = await app.inject({ method: 'POST', url: `/api/sessions/${session_id}/end` });
     expect(res.statusCode).toBe(409);
     expect(res.json().code).toBe('INVALID_TRANSITION');
+    expect(res.json().current_state).toBe('Ended');
   });
 
   it('returns 404 for unknown session', async () => {
@@ -455,6 +459,8 @@ describe('POST /api/sessions/:id/debrief', () => {
 
     const res = await app.inject({ method: 'POST', url: `/api/sessions/${session_id}/debrief` });
     expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('INVALID_TRANSITION');
+    expect(res.json().current_state).toBe('Ended');
   });
 
   it('returns 404 for unknown session', async () => {
@@ -517,6 +523,32 @@ describe('state machine transitions', () => {
       payload: { content: 'skip the start step' },
     });
     expect(res.statusCode).toBe(409);
+  });
+
+  it('allows end from Error state so broken sessions can be exited', async () => {
+    const { session_id } = (
+      await app.inject({ method: 'POST', url: '/api/sessions', payload: validRequest })
+    ).json<SessionCreateResponse>();
+
+    // Force session into Error state directly (no API path sets this yet).
+    getDb().prepare("UPDATE sessions SET state = 'Error' WHERE session_id = ?").run(session_id);
+
+    const endRes = await app.inject({ method: 'POST', url: `/api/sessions/${session_id}/end` });
+    expect(endRes.statusCode).toBe(200);
+    expect(endRes.json<SessionEndResponse>().state).toBe('Ended');
+    expect(endRes.json<SessionEndResponse>().ending_type).toBe('player_exit');
+  });
+
+  it('rejects start from Error state with 409', async () => {
+    const { session_id } = (
+      await app.inject({ method: 'POST', url: '/api/sessions', payload: validRequest })
+    ).json<SessionCreateResponse>();
+    getDb().prepare("UPDATE sessions SET state = 'Error' WHERE session_id = ?").run(session_id);
+
+    const res = await app.inject({ method: 'POST', url: `/api/sessions/${session_id}/start` });
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('INVALID_TRANSITION');
+    expect(res.json().current_state).toBe('Error');
   });
 
   it('does not mutate state on a rejected transition', async () => {

--- a/apps/api/src/routes/sessions.test.ts
+++ b/apps/api/src/routes/sessions.test.ts
@@ -417,6 +417,21 @@ describe('POST /api/sessions/:id/end', () => {
     expect(getRes.json<SessionCreateResponse>().state).toBe('Ended');
   });
 
+  it('preserves an existing ending_type set by the scenario rather than defaulting to player_exit', async () => {
+    const { session_id } = (
+      await app.inject({ method: 'POST', url: '/api/sessions', payload: validRequest })
+    ).json<SessionCreateResponse>();
+
+    // Simulate a scenario that already decided the outcome before the player exited.
+    getDb()
+      .prepare("UPDATE sessions SET ending_type = 'success' WHERE session_id = ?")
+      .run(session_id);
+
+    const res = await app.inject({ method: 'POST', url: `/api/sessions/${session_id}/end` });
+    expect(res.statusCode).toBe(200);
+    expect(res.json<SessionEndResponse>().ending_type).toBe('success');
+  });
+
   it('returns 409 when called on an already-ended session', async () => {
     const { session_id } = (
       await app.inject({ method: 'POST', url: '/api/sessions', payload: validRequest })
@@ -440,6 +455,23 @@ describe('POST /api/sessions/:id/end', () => {
 // ---------------------------------------------------------------------------
 
 describe('POST /api/sessions/:id/debrief', () => {
+  it('generates debrief from DebriefReady state and returns Ended with summary', async () => {
+    const { session_id } = (
+      await app.inject({ method: 'POST', url: '/api/sessions', payload: validRequest })
+    ).json<SessionCreateResponse>();
+
+    // No API path reaches DebriefReady yet; force the state directly.
+    getDb().prepare("UPDATE sessions SET state = 'DebriefReady' WHERE session_id = ?").run(session_id);
+
+    const res = await app.inject({ method: 'POST', url: `/api/sessions/${session_id}/debrief` });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.session_id).toBe(session_id);
+    expect(body.state).toBe('Ended');
+    expect(typeof body.summary).toBe('string');
+    expect(body.summary.length).toBeGreaterThan(0);
+  });
+
   it('returns 409 from NotStarted (not in DebriefReady)', async () => {
     const { session_id } = (
       await app.inject({ method: 'POST', url: '/api/sessions', payload: validRequest })

--- a/apps/api/src/routes/sessions.test.ts
+++ b/apps/api/src/routes/sessions.test.ts
@@ -377,6 +377,16 @@ describe('POST /api/sessions/:id/turn', () => {
     expect(res.statusCode).toBe(400);
   });
 
+  it('returns 400 for empty string turn content', async () => {
+    const session_id = await createStartedSession();
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/sessions/${session_id}/turn`,
+      payload: { content: '' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
   it('returns 404 for unknown session', async () => {
     const res = await app.inject({
       method: 'POST',

--- a/apps/api/src/routes/sessions.test.ts
+++ b/apps/api/src/routes/sessions.test.ts
@@ -245,6 +245,14 @@ describe('DELETE /api/sessions/:session_id', () => {
     });
     expect(getRes.statusCode).toBe(404);
   });
+
+  it('returns 404 for unknown session id', async () => {
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/api/sessions/sess-doesnotexist',
+    });
+    expect(res.statusCode).toBe(404);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -385,14 +385,19 @@ export async function sessionRoutes(app: FastifyInstance) {
         );
       }
 
-      db.prepare("UPDATE sessions SET state = 'Ended' WHERE session_id = ?").run(
-        req.params.session_id,
-      );
+      const summary = 'Stub debrief: the session has completed. Full analysis is not yet available.';
+
+      db.transaction(() => {
+        db.prepare("UPDATE sessions SET state = 'Ended' WHERE session_id = ?").run(
+          req.params.session_id,
+        );
+        insertEvent(req.params.session_id, 'debrief_generated', { summary });
+      })();
 
       return {
         session_id: req.params.session_id,
         state: 'Ended',
-        summary: 'Stub debrief: the session has completed. Full analysis is not yet available.',
+        summary,
       };
     },
   );

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -248,13 +248,15 @@ export async function sessionRoutes(app: FastifyInstance) {
       }
 
       // Stub: skip loading states and emit an NPC opening placeholder.
-      db.prepare("UPDATE sessions SET state = 'PlayerTurnListening' WHERE session_id = ?").run(
-        req.params.session_id,
-      );
-
-      const openingRow = insertEvent(req.params.session_id, 'npc_opening', {
-        content: 'Hello! I am ready to begin our conversation. Please go ahead.',
-      });
+      // Wrapped in a transaction so the state update and event insert are atomic.
+      const openingRow = db.transaction(() => {
+        db.prepare("UPDATE sessions SET state = 'PlayerTurnListening' WHERE session_id = ?").run(
+          req.params.session_id,
+        );
+        return insertEvent(req.params.session_id, 'npc_opening', {
+          content: 'Hello! I am ready to begin our conversation. Please go ahead.',
+        });
+      })();
 
       return {
         session_id: req.params.session_id,
@@ -298,14 +300,17 @@ export async function sessionRoutes(app: FastifyInstance) {
         );
       }
 
-      const playerRow = insertEvent(req.params.session_id, 'player_turn', {
-        content: req.body.content,
-      });
-
-      // Stub NPC response: immediate placeholder reply.
-      const npcRow = insertEvent(req.params.session_id, 'npc_turn', {
-        content: 'Thank you for your response. Please continue.',
-      });
+      // Both event inserts are atomic so a partial failure doesn't leave an
+      // orphaned player_turn without its corresponding npc_turn.
+      const [playerRow, npcRow] = db.transaction(() => {
+        const player = insertEvent(req.params.session_id, 'player_turn', {
+          content: req.body.content,
+        });
+        const npc = insertEvent(req.params.session_id, 'npc_turn', {
+          content: 'Thank you for your response. Please continue.',
+        });
+        return [player, npc] as const;
+      })();
 
       return {
         session_id: req.params.session_id,
@@ -342,12 +347,12 @@ export async function sessionRoutes(app: FastifyInstance) {
       // fall back to player_exit when none is recorded.
       const endingType: EndingType = (row.ending_type as EndingType | null) ?? 'player_exit';
 
-      db.prepare("UPDATE sessions SET state = 'Ended', ending_type = ? WHERE session_id = ?").run(
-        endingType,
-        req.params.session_id,
-      );
-
-      insertEvent(req.params.session_id, 'session_ended', { ending_type: endingType });
+      db.transaction(() => {
+        db.prepare(
+          "UPDATE sessions SET state = 'Ended', ending_type = ? WHERE session_id = ?",
+        ).run(endingType, req.params.session_id);
+        insertEvent(req.params.session_id, 'session_ended', { ending_type: endingType });
+      })();
 
       return {
         session_id: req.params.session_id,

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -26,7 +26,8 @@ type Action = 'start' | 'turn' | 'end' | 'debrief';
 
 // Returns true when the action is a legal next step from the given state.
 function canTransition(state: SessionState, action: Action): boolean {
-  if (state === 'Ended' || state === 'Error') return false;
+  if (state === 'Ended') return false;
+  if (state === 'Error') return action === 'end';
   if (action === 'end') return true;
   if (action === 'start') return state === 'NotStarted';
   if (action === 'turn') return state === 'PlayerTurnListening';

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -68,16 +68,14 @@ function insertEvent(
 ): EventRow {
   const db = getDb();
   const now = new Date().toISOString();
-  db
+  const result = db
     .prepare(
       'INSERT INTO session_events (session_id, event_type, payload_json, created_at) VALUES (?, ?, ?, ?)',
     )
     .run(session_id, event_type, JSON.stringify(payload), now);
   return db
-    .prepare<[string], EventRow>(
-      'SELECT * FROM session_events WHERE session_id = ? ORDER BY event_id DESC LIMIT 1',
-    )
-    .get(session_id)!;
+    .prepare<[number], EventRow>('SELECT * FROM session_events WHERE event_id = ?')
+    .get(Number(result.lastInsertRowid))!;
 }
 
 function rejectTransition(reply: { status: (code: number) => void }, state: SessionState, msg: string): never {

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -3,8 +3,15 @@ import type {
   SessionCreateRequest,
   SessionCreateResponse,
   SessionState,
+  SessionStartResponse,
+  TurnRequest,
+  TurnResponse,
+  SessionEndResponse,
+  SessionDebriefResponse,
+  EndingType,
 } from '@convsim/shared';
 import { SCENARIOS } from '../data/scenarios.js';
+import { getDb } from '../db.js';
 
 function generateSessionId(): string {
   const bytes = Array.from({ length: 8 }, () =>
@@ -15,17 +22,75 @@ function generateSessionId(): string {
   return `sess-${bytes.join('')}`;
 }
 
-interface StoredSession {
-  session_id: string;
-  scenario_id: string;
-  state: SessionState;
-  created_at: string;
-  setup: SessionCreateRequest;
+type Action = 'start' | 'turn' | 'end' | 'debrief';
+
+// Returns true when the action is a legal next step from the given state.
+function canTransition(state: SessionState, action: Action): boolean {
+  if (state === 'Ended' || state === 'Error') return false;
+  if (action === 'end') return true;
+  if (action === 'start') return state === 'NotStarted';
+  if (action === 'turn') return state === 'PlayerTurnListening';
+  if (action === 'debrief') return state === 'DebriefReady';
+  return false;
 }
 
-const sessions = new Map<string, StoredSession>();
+interface SessionRow {
+  session_id: string;
+  scenario_id: string;
+  state: string;
+  ending_type: string | null;
+  created_at: string;
+  setup_json: string;
+}
+
+interface EventRow {
+  event_id: number;
+  session_id: string;
+  event_type: string;
+  payload_json: string;
+  created_at: string;
+}
+
+function rowToEvent(row: EventRow) {
+  return {
+    event_id: row.event_id,
+    session_id: row.session_id,
+    event_type: row.event_type,
+    payload: JSON.parse(row.payload_json) as Record<string, unknown>,
+    created_at: row.created_at,
+  };
+}
+
+function insertEvent(
+  session_id: string,
+  event_type: string,
+  payload: Record<string, unknown>,
+): EventRow {
+  const db = getDb();
+  const now = new Date().toISOString();
+  db
+    .prepare(
+      'INSERT INTO session_events (session_id, event_type, payload_json, created_at) VALUES (?, ?, ?, ?)',
+    )
+    .run(session_id, event_type, JSON.stringify(payload), now);
+  return db
+    .prepare<[string], EventRow>(
+      'SELECT * FROM session_events WHERE session_id = ? ORDER BY event_id DESC LIMIT 1',
+    )
+    .get(session_id)!;
+}
+
+function rejectTransition(reply: { status: (code: number) => void }, state: SessionState, msg: string): never {
+  reply.status(409);
+  const err = new Error(msg) as Error & { statusCode: number; code: string; current_state: string };
+  err.statusCode = 409;
+  err.code = 'INVALID_TRANSITION';
+  err.current_state = state;
+  throw err;
+}
 
 export async function sessionRoutes(app: FastifyInstance) {
+  // POST /api/sessions
   app.post<{ Body: SessionCreateRequest }>(
     '/api/sessions',
     {
@@ -91,49 +156,240 @@ export async function sessionRoutes(app: FastifyInstance) {
 
       if (body.show_state_meters && !scenario.state_meters_permitted) {
         reply.status(400);
-        throw new Error(
-          `Scenario '${body.scenario_id}' does not permit state meters`,
-        );
+        throw new Error(`Scenario '${body.scenario_id}' does not permit state meters`);
       }
 
-      const session: StoredSession = {
-        session_id: generateSessionId(),
-        scenario_id: body.scenario_id,
-        state: 'NotStarted',
-        created_at: new Date().toISOString(),
-        setup: body,
-      };
+      const db = getDb();
+      const now = new Date().toISOString();
+      const session_id = generateSessionId();
 
-      sessions.set(session.session_id, session);
+      db
+        .prepare(
+          'INSERT INTO sessions (session_id, scenario_id, state, created_at, setup_json) VALUES (?, ?, ?, ?, ?)',
+        )
+        .run(session_id, body.scenario_id, 'NotStarted', now, JSON.stringify(body));
 
       reply.status(201);
-      return session;
+      return {
+        session_id,
+        scenario_id: body.scenario_id,
+        state: 'NotStarted',
+        created_at: now,
+        setup: body,
+      };
     },
   );
 
+  // GET /api/sessions/:session_id
   app.get<{ Params: { session_id: string } }>(
     '/api/sessions/:session_id',
-    async (req, reply): Promise<StoredSession> => {
-      const session = sessions.get(req.params.session_id);
-      if (!session) {
+    async (req, reply): Promise<SessionCreateResponse> => {
+      const db = getDb();
+      const row = db
+        .prepare<[string], SessionRow>('SELECT * FROM sessions WHERE session_id = ?')
+        .get(req.params.session_id);
+
+      if (!row) {
         reply.status(404);
         throw new Error(`Session '${req.params.session_id}' not found`);
       }
-      return session;
+
+      return {
+        session_id: row.session_id,
+        scenario_id: row.scenario_id,
+        state: row.state as SessionState,
+        created_at: row.created_at,
+        setup: JSON.parse(row.setup_json) as SessionCreateRequest,
+      };
     },
   );
 
+  // DELETE /api/sessions/:session_id
   app.delete<{ Params: { session_id: string } }>(
     '/api/sessions/:session_id',
     async (req, reply): Promise<void> => {
-      if (!sessions.has(req.params.session_id)) {
+      const db = getDb();
+      const row = db
+        .prepare<[string], Pick<SessionRow, 'session_id'>>(
+          'SELECT session_id FROM sessions WHERE session_id = ?',
+        )
+        .get(req.params.session_id);
+
+      if (!row) {
         reply.status(404);
         throw new Error(`Session '${req.params.session_id}' not found`);
       }
-      sessions.delete(req.params.session_id);
+
+      db.prepare('DELETE FROM sessions WHERE session_id = ?').run(req.params.session_id);
       reply.status(204);
     },
   );
-}
 
-export { sessions };
+  // POST /api/sessions/:session_id/start
+  app.post<{ Params: { session_id: string } }>(
+    '/api/sessions/:session_id/start',
+    async (req, reply): Promise<SessionStartResponse> => {
+      const db = getDb();
+      const row = db
+        .prepare<[string], SessionRow>('SELECT * FROM sessions WHERE session_id = ?')
+        .get(req.params.session_id);
+
+      if (!row) {
+        reply.status(404);
+        throw new Error(`Session '${req.params.session_id}' not found`);
+      }
+
+      const currentState = row.state as SessionState;
+      if (!canTransition(currentState, 'start')) {
+        rejectTransition(
+          reply,
+          currentState,
+          `Cannot start session from state '${currentState}'. Session must be in NotStarted state.`,
+        );
+      }
+
+      // Stub: skip loading states and emit an NPC opening placeholder.
+      db.prepare("UPDATE sessions SET state = 'PlayerTurnListening' WHERE session_id = ?").run(
+        req.params.session_id,
+      );
+
+      const openingRow = insertEvent(req.params.session_id, 'npc_opening', {
+        content: 'Hello! I am ready to begin our conversation. Please go ahead.',
+      });
+
+      return {
+        session_id: req.params.session_id,
+        state: 'PlayerTurnListening',
+        events: [rowToEvent(openingRow)],
+      };
+    },
+  );
+
+  // POST /api/sessions/:session_id/turn
+  app.post<{ Params: { session_id: string }; Body: TurnRequest }>(
+    '/api/sessions/:session_id/turn',
+    {
+      schema: {
+        body: {
+          type: 'object',
+          required: ['content'],
+          properties: {
+            content: { type: 'string', minLength: 1 },
+          },
+        },
+      },
+    },
+    async (req, reply): Promise<TurnResponse> => {
+      const db = getDb();
+      const row = db
+        .prepare<[string], SessionRow>('SELECT * FROM sessions WHERE session_id = ?')
+        .get(req.params.session_id);
+
+      if (!row) {
+        reply.status(404);
+        throw new Error(`Session '${req.params.session_id}' not found`);
+      }
+
+      const currentState = row.state as SessionState;
+      if (!canTransition(currentState, 'turn')) {
+        rejectTransition(
+          reply,
+          currentState,
+          `Cannot submit turn from state '${currentState}'. Session must be in PlayerTurnListening state.`,
+        );
+      }
+
+      const playerRow = insertEvent(req.params.session_id, 'player_turn', {
+        content: req.body.content,
+      });
+
+      // Stub NPC response: immediate placeholder reply.
+      const npcRow = insertEvent(req.params.session_id, 'npc_turn', {
+        content: 'Thank you for your response. Please continue.',
+      });
+
+      return {
+        session_id: req.params.session_id,
+        state: 'PlayerTurnListening',
+        events: [rowToEvent(playerRow), rowToEvent(npcRow)],
+      };
+    },
+  );
+
+  // POST /api/sessions/:session_id/end
+  app.post<{ Params: { session_id: string } }>(
+    '/api/sessions/:session_id/end',
+    async (req, reply): Promise<SessionEndResponse> => {
+      const db = getDb();
+      const row = db
+        .prepare<[string], SessionRow>('SELECT * FROM sessions WHERE session_id = ?')
+        .get(req.params.session_id);
+
+      if (!row) {
+        reply.status(404);
+        throw new Error(`Session '${req.params.session_id}' not found`);
+      }
+
+      const currentState = row.state as SessionState;
+      if (!canTransition(currentState, 'end')) {
+        rejectTransition(
+          reply,
+          currentState,
+          `Cannot end session from state '${currentState}'. Session is already in a terminal state.`,
+        );
+      }
+
+      // Preserve an existing ending type (e.g. success/failure) set by a scenario ending;
+      // fall back to player_exit when none is recorded.
+      const endingType: EndingType = (row.ending_type as EndingType | null) ?? 'player_exit';
+
+      db.prepare("UPDATE sessions SET state = 'Ended', ending_type = ? WHERE session_id = ?").run(
+        endingType,
+        req.params.session_id,
+      );
+
+      insertEvent(req.params.session_id, 'session_ended', { ending_type: endingType });
+
+      return {
+        session_id: req.params.session_id,
+        state: 'Ended',
+        ending_type: endingType,
+      };
+    },
+  );
+
+  // POST /api/sessions/:session_id/debrief
+  app.post<{ Params: { session_id: string } }>(
+    '/api/sessions/:session_id/debrief',
+    async (req, reply): Promise<SessionDebriefResponse> => {
+      const db = getDb();
+      const row = db
+        .prepare<[string], SessionRow>('SELECT * FROM sessions WHERE session_id = ?')
+        .get(req.params.session_id);
+
+      if (!row) {
+        reply.status(404);
+        throw new Error(`Session '${req.params.session_id}' not found`);
+      }
+
+      const currentState = row.state as SessionState;
+      if (!canTransition(currentState, 'debrief')) {
+        rejectTransition(
+          reply,
+          currentState,
+          `Cannot generate debrief from state '${currentState}'. Session must be in DebriefReady state.`,
+        );
+      }
+
+      db.prepare("UPDATE sessions SET state = 'Ended' WHERE session_id = ?").run(
+        req.params.session_id,
+      );
+
+      return {
+        session_id: req.params.session_id,
+        state: 'Ended',
+        summary: 'Stub debrief: the session has completed. Full analysis is not yet available.',
+      };
+    },
+  );
+}

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 import path from 'path';
 
 export default defineConfig({
+  // better-sqlite3 is a native Node.js addon (.node binary). Vite's SSR
+  // transform pipeline cannot handle it, so we declare it external here so
+  // Node.js loads it directly at runtime instead of going through Vite.
+  ssr: {
+    external: ['better-sqlite3'],
+  },
   resolve: {
     alias: {
       '@convsim/shared': path.resolve(__dirname, '../../packages/shared/src/index.ts'),

--- a/packages/shared/src/types/session.ts
+++ b/packages/shared/src/types/session.ts
@@ -17,6 +17,8 @@ export type SessionState =
   | 'Ended'
   | 'Error';
 
+export type EndingType = 'player_exit' | 'success' | 'failure' | 'timeout' | 'safety_stop';
+
 export interface SessionCreateRequest {
   scenario_id: string;
   difficulty: ScenarioDifficulty;
@@ -35,4 +37,46 @@ export interface SessionCreateResponse {
   state: SessionState;
   created_at: string;
   setup: SessionCreateRequest;
+}
+
+export interface SessionEvent {
+  event_id: number;
+  session_id: string;
+  event_type: string;
+  payload: Record<string, unknown>;
+  created_at: string;
+}
+
+export interface SessionStartResponse {
+  session_id: string;
+  state: SessionState;
+  events: SessionEvent[];
+}
+
+export interface TurnRequest {
+  content: string;
+}
+
+export interface TurnResponse {
+  session_id: string;
+  state: SessionState;
+  events: SessionEvent[];
+}
+
+export interface SessionEndResponse {
+  session_id: string;
+  state: SessionState;
+  ending_type: EndingType;
+}
+
+export interface SessionDebriefResponse {
+  session_id: string;
+  state: SessionState;
+  summary: string;
+}
+
+export interface SessionTransitionError {
+  code: 'INVALID_TRANSITION' | 'SESSION_NOT_FOUND' | 'VALIDATION_ERROR';
+  message: string;
+  current_state?: SessionState;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1225,6 +1225,10 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
   deep-eql@4.1.4:
     resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
     engines: {node: '>=6'}
@@ -1247,6 +1251,10 @@ packages:
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
 
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
@@ -1373,6 +1381,10 @@ packages:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
@@ -1474,6 +1486,9 @@ packages:
   get-stream@8.0.1:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
     engines: {node: '>=16'}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
@@ -1685,6 +1700,10 @@ packages:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -1695,6 +1714,12 @@ packages:
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
@@ -1735,6 +1760,9 @@ packages:
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   onetime@6.0.0:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
@@ -1978,6 +2006,12 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
@@ -1998,6 +2032,9 @@ packages:
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   strip-final-newline@3.0.0:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
@@ -2137,6 +2174,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   vite-node@1.6.1:
     resolution: {integrity: sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==}
@@ -3248,6 +3288,10 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
   deep-eql@4.1.4:
     dependencies:
       type-detect: 4.1.0
@@ -3261,6 +3305,8 @@ snapshots:
   delayed-stream@1.0.0: {}
 
   dequal@2.0.3: {}
+
+  detect-libc@2.1.2: {}
 
   diff-sequences@29.6.3: {}
 
@@ -3450,6 +3496,8 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
 
+  expand-template@2.0.3: {}
+
   expect-type@1.4.0: {}
 
   fast-decode-uri-component@1.0.1: {}
@@ -3567,6 +3615,8 @@ snapshots:
       es-object-atoms: 1.1.2
 
   get-stream@8.0.1: {}
+
+  github-from-package@0.0.0: {}
 
   glob-parent@6.0.2:
     dependencies:
@@ -3759,6 +3809,8 @@ snapshots:
 
   mimic-fn@4.0.0: {}
 
+  mimic-response@3.1.0: {}
+
   min-indent@1.0.1: {}
 
   minimatch@10.2.5:
@@ -3768,6 +3820,10 @@ snapshots:
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.15
+
+  minimist@1.2.8: {}
+
+  mkdirp-classic@0.5.3: {}
 
   mlly@1.8.2:
     dependencies:
@@ -3799,6 +3855,10 @@ snapshots:
   nwsapi@2.2.24: {}
 
   on-exit-leak-free@2.1.2: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   onetime@6.0.0:
     dependencies:
@@ -4056,6 +4116,14 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
   sirv@3.0.2:
     dependencies:
       '@polka/url': 1.0.0-next.29
@@ -4073,6 +4141,10 @@ snapshots:
   stackback@0.0.2: {}
 
   std-env@3.10.0: {}
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   strip-final-newline@3.0.0: {}
 
@@ -4196,6 +4268,8 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  util-deprecate@1.0.2: {}
 
   vite-node@1.6.1(@types/node@22.20.0):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,10 +16,16 @@ importers:
       '@fastify/cors':
         specifier: ^11.2.0
         version: 11.2.0
+      better-sqlite3:
+        specifier: ^12.11.1
+        version: 12.11.1
       fastify:
         specifier: ^5.0.0
         version: 5.9.0
     devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
       '@types/node':
         specifier: ^22.0.0
         version: 22.20.0
@@ -824,6 +830,9 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/better-sqlite3@7.6.13':
+    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
+
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
@@ -1017,10 +1026,23 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.10.40:
     resolution: {integrity: sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  better-sqlite3@12.11.1:
+    resolution: {integrity: sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
   brace-expansion@1.1.15:
     resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
@@ -1033,6 +1055,9 @@ packages:
     resolution: {integrity: sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -1060,6 +1085,9 @@ packages:
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -1112,9 +1140,17 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -1126,6 +1162,10 @@ packages:
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
@@ -1139,6 +1179,9 @@ packages:
 
   electron-to-chromium@1.5.381:
     resolution: {integrity: sha512-n9Wa6yB+vDsGuA8AKbl/0z7HbvWqt5jxIdvr1IUicd0ryPrk7/xzwqLv8D9AbbvZ6avVNtXYLTfmgFHkwkyelg==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
@@ -1241,6 +1284,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
@@ -1291,6 +1338,9 @@ packages:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
   find-my-way@9.6.0:
     resolution: {integrity: sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==}
     engines: {node: '>=20'}
@@ -1309,6 +1359,9 @@ packages:
   form-data@4.0.6:
     resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1329,6 +1382,9 @@ packages:
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
@@ -1378,6 +1434,9 @@ packages:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -1397,6 +1456,12 @@ packages:
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   ipaddr.js@2.4.0:
     resolution: {integrity: sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==}
@@ -1506,6 +1571,10 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -1516,6 +1585,12 @@ packages:
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
@@ -1529,8 +1604,15 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  node-abi@3.93.0:
+    resolution: {integrity: sha512-Cu6yUpX5Iavugm8BeX7c0wgU9CvOqfd1yM6A1d2q2ZMjym7GjpASv2GdRcTq3Fx+Sb5OgBkEEpw4VnAbY6Y5RA==}
+    engines: {node: '>=10'}
 
   node-releases@2.0.50:
     resolution: {integrity: sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==}
@@ -1542,6 +1624,9 @@ packages:
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -1598,6 +1683,12 @@ packages:
     resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -1612,12 +1703,19 @@ packages:
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
 
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
@@ -1647,6 +1745,10 @@ packages:
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
 
   real-require@0.2.0:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
@@ -1688,6 +1790,9 @@ packages:
 
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safe-regex2@5.1.1:
     resolution: {integrity: sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==}
@@ -1733,6 +1838,12 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
@@ -1754,9 +1865,16 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
+
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -1768,6 +1886,13 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  tar-fs@2.1.5:
+    resolution: {integrity: sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
 
   thread-stream@4.2.0:
     resolution: {integrity: sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==}
@@ -1829,6 +1954,9 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -1856,6 +1984,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
@@ -1952,6 +2083,9 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   ws@8.21.0:
     resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
@@ -2517,6 +2651,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
+  '@types/better-sqlite3@7.6.13':
+    dependencies:
+      '@types/node': 22.20.0
+
   '@types/estree@1.0.9': {}
 
   '@types/json-schema@7.0.15': {}
@@ -2749,7 +2887,24 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.10.40: {}
+
+  better-sqlite3@12.11.1:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   brace-expansion@1.1.15:
     dependencies:
@@ -2767,6 +2922,11 @@ snapshots:
       electron-to-chromium: 1.5.381
       node-releases: 2.0.50
       update-browserslist-db: 1.2.3(browserslist@4.28.4)
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   cac@6.7.14: {}
 
@@ -2793,6 +2953,8 @@ snapshots:
       supports-color: 7.2.0
 
   check-error@2.1.3: {}
+
+  chownr@1.1.4: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -2836,13 +2998,21 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
   deep-eql@5.0.2: {}
+
+  deep-extend@0.6.0: {}
 
   deep-is@0.1.4: {}
 
   delayed-stream@1.0.0: {}
 
   dequal@2.0.3: {}
+
+  detect-libc@2.1.2: {}
 
   dom-accessibility-api@0.5.16: {}
 
@@ -2855,6 +3025,10 @@ snapshots:
       gopd: 1.2.0
 
   electron-to-chromium@1.5.381: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   entities@6.0.1: {}
 
@@ -3014,6 +3188,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  expand-template@2.0.3: {}
+
   expect-type@1.4.0: {}
 
   fast-decode-uri-component@1.0.1: {}
@@ -3073,6 +3249,8 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
+  file-uri-to-path@1.0.0: {}
+
   find-my-way@9.6.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -3099,6 +3277,8 @@ snapshots:
       hasown: 2.0.4
       mime-types: 2.1.35
 
+  fs-constants@1.0.0: {}
+
   fsevents@2.3.3:
     optional: true
 
@@ -3123,6 +3303,8 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.2
+
+  github-from-package@0.0.0: {}
 
   glob-parent@6.0.2:
     dependencies:
@@ -3168,6 +3350,8 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  ieee754@1.2.1: {}
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -3180,6 +3364,10 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
+
+  inherits@2.0.4: {}
+
+  ini@1.3.8: {}
 
   ipaddr.js@2.4.0: {}
 
@@ -3290,6 +3478,8 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
+  mimic-response@3.1.0: {}
+
   min-indent@1.0.1: {}
 
   minimatch@10.2.5:
@@ -3300,19 +3490,33 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.15
 
+  minimist@1.2.8: {}
+
+  mkdirp-classic@0.5.3: {}
+
   mrmime@2.0.1: {}
 
   ms@2.1.3: {}
 
   nanoid@3.3.15: {}
 
+  napi-build-utils@2.0.0: {}
+
   natural-compare@1.4.0: {}
+
+  node-abi@3.93.0:
+    dependencies:
+      semver: 7.8.5
 
   node-releases@2.0.50: {}
 
   nwsapi@2.2.24: {}
 
   on-exit-leak-free@2.1.2: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   optionator@0.9.4:
     dependencies:
@@ -3377,6 +3581,21 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.93.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.5
+      tunnel-agent: 0.6.0
+
   prelude-ls@1.2.1: {}
 
   pretty-format@27.5.1:
@@ -3389,9 +3608,21 @@ snapshots:
 
   process-warning@5.0.0: {}
 
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
   punycode@2.3.1: {}
 
   quick-format-unescaped@4.0.4: {}
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
 
   react-dom@18.3.1(react@18.3.1):
     dependencies:
@@ -3418,6 +3649,12 @@ snapshots:
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
 
   real-require@0.2.0: {}
 
@@ -3473,6 +3710,8 @@ snapshots:
 
   rrweb-cssom@0.8.0: {}
 
+  safe-buffer@5.2.1: {}
+
   safe-regex2@5.1.1:
     dependencies:
       ret: 0.5.0
@@ -3505,6 +3744,14 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
   sirv@3.0.2:
     dependencies:
       '@polka/url': 1.0.0-next.29
@@ -3523,9 +3770,15 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   strip-indent@3.0.0:
     dependencies:
       min-indent: 1.0.1
+
+  strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
 
@@ -3534,6 +3787,21 @@ snapshots:
       has-flag: 4.0.0
 
   symbol-tree@3.2.4: {}
+
+  tar-fs@2.1.5:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   thread-stream@4.2.0:
     dependencies:
@@ -3582,6 +3850,10 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -3610,6 +3882,8 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  util-deprecate@1.0.2: {}
 
   vite-node@2.1.9(@types/node@22.20.0):
     dependencies:
@@ -3702,6 +3976,8 @@ snapshots:
       stackback: 0.0.2
 
   word-wrap@1.2.5: {}
+
+  wrappy@1.0.2: {}
 
   ws@8.21.0: {}
 


### PR DESCRIPTION
## Summary

Implements a complete session API lifecycle with SQLite persistence and a strict state machine. Sessions can be created, started, progressed through turns, and ended, with all state transitions validated and event history preserved across restarts.

## Key Changes

### API Endpoints

- **`POST /api/sessions/:id/start`** — transitions a `NotStarted` session to `PlayerTurnListening` and records an `npc_opening` event
- **`POST /api/sessions/:id/turn`** — accepts a player message when in `PlayerTurnListening`, records `player_turn` and `npc_turn` events, and maintains the state
- **`POST /api/sessions/:id/end`** — terminates a session from any non-terminal state, preserves any scenario-set `ending_type` (e.g., success/failure), or defaults to `player_exit`
- **`POST /api/sessions/:id/debrief`** — generates a summary when called from `DebriefReady` state only and transitions to `Ended`

Existing endpoints `POST /api/sessions`, `GET /api/sessions/:id`, and `DELETE /api/sessions/:id` remain unchanged and now persist to SQLite.

### State Machine & Validation

- Implemented `canTransition(state, action)` guard that enforces legal progressions
- Illegal transitions return `409 Conflict` with `code: 'INVALID_TRANSITION'` and `current_state` in the response body
- No persisted state is modified on rejected transitions
- `Error` state can transition to `Ended` (allows graceful exit from broken sessions)

### Database (SQLite with better-sqlite3)

- `sessions` table: stores `session_id`, `scenario_id`, `state`, `ending_type`, `created_at`, `setup_json`
- `session_events` table: stores event history with `event_type`, `payload_json`, `created_at`, and cascade-delete on session removal
- Database initialized at `~/.convsim/db/sessions.db` (or `SESSION_DB_PATH` env var)
- Multi-step operations (state update + event insert) wrapped in transactions for atomicity

### Error Handling

- Custom Fastify `setErrorHandler` propagates typed error fields (`code`, `current_state`) while respecting status codes set via `reply.status()` before throw
- Fallback to 500 when no explicit status is set

### Type Definitions

Added to `packages/shared/src/types/session.ts`:
- `EndingType`, `SessionEvent`, `SessionStartResponse`, `TurnRequest`, `TurnResponse`, `SessionEndResponse`, `SessionDebriefResponse`, `SessionTransitionError`

## Test Coverage

Session route tests expanded to 45 tests covering:
- Legal and illegal transitions for every endpoint
- Full lifecycle: create → start → turn → end
- State persistence via `GET /api/sessions/:id`
- 404 for unknown sessions
- Ending type preservation when a scenario has already set an outcome
- Transition guard rejections without state mutation
- Transaction atomicity (no orphaned events)
- Rejection from every invalid source state for each action

All tests across session routes, scenario routes, and shared setup validation pass.

Closes #17