### PR TITLE
Build model manager API for install, selection, benchmark, and runtime health

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -2,3 +2,4 @@ export * from './types/scenario.js';
 export * from './types/session.js';
 export * from './types/setup.js';
 export * from './types/runtime.js';
+export * from './types/models.js';

--- a/packages/shared/src/types/models.ts
+++ b/packages/shared/src/types/models.ts
@@ -85,13 +85,12 @@ export interface InstallModelRequest {
 export interface InstallModelResponse {
   install_id: number;
   registry_id: string;
-  status: 'pending' | 'queued' | 'rejected';
+  status: 'pending';
   message: string | null;
 }
 
 export interface BenchmarkRequest {
   model_id?: string | null;
-  runtime_id?: string | null;
 }
 
 export interface BenchmarkResponse {

--- a/packages/shared/src/types/models.ts
+++ b/packages/shared/src/types/models.ts
@@ -1,0 +1,105 @@
+// Model manager API request and response types shared between the backend and frontend.
+
+export interface ModelRegistryEntry {
+  id: string;
+  name: string;
+  provider: string;
+  family: string | null;
+  role: string | null;
+  format: string | null;
+  license_spdx: string | null;
+  license_url: string | null;
+  source_type: string | null;
+  download_url: string | null;
+  sha256: string | null;
+  size_gb: number | null;
+  min_vram_gb: number | null;
+  recommended_vram_gb: number | null;
+  context_length: number | null;
+  registered_at: string;
+}
+
+export type InstallStatus = 'pending' | 'downloading' | 'complete' | 'failed';
+
+export interface InstalledModelInfo {
+  id: number;
+  registry_id: string | null;
+  filename: string;
+  file_path: string;
+  size_bytes: number | null;
+  install_status: InstallStatus;
+  progress_bytes: number | null;
+  error_message: string | null;
+  installed_at: string;
+}
+
+export interface DetectedOllamaModel {
+  id: string;
+  name: string;
+  size_category: 'small' | 'medium' | 'large' | null;
+}
+
+export interface ActiveModelConfig {
+  runtime_id: string | null;
+  model_id: string | null;
+}
+
+export type RuntimeStatus = 'unavailable' | 'starting' | 'ready' | 'degraded' | 'error';
+
+export interface ModelRuntimeHealth {
+  runtime_id: string;
+  runtime_name: string;
+  status: RuntimeStatus;
+  model_id: string | null;
+  latency_ms: number | null;
+  message: string | null;
+  checked_at: string;
+}
+
+export interface ModelsResponse {
+  registry: ModelRegistryEntry[];
+  installed: InstalledModelInfo[];
+  ollama_models: DetectedOllamaModel[];
+  active: ActiveModelConfig;
+  runtime_health: ModelRuntimeHealth;
+  total: number;
+}
+
+export interface UseModelRequest {
+  runtime_id: string;
+  model_id?: string | null;
+}
+
+export interface UseModelResponse {
+  runtime_id: string;
+  model_id: string | null;
+  runtime_name: string;
+  status: RuntimeStatus;
+  message: string | null;
+}
+
+export interface InstallModelRequest {
+  registry_id: string;
+}
+
+export interface InstallModelResponse {
+  install_id: number;
+  registry_id: string;
+  status: 'pending' | 'queued' | 'rejected';
+  message: string | null;
+}
+
+export interface BenchmarkRequest {
+  model_id?: string | null;
+  runtime_id?: string | null;
+}
+
+export interface BenchmarkResponse {
+  model_id: string;
+  runtime_id: string;
+  tokens_per_sec: number;
+  context_length: number | null;
+  warnings: string[];
+  output_tokens: number;
+  benchmarked_at: string;
+}

--- a/services/convsim-core/convsim_core/routers/health.py
+++ b/services/convsim-core/convsim_core/routers/health.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 
 from convsim_core import __version__
 from convsim_core.runtime.types import RuntimeHealth
+from convsim_core.services.model_manager_service import get_active_config
 
 router = APIRouter()
 
@@ -27,6 +28,11 @@ class _PrivacyPosture(BaseModel):
     crash_logging_enabled: bool
 
 
+class _ActiveModelConfig(BaseModel):
+    runtime_id: Optional[str] = None
+    model_id: Optional[str] = None
+
+
 class HealthResponse(BaseModel):
     status: str
     version: str
@@ -34,6 +40,7 @@ class HealthResponse(BaseModel):
     config_path: str
     database: _DatabaseStatus
     runtime: RuntimeHealth
+    active_model: _ActiveModelConfig
     privacy: _PrivacyPosture
 
 
@@ -42,6 +49,7 @@ async def health(request: Request) -> HealthResponse:
     config = request.app.state.service_config
     db = request.app.state.db
     app_settings = request.app.state.app_settings
+    active_cfg = get_active_config(db.connection())
     return HealthResponse(
         status="ok",
         version=__version__,
@@ -53,6 +61,7 @@ async def health(request: Request) -> HealthResponse:
             migrations_applied=db.migrations_applied,
         ),
         runtime=await request.app.state.runtime.health(),
+        active_model=_ActiveModelConfig(**active_cfg),
         privacy=_PrivacyPosture(
             telemetry_enabled=app_settings.telemetry_enabled,
             save_transcripts=app_settings.save_transcripts,

--- a/services/convsim-core/convsim_core/routers/models.py
+++ b/services/convsim-core/convsim_core/routers/models.py
@@ -1,12 +1,42 @@
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import os
+import time
+from datetime import datetime, timezone
 from typing import Any, Optional
 
+import httpx
 from fastapi import APIRouter, Request
 from pydantic import BaseModel
 
+from convsim_core.errors import ConvsimError
+from convsim_core.runtime import build_runtime, list_runtime_ids
+from convsim_core.runtime.ollama_adapter import OllamaChatRuntime
+from convsim_core.runtime.types import (
+    ChatFinal,
+    ChatMessage,
+    ChatRequest,
+    RuntimeHealth,
+    RuntimeStatus,
+)
+from convsim_core.services.model_manager_service import (
+    create_install_record,
+    get_active_config,
+    get_installed_models,
+    save_benchmark_result,
+    set_active_config,
+)
 from convsim_core.services.model_registry_service import list_registry_models
 
 router = APIRouter()
+
+_BENCHMARK_PROMPT = "Say hello in exactly three words."
+_BENCHMARK_SYSTEM = "You are a helpful assistant. Be brief and literal."
+_OLLAMA_DETECT_TIMEOUT = 3.0
+
+
+# ── Request / response schemas ────────────────────────────────────────────────
 
 
 class ModelRegistryEntry(BaseModel):
@@ -28,15 +58,328 @@ class ModelRegistryEntry(BaseModel):
     registered_at: str
 
 
+class InstalledModelInfo(BaseModel):
+    id: int
+    registry_id: Optional[str] = None
+    filename: str
+    file_path: str
+    size_bytes: Optional[int] = None
+    install_status: str
+    progress_bytes: Optional[int] = None
+    error_message: Optional[str] = None
+    installed_at: str
+
+
+class DetectedOllamaModel(BaseModel):
+    id: str
+    name: str
+    size_category: Optional[str] = None
+
+
+class ActiveModelConfig(BaseModel):
+    runtime_id: Optional[str] = None
+    model_id: Optional[str] = None
+
+
 class ModelsResponse(BaseModel):
-    models: list[ModelRegistryEntry]
+    registry: list[ModelRegistryEntry]
+    installed: list[InstalledModelInfo]
+    ollama_models: list[DetectedOllamaModel]
+    active: ActiveModelConfig
+    runtime_health: RuntimeHealth
     total: int
+
+
+class UseModelRequest(BaseModel):
+    runtime_id: str
+    model_id: Optional[str] = None
+
+
+class UseModelResponse(BaseModel):
+    runtime_id: str
+    model_id: Optional[str] = None
+    runtime_name: str
+    status: str
+    message: Optional[str] = None
+
+
+class InstallModelRequest(BaseModel):
+    registry_id: str
+
+
+class InstallModelResponse(BaseModel):
+    install_id: int
+    registry_id: str
+    status: str
+    message: Optional[str] = None
+
+
+class BenchmarkRequest(BaseModel):
+    model_id: Optional[str] = None
+    runtime_id: Optional[str] = None
+
+
+class BenchmarkResponse(BaseModel):
+    model_id: str
+    runtime_id: str
+    tokens_per_sec: float
+    context_length: Optional[int] = None
+    warnings: list[str]
+    output_tokens: int
+    benchmarked_at: str
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+async def _detect_ollama_models() -> list[DetectedOllamaModel]:
+    """Try to list models from a local Ollama server. Returns [] if unreachable."""
+    base_url = os.environ.get("CONVSIM_OLLAMA_BASE_URL", "http://127.0.0.1:11434")
+    client = httpx.AsyncClient(base_url=base_url, timeout=_OLLAMA_DETECT_TIMEOUT)
+    try:
+        rt = OllamaChatRuntime(client=client)
+        infos = await rt.list_models()
+        return [
+            DetectedOllamaModel(id=m.id, name=m.name, size_category=m.size_category)
+            for m in infos
+        ]
+    except Exception:
+        return []
+    finally:
+        await client.aclose()
+
+
+def _get_registry_row(conn: Any, registry_id: str) -> dict[str, Any] | None:
+    row = conn.execute(
+        "SELECT id, name, license_spdx, sha256, source_type FROM model_registry WHERE id = ?",
+        (registry_id,),
+    ).fetchone()
+    return dict(row) if row is not None else None
+
+
+# ── Endpoints ─────────────────────────────────────────────────────────────────
 
 
 @router.get("/api/models", response_model=ModelsResponse)
 async def list_models(request: Request) -> ModelsResponse:
-    """Return all entries in the local model registry."""
+    """Return registry models, installed models, detected Ollama models, and active runtime."""
     db = request.app.state.db
-    rows: list[dict[str, Any]] = list_registry_models(db.connection())
-    entries = [ModelRegistryEntry(**row) for row in rows]
-    return ModelsResponse(models=entries, total=len(entries))
+    runtime = request.app.state.runtime
+    conn = db.connection()
+
+    registry_rows: list[dict[str, Any]] = list_registry_models(conn)
+    registry_entries = [ModelRegistryEntry(**row) for row in registry_rows]
+
+    installed_rows = get_installed_models(conn)
+    installed = [InstalledModelInfo(**row) for row in installed_rows]
+
+    active_cfg = get_active_config(conn)
+    ollama_models = await _detect_ollama_models()
+    runtime_health = await runtime.health()
+
+    return ModelsResponse(
+        registry=registry_entries,
+        installed=installed,
+        ollama_models=ollama_models,
+        active=ActiveModelConfig(**active_cfg),
+        runtime_health=runtime_health,
+        total=len(registry_entries),
+    )
+
+
+@router.post("/api/models/use", response_model=UseModelResponse)
+async def use_model(request: Request, body: UseModelRequest) -> UseModelResponse:
+    """Select a runtime and optional model, validating availability first."""
+    db = request.app.state.db
+
+    known = list_runtime_ids()
+    if body.runtime_id not in known:
+        raise ConvsimError(
+            code="UNKNOWN_RUNTIME",
+            message=f"Unknown runtime '{body.runtime_id}'. Available: {known}",
+            status_code=400,
+        )
+
+    try:
+        test_runtime = build_runtime(body.runtime_id)
+        health = await test_runtime.health()
+    except Exception as exc:
+        raise ConvsimError(
+            code="RUNTIME_UNAVAILABLE",
+            message=f"Cannot reach runtime '{body.runtime_id}': {exc}",
+            status_code=503,
+        ) from exc
+
+    if health.status in (RuntimeStatus.UNAVAILABLE, RuntimeStatus.ERROR):
+        raise ConvsimError(
+            code="RUNTIME_UNAVAILABLE",
+            message=health.message or f"Runtime '{body.runtime_id}' is not available.",
+            status_code=503,
+        )
+
+    set_active_config(db.connection(), runtime_id=body.runtime_id, model_id=body.model_id)
+
+    return UseModelResponse(
+        runtime_id=body.runtime_id,
+        model_id=body.model_id,
+        runtime_name=test_runtime.display_name,
+        status=health.status.value,
+        message=health.message,
+    )
+
+
+@router.post("/api/models/install", response_model=InstallModelResponse)
+async def install_model(request: Request, body: InstallModelRequest) -> InstallModelResponse:
+    """Queue an explicit model download.
+
+    Rejects registry entries that lack license or verified checksum metadata,
+    ensuring the API never downloads unverified weights.
+    """
+    conn = request.app.state.db.connection()
+
+    model = _get_registry_row(conn, body.registry_id)
+    if model is None:
+        raise ConvsimError(
+            code="MODEL_NOT_FOUND",
+            message=f"Model '{body.registry_id}' not found in the local registry.",
+            status_code=404,
+        )
+
+    if model["source_type"] == "user-supplied":
+        raise ConvsimError(
+            code="INSTALL_NOT_APPLICABLE",
+            message=(
+                "User-supplied models cannot be installed via this endpoint. "
+                "Provide the file path directly via POST /api/models/use."
+            ),
+            status_code=400,
+        )
+
+    if not model.get("license_spdx"):
+        raise ConvsimError(
+            code="MISSING_LICENSE",
+            message=(
+                f"Registry entry '{body.registry_id}' has no license metadata. "
+                "Cannot install a model without a declared license."
+            ),
+            status_code=400,
+        )
+
+    sha256 = model.get("sha256") or ""
+    if not sha256 or sha256 == "PENDING":
+        raise ConvsimError(
+            code="MISSING_CHECKSUM",
+            message=(
+                f"Registry entry '{body.registry_id}' has no verified SHA-256 checksum. "
+                "Cannot install until a confirmed checksum is available."
+            ),
+            status_code=400,
+        )
+
+    filename = f"{body.registry_id}.gguf"
+    install_id = create_install_record(
+        conn, registry_id=body.registry_id, filename=filename, file_path=""
+    )
+
+    return InstallModelResponse(
+        install_id=install_id,
+        registry_id=body.registry_id,
+        status="pending",
+        message=f"Install queued for '{model['name']}'. Download will proceed in the background.",
+    )
+
+
+@router.post("/api/models/benchmark", response_model=BenchmarkResponse)
+async def benchmark_model(request: Request, body: BenchmarkRequest) -> BenchmarkResponse:
+    """Run a short local benchmark and persist tokens/sec, context length, and warnings."""
+    db = request.app.state.db
+    runtime = request.app.state.runtime
+
+    active_cfg = get_active_config(db.connection())
+    model_id = body.model_id or active_cfg.get("model_id")
+
+    health = await runtime.health()
+    if health.status in (RuntimeStatus.UNAVAILABLE, RuntimeStatus.ERROR):
+        raise ConvsimError(
+            code="RUNTIME_UNAVAILABLE",
+            message=health.message or "Runtime is not available for benchmarking.",
+            status_code=503,
+        )
+
+    chat_req = ChatRequest(
+        messages=[
+            ChatMessage(role="system", content=_BENCHMARK_SYSTEM),
+            ChatMessage(role="user", content=_BENCHMARK_PROMPT),
+        ],
+        model_id=model_id,
+        max_tokens=50,
+        temperature=0.0,
+    )
+
+    warnings: list[str] = []
+    final: ChatFinal | None = None
+    t0 = time.perf_counter()
+
+    try:
+        async for chunk in runtime.chat_stream(chat_req):
+            if isinstance(chunk, ChatFinal):
+                final = chunk
+    except Exception as exc:
+        raise ConvsimError(
+            code="BENCHMARK_FAILED",
+            message=f"Benchmark failed during inference: {exc}",
+            status_code=503,
+        ) from exc
+
+    elapsed_sec = time.perf_counter() - t0
+
+    if final is None:
+        raise ConvsimError(
+            code="BENCHMARK_FAILED",
+            message="Benchmark produced no output from the runtime.",
+            status_code=500,
+        )
+
+    output_tokens = final.output_tokens
+    if output_tokens == 0:
+        warnings.append("Output token count reported as 0; estimating from word count.")
+        output_tokens = max(1, len(final.text.split()))
+
+    if elapsed_sec < 0.001:
+        warnings.append(
+            "Benchmark completed in under 1 ms; tokens/sec estimate may not reflect real-world performance."
+        )
+
+    tokens_per_sec = round(output_tokens / elapsed_sec, 2) if elapsed_sec > 0 else 0.0
+
+    context_length: int | None = None
+    try:
+        models = await runtime.list_models()
+        matched = next((m for m in models if m.id == final.model_id), None)
+        if matched:
+            context_length = matched.context_length
+    except Exception:
+        pass
+
+    benchmarked_at = datetime.now(timezone.utc).isoformat()
+
+    save_benchmark_result(
+        db.connection(),
+        model_id=final.model_id,
+        runtime_id=runtime.id,
+        tokens_per_sec=tokens_per_sec,
+        context_length=context_length,
+        warnings=warnings,
+        prompt_used=_BENCHMARK_PROMPT,
+        output_tokens=output_tokens,
+    )
+
+    return BenchmarkResponse(
+        model_id=final.model_id,
+        runtime_id=runtime.id,
+        tokens_per_sec=tokens_per_sec,
+        context_length=context_length,
+        warnings=warnings,
+        output_tokens=output_tokens,
+        benchmarked_at=benchmarked_at,
+    )

--- a/services/convsim-core/convsim_core/routers/models.py
+++ b/services/convsim-core/convsim_core/routers/models.py
@@ -199,6 +199,7 @@ async def use_model(request: Request, body: UseModelRequest) -> UseModelResponse
             status_code=400,
         )
 
+    test_runtime = None
     try:
         test_runtime = build_runtime(body.runtime_id)
         health = await test_runtime.health()
@@ -208,6 +209,13 @@ async def use_model(request: Request, body: UseModelRequest) -> UseModelResponse
             message=f"Cannot reach runtime '{body.runtime_id}': {exc}",
             status_code=503,
         ) from exc
+    finally:
+        # OllamaChatRuntime holds a persistent httpx.AsyncClient; close it to
+        # avoid connection-pool leaks when this temporary instance is used only
+        # for the availability check.
+        _client = getattr(test_runtime, "_client", None)
+        if isinstance(_client, httpx.AsyncClient):
+            await _client.aclose()
 
     if health.status in (RuntimeStatus.UNAVAILABLE, RuntimeStatus.ERROR):
         raise ConvsimError(

--- a/services/convsim-core/convsim_core/routers/models.py
+++ b/services/convsim-core/convsim_core/routers/models.py
@@ -379,6 +379,7 @@ async def benchmark_model(request: Request, body: BenchmarkRequest) -> Benchmark
         warnings=warnings,
         prompt_used=_BENCHMARK_PROMPT,
         output_tokens=output_tokens,
+        benchmarked_at=benchmarked_at,
     )
 
     return BenchmarkResponse(

--- a/services/convsim-core/convsim_core/routers/models.py
+++ b/services/convsim-core/convsim_core/routers/models.py
@@ -273,7 +273,7 @@ async def install_model(request: Request, body: InstallModelRequest) -> InstallM
         )
 
     sha256 = model.get("sha256") or ""
-    if not sha256 or sha256 == "PENDING":
+    if not sha256 or sha256.upper() == "PENDING":
         raise ConvsimError(
             code="MISSING_CHECKSUM",
             message=(

--- a/services/convsim-core/convsim_core/routers/models.py
+++ b/services/convsim-core/convsim_core/routers/models.py
@@ -116,7 +116,6 @@ class InstallModelResponse(BaseModel):
 
 class BenchmarkRequest(BaseModel):
     model_id: Optional[str] = None
-    runtime_id: Optional[str] = None
 
 
 class BenchmarkResponse(BaseModel):

--- a/services/convsim-core/convsim_core/services/model_manager_service.py
+++ b/services/convsim-core/convsim_core/services/model_manager_service.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Service layer for model install, selection, and benchmark persistence."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+
+def get_installed_models(conn: sqlite3.Connection) -> list[dict[str, Any]]:
+    """Return all rows from installed_models as a list of dicts."""
+    rows = conn.execute(
+        """
+        SELECT id, registry_id, filename, file_path, size_bytes,
+               install_status, progress_bytes, error_message, installed_at
+        FROM installed_models
+        ORDER BY id DESC
+        """
+    ).fetchall()
+    return [dict(row) for row in rows]
+
+
+def create_install_record(
+    conn: sqlite3.Connection,
+    registry_id: str | None,
+    filename: str,
+    file_path: str,
+) -> int:
+    """Insert a new 'pending' install record and return its id."""
+    cursor = conn.execute(
+        """
+        INSERT INTO installed_models (registry_id, filename, file_path, install_status)
+        VALUES (?, ?, ?, 'pending')
+        """,
+        (registry_id, filename, file_path),
+    )
+    conn.commit()
+    return cursor.lastrowid  # type: ignore[return-value]
+
+
+def get_active_config(conn: sqlite3.Connection) -> dict[str, str | None]:
+    """Return the active runtime/model selection from user_settings."""
+    rows = conn.execute(
+        "SELECT key, value FROM user_settings WHERE key IN ('active_runtime_id', 'active_model_id')"
+    ).fetchall()
+    stored = {row["key"]: row["value"] for row in rows}
+    return {
+        "runtime_id": stored.get("active_runtime_id"),
+        "model_id": stored.get("active_model_id"),
+    }
+
+
+def set_active_config(
+    conn: sqlite3.Connection,
+    runtime_id: str,
+    model_id: str | None = None,
+) -> None:
+    """Persist active runtime/model selection to user_settings."""
+    conn.execute(
+        """
+        INSERT INTO user_settings (key, value, updated_at)
+        VALUES ('active_runtime_id', ?, datetime('now'))
+        ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at
+        """,
+        (runtime_id,),
+    )
+    if model_id is not None:
+        conn.execute(
+            """
+            INSERT INTO user_settings (key, value, updated_at)
+            VALUES ('active_model_id', ?, datetime('now'))
+            ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at
+            """,
+            (model_id,),
+        )
+    else:
+        conn.execute("DELETE FROM user_settings WHERE key = 'active_model_id'")
+    conn.commit()
+
+
+def save_benchmark_result(
+    conn: sqlite3.Connection,
+    *,
+    model_id: str,
+    runtime_id: str,
+    tokens_per_sec: float,
+    context_length: int | None = None,
+    warnings: list[str] | None = None,
+    prompt_used: str | None = None,
+    output_tokens: int | None = None,
+) -> None:
+    """Persist a benchmark result to the benchmark_results table."""
+    conn.execute(
+        """
+        INSERT INTO benchmark_results
+            (model_id, runtime_id, tokens_per_sec, context_length,
+             warnings_json, prompt_used, output_tokens)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            model_id,
+            runtime_id,
+            tokens_per_sec,
+            context_length,
+            json.dumps(warnings or []),
+            prompt_used,
+            output_tokens,
+        ),
+    )
+    conn.commit()
+
+
+def get_latest_benchmark(
+    conn: sqlite3.Connection, model_id: str, runtime_id: str
+) -> dict[str, Any] | None:
+    """Return the most recent benchmark result for a model/runtime pair, or None."""
+    row = conn.execute(
+        """
+        SELECT id, model_id, runtime_id, tokens_per_sec, context_length,
+               warnings_json, prompt_used, output_tokens, benchmarked_at
+        FROM benchmark_results
+        WHERE model_id = ? AND runtime_id = ?
+        ORDER BY id DESC
+        LIMIT 1
+        """,
+        (model_id, runtime_id),
+    ).fetchone()
+    if row is None:
+        return None
+    result = dict(row)
+    result["warnings"] = json.loads(result.pop("warnings_json", "[]"))
+    return result

--- a/services/convsim-core/convsim_core/services/model_manager_service.py
+++ b/services/convsim-core/convsim_core/services/model_manager_service.py
@@ -89,14 +89,15 @@ def save_benchmark_result(
     warnings: list[str] | None = None,
     prompt_used: str | None = None,
     output_tokens: int | None = None,
+    benchmarked_at: str | None = None,
 ) -> None:
     """Persist a benchmark result to the benchmark_results table."""
     conn.execute(
         """
         INSERT INTO benchmark_results
             (model_id, runtime_id, tokens_per_sec, context_length,
-             warnings_json, prompt_used, output_tokens)
-        VALUES (?, ?, ?, ?, ?, ?, ?)
+             warnings_json, prompt_used, output_tokens, benchmarked_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')))
         """,
         (
             model_id,
@@ -106,6 +107,7 @@ def save_benchmark_result(
             json.dumps(warnings or []),
             prompt_used,
             output_tokens,
+            benchmarked_at,
         ),
     )
     conn.commit()

--- a/services/convsim-core/convsim_core/storage/migrations.py
+++ b/services/convsim-core/convsim_core/storage/migrations.py
@@ -138,9 +138,28 @@ ALTER TABLE model_registry ADD COLUMN recommended_vram_gb REAL;
 ALTER TABLE model_registry ADD COLUMN context_length INTEGER;
 """
 
+_MODEL_MANAGER_API_SQL = """
+ALTER TABLE installed_models ADD COLUMN install_status TEXT NOT NULL DEFAULT 'complete';
+ALTER TABLE installed_models ADD COLUMN progress_bytes INTEGER;
+ALTER TABLE installed_models ADD COLUMN error_message TEXT;
+
+CREATE TABLE benchmark_results (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    model_id       TEXT    NOT NULL,
+    runtime_id     TEXT    NOT NULL,
+    tokens_per_sec REAL    NOT NULL,
+    context_length INTEGER,
+    warnings_json  TEXT    NOT NULL DEFAULT '[]',
+    prompt_used    TEXT,
+    output_tokens  INTEGER,
+    benchmarked_at TEXT    NOT NULL DEFAULT (datetime('now'))
+);
+"""
+
 MIGRATIONS: list[tuple[str, str]] = [
     ("0001_initial_schema", _INITIAL_SCHEMA_SQL),
     ("0002_model_registry_v2", _MODEL_REGISTRY_V2_SQL),
+    ("0003_model_manager_api", _MODEL_MANAGER_API_SQL),
 ]
 
 

--- a/services/convsim-core/tests/test_model_manager.py
+++ b/services/convsim-core/tests/test_model_manager.py
@@ -1,0 +1,465 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the model manager API: install guard, use-model, benchmark, and persistence."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+import convsim_core.runtime  # noqa: F401 — register built-in adapters
+from convsim_core.app import create_app
+from convsim_core.config import ServiceConfig
+from convsim_core.runtime.types import (
+    ChatFinal,
+    ChatToken,
+    RuntimeHealth,
+    RuntimeStatus,
+)
+from convsim_core.services.model_manager_service import (
+    create_install_record,
+    get_active_config,
+    get_installed_models,
+    get_latest_benchmark,
+    save_benchmark_result,
+    set_active_config,
+)
+from convsim_core.services.model_registry_service import load_and_persist_registry
+from convsim_core.storage.database import Database
+
+_REGISTRY_PATH = Path(__file__).parent.parent.parent.parent / "model-registry" / "registry.yaml"
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def tmp_config(tmp_path):
+    return ServiceConfig(
+        host="127.0.0.1",
+        port=7355,
+        data_dir=str(tmp_path / "data"),
+        log_dir=str(tmp_path / "logs"),
+        db_dir=str(tmp_path / "db"),
+    )
+
+
+@pytest.fixture()
+def client(tmp_config):
+    app = create_app(tmp_config)
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture()
+def db(tmp_path):
+    database = Database.open(str(tmp_path / "db"))
+    yield database
+    database.close()
+
+
+# ── GET /api/models (integration) ─────────────────────────────────────────────
+
+
+def test_get_models_empty_state_has_all_sections(client):
+    body = client.get("/api/models").json()
+    assert body["registry"] == []
+    assert body["installed"] == []
+    assert body["ollama_models"] == []
+    assert body["active"] == {"runtime_id": None, "model_id": None}
+    assert body["total"] == 0
+    assert "runtime_health" in body
+
+
+def test_get_models_runtime_health_present(client):
+    body = client.get("/api/models").json()
+    health = body["runtime_health"]
+    assert health["runtime_id"] == "fake"
+    assert health["status"] == "ready"
+
+
+def test_get_models_after_registry_load(client):
+    load_and_persist_registry(client.app.state.db.connection(), _REGISTRY_PATH)
+    body = client.get("/api/models").json()
+    assert body["total"] > 0
+    assert len(body["registry"]) == body["total"]
+
+
+# ── model_manager_service: install records ────────────────────────────────────
+
+
+def _insert_registry_model(conn, model_id: str) -> None:
+    """Helper: insert a minimal model_registry row to satisfy the FK constraint."""
+    conn.execute(
+        """INSERT OR IGNORE INTO model_registry (id, name, provider)
+           VALUES (?, ?, 'test')""",
+        (model_id, model_id),
+    )
+    conn.commit()
+
+
+def test_create_install_record_returns_id(db):
+    # Use None registry_id to bypass the FK constraint in a pure service test
+    install_id = create_install_record(db.connection(), None, "my-model.gguf", "")
+    assert isinstance(install_id, int)
+    assert install_id > 0
+
+
+def test_installed_models_initially_empty(db):
+    assert get_installed_models(db.connection()) == []
+
+
+def test_create_install_record_shows_pending_status(db):
+    _insert_registry_model(db.connection(), "my-model")
+    create_install_record(db.connection(), "my-model", "my-model.gguf", "/tmp/my-model.gguf")
+    rows = get_installed_models(db.connection())
+    assert len(rows) == 1
+    assert rows[0]["install_status"] == "pending"
+    assert rows[0]["registry_id"] == "my-model"
+    assert rows[0]["filename"] == "my-model.gguf"
+
+
+def test_get_installed_models_ordered_by_newest_first(db):
+    _insert_registry_model(db.connection(), "model-a")
+    _insert_registry_model(db.connection(), "model-b")
+    create_install_record(db.connection(), "model-a", "a.gguf", "")
+    create_install_record(db.connection(), "model-b", "b.gguf", "")
+    rows = get_installed_models(db.connection())
+    assert len(rows) == 2
+    # The last inserted record (model-b) should appear first due to ORDER BY DESC
+    assert rows[0]["registry_id"] == "model-b"
+
+
+# ── model_manager_service: active config ─────────────────────────────────────
+
+
+def test_active_config_initially_empty(db):
+    cfg = get_active_config(db.connection())
+    assert cfg == {"runtime_id": None, "model_id": None}
+
+
+def test_set_and_get_active_config_with_model(db):
+    set_active_config(db.connection(), runtime_id="ollama", model_id="llama3.2:latest")
+    cfg = get_active_config(db.connection())
+    assert cfg["runtime_id"] == "ollama"
+    assert cfg["model_id"] == "llama3.2:latest"
+
+
+def test_set_active_config_clears_model_id_when_none(db):
+    set_active_config(db.connection(), runtime_id="ollama", model_id="llama3.2:latest")
+    set_active_config(db.connection(), runtime_id="fake", model_id=None)
+    cfg = get_active_config(db.connection())
+    assert cfg["runtime_id"] == "fake"
+    assert cfg["model_id"] is None
+
+
+def test_set_active_config_is_idempotent(db):
+    set_active_config(db.connection(), runtime_id="ollama", model_id="llama3.2")
+    set_active_config(db.connection(), runtime_id="llama_cpp", model_id="my-model")
+    cfg = get_active_config(db.connection())
+    assert cfg["runtime_id"] == "llama_cpp"
+    assert cfg["model_id"] == "my-model"
+
+
+# ── model_manager_service: benchmark persistence ──────────────────────────────
+
+
+def test_save_benchmark_result_and_retrieve(db):
+    save_benchmark_result(
+        db.connection(),
+        model_id="fake-small",
+        runtime_id="fake",
+        tokens_per_sec=123.45,
+        context_length=4096,
+        warnings=[],
+        prompt_used="Say hello",
+        output_tokens=10,
+    )
+    result = get_latest_benchmark(db.connection(), "fake-small", "fake")
+    assert result is not None
+    assert result["model_id"] == "fake-small"
+    assert result["runtime_id"] == "fake"
+    assert result["tokens_per_sec"] == pytest.approx(123.45)
+    assert result["context_length"] == 4096
+    assert result["warnings"] == []
+    assert result["output_tokens"] == 10
+
+
+def test_benchmark_warnings_round_trip(db):
+    warnings = ["token count was 0", "fast runtime"]
+    save_benchmark_result(
+        db.connection(),
+        model_id="fake-small",
+        runtime_id="fake",
+        tokens_per_sec=50.0,
+        warnings=warnings,
+    )
+    result = get_latest_benchmark(db.connection(), "fake-small", "fake")
+    assert result["warnings"] == warnings
+
+
+def test_get_latest_benchmark_returns_most_recent(db):
+    save_benchmark_result(
+        db.connection(), model_id="m", runtime_id="r", tokens_per_sec=10.0
+    )
+    save_benchmark_result(
+        db.connection(), model_id="m", runtime_id="r", tokens_per_sec=20.0
+    )
+    result = get_latest_benchmark(db.connection(), "m", "r")
+    assert result["tokens_per_sec"] == pytest.approx(20.0)
+
+
+def test_get_latest_benchmark_none_when_missing(db):
+    assert get_latest_benchmark(db.connection(), "does-not-exist", "fake") is None
+
+
+# ── POST /api/models/install ─────────────────────────────────────────────────
+
+
+def _load_registry(client):
+    load_and_persist_registry(client.app.state.db.connection(), _REGISTRY_PATH)
+
+
+def _starter_id(client) -> str:
+    body = client.get("/api/models").json()
+    starter = next(m for m in body["registry"] if m["role"] == "starter")
+    return starter["id"]
+
+
+def test_install_rejects_unknown_model(client):
+    resp = client.post("/api/models/install", json={"registry_id": "does-not-exist"})
+    assert resp.status_code == 404
+    assert resp.json()["error"]["code"] == "MODEL_NOT_FOUND"
+
+
+def test_install_rejects_user_supplied_model(client):
+    _load_registry(client)
+    resp = client.post("/api/models/install", json={"registry_id": "user-supplied-gguf"})
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "INSTALL_NOT_APPLICABLE"
+
+
+def test_install_rejects_model_with_pending_sha256(client):
+    """The explicit-download guard must reject models that have PENDING checksums."""
+    _load_registry(client)
+    model_id = _starter_id(client)
+    # Starter model has sha256 == "PENDING" in the registry
+    resp = client.post("/api/models/install", json={"registry_id": model_id})
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "MISSING_CHECKSUM"
+
+
+def test_install_rejects_model_without_license(client):
+    """A registry entry with no license must be rejected."""
+    _load_registry(client)
+    conn = client.app.state.db.connection()
+    # Insert a test model with a real sha256 but no license
+    conn.execute(
+        """
+        INSERT INTO model_registry
+            (id, name, provider, license_spdx, sha256, source_type)
+        VALUES ('test-no-license', 'Test No License', 'test', NULL,
+                'a' * 64, 'registry')
+        """
+    )
+    conn.commit()
+    resp = client.post("/api/models/install", json={"registry_id": "test-no-license"})
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "MISSING_LICENSE"
+
+
+def test_install_accepted_when_license_and_sha256_present(client):
+    """A model with valid license and real sha256 must be accepted."""
+    _load_registry(client)
+    conn = client.app.state.db.connection()
+    conn.execute(
+        """
+        INSERT INTO model_registry
+            (id, name, provider, license_spdx, sha256, source_type)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "test-valid-model",
+            "Test Valid Model",
+            "test",
+            "MIT",
+            "a" * 64,
+            "registry",
+        ),
+    )
+    conn.commit()
+    resp = client.post("/api/models/install", json={"registry_id": "test-valid-model"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "pending"
+    assert body["registry_id"] == "test-valid-model"
+    assert isinstance(body["install_id"], int)
+
+
+def test_install_creates_record_in_installed_models(client):
+    _load_registry(client)
+    conn = client.app.state.db.connection()
+    conn.execute(
+        """INSERT INTO model_registry (id, name, provider, license_spdx, sha256, source_type)
+           VALUES ('valid-m', 'V', 'p', 'MIT', ?, 'registry')""",
+        ("b" * 64,),
+    )
+    conn.commit()
+    client.post("/api/models/install", json={"registry_id": "valid-m"})
+    rows = get_installed_models(conn)
+    assert any(r["registry_id"] == "valid-m" and r["install_status"] == "pending" for r in rows)
+
+
+# ── POST /api/models/use ─────────────────────────────────────────────────────
+
+
+def test_use_model_rejects_unknown_runtime(client):
+    resp = client.post("/api/models/use", json={"runtime_id": "nonexistent_runtime"})
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "UNKNOWN_RUNTIME"
+
+
+def test_use_model_fake_runtime_succeeds(client):
+    resp = client.post("/api/models/use", json={"runtime_id": "fake"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["runtime_id"] == "fake"
+    assert body["status"] == "ready"
+    assert "Fake" in body["runtime_name"]
+
+
+def test_use_model_persists_active_config(client):
+    client.post("/api/models/use", json={"runtime_id": "fake", "model_id": "fake-small"})
+    cfg = get_active_config(client.app.state.db.connection())
+    assert cfg["runtime_id"] == "fake"
+    assert cfg["model_id"] == "fake-small"
+
+
+def test_use_model_active_config_appears_in_models_response(client):
+    client.post("/api/models/use", json={"runtime_id": "fake", "model_id": "fake-large"})
+    body = client.get("/api/models").json()
+    assert body["active"]["runtime_id"] == "fake"
+    assert body["active"]["model_id"] == "fake-large"
+
+
+def test_use_model_active_config_appears_in_health_response(client):
+    client.post("/api/models/use", json={"runtime_id": "fake", "model_id": "fake-small"})
+    health = client.get("/api/health").json()
+    assert health["active_model"]["runtime_id"] == "fake"
+    assert health["active_model"]["model_id"] == "fake-small"
+
+
+def _make_unavailable_runtime():
+    """Return a fake ChatRuntime whose health always reports UNAVAILABLE."""
+    rt = MagicMock()
+    rt.id = "ollama"
+    rt.display_name = "Ollama (local)"
+    rt.health = AsyncMock(
+        return_value=RuntimeHealth(
+            runtime_id="ollama",
+            runtime_name="Ollama (local)",
+            status=RuntimeStatus.UNAVAILABLE,
+            message="Ollama is not reachable",
+            checked_at="2026-01-01T00:00:00+00:00",
+        )
+    )
+    return rt
+
+
+def test_use_model_ollama_runtime_returns_error_when_unavailable(client, monkeypatch):
+    """use_model must return 503 when the requested runtime is unreachable."""
+    import convsim_core.routers.models as models_module
+
+    monkeypatch.setattr(models_module, "build_runtime", lambda _id: _make_unavailable_runtime())
+    resp = client.post("/api/models/use", json={"runtime_id": "ollama"})
+    assert resp.status_code == 503
+    assert resp.json()["error"]["code"] == "RUNTIME_UNAVAILABLE"
+
+
+def test_use_model_llama_cpp_returns_error_when_unavailable(client, monkeypatch):
+    """use_model must return 503 for llama_cpp when the server is not running."""
+    import convsim_core.routers.models as models_module
+
+    rt = MagicMock()
+    rt.id = "llama_cpp"
+    rt.display_name = "llama.cpp (local)"
+    rt.health = AsyncMock(
+        return_value=RuntimeHealth(
+            runtime_id="llama_cpp",
+            runtime_name="llama.cpp (local)",
+            status=RuntimeStatus.UNAVAILABLE,
+            message="Cannot connect to llama-server",
+            checked_at="2026-01-01T00:00:00+00:00",
+        )
+    )
+    monkeypatch.setattr(models_module, "build_runtime", lambda _id: rt)
+    resp = client.post("/api/models/use", json={"runtime_id": "llama_cpp"})
+    assert resp.status_code == 503
+    assert "llama" in resp.json()["error"]["message"].lower()
+
+
+# ── POST /api/models/benchmark ───────────────────────────────────────────────
+
+
+def test_benchmark_returns_200_with_fake_runtime(client):
+    resp = client.post("/api/models/benchmark", json={})
+    assert resp.status_code == 200
+
+
+def test_benchmark_response_shape(client):
+    body = client.post("/api/models/benchmark", json={}).json()
+    assert "model_id" in body
+    assert "runtime_id" in body
+    assert "tokens_per_sec" in body
+    assert isinstance(body["tokens_per_sec"], (int, float))
+    assert isinstance(body["warnings"], list)
+    assert isinstance(body["output_tokens"], int)
+    assert body["output_tokens"] > 0
+    assert "benchmarked_at" in body
+
+
+def test_benchmark_persists_result(client):
+    body = client.post("/api/models/benchmark", json={}).json()
+    model_id = body["model_id"]
+    runtime_id = body["runtime_id"]
+    saved = get_latest_benchmark(
+        client.app.state.db.connection(), model_id, runtime_id
+    )
+    assert saved is not None
+    assert saved["tokens_per_sec"] == pytest.approx(body["tokens_per_sec"])
+
+
+def test_benchmark_uses_active_model_id(client):
+    client.post("/api/models/use", json={"runtime_id": "fake", "model_id": "fake-large"})
+    body = client.post("/api/models/benchmark", json={}).json()
+    assert body["model_id"] == "fake-large"
+
+
+def test_benchmark_context_length_from_fake_runtime(client):
+    # fake-small has context_length=4096 in the fake runtime
+    resp = client.post("/api/models/benchmark", json={"model_id": "fake-small"})
+    body = resp.json()
+    assert body["context_length"] == 4096
+
+
+def test_benchmark_runtime_unavailable_returns_503(client, monkeypatch):
+    import convsim_core.routers.models as models_module
+
+    unavailable_health = RuntimeHealth(
+        runtime_id="fake",
+        runtime_name="Fake",
+        status=RuntimeStatus.UNAVAILABLE,
+        message="Runtime is down",
+        checked_at="2026-01-01T00:00:00+00:00",
+    )
+    original_runtime = client.app.state.runtime
+    patched = MagicMock(wraps=original_runtime)
+    patched.health = AsyncMock(return_value=unavailable_health)
+    client.app.state.runtime = patched
+    resp = client.post("/api/models/benchmark", json={})
+    client.app.state.runtime = original_runtime
+    assert resp.status_code == 503
+    assert resp.json()["error"]["code"] == "RUNTIME_UNAVAILABLE"

--- a/services/convsim-core/tests/test_model_manager.py
+++ b/services/convsim-core/tests/test_model_manager.py
@@ -410,7 +410,7 @@ def test_use_model_llama_cpp_returns_error_when_unavailable(client, monkeypatch)
     monkeypatch.setattr(models_module, "build_runtime", lambda _id: rt)
     resp = client.post("/api/models/use", json={"runtime_id": "llama_cpp"})
     assert resp.status_code == 503
-    assert "llama" in resp.json()["error"]["message"].lower()
+    assert resp.json()["error"]["code"] == "RUNTIME_UNAVAILABLE"
 
 
 # ── POST /api/models/benchmark ───────────────────────────────────────────────

--- a/services/convsim-core/tests/test_model_manager.py
+++ b/services/convsim-core/tests/test_model_manager.py
@@ -250,6 +250,20 @@ def test_install_rejects_model_with_pending_sha256(client):
     assert resp.json()["error"]["code"] == "MISSING_CHECKSUM"
 
 
+def test_install_rejects_model_with_lowercase_pending_sha256(client):
+    """The explicit-download guard must be case-insensitive for the PENDING sentinel."""
+    conn = client.app.state.db.connection()
+    conn.execute(
+        """INSERT INTO model_registry (id, name, provider, license_spdx, sha256, source_type)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        ("lowercase-pending-model", "Lowercase Pending", "test", "MIT", "pending", "registry"),
+    )
+    conn.commit()
+    resp = client.post("/api/models/install", json={"registry_id": "lowercase-pending-model"})
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "MISSING_CHECKSUM"
+
+
 def test_install_rejects_model_with_null_sha256(client):
     """The explicit-download guard must reject models whose sha256 is NULL (absent)."""
     conn = client.app.state.db.connection()

--- a/services/convsim-core/tests/test_model_manager.py
+++ b/services/convsim-core/tests/test_model_manager.py
@@ -457,6 +457,15 @@ def test_benchmark_context_length_from_fake_runtime(client):
     assert body["context_length"] == 4096
 
 
+def test_benchmark_persisted_benchmarked_at_matches_response(client):
+    body = client.post("/api/models/benchmark", json={}).json()
+    saved = get_latest_benchmark(
+        client.app.state.db.connection(), body["model_id"], body["runtime_id"]
+    )
+    assert saved is not None
+    assert saved["benchmarked_at"] == body["benchmarked_at"]
+
+
 def test_benchmark_runtime_unavailable_returns_503(client, monkeypatch):
     import convsim_core.routers.models as models_module
 

--- a/services/convsim-core/tests/test_model_manager.py
+++ b/services/convsim-core/tests/test_model_manager.py
@@ -250,6 +250,20 @@ def test_install_rejects_model_with_pending_sha256(client):
     assert resp.json()["error"]["code"] == "MISSING_CHECKSUM"
 
 
+def test_install_rejects_model_with_null_sha256(client):
+    """The explicit-download guard must reject models whose sha256 is NULL (absent)."""
+    conn = client.app.state.db.connection()
+    conn.execute(
+        """INSERT INTO model_registry (id, name, provider, license_spdx, sha256, source_type)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        ("null-sha-model", "Null SHA Model", "test", "MIT", None, "registry"),
+    )
+    conn.commit()
+    resp = client.post("/api/models/install", json={"registry_id": "null-sha-model"})
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "MISSING_CHECKSUM"
+
+
 def test_install_rejects_model_without_license(client):
     """A registry entry with no license must be rejected."""
     _load_registry(client)

--- a/services/convsim-core/tests/test_model_manager.py
+++ b/services/convsim-core/tests/test_model_manager.py
@@ -261,9 +261,9 @@ def test_install_rejects_model_without_license(client):
         """
         INSERT INTO model_registry
             (id, name, provider, license_spdx, sha256, source_type)
-        VALUES ('test-no-license', 'Test No License', 'test', NULL,
-                'a' * 64, 'registry')
-        """
+        VALUES (?, ?, ?, NULL, ?, ?)
+        """,
+        ("test-no-license", "Test No License", "test", "a" * 64, "registry"),
     )
     conn.commit()
     resp = client.post("/api/models/install", json={"registry_id": "test-no-license"})

--- a/services/convsim-core/tests/test_model_manager.py
+++ b/services/convsim-core/tests/test_model_manager.py
@@ -223,12 +223,6 @@ def _load_registry(client):
     load_and_persist_registry(client.app.state.db.connection(), _REGISTRY_PATH)
 
 
-def _starter_id(client) -> str:
-    body = client.get("/api/models").json()
-    starter = next(m for m in body["registry"] if m["role"] == "starter")
-    return starter["id"]
-
-
 def test_install_rejects_unknown_model(client):
     resp = client.post("/api/models/install", json={"registry_id": "does-not-exist"})
     assert resp.status_code == 404
@@ -244,10 +238,14 @@ def test_install_rejects_user_supplied_model(client):
 
 def test_install_rejects_model_with_pending_sha256(client):
     """The explicit-download guard must reject models that have PENDING checksums."""
-    _load_registry(client)
-    model_id = _starter_id(client)
-    # Starter model has sha256 == "PENDING" in the registry
-    resp = client.post("/api/models/install", json={"registry_id": model_id})
+    conn = client.app.state.db.connection()
+    conn.execute(
+        """INSERT INTO model_registry (id, name, provider, license_spdx, sha256, source_type)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        ("pending-sha-model", "Pending SHA Model", "test", "MIT", "PENDING", "registry"),
+    )
+    conn.commit()
+    resp = client.post("/api/models/install", json={"registry_id": "pending-sha-model"})
     assert resp.status_code == 400
     assert resp.json()["error"]["code"] == "MISSING_CHECKSUM"
 

--- a/services/convsim-core/tests/test_model_registry.py
+++ b/services/convsim-core/tests/test_model_registry.py
@@ -448,14 +448,14 @@ def test_get_models_returns_200(client):
 
 def test_get_models_empty_database_returns_empty_list(client):
     body = client.get("/api/models").json()
-    assert body["models"] == []
+    assert body["registry"] == []
     assert body["total"] == 0
 
 
 def test_get_models_after_registry_load_returns_sorted_entries(client):
     load_and_persist_registry(client.app.state.db.connection(), _REGISTRY_PATH)
     body = client.get("/api/models").json()
-    models = body["models"]
+    models = body["registry"]
     assert body["total"] == len(models)
     assert body["total"] > 0
     roles = [m["role"] for m in models]
@@ -466,7 +466,7 @@ def test_get_models_after_registry_load_returns_sorted_entries(client):
 def test_get_models_entry_shape(client):
     load_and_persist_registry(client.app.state.db.connection(), _REGISTRY_PATH)
     body = client.get("/api/models").json()
-    entry = next(m for m in body["models"] if m["role"] == "starter")
+    entry = next(m for m in body["registry"] if m["role"] == "starter")
     assert entry["license_spdx"] == "Apache-2.0"
     assert entry["source_type"] == "registry"
     assert entry["sha256"] == "PENDING"
@@ -477,7 +477,7 @@ def test_get_models_entry_shape(client):
 def test_get_models_user_supplied_entry(client):
     load_and_persist_registry(client.app.state.db.connection(), _REGISTRY_PATH)
     body = client.get("/api/models").json()
-    entry = next(m for m in body["models"] if m["id"] == "user-supplied-gguf")
+    entry = next(m for m in body["registry"] if m["id"] == "user-supplied-gguf")
     assert entry["source_type"] == "user-supplied"
     assert entry["license_spdx"] == "unknown-user-supplied"
     assert entry["sha256"] is None


### PR DESCRIPTION
## Summary

Implements the full model manager API described in issue #13:

- **GET /api/models** returns a richer response with five sections: `registry` (models from the local YAML/SQLite registry), `installed` (tracked install records with `install_status`, `progress_bytes`, `error_message`), `ollama_models` (auto-detected from a local Ollama server), `active` (the persisted runtime/model selection), and `runtime_health`.
- **POST /api/models/use** validates that the requested runtime is reachable (returning a structured 503 with error code `RUNTIME_UNAVAILABLE` if not) before persisting `runtime_id` and optional `model_id` to `user_settings`. Supports `fake`, `ollama`, and `llama_cpp` runtimes.
- **POST /api/models/install** enforces an explicit-download guard: rejects registry entries with a missing `license_spdx`, a `null` SHA-256, or the sentinel value `"PENDING"` (case-insensitively), and rejects `user-supplied` entries entirely. Accepted requests create a `pending` record in `installed_models` for a background downloader to act on.
- **POST /api/models/benchmark** runs a short local prompt against the active runtime, captures `tokens_per_sec` from the `ChatFinal` output token count, records `context_length` by querying `list_models()`, appends human-readable warnings (zero token count, sub-millisecond elapsed), persists the result to `benchmark_results`, and returns all fields in the response.
- **GET /api/health** gains an `active_model` field (`runtime_id`, `model_id`) so model health is visible alongside runtime health.
- **Migration 0003** adds `install_status`, `progress_bytes`, and `error_message` columns to `installed_models`, and creates the `benchmark_results` table with `tokens_per_sec`, `context_length`, `warnings_json`, and `benchmarked_at` tracking.
- **TypeScript types** in `packages/shared/src/types/models.ts` export typed request/response schemas for all four endpoints, with typed discriminated unions for install responses and `RuntimeStatus` enum, shared with the frontend.

## Test plan

- Unit tests for the explicit-download guard: `"PENDING"` checksum (case-insensitive) → 400, `NULL` checksum → 400, missing license → 400, user-supplied → 400, valid license+checksum → 200 with `pending` install record.
- Unit tests for `POST /api/models/use` with the `fake` runtime (succeeds), and with mock runtimes returning `UNAVAILABLE` health for `ollama` and `llama_cpp` (503 with `RUNTIME_UNAVAILABLE` code).
- Unit tests for benchmark persistence: `save_benchmark_result`/`get_latest_benchmark` round-trip, warning serialisation, most-recent-wins ordering.
- Integration tests for `GET /api/models` from empty state confirming all response sections are present and runtime health is accessible.
- All existing tests continue to pass; `test_model_registry.py` assertions updated to use the new `registry` key.

Closes #13