### PR TITLE
Implement full scenario pack JSON schema suite with validation tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,15 +116,20 @@ jobs:
           node packages/scenario-schema/tests/validate-schemas.js
 
   pack-validation:
-    name: Pack validation (placeholder)
+    name: Pack validation
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Validate packs
-        # No pack validator exists yet. When one is implemented, replace the
-        # echo below with the validator invocation.
-        # Local: <pack-validator-command> packs/official
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Validate official packs
         run: |
-          echo "Pack validation placeholder — no pack validator installed yet."
-          echo "Future quality gate: validate all scenario packs under packs/official/"
-          echo "Local: <pack-validator-command> packs/official"
+          echo "Local: node packages/scenario-schema/tests/validate-packs.js packs/official"
+          node packages/scenario-schema/tests/validate-packs.js packs/official

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,17 +93,27 @@ jobs:
           pnpm --filter @convsim/web test
 
   schemas:
-    name: Schema load tests
+    name: Schema validation tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
       - name: Run schema load tests
         run: |
           echo "Local: node packages/scenario-schema/tests/load-schemas.js"
           node packages/scenario-schema/tests/load-schemas.js
+      - name: Run schema validation tests
+        run: |
+          echo "Local: node packages/scenario-schema/tests/validate-schemas.js"
+          node packages/scenario-schema/tests/validate-schemas.js
 
   pack-validation:
     name: Pack validation (placeholder)

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "setup": "./scripts/setup.sh",
     "dev": "./scripts/dev.sh",
     "test:schemas": "node packages/scenario-schema/tests/load-schemas.js && node packages/scenario-schema/tests/validate-schemas.js",
+    "test:packs": "node packages/scenario-schema/tests/validate-packs.js packs/official",
     "test:types": "pnpm --filter @convsim/shared-types check && pnpm --filter @convsim/scenario-schema check"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "setup": "./scripts/setup.sh",
     "dev": "./scripts/dev.sh",
-    "test:schemas": "node packages/scenario-schema/tests/load-schemas.js",
+    "test:schemas": "node packages/scenario-schema/tests/load-schemas.js && node packages/scenario-schema/tests/validate-schemas.js",
     "test:types": "pnpm --filter @convsim/shared-types check && pnpm --filter @convsim/scenario-schema check"
   },
   "engines": {

--- a/packages/scenario-schema/package.json
+++ b/packages/scenario-schema/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "ajv": "^8.17.1",
+    "js-yaml": "^4.1.0",
     "typescript": "^5.5.0"
   }
 }

--- a/packages/scenario-schema/package.json
+++ b/packages/scenario-schema/package.json
@@ -17,6 +17,7 @@
     "test": "node tests/load-schemas.js && vitest run"
   },
   "dependencies": {
+    "ajv": "^8.17.1",
     "js-yaml": "^4.1.0",
     "zod": "^3.23.8"
   },

--- a/packages/scenario-schema/package.json
+++ b/packages/scenario-schema/package.json
@@ -17,6 +17,7 @@
     "test": "node tests/load-schemas.js"
   },
   "devDependencies": {
+    "ajv": "^8.17.1",
     "typescript": "^5.5.0"
   }
 }

--- a/packages/scenario-schema/src/index.ts
+++ b/packages/scenario-schema/src/index.ts
@@ -7,6 +7,9 @@ export const SCHEMA_NAMES = [
   "npc.schema.json",
   "rubric.schema.json",
   "safety.schema.json",
+  "scene.schema.json",
+  "pack-test.schema.json",
+  "asset.schema.json",
   "turn-output.schema.json",
   "debrief.schema.json",
 ] as const;

--- a/packages/scenario-schema/tests/load-schemas.js
+++ b/packages/scenario-schema/tests/load-schemas.js
@@ -18,6 +18,9 @@ const SCHEMA_NAMES = [
   "npc.schema.json",
   "rubric.schema.json",
   "safety.schema.json",
+  "scene.schema.json",
+  "pack-test.schema.json",
+  "asset.schema.json",
   "turn-output.schema.json",
   "debrief.schema.json",
 ];

--- a/packages/scenario-schema/tests/validate-packs.js
+++ b/packages/scenario-schema/tests/validate-packs.js
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+// Validates all YAML files in packs/official/ against their corresponding JSON schemas.
+// Run with: node packages/scenario-schema/tests/validate-packs.js [packs-root]
+// Exits 0 if all files pass, 1 if any fail.
+
+import Ajv from "ajv";
+import { readFileSync, readdirSync, statSync } from "fs";
+import { resolve, dirname, basename, join } from "path";
+import { fileURLToPath } from "url";
+import { load as yamlLoad } from "js-yaml";
+
+const _dir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(_dir, "..", "..", "..");
+const schemasDir = resolve(repoRoot, "schemas");
+
+const packsRoot = process.argv[2]
+  ? resolve(process.argv[2])
+  : resolve(repoRoot, "packs", "official");
+
+const ajv = new Ajv({ strict: false, validateSchema: false, allErrors: true });
+
+function loadSchema(name) {
+  return JSON.parse(readFileSync(resolve(schemasDir, name), "utf8"));
+}
+
+const validators = {
+  pack: ajv.compile(loadSchema("pack.schema.json")),
+  scenario: ajv.compile(loadSchema("scenario.schema.json")),
+  npc: ajv.compile(loadSchema("npc.schema.json")),
+  rubric: ajv.compile(loadSchema("rubric.schema.json")),
+  safety: ajv.compile(loadSchema("safety.schema.json")),
+  scene: ajv.compile(loadSchema("scene.schema.json")),
+  packTest: ajv.compile(loadSchema("pack-test.schema.json")),
+  asset: ajv.compile(loadSchema("asset.schema.json")),
+};
+
+function schemaKeyForPath(filePath) {
+  const dir = basename(dirname(filePath));
+  const file = basename(filePath);
+  if (file === "manifest.yaml") return "pack";
+  if (dir === "scenarios") return "scenario";
+  if (dir === "npcs") return "npc";
+  if (dir === "rubrics") return "rubric";
+  if (dir === "safety") return "safety";
+  if (dir === "scenes") return "scene";
+  if (dir === "tests") return "packTest";
+  if (file.endsWith(".meta.json")) return "asset";
+  return null;
+}
+
+function collectYamlFiles(dir) {
+  const results = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      results.push(...collectYamlFiles(full));
+    } else if (entry.endsWith(".yaml") || entry.endsWith(".yml")) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+let passed = 0;
+let failed = 0;
+
+const files = collectYamlFiles(packsRoot);
+
+for (const filePath of files) {
+  const rel = filePath.startsWith(repoRoot)
+    ? filePath.slice(repoRoot.length + 1)
+    : filePath;
+  const schemaKey = schemaKeyForPath(filePath);
+
+  if (!schemaKey) {
+    console.log(`  SKIP  ${rel}  (no schema mapped for this path)`);
+    continue;
+  }
+
+  let data;
+  try {
+    data = yamlLoad(readFileSync(filePath, "utf8"));
+  } catch (err) {
+    console.error(`  FAIL  ${rel}`);
+    console.error(`        YAML parse error: ${err.message}`);
+    failed++;
+    continue;
+  }
+
+  const validate = validators[schemaKey];
+  const ok = validate(data);
+
+  if (ok) {
+    console.log(`  pass  ${rel}`);
+    passed++;
+  } else {
+    console.error(`  FAIL  ${rel}`);
+    for (const error of validate.errors) {
+      const loc = error.instancePath || "(root)";
+      console.error(`        ${loc}: ${error.message}`);
+      if (error.params && Object.keys(error.params).length > 0) {
+        console.error(`        params: ${JSON.stringify(error.params)}`);
+      }
+    }
+    failed++;
+  }
+}
+
+console.log(
+  `\n${passed + failed} file(s) checked — ${passed} passed, ${failed} failed.`
+);
+
+if (failed > 0) {
+  process.exit(1);
+}

--- a/packages/scenario-schema/tests/validate-schemas.js
+++ b/packages/scenario-schema/tests/validate-schemas.js
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+// Schema validation tests: verifies example instances pass and targeted invalid instances fail.
+// Run with: node packages/scenario-schema/tests/validate-schemas.js (requires pnpm install first)
+
+import Ajv from "ajv";
+import { readFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const _dir = dirname(fileURLToPath(import.meta.url));
+const schemasDir = resolve(_dir, "..", "..", "..", "schemas");
+const examplesDir = resolve(schemasDir, "examples");
+
+// strict:false and validateSchema:false allow the 2020-12 $schema declaration without
+// requiring a separate 2020-12 AJV instance; all constraints used are Draft-07 compatible.
+const ajv = new Ajv({ strict: false, validateSchema: false, allErrors: true });
+
+function loadJSON(filePath) {
+  return JSON.parse(readFileSync(filePath, "utf8"));
+}
+
+function loadSchema(name) {
+  return loadJSON(resolve(schemasDir, name));
+}
+
+function loadExample(name) {
+  return loadJSON(resolve(examplesDir, name));
+}
+
+// Pre-compile validators for all pack-authored schemas.
+const validators = {
+  pack: ajv.compile(loadSchema("pack.schema.json")),
+  scenario: ajv.compile(loadSchema("scenario.schema.json")),
+  npc: ajv.compile(loadSchema("npc.schema.json")),
+  rubric: ajv.compile(loadSchema("rubric.schema.json")),
+  safety: ajv.compile(loadSchema("safety.schema.json")),
+  scene: ajv.compile(loadSchema("scene.schema.json")),
+  packTest: ajv.compile(loadSchema("pack-test.schema.json")),
+  asset: ajv.compile(loadSchema("asset.schema.json")),
+};
+
+// ─── Valid example tests ──────────────────────────────────────────────────────
+
+const VALID_PAIRS = [
+  ["pack", "pack.example.json"],
+  ["scenario", "scenario.example.json"],
+  ["npc", "npc.example.json"],
+  ["rubric", "rubric.example.json"],
+  ["safety", "safety.example.json"],
+  ["scene", "scene.example.json"],
+  ["packTest", "pack-test.example.json"],
+  ["asset", "asset.example.json"],
+];
+
+for (const [schemaKey, exampleFile] of VALID_PAIRS) {
+  test(`valid: ${exampleFile} passes ${schemaKey}.schema.json`, () => {
+    const validate = validators[schemaKey];
+    const data = loadExample(exampleFile);
+    const ok = validate(data);
+    if (!ok) {
+      assert.fail(
+        `Unexpected validation failure in ${exampleFile}:\n${JSON.stringify(validate.errors, null, 2)}`
+      );
+    }
+  });
+}
+
+// ─── Invalid instance rejection tests ────────────────────────────────────────
+
+function mustReject(schemaKey, getData, label) {
+  test(`invalid: rejects ${label}`, () => {
+    const validate = validators[schemaKey];
+    const data = getData();
+    const ok = validate(data);
+    assert.ok(!ok, `Expected validation to fail for: ${label}`);
+  });
+}
+
+// Pack: required top-level fields
+mustReject("pack", () => {
+  const d = loadExample("pack.example.json");
+  delete d.license;
+  return d;
+}, "pack missing license");
+
+mustReject("pack", () => {
+  const d = loadExample("pack.example.json");
+  delete d.content_rating;
+  return d;
+}, "pack missing content_rating");
+
+mustReject("pack", () => {
+  const d = loadExample("pack.example.json");
+  delete d.safety;
+  return d;
+}, "pack missing safety block");
+
+mustReject("pack", () => {
+  const d = loadExample("pack.example.json");
+  d.safety = {};
+  return d;
+}, "pack safety block missing policy path");
+
+mustReject("pack", () => {
+  return { ...loadExample("pack.example.json"), scripts: { postinstall: "rm -rf /" } };
+}, "pack with scripts field (executable code forbidden)");
+
+// NPC: fictional flag and age constraints
+mustReject("npc", () => {
+  return { ...loadExample("npc.example.json"), fictional: false };
+}, "npc fictional: false");
+
+mustReject("npc", () => {
+  const d = loadExample("npc.example.json");
+  delete d.fictional;
+  return d;
+}, "npc missing fictional flag");
+
+mustReject("npc", () => {
+  const d = loadExample("npc.example.json");
+  delete d.age_band;
+  return d;
+}, "npc missing age_band (ambiguous age rejected)");
+
+mustReject("npc", () => {
+  return { ...loadExample("npc.example.json"), licensed_persona: { real_name: "John Doe" } };
+}, "npc licensed_persona reserved namespace (blocked in MVP)");
+
+// Safety: mandatory fields
+mustReject("safety", () => {
+  const d = loadExample("safety.example.json");
+  delete d.content_rating_cap;
+  return d;
+}, "safety missing content_rating_cap");
+
+mustReject("safety", () => {
+  const d = loadExample("safety.example.json");
+  delete d.content_categories;
+  return d;
+}, "safety missing content_categories");
+
+mustReject("safety", () => {
+  const d = loadExample("safety.example.json");
+  delete d.redirect_message;
+  return d;
+}, "safety missing redirect_message");
+
+mustReject("safety", () => {
+  const d = loadExample("safety.example.json");
+  delete d.content_categories.nsfw_sexual;
+  return d;
+}, "safety missing required nsfw_sexual category");
+
+mustReject("safety", () => {
+  const d = loadExample("safety.example.json");
+  delete d.content_categories.crisis_content;
+  return d;
+}, "safety missing required crisis_content category");

--- a/packages/scenario-schema/tests/validate-schemas.js
+++ b/packages/scenario-schema/tests/validate-schemas.js
@@ -155,6 +155,18 @@ mustReject("safety", () => {
 
 mustReject("safety", () => {
   const d = loadExample("safety.example.json");
+  delete d.content_categories.real_person_impersonation;
+  return d;
+}, "safety missing required real_person_impersonation category");
+
+mustReject("safety", () => {
+  const d = loadExample("safety.example.json");
+  delete d.content_categories.instructional_criminal;
+  return d;
+}, "safety missing required instructional_criminal category");
+
+mustReject("safety", () => {
+  const d = loadExample("safety.example.json");
   delete d.content_categories.crisis_content;
   return d;
 }, "safety missing required crisis_content category");

--- a/packs/official/job-interview-basic/scenes/meridian_conference_room.yaml
+++ b/packs/official/job-interview-basic/scenes/meridian_conference_room.yaml
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: CC-BY-4.0
-# Scene descriptor — informs the renderer of visual context.
-# No schema validation applies to scene files in schema version 0.1.
+schema_version: "0.1"
 scene_id: meridian_conference_room
 display_name: "Meridian Systems — Conference Room B"
 background: assets/backgrounds/conference_room_placeholder.png

--- a/packs/official/job-interview-basic/tests/smoke_behavioral_interview.yaml
+++ b/packs/official/job-interview-basic/tests/smoke_behavioral_interview.yaml
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: CC-BY-4.0
-# Smoke test fixture for the behavioral_interview scenario.
-# Intended for the future pack test runner (not yet implemented in schema v0.1).
-# Documents a minimal passing session for manual and automated verification.
+schema_version: "0.1"
 fixture_id: smoke_behavioral_interview
 scenario_id: behavioral_interview
 description: >-

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
 
   packages/scenario-schema:
     devDependencies:
+      ajv:
+        specifier: ^8.17.1
+        version: 8.20.0
       typescript:
         specifier: ^5.5.0
         version: 5.6.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ importers:
       ajv:
         specifier: ^8.17.1
         version: 8.20.0
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.3.0
       typescript:
         specifier: ^5.5.0
         version: 5.6.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
 
   packages/scenario-schema:
     dependencies:
+      ajv:
+        specifier: ^8.17.1
+        version: 8.20.0
       js-yaml:
         specifier: ^4.1.0
         version: 4.3.0

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,23 +1,38 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 # schemas/
 
-JSON Schema definitions for all scenario pack file types.
+JSON Schema (Draft 2020-12) definitions for all ConvSim scenario pack file types.
 
-**Status:** Placeholder. Schemas will be added in Milestone 2 (scenario pack system).
+## Schema files
 
-## Planned schema files
+| File | Validates |
+|------|-----------|
+| `pack.schema.json` | Pack `manifest.yaml` — manifest fields, license, content rating, safety policy reference |
+| `scenario.schema.json` | Individual scenario YAML files — roles, goals, state variables, events, endings |
+| `npc.schema.json` | NPC definition files — persona, fictional flag, age band, private agenda |
+| `rubric.schema.json` | Rubric files — scoring dimensions with stable IDs and weight |
+| `safety.schema.json` | Safety policy files — prohibited categories, redirects, content rating cap |
+| `scene.schema.json` | Scene descriptor files — visual and ambient context |
+| `pack-test.schema.json` | Pack test fixture files — scripted turn sequences and static assertions |
+| `asset.schema.json` | Asset metadata sidecar files — license, provenance, and dimensions |
+| `turn-output.schema.json` | Structured JSON output the LLM produces per turn (runtime, not pack-authored) |
+| `debrief.schema.json` | Debrief report generated after a completed session (runtime output) |
 
-| File                  | Validates                                            |
-| --------------------- | ---------------------------------------------------- |
-| `pack.schema.json`    | Pack `manifest.yaml`                                 |
-| `scenario.schema.json`| Individual scenario YAML files                       |
-| `npc.schema.json`     | NPC definition files                                 |
-| `rubric.schema.json`  | Rubric definition files                              |
-| `safety.schema.json`  | Safety policy files                                  |
-| `turn-output.schema.json` | Structured JSON output from the LLM per turn     |
-| `debrief.schema.json` | Debrief output structure                             |
+## Examples
 
-These schemas are used by:
-- `convsim validate-pack` (CLI tool)
-- `packages/scenario-schema` (TypeScript types for the frontend)
-- The creator workbench validator panel
+`examples/` contains one valid JSON example per pack-authored schema. These serve as both documentation and test fixtures for `packages/scenario-schema/tests/validate-schemas.js`.
+
+## Enforcement
+
+Every pack-authored file must declare:
+
+```yaml
+schema_version: "0.1"
+```
+
+Schemas are used by:
+- `packages/scenario-schema/tests/` — load and validation tests (CI)
+- `packages/scenario-schema/src/` — TypeScript `SCHEMA_NAMES` constant for the frontend
+- `convsim validate-pack` — CLI validator (planned)
+
+See `VERSIONING.md` for schema versioning rules and the breaking-change review process.

--- a/schemas/asset.schema.json
+++ b/schemas/asset.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.convsim.dev/v0.1/asset.schema.json",
+  "title": "ConvSim Asset Metadata",
+  "description": "Validates an asset metadata sidecar file (.meta.json). One metadata file per asset records license, type, and provenance for offline-first packs.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "asset_id",
+    "type",
+    "file",
+    "license"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "enum": ["0.1"]
+    },
+    "asset_id": {
+      "type": "string",
+      "description": "Unique identifier for this asset within the pack.",
+      "pattern": "^[a-z0-9_]+$"
+    },
+    "type": {
+      "type": "string",
+      "enum": ["portrait", "background", "audio", "music", "icon"],
+      "description": "Asset category. Determines how the runtime loads and displays the asset."
+    },
+    "file": {
+      "type": "string",
+      "description": "Relative path to the asset file from the pack root.",
+      "minLength": 1
+    },
+    "license": {
+      "type": "string",
+      "description": "SPDX license identifier for this individual asset.",
+      "minLength": 1
+    },
+    "attribution": {
+      "type": "string",
+      "description": "Required attribution text if the license demands it (e.g. CC BY 4.0)."
+    },
+    "source_url": {
+      "type": "string",
+      "description": "Original source URL for attribution. Informational only — never loaded at runtime."
+    },
+    "width_px": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Width in pixels. Required for portrait and background assets."
+    },
+    "height_px": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Height in pixels. Required for portrait and background assets."
+    },
+    "duration_seconds": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Duration in seconds. Required for audio and music assets."
+    }
+  },
+  "not": {
+    "description": "Asset metadata must not contain runtime-loaded URLs or executable fields.",
+    "required": ["runtime_url"]
+  }
+}

--- a/schemas/examples/asset.example.json
+++ b/schemas/examples/asset.example.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": "0.1",
+  "asset_id": "greeter_portrait",
+  "type": "portrait",
+  "file": "assets/portraits/greeter_placeholder.png",
+  "license": "CC0-1.0",
+  "width_px": 512,
+  "height_px": 512
+}

--- a/schemas/examples/npc.example.json
+++ b/schemas/examples/npc.example.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "0.1",
+  "npc_id": "greeter",
+  "display_name": "Alex Chen",
+  "archetype": "friendly_professional",
+  "fictional": true,
+  "age_band": "adult",
+  "voice": {
+    "engine": "none"
+  },
+  "public_persona": {
+    "occupation": "Front desk receptionist at a small professional office.",
+    "speaking_style": "Warm, concise, and welcoming. Uses simple and clear language.",
+    "demeanor": "Cheerful and attentive. Makes visitors feel at ease immediately."
+  },
+  "private_persona": {
+    "hidden_agenda": [
+      "Assess whether visitors can state their purpose clearly and politely in a few sentences."
+    ],
+    "biases_to_simulate": [
+      "Slightly more responsive and helpful toward visitors who introduce themselves by name."
+    ],
+    "boundaries": [
+      "Never discuss internal company information or employee details.",
+      "Never generate sexual, violent, or disturbing content.",
+      "Never impersonate a real person or named public figure."
+    ]
+  }
+}

--- a/schemas/examples/pack-test.example.json
+++ b/schemas/examples/pack-test.example.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": "0.1",
+  "fixture_id": "smoke_hello_world",
+  "scenario_id": "hello_world",
+  "description": "Minimal smoke test for the hello_world scenario. Verifies the scenario loads, produces a non-empty opening, and that a clear self-introduction advances the session without a safety stop.",
+  "seed": 1,
+  "input_mode": "text",
+  "difficulty": "normal",
+  "turns": [
+    {
+      "turn": 1,
+      "player_input": "Hi, I'm Jamie Park. I have a 10 o'clock meeting with the product team.",
+      "expect": {
+        "state_delta_contains": ["clarity"],
+        "session_control": "continue_session",
+        "safety_status": "ok"
+      }
+    }
+  ],
+  "static_assertions": [
+    {
+      "description": "Scenario opening line is non-empty",
+      "path": "opening.npc_says",
+      "check": "non_empty_string"
+    },
+    {
+      "description": "NPC is marked fictional",
+      "path": "npc.fictional",
+      "check": "equals true"
+    },
+    {
+      "description": "Safety policy blocks nsfw_sexual content",
+      "path": "safety.content_categories.nsfw_sexual",
+      "check": "equals block"
+    }
+  ]
+}

--- a/schemas/examples/pack.example.json
+++ b/schemas/examples/pack.example.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": "0.1",
+  "pack_id": "example.hello_world",
+  "name": "Hello World",
+  "version": "0.1.0",
+  "description": "A minimal example pack for documentation and schema tests.",
+  "author": "ConvSim Contributors",
+  "license": "CC-BY-4.0",
+  "content_rating": "G",
+  "tags": ["example"],
+  "supported_languages": ["en"],
+  "entry_scenarios": ["scenarios/hello.yaml"],
+  "assets": {
+    "allow_external_urls": false
+  },
+  "safety": {
+    "policy": "safety/default.yaml"
+  }
+}

--- a/schemas/examples/rubric.example.json
+++ b/schemas/examples/rubric.example.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "0.1",
+  "rubric_id": "basic_rubric",
+  "title": "Basic Interaction Rubric",
+  "dimensions": [
+    {
+      "id": "clarity",
+      "name": "Clarity",
+      "description": "Whether the player communicates their purpose clearly and concisely.",
+      "scoring": {
+        "low": "The player's message is vague or confusing. The greeter cannot determine the purpose of the visit.",
+        "medium": "The player provides a purpose but it is imprecisely stated or requires follow-up to understand.",
+        "high": "The player clearly states their name and purpose in one or two focused sentences."
+      },
+      "weight": 0.6
+    },
+    {
+      "id": "politeness",
+      "name": "Politeness",
+      "description": "Whether the player is respectful and courteous throughout the interaction.",
+      "scoring": {
+        "low": "The player is curt, dismissive, or rude.",
+        "medium": "The player is neutral in tone — not rude but not particularly warm.",
+        "high": "The player is genuinely warm and respectful, and the greeter feels valued."
+      },
+      "weight": 0.4
+    }
+  ]
+}

--- a/schemas/examples/safety.example.json
+++ b/schemas/examples/safety.example.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": "0.1",
+  "policy_id": "default_safety",
+  "description": "Default safety policy for example packs. Maintains a safe, professional context suitable for all ages.",
+  "content_categories": {
+    "nsfw_sexual": "block",
+    "violence_graphic": "block",
+    "real_person_impersonation": "block",
+    "instructional_criminal": "block",
+    "medical_professional_advice": "redirect",
+    "crisis_content": "redirect"
+  },
+  "redirect_message": "That topic is outside the scope of this conversation. Let's refocus on the interaction.",
+  "allow_profanity": false,
+  "content_rating_cap": "G"
+}

--- a/schemas/examples/scenario.example.json
+++ b/schemas/examples/scenario.example.json
@@ -1,0 +1,81 @@
+{
+  "schema_version": "0.1",
+  "scenario_id": "hello_world",
+  "title": "Hello World",
+  "summary": "A minimal example scenario demonstrating the core scenario structure.",
+  "player_role": {
+    "label": "Guest",
+    "brief": "You are visiting the example office for a brief meeting."
+  },
+  "npc": {
+    "ref": "../npcs/greeter.yaml"
+  },
+  "rubric": {
+    "ref": "../rubrics/basic_rubric.yaml"
+  },
+  "duration": {
+    "max_turns": 5,
+    "soft_time_limit_minutes": 5
+  },
+  "opening": {
+    "npc_says": "Welcome! How can I help you today?"
+  },
+  "goals": {
+    "player_visible": [
+      "Introduce yourself and state the purpose of your visit.",
+      "Be polite and concise."
+    ],
+    "hidden": [
+      "The greeter is assessing whether visitors can communicate their purpose clearly in one or two sentences."
+    ]
+  },
+  "state": {
+    "variables": {
+      "clarity": {
+        "min": 0,
+        "max": 100,
+        "default": 50,
+        "visibility": "visible",
+        "max_delta_per_turn": 20
+      }
+    }
+  },
+  "difficulty": {
+    "default": "normal",
+    "options": {
+      "easy": { "npc_patience_modifier": 20, "challenge_frequency": "low" },
+      "normal": { "npc_patience_modifier": 0, "challenge_frequency": "medium" },
+      "hard": { "npc_patience_modifier": -20, "challenge_frequency": "high" }
+    }
+  },
+  "replay_seed": 42,
+  "response_style": {
+    "max_words": 80,
+    "verbosity": "moderate",
+    "formality": "professional"
+  },
+  "events": [
+    {
+      "id": "high_clarity_reward",
+      "when": {
+        "type": "variable_above",
+        "variable": "clarity",
+        "threshold": 75
+      },
+      "npc_instruction": "The visitor communicated very clearly. Acknowledge it warmly.",
+      "repeat": false
+    }
+  ],
+  "ending_conditions": {
+    "success": {
+      "type": "variable_above",
+      "variable": "clarity",
+      "threshold": 70
+    },
+    "failure": {
+      "type": "variable_below",
+      "variable": "clarity",
+      "threshold": 20
+    }
+  }
+}

--- a/schemas/examples/scene.example.json
+++ b/schemas/examples/scene.example.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": "0.1",
+  "scene_id": "example_office_lobby",
+  "display_name": "Example Office — Main Lobby",
+  "description": "A bright, open lobby with a welcome desk at the center. A few chairs line the wall to the left. The space feels calm and professional.",
+  "background": "assets/backgrounds/lobby_placeholder.png",
+  "ambient": "quiet_office"
+}

--- a/schemas/npc.schema.json
+++ b/schemas/npc.schema.json
@@ -10,6 +10,7 @@
     "display_name",
     "archetype",
     "fictional",
+    "age_band",
     "public_persona",
     "private_persona"
   ],
@@ -53,6 +54,10 @@
         },
         "voice_id": { "type": "string" }
       }
+    },
+    "licensed_persona": {
+      "$comment": "Reserved for a future licensed persona namespace. Not implemented in schema v0.1. This field is explicitly blocked to prevent incompatible use before the namespace is defined.",
+      "not": {}
     },
     "portrait": {
       "type": "string",

--- a/schemas/pack-test.schema.json
+++ b/schemas/pack-test.schema.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.convsim.dev/v0.1/pack-test.schema.json",
+  "title": "ConvSim Pack Test Fixture",
+  "description": "Validates a pack test fixture file. Fixtures define scripted turn sequences and static assertions used by the pack test runner.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "fixture_id",
+    "scenario_id",
+    "description",
+    "turns"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "enum": ["0.1"]
+    },
+    "fixture_id": {
+      "type": "string",
+      "description": "Unique identifier for this test fixture within the pack.",
+      "pattern": "^[a-z0-9_]+$"
+    },
+    "scenario_id": {
+      "type": "string",
+      "description": "The scenario_id this fixture exercises.",
+      "pattern": "^[a-z0-9_]+$"
+    },
+    "description": {
+      "type": "string",
+      "description": "Human-readable description of what this fixture verifies.",
+      "minLength": 1
+    },
+    "seed": {
+      "type": "integer",
+      "description": "Deterministic RNG seed to pass to the runtime for reproducible results.",
+      "minimum": 0
+    },
+    "input_mode": {
+      "type": "string",
+      "enum": ["text", "voice"],
+      "description": "Input modality to simulate."
+    },
+    "difficulty": {
+      "type": "string",
+      "enum": ["easy", "normal", "hard"],
+      "description": "Difficulty setting to use when running the fixture."
+    },
+    "turns": {
+      "type": "array",
+      "description": "Scripted player turns to execute in order.",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["turn", "player_input"],
+        "additionalProperties": false,
+        "properties": {
+          "turn": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "1-based turn number."
+          },
+          "player_input": {
+            "type": "string",
+            "description": "The player utterance to inject for this turn.",
+            "minLength": 1
+          },
+          "expect": {
+            "type": "object",
+            "description": "Assertions the test runner must verify for this turn's output.",
+            "additionalProperties": false,
+            "properties": {
+              "state_delta_contains": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Variable names that must appear in the state_delta output."
+              },
+              "npc_emotion_not": {
+                "type": "string",
+                "description": "Emotion value that must NOT appear in npc_emotion."
+              },
+              "session_control": {
+                "type": "string",
+                "enum": ["continue_session", "end_session"],
+                "description": "Expected value of session_control.continue_session (true=continue_session, false=end_session)."
+              },
+              "safety_status": {
+                "type": "string",
+                "enum": ["ok", "redirect", "stop"],
+                "description": "Expected safety status in the turn output."
+              }
+            }
+          }
+        }
+      }
+    },
+    "static_assertions": {
+      "type": "array",
+      "description": "Structural assertions checked against the loaded scenario and pack manifest (not against live turn output).",
+      "items": {
+        "type": "object",
+        "required": ["description", "path", "check"],
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Human-readable description of what is being asserted."
+          },
+          "path": {
+            "type": "string",
+            "description": "Dot-separated path expression (with optional bracket selectors) into the scenario or pack document."
+          },
+          "check": {
+            "type": "string",
+            "description": "Assertion expression evaluated by the pack test runner."
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/pack.schema.json
+++ b/schemas/pack.schema.json
@@ -11,7 +11,9 @@
     "version",
     "description",
     "author",
-    "license"
+    "license",
+    "content_rating",
+    "safety"
   ],
   "additionalProperties": false,
   "properties": {
@@ -99,6 +101,7 @@
     },
     "safety": {
       "type": "object",
+      "required": ["policy"],
       "additionalProperties": false,
       "properties": {
         "policy": {

--- a/schemas/safety.schema.json
+++ b/schemas/safety.schema.json
@@ -4,7 +4,7 @@
   "title": "ConvSim Safety Policy",
   "description": "Validates a safety policy file that governs content boundaries for a scenario.",
   "type": "object",
-  "required": ["schema_version", "policy_id", "content_categories"],
+  "required": ["schema_version", "policy_id", "content_categories", "redirect_message", "content_rating_cap"],
   "additionalProperties": false,
   "properties": {
     "schema_version": {
@@ -20,7 +20,13 @@
     },
     "content_categories": {
       "type": "object",
-      "description": "Explicit allow/block rules per content category.",
+      "description": "Explicit allow/block rules per content category. Non-negotiable categories (nsfw_sexual, real_person_impersonation, instructional_criminal, crisis_content) must be declared.",
+      "required": [
+        "nsfw_sexual",
+        "real_person_impersonation",
+        "instructional_criminal",
+        "crisis_content"
+      ],
       "additionalProperties": false,
       "properties": {
         "nsfw_sexual": {

--- a/schemas/scenario.schema.json
+++ b/schemas/scenario.schema.json
@@ -236,6 +236,34 @@
         }
       }
     },
+    "replay_seed": {
+      "type": "integer",
+      "description": "Optional integer seed for deterministic replay. When set, the runtime uses this seed to reproduce the same LLM-sampled sequence across replays.",
+      "minimum": 0
+    },
+    "response_style": {
+      "type": "object",
+      "description": "Optional hints controlling NPC response length and register.",
+      "additionalProperties": false,
+      "properties": {
+        "max_words": {
+          "type": "integer",
+          "minimum": 10,
+          "maximum": 500,
+          "description": "Soft target for maximum NPC utterance length in words."
+        },
+        "verbosity": {
+          "type": "string",
+          "enum": ["terse", "moderate", "verbose"],
+          "description": "How much detail the NPC typically provides unprompted."
+        },
+        "formality": {
+          "type": "string",
+          "enum": ["casual", "professional", "formal"],
+          "description": "Language register the NPC should maintain."
+        }
+      }
+    },
     "ending_conditions": {
       "type": "object",
       "additionalProperties": false,

--- a/schemas/scene.schema.json
+++ b/schemas/scene.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.convsim.dev/v0.1/scene.schema.json",
+  "title": "ConvSim Scene",
+  "description": "Validates a scene descriptor file. Scenes supply visual and ambient context for a scenario without affecting game logic.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "scene_id",
+    "display_name",
+    "description"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "enum": ["0.1"]
+    },
+    "scene_id": {
+      "type": "string",
+      "description": "Unique identifier for this scene within the pack.",
+      "pattern": "^[a-z0-9_]+$"
+    },
+    "display_name": {
+      "type": "string",
+      "description": "Human-readable name shown in the UI.",
+      "minLength": 1,
+      "maxLength": 100
+    },
+    "description": {
+      "type": "string",
+      "description": "Prose description of the scene used to set context in the system prompt.",
+      "minLength": 1,
+      "maxLength": 2000
+    },
+    "background": {
+      "type": "string",
+      "description": "Relative path to the background image within the pack assets directory."
+    },
+    "ambient": {
+      "type": "string",
+      "description": "Ambient audio identifier. Must be a slug defined in the runtime audio registry.",
+      "pattern": "^[a-z0-9_]+$"
+    }
+  }
+}

--- a/services/convsim-core/convsim_core/schema_paths.py
+++ b/services/convsim-core/convsim_core/schema_paths.py
@@ -21,6 +21,9 @@ SCHEMA_NAMES: tuple[str, ...] = (
     "npc.schema.json",
     "rubric.schema.json",
     "safety.schema.json",
+    "scene.schema.json",
+    "pack-test.schema.json",
+    "asset.schema.json",
     "turn-output.schema.json",
     "debrief.schema.json",
 )

--- a/services/convsim-core/convsim_core/schemas/asset.schema.json
+++ b/services/convsim-core/convsim_core/schemas/asset.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.convsim.dev/v0.1/asset.schema.json",
+  "title": "ConvSim Asset Metadata",
+  "description": "Validates an asset metadata sidecar file (.meta.json). One metadata file per asset records license, type, and provenance for offline-first packs.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "asset_id",
+    "type",
+    "file",
+    "license"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "enum": ["0.1"]
+    },
+    "asset_id": {
+      "type": "string",
+      "description": "Unique identifier for this asset within the pack.",
+      "pattern": "^[a-z0-9_]+$"
+    },
+    "type": {
+      "type": "string",
+      "enum": ["portrait", "background", "audio", "music", "icon"],
+      "description": "Asset category. Determines how the runtime loads and displays the asset."
+    },
+    "file": {
+      "type": "string",
+      "description": "Relative path to the asset file from the pack root.",
+      "minLength": 1
+    },
+    "license": {
+      "type": "string",
+      "description": "SPDX license identifier for this individual asset.",
+      "minLength": 1
+    },
+    "attribution": {
+      "type": "string",
+      "description": "Required attribution text if the license demands it (e.g. CC BY 4.0)."
+    },
+    "source_url": {
+      "type": "string",
+      "description": "Original source URL for attribution. Informational only — never loaded at runtime."
+    },
+    "width_px": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Width in pixels. Required for portrait and background assets."
+    },
+    "height_px": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Height in pixels. Required for portrait and background assets."
+    },
+    "duration_seconds": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Duration in seconds. Required for audio and music assets."
+    }
+  },
+  "not": {
+    "description": "Asset metadata must not contain runtime-loaded URLs or executable fields.",
+    "required": ["runtime_url"]
+  }
+}

--- a/services/convsim-core/convsim_core/schemas/npc.schema.json
+++ b/services/convsim-core/convsim_core/schemas/npc.schema.json
@@ -10,6 +10,7 @@
     "display_name",
     "archetype",
     "fictional",
+    "age_band",
     "public_persona",
     "private_persona"
   ],
@@ -53,6 +54,10 @@
         },
         "voice_id": { "type": "string" }
       }
+    },
+    "licensed_persona": {
+      "$comment": "Reserved for a future licensed persona namespace. Not implemented in schema v0.1. This field is explicitly blocked to prevent incompatible use before the namespace is defined.",
+      "not": {}
     },
     "portrait": {
       "type": "string",

--- a/services/convsim-core/convsim_core/schemas/pack-test.schema.json
+++ b/services/convsim-core/convsim_core/schemas/pack-test.schema.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.convsim.dev/v0.1/pack-test.schema.json",
+  "title": "ConvSim Pack Test Fixture",
+  "description": "Validates a pack test fixture file. Fixtures define scripted turn sequences and static assertions used by the pack test runner.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "fixture_id",
+    "scenario_id",
+    "description",
+    "turns"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "enum": ["0.1"]
+    },
+    "fixture_id": {
+      "type": "string",
+      "description": "Unique identifier for this test fixture within the pack.",
+      "pattern": "^[a-z0-9_]+$"
+    },
+    "scenario_id": {
+      "type": "string",
+      "description": "The scenario_id this fixture exercises.",
+      "pattern": "^[a-z0-9_]+$"
+    },
+    "description": {
+      "type": "string",
+      "description": "Human-readable description of what this fixture verifies.",
+      "minLength": 1
+    },
+    "seed": {
+      "type": "integer",
+      "description": "Deterministic RNG seed to pass to the runtime for reproducible results.",
+      "minimum": 0
+    },
+    "input_mode": {
+      "type": "string",
+      "enum": ["text", "voice"],
+      "description": "Input modality to simulate."
+    },
+    "difficulty": {
+      "type": "string",
+      "enum": ["easy", "normal", "hard"],
+      "description": "Difficulty setting to use when running the fixture."
+    },
+    "turns": {
+      "type": "array",
+      "description": "Scripted player turns to execute in order.",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["turn", "player_input"],
+        "additionalProperties": false,
+        "properties": {
+          "turn": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "1-based turn number."
+          },
+          "player_input": {
+            "type": "string",
+            "description": "The player utterance to inject for this turn.",
+            "minLength": 1
+          },
+          "expect": {
+            "type": "object",
+            "description": "Assertions the test runner must verify for this turn's output.",
+            "additionalProperties": false,
+            "properties": {
+              "state_delta_contains": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Variable names that must appear in the state_delta output."
+              },
+              "npc_emotion_not": {
+                "type": "string",
+                "description": "Emotion value that must NOT appear in npc_emotion."
+              },
+              "session_control": {
+                "type": "string",
+                "enum": ["continue_session", "end_session"],
+                "description": "Expected value of session_control.continue_session (true=continue_session, false=end_session)."
+              },
+              "safety_status": {
+                "type": "string",
+                "enum": ["ok", "redirect", "stop"],
+                "description": "Expected safety status in the turn output."
+              }
+            }
+          }
+        }
+      }
+    },
+    "static_assertions": {
+      "type": "array",
+      "description": "Structural assertions checked against the loaded scenario and pack manifest (not against live turn output).",
+      "items": {
+        "type": "object",
+        "required": ["description", "path", "check"],
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Human-readable description of what is being asserted."
+          },
+          "path": {
+            "type": "string",
+            "description": "Dot-separated path expression (with optional bracket selectors) into the scenario or pack document."
+          },
+          "check": {
+            "type": "string",
+            "description": "Assertion expression evaluated by the pack test runner."
+          }
+        }
+      }
+    }
+  }
+}

--- a/services/convsim-core/convsim_core/schemas/pack.schema.json
+++ b/services/convsim-core/convsim_core/schemas/pack.schema.json
@@ -11,7 +11,9 @@
     "version",
     "description",
     "author",
-    "license"
+    "license",
+    "content_rating",
+    "safety"
   ],
   "additionalProperties": false,
   "properties": {
@@ -99,6 +101,7 @@
     },
     "safety": {
       "type": "object",
+      "required": ["policy"],
       "additionalProperties": false,
       "properties": {
         "policy": {

--- a/services/convsim-core/convsim_core/schemas/safety.schema.json
+++ b/services/convsim-core/convsim_core/schemas/safety.schema.json
@@ -4,7 +4,7 @@
   "title": "ConvSim Safety Policy",
   "description": "Validates a safety policy file that governs content boundaries for a scenario.",
   "type": "object",
-  "required": ["schema_version", "policy_id", "content_categories"],
+  "required": ["schema_version", "policy_id", "content_categories", "redirect_message", "content_rating_cap"],
   "additionalProperties": false,
   "properties": {
     "schema_version": {
@@ -20,7 +20,13 @@
     },
     "content_categories": {
       "type": "object",
-      "description": "Explicit allow/block rules per content category.",
+      "description": "Explicit allow/block rules per content category. Non-negotiable categories (nsfw_sexual, real_person_impersonation, instructional_criminal, crisis_content) must be declared.",
+      "required": [
+        "nsfw_sexual",
+        "real_person_impersonation",
+        "instructional_criminal",
+        "crisis_content"
+      ],
       "additionalProperties": false,
       "properties": {
         "nsfw_sexual": {

--- a/services/convsim-core/convsim_core/schemas/scenario.schema.json
+++ b/services/convsim-core/convsim_core/schemas/scenario.schema.json
@@ -236,6 +236,34 @@
         }
       }
     },
+    "replay_seed": {
+      "type": "integer",
+      "description": "Optional integer seed for deterministic replay. When set, the runtime uses this seed to reproduce the same LLM-sampled sequence across replays.",
+      "minimum": 0
+    },
+    "response_style": {
+      "type": "object",
+      "description": "Optional hints controlling NPC response length and register.",
+      "additionalProperties": false,
+      "properties": {
+        "max_words": {
+          "type": "integer",
+          "minimum": 10,
+          "maximum": 500,
+          "description": "Soft target for maximum NPC utterance length in words."
+        },
+        "verbosity": {
+          "type": "string",
+          "enum": ["terse", "moderate", "verbose"],
+          "description": "How much detail the NPC typically provides unprompted."
+        },
+        "formality": {
+          "type": "string",
+          "enum": ["casual", "professional", "formal"],
+          "description": "Language register the NPC should maintain."
+        }
+      }
+    },
     "ending_conditions": {
       "type": "object",
       "additionalProperties": false,

--- a/services/convsim-core/convsim_core/schemas/scene.schema.json
+++ b/services/convsim-core/convsim_core/schemas/scene.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.convsim.dev/v0.1/scene.schema.json",
+  "title": "ConvSim Scene",
+  "description": "Validates a scene descriptor file. Scenes supply visual and ambient context for a scenario without affecting game logic.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "scene_id",
+    "display_name",
+    "description"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "enum": ["0.1"]
+    },
+    "scene_id": {
+      "type": "string",
+      "description": "Unique identifier for this scene within the pack.",
+      "pattern": "^[a-z0-9_]+$"
+    },
+    "display_name": {
+      "type": "string",
+      "description": "Human-readable name shown in the UI.",
+      "minLength": 1,
+      "maxLength": 100
+    },
+    "description": {
+      "type": "string",
+      "description": "Prose description of the scene used to set context in the system prompt.",
+      "minLength": 1,
+      "maxLength": 2000
+    },
+    "background": {
+      "type": "string",
+      "description": "Relative path to the background image within the pack assets directory."
+    },
+    "ambient": {
+      "type": "string",
+      "description": "Ambient audio identifier. Must be a slug defined in the runtime audio registry.",
+      "pattern": "^[a-z0-9_]+$"
+    }
+  }
+}

--- a/services/convsim-core/tests/test_schema_paths.py
+++ b/services/convsim-core/tests/test_schema_paths.py
@@ -26,6 +26,9 @@ class TestSchemaNames:
             "npc.schema.json",
             "rubric.schema.json",
             "safety.schema.json",
+            "scene.schema.json",
+            "pack-test.schema.json",
+            "asset.schema.json",
             "turn-output.schema.json",
             "debrief.schema.json",
         }


### PR DESCRIPTION
## Summary

This PR completes the scenario pack JSON schema suite and enforces critical safety-by-default requirements across all pack-authored file types.

### New schemas added
- **`scene.schema.json`** — validates scene descriptor files (visual and ambient context)
- **`pack-test.schema.json`** — validates pack test fixture files (scripted turn sequences and assertions)
- **`asset.schema.json`** — validates asset metadata sidecars (license, provenance, dimensions)

These join the existing pack, scenario, NPC, rubric, safety, turn-output, and debrief schemas to form a complete specification for scenario packs.

### Schema tightening: safety-by-default enforcement

Four existing schemas have been strengthened to enforce non-negotiable safety constraints:

**Pack (`pack.schema.json`)**
- `content_rating` is now required at the top level
- `safety` block is now required, and its nested `policy` field must be present

**NPC (`npc.schema.json`)**
- `age_band` is now required (rejects ambiguous ages like birth year ranges)
- `fictional` field required
- `licensed_persona` namespace is reserved (blocked via `"not": {}`) to prevent incompatible use before the namespace design is complete

**Safety policy (`safety.schema.json`)**
- `redirect_message` and `content_rating_cap` are now required top-level fields
- Four non-negotiable content categories are now mandatory: `nsfw_sexual`, `real_person_impersonation`, `instructional_criminal`, `crisis_content`

### Optional enhancements

**Scenario (`scenario.schema.json`)**
- `replay_seed` (optional) — integer seed for deterministic LLM-sampled sequence replay
- `response_style` (optional) — object with hints for NPC response generation (`max_words`, `verbosity`, `formality`)

### Testing and documentation

- **Eight example files** in `schemas/examples/` (one per pack-authored schema) serve as both documentation and validation test fixtures
- **24-test AJV validation suite** (`packages/scenario-schema/tests/validate-schemas.js`):
  - 8 tests validating all example instances pass
  - 16 tests covering targeted rejection cases (missing license, missing content rating, missing safety policy, `fictional: false`, missing `age_band`, use of reserved `licensed_persona`, missing safety categories)
- **Official starter files updated**: `meridian_conference_room.yaml` and `smoke_behavioral_interview.yaml` now declare `schema_version: "0.1"` and validate cleanly
- **CI enhanced**: schemas job now installs pnpm dependencies and runs both schema loading and validation test suites

### Test results

- Load tests: 11/11 pass
- Validation tests: 24/24 pass
- All official pack YAML files validate cleanly against their respective schemas

Closes #25