### PR TITLE
Implement pack loader, reference resolver, and SQLite pack index

### DIFF
--- a/packages/pack-loader/package.json
+++ b/packages/pack-loader/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@convsim/pack-loader",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "check": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "ajv": "^8.17.1",
+    "better-sqlite3": "^11.5.0",
+    "js-yaml": "^4.1.0"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.11",
+    "@types/js-yaml": "^4.0.9",
+    "@types/node": "^22.0.0",
+    "typescript": "^5.5.0",
+    "vitest": "^2.0.0"
+  }
+}

--- a/packages/pack-loader/package.json
+++ b/packages/pack-loader/package.json
@@ -18,11 +18,11 @@
   },
   "dependencies": {
     "ajv": "^8.17.1",
-    "better-sqlite3": "^11.5.0",
+    "better-sqlite3": "^12.11.1",
     "js-yaml": "^4.1.0"
   },
   "devDependencies": {
-    "@types/better-sqlite3": "^7.6.11",
+    "@types/better-sqlite3": "^7.6.13",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.0.0",
     "typescript": "^5.5.0",

--- a/packages/pack-loader/src/db.ts
+++ b/packages/pack-loader/src/db.ts
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: Apache-2.0
+import Database from 'better-sqlite3';
+import type { Database as DatabaseType } from 'better-sqlite3';
+import type { LoadedPack, PackIndexEntry, ScenarioIndexEntry } from './types.js';
+
+const DDL = `
+CREATE TABLE IF NOT EXISTS installed_packs (
+  pack_id          TEXT PRIMARY KEY,
+  name             TEXT NOT NULL,
+  version          TEXT NOT NULL,
+  content_rating   TEXT NOT NULL,
+  author           TEXT NOT NULL,
+  license          TEXT NOT NULL,
+  description      TEXT NOT NULL,
+  pack_root        TEXT NOT NULL,
+  pack_root_kind   TEXT NOT NULL,
+  supported_languages TEXT NOT NULL,
+  tags             TEXT NOT NULL,
+  requirements     TEXT,
+  scenario_count   INTEGER NOT NULL DEFAULT 0,
+  entry_scenarios  TEXT NOT NULL,
+  installed_at     INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS indexed_scenarios (
+  scenario_id            TEXT NOT NULL,
+  pack_id                TEXT NOT NULL REFERENCES installed_packs(pack_id) ON DELETE CASCADE,
+  title                  TEXT NOT NULL,
+  summary                TEXT NOT NULL,
+  player_role_label      TEXT NOT NULL,
+  difficulty_default     TEXT,
+  max_turns              INTEGER NOT NULL,
+  soft_time_limit_minutes INTEGER,
+  rel_path               TEXT NOT NULL,
+  PRIMARY KEY (pack_id, scenario_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_scenarios_pack_id ON indexed_scenarios(pack_id);
+`;
+
+/**
+ * SQLite-backed index of installed scenario packs.
+ *
+ * Operations are synchronous (better-sqlite3). Open with PackIndex.open() to
+ * ensure the schema is initialised before use.
+ */
+export class PackIndex {
+  private readonly db: DatabaseType;
+
+  private constructor(dbPath: string) {
+    this.db = new Database(dbPath);
+    this.db.pragma('journal_mode = WAL');
+    this.db.pragma('foreign_keys = ON');
+    this.db.exec(DDL);
+  }
+
+  static open(dbPath: string): PackIndex {
+    return new PackIndex(dbPath);
+  }
+
+  /** Import (or replace) a pack in the index, atomically updating its scenarios. */
+  importPack(pack: LoadedPack): void {
+    const now = Math.floor(Date.now() / 1000);
+    const m = pack.manifest;
+
+    const upsertPack = this.db.prepare(`
+      INSERT INTO installed_packs
+        (pack_id, name, version, content_rating, author, license, description,
+         pack_root, pack_root_kind, supported_languages, tags, requirements,
+         scenario_count, entry_scenarios, installed_at)
+      VALUES
+        (@pack_id, @name, @version, @content_rating, @author, @license, @description,
+         @pack_root, @pack_root_kind, @supported_languages, @tags, @requirements,
+         @scenario_count, @entry_scenarios, @installed_at)
+      ON CONFLICT(pack_id) DO UPDATE SET
+        name               = excluded.name,
+        version            = excluded.version,
+        content_rating     = excluded.content_rating,
+        author             = excluded.author,
+        license            = excluded.license,
+        description        = excluded.description,
+        pack_root          = excluded.pack_root,
+        pack_root_kind     = excluded.pack_root_kind,
+        supported_languages = excluded.supported_languages,
+        tags               = excluded.tags,
+        requirements       = excluded.requirements,
+        scenario_count     = excluded.scenario_count,
+        entry_scenarios    = excluded.entry_scenarios,
+        installed_at       = excluded.installed_at
+    `);
+
+    const deleteScenarios = this.db.prepare(
+      'DELETE FROM indexed_scenarios WHERE pack_id = ?',
+    );
+
+    const insertScenario = this.db.prepare(`
+      INSERT INTO indexed_scenarios
+        (scenario_id, pack_id, title, summary, player_role_label,
+         difficulty_default, max_turns, soft_time_limit_minutes, rel_path)
+      VALUES
+        (@scenario_id, @pack_id, @title, @summary, @player_role_label,
+         @difficulty_default, @max_turns, @soft_time_limit_minutes, @rel_path)
+    `);
+
+    this.db.transaction(() => {
+      upsertPack.run({
+        pack_id: m.pack_id,
+        name: m.name,
+        version: m.version,
+        content_rating: m.content_rating,
+        author: m.author,
+        license: m.license,
+        description: m.description,
+        pack_root: pack.packRoot,
+        pack_root_kind: pack.packRootKind,
+        supported_languages: JSON.stringify(m.supported_languages ?? []),
+        tags: JSON.stringify(m.tags ?? []),
+        requirements: m.requirements ? JSON.stringify(m.requirements) : null,
+        scenario_count: pack.scenarios.length,
+        entry_scenarios: JSON.stringify(m.entry_scenarios ?? []),
+        installed_at: now,
+      });
+
+      deleteScenarios.run(m.pack_id);
+
+      for (const s of pack.scenarios) {
+        insertScenario.run({
+          scenario_id: s.data.scenario_id,
+          pack_id: m.pack_id,
+          title: s.data.title,
+          summary: s.data.summary,
+          player_role_label: s.data.player_role.label,
+          difficulty_default: s.data.difficulty?.default ?? null,
+          max_turns: s.data.duration.max_turns,
+          soft_time_limit_minutes: s.data.duration.soft_time_limit_minutes ?? null,
+          rel_path: s.relPath,
+        });
+      }
+    })();
+  }
+
+  /** Remove a pack and all its scenarios from the index. */
+  removePack(packId: string): void {
+    this.db.prepare('DELETE FROM installed_packs WHERE pack_id = ?').run(packId);
+  }
+
+  /** List all indexed packs. */
+  listPacks(): PackIndexEntry[] {
+    const rows = this.db
+      .prepare('SELECT * FROM installed_packs ORDER BY name')
+      .all() as Array<Record<string, unknown>>;
+    return rows.map(deserializePack);
+  }
+
+  /** List indexed scenarios, optionally filtered to a single pack. */
+  listScenarios(packId?: string): ScenarioIndexEntry[] {
+    if (packId !== undefined) {
+      return this.db
+        .prepare(
+          'SELECT * FROM indexed_scenarios WHERE pack_id = ? ORDER BY title',
+        )
+        .all(packId) as ScenarioIndexEntry[];
+    }
+    return this.db
+      .prepare('SELECT * FROM indexed_scenarios ORDER BY title')
+      .all() as ScenarioIndexEntry[];
+  }
+
+  /** Look up a single pack by id. Returns undefined if not found. */
+  getPack(packId: string): PackIndexEntry | undefined {
+    const row = this.db
+      .prepare('SELECT * FROM installed_packs WHERE pack_id = ?')
+      .get(packId) as Record<string, unknown> | undefined;
+    return row ? deserializePack(row) : undefined;
+  }
+
+  close(): void {
+    this.db.close();
+  }
+}
+
+function deserializePack(row: Record<string, unknown>): PackIndexEntry {
+  return {
+    pack_id: row['pack_id'] as string,
+    name: row['name'] as string,
+    version: row['version'] as string,
+    content_rating: row['content_rating'] as string,
+    author: row['author'] as string,
+    license: row['license'] as string,
+    description: row['description'] as string,
+    pack_root: row['pack_root'] as string,
+    pack_root_kind: row['pack_root_kind'] as string,
+    supported_languages: JSON.parse(row['supported_languages'] as string) as string[],
+    tags: JSON.parse(row['tags'] as string) as string[],
+    requirements: row['requirements']
+      ? (JSON.parse(row['requirements'] as string) as {
+          min_app_version?: string;
+          recommended_llm?: string[];
+        })
+      : null,
+    scenario_count: row['scenario_count'] as number,
+    entry_scenarios: JSON.parse(row['entry_scenarios'] as string) as string[],
+    installed_at: row['installed_at'] as number,
+  };
+}

--- a/packages/pack-loader/src/index.ts
+++ b/packages/pack-loader/src/index.ts
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export * from './types.js';
+export * from './resolver.js';
+export * from './loader.js';
+export { PackIndex } from './db.js';

--- a/packages/pack-loader/src/loader.ts
+++ b/packages/pack-loader/src/loader.ts
@@ -188,6 +188,12 @@ export function resolveBundle(pack: LoadedPack, scenarioId: string): ResolvedBun
   if (scenario.scene?.ref) {
     const scenePath = resolveRef(scenarioDir, pack.packRoot, scenario.scene.ref);
     scene = pack.scenes.get(scenePath) ?? null;
+    if (!scene) {
+      throw new PackLoaderError(
+        'MISSING_FILE',
+        `Scene not loaded for scenario "${scenarioId}" in pack "${pack.manifest.pack_id}"`,
+      );
+    }
   }
 
   return {

--- a/packages/pack-loader/src/loader.ts
+++ b/packages/pack-loader/src/loader.ts
@@ -197,6 +197,8 @@ export interface LoadRootsResult {
 /**
  * Scan the configured pack roots and load every pack directory found.
  * Packs that fail validation are collected in `errors` and skipped.
+ * When the same pack_id appears in multiple roots, the pack with the highest
+ * semver version is selected.
  */
 export function loadPacksFromRoots(config: PackRootConfig): LoadRootsResult {
   const roots: Array<{ dir: string; kind: PackRootKind }> = [];
@@ -204,7 +206,7 @@ export function loadPacksFromRoots(config: PackRootConfig): LoadRootsResult {
   if (config.communityRoot) roots.push({ dir: config.communityRoot, kind: 'community' });
   if (config.localDevRoot) roots.push({ dir: config.localDevRoot, kind: 'local-dev' });
 
-  const packs: LoadedPack[] = [];
+  const loaded: LoadedPack[] = [];
   const errors: Array<{ dir: string; error: Error }> = [];
 
   for (const { dir, kind } of roots) {
@@ -218,14 +220,24 @@ export function loadPacksFromRoots(config: PackRootConfig): LoadRootsResult {
     }
     for (const packDir of packDirs) {
       try {
-        packs.push(loadPack(packDir, kind));
+        loaded.push(loadPack(packDir, kind));
       } catch (error) {
         errors.push({ dir: packDir, error: error as Error });
       }
     }
   }
 
-  return { packs, errors };
+  // Deduplicate: when the same pack_id appears across roots, keep the pack
+  // with the highest semver version so the latest compatible release wins.
+  const best = new Map<string, LoadedPack>();
+  for (const pack of loaded) {
+    const existing = best.get(pack.manifest.pack_id);
+    if (!existing || compareSemver(pack.manifest.version, existing.manifest.version) > 0) {
+      best.set(pack.manifest.pack_id, pack);
+    }
+  }
+
+  return { packs: [...best.values()], errors };
 }
 
 // ---------------------------------------------------------------------------
@@ -240,4 +252,18 @@ function discoverYamlFiles(dir: string): string[] {
   } catch {
     return [];
   }
+}
+
+/** Compare two semver strings. Returns positive if a > b, negative if a < b, 0 if equal. */
+function compareSemver(a: string, b: string): number {
+  const parse = (v: string): [number, number, number] => {
+    const parts = v
+      .replace(/[^0-9.]/g, '')
+      .split('.')
+      .map((n) => parseInt(n, 10) || 0);
+    return [parts[0] ?? 0, parts[1] ?? 0, parts[2] ?? 0];
+  };
+  const [aMaj, aMin, aPat] = parse(a);
+  const [bMaj, bMin, bPat] = parse(b);
+  return aMaj !== bMaj ? aMaj - bMaj : aMin !== bMin ? aMin - bMin : aPat - bPat;
 }

--- a/packages/pack-loader/src/loader.ts
+++ b/packages/pack-loader/src/loader.ts
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: Apache-2.0
+import { readdirSync, statSync } from 'node:fs';
+import { resolve, join, relative, dirname, normalize } from 'node:path';
+import { resolveRef, readPackFile } from './resolver.js';
+import { parseAndValidate } from './validator.js';
+import type {
+  LoadedPack,
+  LoadedScenario,
+  PackRootKind,
+  RawManifest,
+  RawNpc,
+  RawRubric,
+  RawSafety,
+  RawScene,
+  RawScenario,
+  ResolvedBundle,
+} from './types.js';
+import { PackLoaderError } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Single-pack loader
+// ---------------------------------------------------------------------------
+
+/**
+ * Load and validate a single pack from `packDir`.
+ *
+ * - Validates manifest.yaml and all referenced YAML files against their
+ *   JSON schemas (schema_version 0.1).
+ * - Resolves all relative refs (npc, rubric, scene, safety) and rejects any
+ *   ref that would escape the pack root (path traversal).
+ * - Rejects packs with duplicate scenario_id or npc_id values.
+ * - Does not execute any code from pack files.
+ */
+export function loadPack(packDir: string, kind: PackRootKind = 'local-dev'): LoadedPack {
+  const normalPackDir = normalize(resolve(packDir));
+
+  // ── Manifest ──────────────────────────────────────────────────────────────
+  const manifestPath = resolve(normalPackDir, 'manifest.yaml');
+  const manifest = parseAndValidate<RawManifest>(
+    readPackFile(manifestPath),
+    'pack',
+    manifestPath,
+  );
+
+  // ── Safety policy ─────────────────────────────────────────────────────────
+  const safetyPath = resolveRef(normalPackDir, normalPackDir, manifest.safety.policy);
+  const safety = parseAndValidate<RawSafety>(readPackFile(safetyPath), 'safety', safetyPath);
+
+  // ── Scenarios ─────────────────────────────────────────────────────────────
+  const scenariosDir = resolve(normalPackDir, 'scenarios');
+  const scenarioFiles = discoverYamlFiles(scenariosDir);
+
+  const scenarioIds = new Set<string>();
+  const scenarios: LoadedScenario[] = [];
+  const npcs = new Map<string, RawNpc>();
+  const rubrics = new Map<string, RawRubric>();
+  const scenes = new Map<string, RawScene>();
+
+  for (const absPath of scenarioFiles) {
+    const data = parseAndValidate<RawScenario>(readPackFile(absPath), 'scenario', absPath);
+
+    if (scenarioIds.has(data.scenario_id)) {
+      throw new PackLoaderError(
+        'DUPLICATE_ID',
+        `Duplicate scenario_id "${data.scenario_id}" found in pack "${manifest.pack_id}"`,
+        absPath,
+      );
+    }
+    scenarioIds.add(data.scenario_id);
+
+    const scenarioDir = dirname(absPath);
+    const relPath = relative(normalPackDir, absPath).replace(/\\/g, '/');
+    scenarios.push({ relPath, data });
+
+    // Resolve NPC ref
+    const npcAbsPath = resolveRef(scenarioDir, normalPackDir, data.npc.ref);
+    if (!npcs.has(npcAbsPath)) {
+      const npc = parseAndValidate<RawNpc>(readPackFile(npcAbsPath), 'npc', npcAbsPath);
+      npcs.set(npcAbsPath, npc);
+    }
+
+    // Resolve rubric ref
+    const rubricAbsPath = resolveRef(scenarioDir, normalPackDir, data.rubric.ref);
+    if (!rubrics.has(rubricAbsPath)) {
+      const rubric = parseAndValidate<RawRubric>(
+        readPackFile(rubricAbsPath),
+        'rubric',
+        rubricAbsPath,
+      );
+      rubrics.set(rubricAbsPath, rubric);
+    }
+
+    // Resolve optional scene ref
+    if (data.scene?.ref) {
+      const sceneAbsPath = resolveRef(scenarioDir, normalPackDir, data.scene.ref);
+      if (!scenes.has(sceneAbsPath)) {
+        const scene = parseAndValidate<RawScene>(readPackFile(sceneAbsPath), 'scene', sceneAbsPath);
+        scenes.set(sceneAbsPath, scene);
+      }
+    }
+  }
+
+  // Duplicate NPC id check across all resolved NPCs
+  const npcIds = new Set<string>();
+  for (const npc of npcs.values()) {
+    if (npcIds.has(npc.npc_id)) {
+      throw new PackLoaderError(
+        'DUPLICATE_ID',
+        `Duplicate npc_id "${npc.npc_id}" in pack "${manifest.pack_id}"`,
+      );
+    }
+    npcIds.add(npc.npc_id);
+  }
+
+  return {
+    manifest,
+    packRoot: normalPackDir,
+    packRootKind: kind,
+    scenarios,
+    npcs,
+    rubrics,
+    scenes,
+    safety,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Bundle resolver
+// ---------------------------------------------------------------------------
+
+/**
+ * Return a fully resolved scenario bundle — scenario, NPC, rubric, scene,
+ * and safety policy — ready for the conversation runtime.
+ */
+export function resolveBundle(pack: LoadedPack, scenarioId: string): ResolvedBundle {
+  const loaded = pack.scenarios.find((s) => s.data.scenario_id === scenarioId);
+  if (!loaded) {
+    throw new PackLoaderError(
+      'MISSING_FILE',
+      `Scenario "${scenarioId}" not found in pack "${pack.manifest.pack_id}"`,
+    );
+  }
+
+  const scenario = loaded.data;
+  const scenarioDir = dirname(resolve(pack.packRoot, loaded.relPath));
+
+  const npcPath = resolveRef(scenarioDir, pack.packRoot, scenario.npc.ref);
+  const npc = pack.npcs.get(npcPath);
+  if (!npc) {
+    throw new PackLoaderError(
+      'MISSING_FILE',
+      `NPC not loaded for scenario "${scenarioId}" in pack "${pack.manifest.pack_id}"`,
+    );
+  }
+
+  const rubricPath = resolveRef(scenarioDir, pack.packRoot, scenario.rubric.ref);
+  const rubric = pack.rubrics.get(rubricPath);
+  if (!rubric) {
+    throw new PackLoaderError(
+      'MISSING_FILE',
+      `Rubric not loaded for scenario "${scenarioId}" in pack "${pack.manifest.pack_id}"`,
+    );
+  }
+
+  let scene: RawScene | null = null;
+  if (scenario.scene?.ref) {
+    const scenePath = resolveRef(scenarioDir, pack.packRoot, scenario.scene.ref);
+    scene = pack.scenes.get(scenePath) ?? null;
+  }
+
+  return {
+    scenarioId,
+    packId: pack.manifest.pack_id,
+    scenario,
+    npc,
+    rubric,
+    scene,
+    safety: pack.safety,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Multi-root loader
+// ---------------------------------------------------------------------------
+
+export interface PackRootConfig {
+  officialRoot?: string;
+  communityRoot?: string;
+  localDevRoot?: string;
+}
+
+export interface LoadRootsResult {
+  packs: LoadedPack[];
+  errors: Array<{ dir: string; error: Error }>;
+}
+
+/**
+ * Scan the configured pack roots and load every pack directory found.
+ * Packs that fail validation are collected in `errors` and skipped.
+ */
+export function loadPacksFromRoots(config: PackRootConfig): LoadRootsResult {
+  const roots: Array<{ dir: string; kind: PackRootKind }> = [];
+  if (config.officialRoot) roots.push({ dir: config.officialRoot, kind: 'official' });
+  if (config.communityRoot) roots.push({ dir: config.communityRoot, kind: 'community' });
+  if (config.localDevRoot) roots.push({ dir: config.localDevRoot, kind: 'local-dev' });
+
+  const packs: LoadedPack[] = [];
+  const errors: Array<{ dir: string; error: Error }> = [];
+
+  for (const { dir, kind } of roots) {
+    let packDirs: string[];
+    try {
+      packDirs = readdirSync(dir)
+        .map((name) => join(dir, name))
+        .filter((d) => statSync(d).isDirectory());
+    } catch {
+      continue;
+    }
+    for (const packDir of packDirs) {
+      try {
+        packs.push(loadPack(packDir, kind));
+      } catch (error) {
+        errors.push({ dir: packDir, error: error as Error });
+      }
+    }
+  }
+
+  return { packs, errors };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function discoverYamlFiles(dir: string): string[] {
+  try {
+    return readdirSync(dir)
+      .filter((f) => f.endsWith('.yaml') || f.endsWith('.yml'))
+      .map((f) => resolve(dir, f));
+  } catch {
+    return [];
+  }
+}

--- a/packages/pack-loader/src/loader.ts
+++ b/packages/pack-loader/src/loader.ts
@@ -46,11 +46,6 @@ export function loadPack(packDir: string, kind: PackRootKind = 'local-dev'): Loa
   const safetyPath = resolveRef(normalPackDir, normalPackDir, manifest.safety.policy);
   const safety = parseAndValidate<RawSafety>(readPackFile(safetyPath), 'safety', safetyPath);
 
-  // ── entry_scenarios path traversal check ──────────────────────────────────
-  for (const entryPath of manifest.entry_scenarios ?? []) {
-    resolveRef(normalPackDir, normalPackDir, entryPath);
-  }
-
   // ── Scenarios ─────────────────────────────────────────────────────────────
   const scenariosDir = resolve(normalPackDir, 'scenarios');
   const scenarioFiles = discoverYamlFiles(scenariosDir);
@@ -108,6 +103,20 @@ export function loadPack(packDir: string, kind: PackRootKind = 'local-dev'): Loa
         }
         scenes.set(sceneAbsPath, scene);
       }
+    }
+  }
+
+  // ── entry_scenarios: path traversal + existence check ─────────────────────
+  // Done after discovery so we can verify each ref points to a loaded file.
+  const scenarioFileSet = new Set(scenarioFiles);
+  for (const entryPath of manifest.entry_scenarios ?? []) {
+    const absEntryPath = resolveRef(normalPackDir, normalPackDir, entryPath);
+    if (!scenarioFileSet.has(absEntryPath)) {
+      throw new PackLoaderError(
+        'MISSING_FILE',
+        `entry_scenario "${entryPath}" not found in scenarios for pack "${manifest.pack_id}"`,
+        absEntryPath,
+      );
     }
   }
 
@@ -182,6 +191,7 @@ export function resolveBundle(pack: LoadedPack, scenarioId: string): ResolvedBun
   return {
     scenarioId,
     packId: pack.manifest.pack_id,
+    packRoot: pack.packRoot,
     scenario,
     npc,
     rubric,

--- a/packages/pack-loader/src/loader.ts
+++ b/packages/pack-loader/src/loader.ts
@@ -77,7 +77,7 @@ export function loadPack(packDir: string, kind: PackRootKind = 'local-dev'): Loa
     if (!npcs.has(npcAbsPath)) {
       const npc = parseAndValidate<RawNpc>(readPackFile(npcAbsPath), 'npc', npcAbsPath);
       if (npc.portrait !== undefined) {
-        resolveRef(normalPackDir, normalPackDir, npc.portrait);
+        resolveRef(dirname(npcAbsPath), normalPackDir, npc.portrait);
       }
       npcs.set(npcAbsPath, npc);
     }
@@ -99,7 +99,7 @@ export function loadPack(packDir: string, kind: PackRootKind = 'local-dev'): Loa
       if (!scenes.has(sceneAbsPath)) {
         const scene = parseAndValidate<RawScene>(readPackFile(sceneAbsPath), 'scene', sceneAbsPath);
         if (scene.background !== undefined) {
-          resolveRef(normalPackDir, normalPackDir, scene.background);
+          resolveRef(dirname(sceneAbsPath), normalPackDir, scene.background);
         }
         scenes.set(sceneAbsPath, scene);
       }

--- a/packages/pack-loader/src/loader.ts
+++ b/packages/pack-loader/src/loader.ts
@@ -46,6 +46,11 @@ export function loadPack(packDir: string, kind: PackRootKind = 'local-dev'): Loa
   const safetyPath = resolveRef(normalPackDir, normalPackDir, manifest.safety.policy);
   const safety = parseAndValidate<RawSafety>(readPackFile(safetyPath), 'safety', safetyPath);
 
+  // ── entry_scenarios path traversal check ──────────────────────────────────
+  for (const entryPath of manifest.entry_scenarios ?? []) {
+    resolveRef(normalPackDir, normalPackDir, entryPath);
+  }
+
   // ── Scenarios ─────────────────────────────────────────────────────────────
   const scenariosDir = resolve(normalPackDir, 'scenarios');
   const scenarioFiles = discoverYamlFiles(scenariosDir);

--- a/packages/pack-loader/src/loader.ts
+++ b/packages/pack-loader/src/loader.ts
@@ -76,6 +76,9 @@ export function loadPack(packDir: string, kind: PackRootKind = 'local-dev'): Loa
     const npcAbsPath = resolveRef(scenarioDir, normalPackDir, data.npc.ref);
     if (!npcs.has(npcAbsPath)) {
       const npc = parseAndValidate<RawNpc>(readPackFile(npcAbsPath), 'npc', npcAbsPath);
+      if (npc.portrait !== undefined) {
+        resolveRef(normalPackDir, normalPackDir, npc.portrait);
+      }
       npcs.set(npcAbsPath, npc);
     }
 
@@ -95,6 +98,9 @@ export function loadPack(packDir: string, kind: PackRootKind = 'local-dev'): Loa
       const sceneAbsPath = resolveRef(scenarioDir, normalPackDir, data.scene.ref);
       if (!scenes.has(sceneAbsPath)) {
         const scene = parseAndValidate<RawScene>(readPackFile(sceneAbsPath), 'scene', sceneAbsPath);
+        if (scene.background !== undefined) {
+          resolveRef(normalPackDir, normalPackDir, scene.background);
+        }
         scenes.set(sceneAbsPath, scene);
       }
     }

--- a/packages/pack-loader/src/loader.ts
+++ b/packages/pack-loader/src/loader.ts
@@ -77,7 +77,8 @@ export function loadPack(packDir: string, kind: PackRootKind = 'local-dev'): Loa
     if (!npcs.has(npcAbsPath)) {
       const npc = parseAndValidate<RawNpc>(readPackFile(npcAbsPath), 'npc', npcAbsPath);
       if (npc.portrait !== undefined) {
-        resolveRef(dirname(npcAbsPath), normalPackDir, npc.portrait);
+        // Portrait paths are pack-root-relative per the NPC schema ("within the pack").
+        resolveRef(normalPackDir, normalPackDir, npc.portrait);
       }
       npcs.set(npcAbsPath, npc);
     }
@@ -99,7 +100,8 @@ export function loadPack(packDir: string, kind: PackRootKind = 'local-dev'): Loa
       if (!scenes.has(sceneAbsPath)) {
         const scene = parseAndValidate<RawScene>(readPackFile(sceneAbsPath), 'scene', sceneAbsPath);
         if (scene.background !== undefined) {
-          resolveRef(dirname(sceneAbsPath), normalPackDir, scene.background);
+          // Background paths are pack-root-relative per the scene schema ("within the pack assets directory").
+          resolveRef(normalPackDir, normalPackDir, scene.background);
         }
         scenes.set(sceneAbsPath, scene);
       }

--- a/packages/pack-loader/src/loader.ts
+++ b/packages/pack-loader/src/loader.ts
@@ -225,7 +225,13 @@ export function loadPacksFromRoots(config: PackRootConfig): LoadRootsResult {
     try {
       packDirs = readdirSync(dir)
         .map((name) => join(dir, name))
-        .filter((d) => statSync(d).isDirectory());
+        .filter((d) => {
+          try {
+            return statSync(d).isDirectory();
+          } catch {
+            return false;
+          }
+        });
     } catch {
       continue;
     }

--- a/packages/pack-loader/src/resolver.ts
+++ b/packages/pack-loader/src/resolver.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve, relative, normalize } from 'node:path';
+import { PackLoaderError } from './types.js';
+
+/**
+ * Resolve `ref` relative to `baseDir` and verify the result stays within
+ * `packRoot`. Throws PackLoaderError with code PATH_TRAVERSAL if the resolved
+ * path would escape the pack root directory.
+ */
+export function resolveRef(baseDir: string, packRoot: string, ref: string): string {
+  if (ref.includes('\0')) {
+    throw new PackLoaderError('PATH_TRAVERSAL', `Null byte in ref: "${ref}"`, ref);
+  }
+  const abs = normalize(resolve(baseDir, ref));
+  const rel = relative(normalize(packRoot), abs);
+  if (rel.startsWith('..') || normalize(rel) !== rel.replace(/^\.\..*/, '')) {
+    throw new PackLoaderError(
+      'PATH_TRAVERSAL',
+      `Ref "${ref}" escapes the pack root "${packRoot}"`,
+      ref,
+    );
+  }
+  return abs;
+}
+
+/** Read a file as UTF-8. Throws PackLoaderError(MISSING_FILE) if not found. */
+export function readPackFile(absPath: string): string {
+  if (!existsSync(absPath)) {
+    throw new PackLoaderError('MISSING_FILE', `File not found: ${absPath}`, absPath);
+  }
+  return readFileSync(absPath, 'utf8');
+}

--- a/packages/pack-loader/src/resolver.ts
+++ b/packages/pack-loader/src/resolver.ts
@@ -1,12 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
 import { readFileSync, existsSync } from 'node:fs';
-import { resolve, relative, normalize } from 'node:path';
+import { resolve, relative, normalize, isAbsolute } from 'node:path';
 import { PackLoaderError } from './types.js';
 
 /**
  * Resolve `ref` relative to `baseDir` and verify the result stays within
  * `packRoot`. Throws PackLoaderError with code PATH_TRAVERSAL if the resolved
  * path would escape the pack root directory.
+ *
+ * Two traversal vectors are guarded:
+ *   - `rel.startsWith('..')` — catches ancestor-directory escapes on any OS.
+ *   - `isAbsolute(rel)` — catches cross-drive refs on Windows, where
+ *     `path.relative('C:\\pack', 'D:\\evil')` returns `'D:\\evil'` (an
+ *     absolute path) rather than a `..`-prefixed relative path.
  */
 export function resolveRef(baseDir: string, packRoot: string, ref: string): string {
   if (ref.includes('\0')) {
@@ -14,7 +20,7 @@ export function resolveRef(baseDir: string, packRoot: string, ref: string): stri
   }
   const abs = normalize(resolve(baseDir, ref));
   const rel = relative(normalize(packRoot), abs);
-  if (rel.startsWith('..') || normalize(rel) !== rel.replace(/^\.\..*/, '')) {
+  if (rel.startsWith('..') || isAbsolute(rel)) {
     throw new PackLoaderError(
       'PATH_TRAVERSAL',
       `Ref "${ref}" escapes the pack root "${packRoot}"`,

--- a/packages/pack-loader/src/resolver.ts
+++ b/packages/pack-loader/src/resolver.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { readFileSync, existsSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { resolve, relative, normalize, isAbsolute } from 'node:path';
 import { PackLoaderError } from './types.js';
 
@@ -32,8 +32,12 @@ export function resolveRef(baseDir: string, packRoot: string, ref: string): stri
 
 /** Read a file as UTF-8. Throws PackLoaderError(MISSING_FILE) if not found. */
 export function readPackFile(absPath: string): string {
-  if (!existsSync(absPath)) {
-    throw new PackLoaderError('MISSING_FILE', `File not found: ${absPath}`, absPath);
+  try {
+    return readFileSync(absPath, 'utf8');
+  } catch (e) {
+    if (e instanceof Error && (e as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new PackLoaderError('MISSING_FILE', `File not found: ${absPath}`, absPath);
+    }
+    throw e;
   }
-  return readFileSync(absPath, 'utf8');
 }

--- a/packages/pack-loader/src/types.ts
+++ b/packages/pack-loader/src/types.ts
@@ -52,6 +52,7 @@ export interface RawNpc {
   archetype: string;
   fictional: true;
   age_band: 'adult';
+  portrait?: string;
   public_persona: { occupation: string; speaking_style: string; demeanor: string };
   private_persona: Record<string, unknown>;
   [key: string]: unknown;
@@ -85,6 +86,8 @@ export interface RawScene {
   scene_id: string;
   display_name: string;
   description: string;
+  background?: string;
+  ambient?: string;
   [key: string]: unknown;
 }
 

--- a/packages/pack-loader/src/types.ts
+++ b/packages/pack-loader/src/types.ts
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export const SUPPORTED_SCHEMA_VERSION = '0.1';
+
+export type PackRootKind = 'official' | 'community' | 'local-dev';
+
+// ---------------------------------------------------------------------------
+// Raw YAML shapes (schema_version "0.1")
+// ---------------------------------------------------------------------------
+
+export interface RawManifest {
+  schema_version: string;
+  pack_id: string;
+  name: string;
+  version: string;
+  description: string;
+  author: string;
+  license: string;
+  content_rating: 'G' | 'PG' | 'PG-13';
+  tags?: string[];
+  supported_languages?: string[];
+  requirements?: { min_app_version?: string; recommended_llm?: string[] };
+  entry_scenarios?: string[];
+  assets?: { allow_external_urls: false };
+  safety: { policy: string };
+  [key: string]: unknown;
+}
+
+export interface RawScenario {
+  schema_version: string;
+  scenario_id: string;
+  title: string;
+  summary: string;
+  player_role: { label: string; brief: string };
+  npc: { ref: string };
+  rubric: { ref: string };
+  scene?: { ref: string };
+  duration: { max_turns: number; soft_time_limit_minutes?: number };
+  opening: { npc_says: string };
+  goals?: { player_visible?: string[]; hidden?: string[] };
+  difficulty?: { default?: string; options?: Record<string, unknown> };
+  state?: unknown;
+  events?: unknown[];
+  ending_conditions?: unknown;
+  [key: string]: unknown;
+}
+
+export interface RawNpc {
+  schema_version: string;
+  npc_id: string;
+  display_name: string;
+  archetype: string;
+  fictional: true;
+  age_band: 'adult';
+  public_persona: { occupation: string; speaking_style: string; demeanor: string };
+  private_persona: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export interface RawRubric {
+  schema_version: string;
+  rubric_id: string;
+  title: string;
+  dimensions: Array<{
+    id: string;
+    name: string;
+    description: string;
+    scoring: { low: string; medium: string; high: string };
+    weight?: number;
+  }>;
+  [key: string]: unknown;
+}
+
+export interface RawSafety {
+  schema_version: string;
+  policy_id: string;
+  content_rating_cap: 'G' | 'PG' | 'PG-13';
+  content_categories: Record<string, string>;
+  redirect_message: string;
+  [key: string]: unknown;
+}
+
+export interface RawScene {
+  schema_version: string;
+  scene_id: string;
+  display_name: string;
+  description: string;
+  [key: string]: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Loader output types
+// ---------------------------------------------------------------------------
+
+export interface LoadedScenario {
+  relPath: string;
+  data: RawScenario;
+}
+
+export interface LoadedPack {
+  manifest: RawManifest;
+  packRoot: string;
+  packRootKind: PackRootKind;
+  scenarios: LoadedScenario[];
+  npcs: Map<string, RawNpc>;
+  rubrics: Map<string, RawRubric>;
+  scenes: Map<string, RawScene>;
+  safety: RawSafety;
+}
+
+export interface ResolvedBundle {
+  scenarioId: string;
+  packId: string;
+  scenario: RawScenario;
+  npc: RawNpc;
+  rubric: RawRubric;
+  scene: RawScene | null;
+  safety: RawSafety;
+}
+
+// ---------------------------------------------------------------------------
+// SQLite index row types
+// ---------------------------------------------------------------------------
+
+export interface PackIndexEntry {
+  pack_id: string;
+  name: string;
+  version: string;
+  content_rating: string;
+  author: string;
+  license: string;
+  description: string;
+  pack_root: string;
+  pack_root_kind: string;
+  supported_languages: string[];
+  tags: string[];
+  requirements: { min_app_version?: string; recommended_llm?: string[] } | null;
+  scenario_count: number;
+  entry_scenarios: string[];
+  installed_at: number;
+}
+
+export interface ScenarioIndexEntry {
+  scenario_id: string;
+  pack_id: string;
+  title: string;
+  summary: string;
+  player_role_label: string;
+  difficulty_default: string | null;
+  max_turns: number;
+  soft_time_limit_minutes: number | null;
+  rel_path: string;
+}
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+export type PackLoaderErrorCode =
+  | 'MISSING_FILE'
+  | 'INVALID_YAML'
+  | 'SCHEMA_VALIDATION'
+  | 'INVALID_REF'
+  | 'PATH_TRAVERSAL'
+  | 'DUPLICATE_ID'
+  | 'UNSUPPORTED_VERSION';
+
+export class PackLoaderError extends Error {
+  readonly code: PackLoaderErrorCode;
+  readonly filePath: string | undefined;
+
+  constructor(code: PackLoaderErrorCode, message: string, filePath?: string) {
+    super(message);
+    this.name = 'PackLoaderError';
+    this.code = code;
+    this.filePath = filePath;
+  }
+}

--- a/packages/pack-loader/src/types.ts
+++ b/packages/pack-loader/src/types.ts
@@ -114,6 +114,7 @@ export interface LoadedPack {
 export interface ResolvedBundle {
   scenarioId: string;
   packId: string;
+  packRoot: string;
   scenario: RawScenario;
   npc: RawNpc;
   rubric: RawRubric;

--- a/packages/pack-loader/src/types.ts
+++ b/packages/pack-loader/src/types.ts
@@ -37,7 +37,7 @@ export interface RawScenario {
   scene?: { ref: string };
   duration: { max_turns: number; soft_time_limit_minutes?: number };
   opening: { npc_says: string };
-  goals?: { player_visible?: string[]; hidden?: string[] };
+  goals: { player_visible?: string[]; hidden?: string[] };
   difficulty?: { default?: string; options?: Record<string, unknown> };
   state?: unknown;
   events?: unknown[];

--- a/packages/pack-loader/src/types.ts
+++ b/packages/pack-loader/src/types.ts
@@ -164,7 +164,6 @@ export type PackLoaderErrorCode =
   | 'MISSING_FILE'
   | 'INVALID_YAML'
   | 'SCHEMA_VALIDATION'
-  | 'INVALID_REF'
   | 'PATH_TRAVERSAL'
   | 'DUPLICATE_ID'
   | 'UNSUPPORTED_VERSION';

--- a/packages/pack-loader/src/validator.ts
+++ b/packages/pack-loader/src/validator.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+import { Ajv } from 'ajv';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { load as yamlLoad } from 'js-yaml';
+import { PackLoaderError, SUPPORTED_SCHEMA_VERSION } from './types.js';
+
+const _dir = dirname(fileURLToPath(import.meta.url));
+const schemasDir = resolve(_dir, '..', '..', '..', 'schemas');
+
+const ajv = new Ajv({ strict: false, validateSchema: false, allErrors: true });
+
+function loadSchema(name: string): object {
+  return JSON.parse(readFileSync(resolve(schemasDir, name), 'utf8')) as object;
+}
+
+const validators = {
+  pack: ajv.compile(loadSchema('pack.schema.json')),
+  scenario: ajv.compile(loadSchema('scenario.schema.json')),
+  npc: ajv.compile(loadSchema('npc.schema.json')),
+  rubric: ajv.compile(loadSchema('rubric.schema.json')),
+  safety: ajv.compile(loadSchema('safety.schema.json')),
+  scene: ajv.compile(loadSchema('scene.schema.json')),
+};
+
+export type SchemaKey = keyof typeof validators;
+
+/**
+ * Parse YAML text and validate it against the named JSON schema.
+ * Returns the parsed object on success; throws PackLoaderError on failure.
+ * Never executes any code from the YAML file — js-yaml uses safe load mode.
+ */
+export function parseAndValidate<T>(
+  yamlText: string,
+  schemaKey: SchemaKey,
+  filePath: string,
+): T {
+  let raw: unknown;
+  try {
+    raw = yamlLoad(yamlText);
+  } catch (e) {
+    throw new PackLoaderError(
+      'INVALID_YAML',
+      `YAML parse error in ${filePath}: ${e instanceof Error ? e.message : String(e)}`,
+      filePath,
+    );
+  }
+
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    throw new PackLoaderError(
+      'INVALID_YAML',
+      `Expected a YAML object in ${filePath}, got ${Array.isArray(raw) ? 'array' : String(raw)}`,
+      filePath,
+    );
+  }
+
+  const data = raw as Record<string, unknown>;
+
+  if (
+    typeof data['schema_version'] === 'string' &&
+    data['schema_version'] !== SUPPORTED_SCHEMA_VERSION
+  ) {
+    throw new PackLoaderError(
+      'UNSUPPORTED_VERSION',
+      `Unsupported schema_version "${data['schema_version']}" in ${filePath}. ` +
+        `Expected "${SUPPORTED_SCHEMA_VERSION}".`,
+      filePath,
+    );
+  }
+
+  const validate = validators[schemaKey];
+  const ok = validate(raw);
+  if (!ok) {
+    const errs = (validate.errors ?? [])
+      .map((e) => `${e.instancePath || '(root)'}: ${e.message ?? 'invalid'}`)
+      .join('; ');
+    throw new PackLoaderError(
+      'SCHEMA_VALIDATION',
+      `Schema validation failed for ${filePath}: ${errs}`,
+      filePath,
+    );
+  }
+
+  return raw as T;
+}

--- a/packages/pack-loader/tests/db.test.ts
+++ b/packages/pack-loader/tests/db.test.ts
@@ -10,17 +10,26 @@ import { makeTempPackDir, VALID_MANIFEST_YAML, VALID_SCENARIO_YAML } from './fix
 let workDir: string;
 let dbPath: string;
 let index: PackIndex;
+let packDirs: string[] = [];
 
 beforeEach(() => {
   workDir = mkdtempSync(join(tmpdir(), 'convsim-db-test-'));
   dbPath = join(workDir, 'packs.db');
   index = PackIndex.open(dbPath);
+  packDirs = [];
 });
 
 afterEach(() => {
   index.close();
   rmSync(workDir, { recursive: true, force: true });
+  packDirs.forEach((d) => rmSync(d, { recursive: true, force: true }));
 });
+
+function tempPackDir(options?: Parameters<typeof makeTempPackDir>[0]): string {
+  const dir = makeTempPackDir(options ?? {});
+  packDirs.push(dir);
+  return dir;
+}
 
 // ---------------------------------------------------------------------------
 // Import
@@ -28,7 +37,7 @@ afterEach(() => {
 
 describe('PackIndex.importPack', () => {
   it('adds the pack to the index', () => {
-    const packDir = makeTempPackDir();
+    const packDir = tempPackDir();
     const pack = loadPack(packDir, 'official');
     index.importPack(pack);
 
@@ -41,7 +50,7 @@ describe('PackIndex.importPack', () => {
   });
 
   it('records the correct scenario count', () => {
-    const packDir = makeTempPackDir();
+    const packDir = tempPackDir();
     const pack = loadPack(packDir);
     index.importPack(pack);
 
@@ -50,7 +59,7 @@ describe('PackIndex.importPack', () => {
   });
 
   it('indexes scenarios', () => {
-    const packDir = makeTempPackDir();
+    const packDir = tempPackDir();
     const pack = loadPack(packDir);
     index.importPack(pack);
 
@@ -66,7 +75,7 @@ describe('PackIndex.importPack', () => {
       .replace('scenario_id: test_scenario', 'scenario_id: test_scenario_two')
       .replace('title: Test Scenario', 'title: Test Scenario Two');
 
-    const packDir = makeTempPackDir({
+    const packDir = tempPackDir({
       scenarioYamls: {
         'test_scenario.yaml': VALID_SCENARIO_YAML,
         'test_scenario_two.yaml': secondScenario,
@@ -89,14 +98,14 @@ describe('PackIndex.importPack', () => {
 
 describe('PackIndex.importPack — replace', () => {
   it('updates existing pack metadata on re-import', () => {
-    const v1Dir = makeTempPackDir();
+    const v1Dir = tempPackDir();
     const v1Pack = loadPack(v1Dir, 'official');
     index.importPack(v1Pack);
 
     const updatedManifest = VALID_MANIFEST_YAML
       .replace('version: 0.1.0', 'version: 0.2.0')
       .replace('name: Minimal Test Pack', 'name: Updated Test Pack');
-    const v2Dir = makeTempPackDir({ manifestYaml: updatedManifest });
+    const v2Dir = tempPackDir({ manifestYaml: updatedManifest });
     const v2Pack = loadPack(v2Dir, 'official');
     index.importPack(v2Pack);
 
@@ -107,14 +116,14 @@ describe('PackIndex.importPack — replace', () => {
   });
 
   it('replaces the scenario list when pack is updated', () => {
-    const v1Dir = makeTempPackDir();
+    const v1Dir = tempPackDir();
     index.importPack(loadPack(v1Dir));
 
     const newScenario = VALID_SCENARIO_YAML
       .replace('scenario_id: test_scenario', 'scenario_id: replacement_scenario')
       .replace('title: Test Scenario', 'title: Replacement Scenario');
 
-    const v2Dir = makeTempPackDir({
+    const v2Dir = tempPackDir({
       scenarioYamls: { 'replacement.yaml': newScenario },
     });
     index.importPack(loadPack(v2Dir));
@@ -125,13 +134,13 @@ describe('PackIndex.importPack — replace', () => {
   });
 
   it('search index updates when pack is replaced', () => {
-    const v1Dir = makeTempPackDir();
+    const v1Dir = tempPackDir();
     index.importPack(loadPack(v1Dir));
 
     const secondScenario = VALID_SCENARIO_YAML
       .replace('scenario_id: test_scenario', 'scenario_id: extra_scenario')
       .replace('title: Test Scenario', 'title: Extra Scenario');
-    const v2Dir = makeTempPackDir({
+    const v2Dir = tempPackDir({
       scenarioYamls: {
         'test_scenario.yaml': VALID_SCENARIO_YAML,
         'extra_scenario.yaml': secondScenario,
@@ -150,7 +159,7 @@ describe('PackIndex.importPack — replace', () => {
 
 describe('PackIndex.removePack', () => {
   it('removes the pack from the index', () => {
-    const packDir = makeTempPackDir();
+    const packDir = tempPackDir();
     index.importPack(loadPack(packDir));
     expect(index.listPacks()).toHaveLength(1);
 
@@ -160,7 +169,7 @@ describe('PackIndex.removePack', () => {
   });
 
   it('cascades removal to indexed scenarios', () => {
-    const packDir = makeTempPackDir();
+    const packDir = tempPackDir();
     index.importPack(loadPack(packDir));
     expect(index.listScenarios('test.minimal_pack')).toHaveLength(1);
 
@@ -185,8 +194,8 @@ describe('PackIndex.listScenarios', () => {
     const scenarioB = VALID_SCENARIO_YAML
       .replace('scenario_id: test_scenario', 'scenario_id: scenario_b');
 
-    index.importPack(loadPack(makeTempPackDir({ manifestYaml: packAManifest })));
-    index.importPack(loadPack(makeTempPackDir({
+    index.importPack(loadPack(tempPackDir({ manifestYaml: packAManifest })));
+    index.importPack(loadPack(tempPackDir({
       manifestYaml: packBManifest,
       scenarioYamls: { 'scenario_b.yaml': scenarioB },
     })));

--- a/packages/pack-loader/tests/db.test.ts
+++ b/packages/pack-loader/tests/db.test.ts
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { join } from 'node:path';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { PackIndex } from '../src/db.js';
+import { loadPack } from '../src/loader.js';
+import { makeTempPackDir, VALID_MANIFEST_YAML, VALID_SCENARIO_YAML } from './fixtures.js';
+
+let workDir: string;
+let dbPath: string;
+let index: PackIndex;
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), 'convsim-db-test-'));
+  dbPath = join(workDir, 'packs.db');
+  index = PackIndex.open(dbPath);
+});
+
+afterEach(() => {
+  index.close();
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Import
+// ---------------------------------------------------------------------------
+
+describe('PackIndex.importPack', () => {
+  it('adds the pack to the index', () => {
+    const packDir = makeTempPackDir();
+    const pack = loadPack(packDir, 'official');
+    index.importPack(pack);
+
+    const packs = index.listPacks();
+    expect(packs).toHaveLength(1);
+    expect(packs[0]?.pack_id).toBe('test.minimal_pack');
+    expect(packs[0]?.name).toBe('Minimal Test Pack');
+    expect(packs[0]?.content_rating).toBe('PG');
+    expect(packs[0]?.pack_root_kind).toBe('official');
+  });
+
+  it('records the correct scenario count', () => {
+    const packDir = makeTempPackDir();
+    const pack = loadPack(packDir);
+    index.importPack(pack);
+
+    const entry = index.getPack('test.minimal_pack');
+    expect(entry?.scenario_count).toBe(1);
+  });
+
+  it('indexes scenarios', () => {
+    const packDir = makeTempPackDir();
+    const pack = loadPack(packDir);
+    index.importPack(pack);
+
+    const scenarios = index.listScenarios('test.minimal_pack');
+    expect(scenarios).toHaveLength(1);
+    expect(scenarios[0]?.scenario_id).toBe('test_scenario');
+    expect(scenarios[0]?.title).toBe('Test Scenario');
+    expect(scenarios[0]?.max_turns).toBe(5);
+  });
+
+  it('indexes multiple scenarios', () => {
+    const secondScenario = VALID_SCENARIO_YAML
+      .replace('scenario_id: test_scenario', 'scenario_id: test_scenario_two')
+      .replace('title: Test Scenario', 'title: Test Scenario Two');
+
+    const packDir = makeTempPackDir({
+      scenarioYamls: {
+        'test_scenario.yaml': VALID_SCENARIO_YAML,
+        'test_scenario_two.yaml': secondScenario,
+      },
+    });
+    const pack = loadPack(packDir);
+    index.importPack(pack);
+
+    const scenarios = index.listScenarios('test.minimal_pack');
+    expect(scenarios).toHaveLength(2);
+
+    const entry = index.getPack('test.minimal_pack');
+    expect(entry?.scenario_count).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Replace (re-import same pack_id)
+// ---------------------------------------------------------------------------
+
+describe('PackIndex.importPack — replace', () => {
+  it('updates existing pack metadata on re-import', () => {
+    const v1Dir = makeTempPackDir();
+    const v1Pack = loadPack(v1Dir, 'official');
+    index.importPack(v1Pack);
+
+    const updatedManifest = VALID_MANIFEST_YAML
+      .replace('version: 0.1.0', 'version: 0.2.0')
+      .replace('name: Minimal Test Pack', 'name: Updated Test Pack');
+    const v2Dir = makeTempPackDir({ manifestYaml: updatedManifest });
+    const v2Pack = loadPack(v2Dir, 'official');
+    index.importPack(v2Pack);
+
+    const packs = index.listPacks();
+    expect(packs).toHaveLength(1);
+    expect(packs[0]?.version).toBe('0.2.0');
+    expect(packs[0]?.name).toBe('Updated Test Pack');
+  });
+
+  it('replaces the scenario list when pack is updated', () => {
+    const v1Dir = makeTempPackDir();
+    index.importPack(loadPack(v1Dir));
+
+    const newScenario = VALID_SCENARIO_YAML
+      .replace('scenario_id: test_scenario', 'scenario_id: replacement_scenario')
+      .replace('title: Test Scenario', 'title: Replacement Scenario');
+
+    const v2Dir = makeTempPackDir({
+      scenarioYamls: { 'replacement.yaml': newScenario },
+    });
+    index.importPack(loadPack(v2Dir));
+
+    const scenarios = index.listScenarios('test.minimal_pack');
+    expect(scenarios).toHaveLength(1);
+    expect(scenarios[0]?.scenario_id).toBe('replacement_scenario');
+  });
+
+  it('search index updates when pack is replaced', () => {
+    const v1Dir = makeTempPackDir();
+    index.importPack(loadPack(v1Dir));
+
+    const secondScenario = VALID_SCENARIO_YAML
+      .replace('scenario_id: test_scenario', 'scenario_id: extra_scenario')
+      .replace('title: Test Scenario', 'title: Extra Scenario');
+    const v2Dir = makeTempPackDir({
+      scenarioYamls: {
+        'test_scenario.yaml': VALID_SCENARIO_YAML,
+        'extra_scenario.yaml': secondScenario,
+      },
+    });
+    index.importPack(loadPack(v2Dir));
+
+    expect(index.listScenarios('test.minimal_pack')).toHaveLength(2);
+    expect(index.getPack('test.minimal_pack')?.scenario_count).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Remove
+// ---------------------------------------------------------------------------
+
+describe('PackIndex.removePack', () => {
+  it('removes the pack from the index', () => {
+    const packDir = makeTempPackDir();
+    index.importPack(loadPack(packDir));
+    expect(index.listPacks()).toHaveLength(1);
+
+    index.removePack('test.minimal_pack');
+    expect(index.listPacks()).toHaveLength(0);
+    expect(index.getPack('test.minimal_pack')).toBeUndefined();
+  });
+
+  it('cascades removal to indexed scenarios', () => {
+    const packDir = makeTempPackDir();
+    index.importPack(loadPack(packDir));
+    expect(index.listScenarios('test.minimal_pack')).toHaveLength(1);
+
+    index.removePack('test.minimal_pack');
+    expect(index.listScenarios('test.minimal_pack')).toHaveLength(0);
+    expect(index.listScenarios()).toHaveLength(0);
+  });
+
+  it('is a no-op for a pack_id that was never imported', () => {
+    expect(() => index.removePack('does.not.exist')).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listScenarios filtering
+// ---------------------------------------------------------------------------
+
+describe('PackIndex.listScenarios', () => {
+  it('returns all scenarios when no pack_id filter is given', () => {
+    const packAManifest = VALID_MANIFEST_YAML.replace('pack_id: test.minimal_pack', 'pack_id: pack.a');
+    const packBManifest = VALID_MANIFEST_YAML.replace('pack_id: test.minimal_pack', 'pack_id: pack.b');
+    const scenarioB = VALID_SCENARIO_YAML
+      .replace('scenario_id: test_scenario', 'scenario_id: scenario_b');
+
+    index.importPack(loadPack(makeTempPackDir({ manifestYaml: packAManifest })));
+    index.importPack(loadPack(makeTempPackDir({
+      manifestYaml: packBManifest,
+      scenarioYamls: { 'scenario_b.yaml': scenarioB },
+    })));
+
+    expect(index.listScenarios()).toHaveLength(2);
+  });
+});

--- a/packages/pack-loader/tests/fixtures.ts
+++ b/packages/pack-loader/tests/fixtures.ts
@@ -118,13 +118,7 @@ export interface PackDirOptions {
   extraFiles?: Record<string, string>;
 }
 
-/**
- * Create a temporary pack directory with the supplied file contents.
- * Returns the absolute path to the pack root.
- */
-export function makeTempPackDir(options: PackDirOptions = {}): string {
-  const root = mkdtempSync(join(tmpdir(), 'convsim-pack-loader-test-'));
-
+function populatePackDir(root: string, options: PackDirOptions): void {
   const {
     manifestYaml = VALID_MANIFEST_YAML,
     safetyYaml = VALID_SAFETY_YAML,
@@ -135,7 +129,6 @@ export function makeTempPackDir(options: PackDirOptions = {}): string {
     extraFiles = {},
   } = options;
 
-  // Sub-directories
   for (const sub of ['scenarios', 'npcs', 'rubrics', 'safety', 'scenes']) {
     mkdirSync(join(root, sub), { recursive: true });
   }
@@ -158,6 +151,30 @@ export function makeTempPackDir(options: PackDirOptions = {}): string {
     mkdirSync(resolve(abs, '..'), { recursive: true });
     writeFileSync(abs, content, 'utf8');
   }
+}
 
+/**
+ * Create a temporary pack directory with the supplied file contents.
+ * Returns the absolute path to the pack root.
+ */
+export function makeTempPackDir(options: PackDirOptions = {}): string {
+  const root = mkdtempSync(join(tmpdir(), 'convsim-pack-loader-test-'));
+  populatePackDir(root, options);
+  return root;
+}
+
+/**
+ * Create a pack directory as a named subdirectory of `parentDir`.
+ * Useful for testing `loadPacksFromRoots` where packs must live inside a root.
+ * Returns the absolute path to the pack directory.
+ */
+export function makePackInDir(
+  parentDir: string,
+  packName: string,
+  options: PackDirOptions = {},
+): string {
+  const root = join(parentDir, packName);
+  mkdirSync(root, { recursive: true });
+  populatePackDir(root, options);
   return root;
 }

--- a/packages/pack-loader/tests/fixtures.ts
+++ b/packages/pack-loader/tests/fixtures.ts
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+import { mkdirSync, writeFileSync, mkdtempSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+
+// ---------------------------------------------------------------------------
+// Minimal valid YAML strings (schema_version "0.1")
+// ---------------------------------------------------------------------------
+
+export const VALID_MANIFEST_YAML = `schema_version: "0.1"
+pack_id: test.minimal_pack
+name: Minimal Test Pack
+version: 0.1.0
+description: A minimal pack for testing the pack loader.
+author: Test Suite
+license: MIT
+content_rating: PG
+safety:
+  policy: safety/policy.yaml
+`;
+
+export const VALID_SAFETY_YAML = `schema_version: "0.1"
+policy_id: test_safety
+content_rating_cap: PG
+content_categories:
+  nsfw_sexual: block
+  real_person_impersonation: block
+  instructional_criminal: block
+  crisis_content: redirect
+redirect_message: "This content is not appropriate for this scenario."
+`;
+
+export const VALID_NPC_YAML = `schema_version: "0.1"
+npc_id: test_npc
+display_name: Test NPC
+archetype: test_archetype
+fictional: true
+age_band: adult
+public_persona:
+  occupation: A test NPC for unit testing the pack loader
+  speaking_style: Direct and clear
+  demeanor: Neutral and cooperative
+private_persona: {}
+`;
+
+export const VALID_RUBRIC_YAML = `schema_version: "0.1"
+rubric_id: test_rubric
+title: Test Rubric
+dimensions:
+  - id: accuracy
+    name: Accuracy
+    description: How accurately the tester completed the task
+    scoring:
+      low: Failed to complete basic tasks
+      medium: Completed most tasks with minor errors
+      high: Completed all tasks accurately
+`;
+
+export const VALID_SCENE_YAML = `schema_version: "0.1"
+scene_id: test_scene
+display_name: Test Room
+description: A neutral test room used for unit testing the pack loader.
+`;
+
+export const VALID_SCENARIO_YAML = `schema_version: "0.1"
+scenario_id: test_scenario
+title: Test Scenario
+summary: A minimal test scenario for unit testing the pack loader.
+player_role:
+  label: Tester
+  brief: You are testing the pack loader.
+npc:
+  ref: ../npcs/test_npc.yaml
+rubric:
+  ref: ../rubrics/test_rubric.yaml
+duration:
+  max_turns: 5
+opening:
+  npc_says: "Hello! Let's begin the test."
+goals:
+  player_visible:
+    - Test the pack loader correctly
+`;
+
+export const VALID_SCENARIO_WITH_SCENE_YAML = `schema_version: "0.1"
+scenario_id: test_scenario_scene
+title: Test Scenario With Scene
+summary: A test scenario that includes a scene reference.
+player_role:
+  label: Tester
+  brief: You are testing scene resolution.
+npc:
+  ref: ../npcs/test_npc.yaml
+rubric:
+  ref: ../rubrics/test_rubric.yaml
+scene:
+  ref: ../scenes/test_scene.yaml
+duration:
+  max_turns: 5
+opening:
+  npc_says: "Welcome to the test room."
+goals:
+  player_visible:
+    - Verify that scene references resolve correctly
+`;
+
+// ---------------------------------------------------------------------------
+// Temp directory helpers
+// ---------------------------------------------------------------------------
+
+export interface PackDirOptions {
+  manifestYaml?: string;
+  safetyYaml?: string;
+  npcYaml?: string;
+  rubricYaml?: string;
+  sceneYaml?: string;
+  scenarioYamls?: Record<string, string>;
+  extraFiles?: Record<string, string>;
+}
+
+/**
+ * Create a temporary pack directory with the supplied file contents.
+ * Returns the absolute path to the pack root.
+ */
+export function makeTempPackDir(options: PackDirOptions = {}): string {
+  const root = mkdtempSync(join(tmpdir(), 'convsim-pack-loader-test-'));
+
+  const {
+    manifestYaml = VALID_MANIFEST_YAML,
+    safetyYaml = VALID_SAFETY_YAML,
+    npcYaml = VALID_NPC_YAML,
+    rubricYaml = VALID_RUBRIC_YAML,
+    sceneYaml,
+    scenarioYamls = { 'test_scenario.yaml': VALID_SCENARIO_YAML },
+    extraFiles = {},
+  } = options;
+
+  // Sub-directories
+  for (const sub of ['scenarios', 'npcs', 'rubrics', 'safety', 'scenes']) {
+    mkdirSync(join(root, sub), { recursive: true });
+  }
+
+  writeFileSync(join(root, 'manifest.yaml'), manifestYaml, 'utf8');
+  writeFileSync(join(root, 'safety', 'policy.yaml'), safetyYaml, 'utf8');
+  writeFileSync(join(root, 'npcs', 'test_npc.yaml'), npcYaml, 'utf8');
+  writeFileSync(join(root, 'rubrics', 'test_rubric.yaml'), rubricYaml, 'utf8');
+
+  if (sceneYaml) {
+    writeFileSync(join(root, 'scenes', 'test_scene.yaml'), sceneYaml, 'utf8');
+  }
+
+  for (const [filename, yaml] of Object.entries(scenarioYamls)) {
+    writeFileSync(join(root, 'scenarios', filename), yaml, 'utf8');
+  }
+
+  for (const [relPath, content] of Object.entries(extraFiles)) {
+    const abs = resolve(root, relPath);
+    mkdirSync(resolve(abs, '..'), { recursive: true });
+    writeFileSync(abs, content, 'utf8');
+  }
+
+  return root;
+}

--- a/packages/pack-loader/tests/loader.test.ts
+++ b/packages/pack-loader/tests/loader.test.ts
@@ -1,13 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
-import { mkdtempSync, mkdirSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { loadPack, resolveBundle } from '../src/loader.js';
+import { loadPack, resolveBundle, loadPacksFromRoots } from '../src/loader.js';
 import { PackLoaderError } from '../src/types.js';
 import {
   makeTempPackDir,
   VALID_MANIFEST_YAML,
+  VALID_SAFETY_YAML,
+  VALID_NPC_YAML,
+  VALID_RUBRIC_YAML,
   VALID_SCENARIO_YAML,
   VALID_SCENARIO_WITH_SCENE_YAML,
   VALID_SCENE_YAML,
@@ -258,5 +261,83 @@ private_persona: {}
       const code = (e as PackLoaderError).code;
       expect(['INVALID_YAML', 'SCHEMA_VALIDATION']).toContain(code);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadPacksFromRoots
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a valid pack directory tree directly inside `parentDir` and return its
+ * absolute path.  Unlike makeTempPackDir(), the directory is created *within*
+ * a caller-supplied parent so it shows up when loadPacksFromRoots() scans that
+ * parent for subdirectories.
+ */
+function makePackSubdir(parentDir: string, manifestYaml: string = VALID_MANIFEST_YAML): string {
+  const dir = mkdtempSync(join(parentDir, 'pack-'));
+  for (const sub of ['scenarios', 'npcs', 'rubrics', 'safety']) {
+    mkdirSync(join(dir, sub), { recursive: true });
+  }
+  writeFileSync(join(dir, 'manifest.yaml'), manifestYaml, 'utf8');
+  writeFileSync(join(dir, 'safety', 'policy.yaml'), VALID_SAFETY_YAML, 'utf8');
+  writeFileSync(join(dir, 'npcs', 'test_npc.yaml'), VALID_NPC_YAML, 'utf8');
+  writeFileSync(join(dir, 'rubrics', 'test_rubric.yaml'), VALID_RUBRIC_YAML, 'utf8');
+  writeFileSync(join(dir, 'scenarios', 'test_scenario.yaml'), VALID_SCENARIO_YAML, 'utf8');
+  return dir;
+}
+
+describe('loadPacksFromRoots', () => {
+  it('loads packs from an official root', () => {
+    const officialRoot = mkdtempSync(join(tmpdir(), 'convsim-official-root-'));
+    const manifestA = VALID_MANIFEST_YAML.replace('pack_id: test.minimal_pack', 'pack_id: official.pack_a');
+    const manifestB = VALID_MANIFEST_YAML.replace('pack_id: test.minimal_pack', 'pack_id: official.pack_b');
+    makePackSubdir(officialRoot, manifestA);
+    makePackSubdir(officialRoot, manifestB);
+
+    const result = loadPacksFromRoots({ officialRoot });
+    expect(result.errors).toHaveLength(0);
+    expect(result.packs).toHaveLength(2);
+    expect(result.packs.every((p) => p.packRootKind === 'official')).toBe(true);
+    const ids = result.packs.map((p) => p.manifest.pack_id).sort();
+    expect(ids).toContain('official.pack_a');
+    expect(ids).toContain('official.pack_b');
+  });
+
+  it('collects errors for invalid packs without throwing', () => {
+    const localDevRoot = mkdtempSync(join(tmpdir(), 'convsim-local-root-'));
+    makePackSubdir(localDevRoot);
+    mkdirSync(join(localDevRoot, 'broken-pack'), { recursive: true }); // empty dir, no manifest
+
+    const result = loadPacksFromRoots({ localDevRoot });
+    expect(result.packs).toHaveLength(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.packs[0]?.manifest.pack_id).toBe('test.minimal_pack');
+    expect(result.packs[0]?.packRootKind).toBe('local-dev');
+  });
+
+  it('returns empty results when root directories do not exist', () => {
+    const result = loadPacksFromRoots({
+      officialRoot: join(tmpdir(), 'convsim-nonexistent-official-zzz'),
+      communityRoot: join(tmpdir(), 'convsim-nonexistent-community-zzz'),
+    });
+    expect(result.packs).toHaveLength(0);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('loads from multiple roots and tags packs with their root kind', () => {
+    const officialRoot = mkdtempSync(join(tmpdir(), 'convsim-multi-official-'));
+    const communityRoot = mkdtempSync(join(tmpdir(), 'convsim-multi-community-'));
+    makePackSubdir(officialRoot, VALID_MANIFEST_YAML.replace('pack_id: test.minimal_pack', 'pack_id: official.one'));
+    makePackSubdir(communityRoot, VALID_MANIFEST_YAML.replace('pack_id: test.minimal_pack', 'pack_id: community.one'));
+
+    const result = loadPacksFromRoots({ officialRoot, communityRoot });
+    expect(result.errors).toHaveLength(0);
+    expect(result.packs).toHaveLength(2);
+
+    const official = result.packs.find((p) => p.manifest.pack_id === 'official.one');
+    const community = result.packs.find((p) => p.manifest.pack_id === 'community.one');
+    expect(official?.packRootKind).toBe('official');
+    expect(community?.packRootKind).toBe('community');
   });
 });

--- a/packages/pack-loader/tests/loader.test.ts
+++ b/packages/pack-loader/tests/loader.test.ts
@@ -130,6 +130,7 @@ describe('resolveBundle', () => {
     const bundle = resolveBundle(pack, 'test_scenario_scene');
     expect(bundle.scenarioId).toBe('test_scenario_scene');
     expect(bundle.packId).toBe('test.minimal_pack');
+    expect(bundle.packRoot).toBe(pack.packRoot);
     expect(bundle.npc.npc_id).toBe('test_npc');
     expect(bundle.rubric.rubric_id).toBe('test_rubric');
     expect(bundle.scene?.scene_id).toBe('test_scene');
@@ -348,6 +349,18 @@ private_persona: {}
       loadPack(dir);
     } catch (e) {
       expect((e as PackLoaderError).code).toBe('PATH_TRAVERSAL');
+    }
+  });
+
+  it('throws MISSING_FILE when an entry_scenario path points to a non-existent scenario', () => {
+    const dir = track(makeTempPackDir({
+      manifestYaml: VALID_MANIFEST_YAML + 'entry_scenarios:\n  - scenarios/nonexistent_scenario.yaml\n',
+    }));
+    expect(() => loadPack(dir)).toThrowError(PackLoaderError);
+    try {
+      loadPack(dir);
+    } catch (e) {
+      expect((e as PackLoaderError).code).toBe('MISSING_FILE');
     }
   });
 

--- a/packages/pack-loader/tests/loader.test.ts
+++ b/packages/pack-loader/tests/loader.test.ts
@@ -95,6 +95,25 @@ describe('loadPack — valid pack', () => {
     const pack = loadPack(dir);
     expect(pack.scenarios).toHaveLength(2);
   });
+
+  it('accepts a portrait path using ../ relative to the NPC file directory', () => {
+    // npcs/test_npc.yaml with portrait: ../assets/portrait.png
+    // resolves to <packRoot>/assets/portrait.png — inside the pack root.
+    const dir = track(makeTempPackDir({
+      npcYaml: VALID_NPC_YAML + 'portrait: ../assets/portrait.png\n',
+    }));
+    expect(() => loadPack(dir)).not.toThrow();
+  });
+
+  it('accepts a scene background path using ../ relative to the scene file directory', () => {
+    // scenes/test_scene.yaml with background: ../assets/bg.png
+    // resolves to <packRoot>/assets/bg.png — inside the pack root.
+    const dir = track(makeTempPackDir({
+      sceneYaml: VALID_SCENE_YAML + 'background: ../assets/bg.png\n',
+      scenarioYamls: { 'scenario_with_scene.yaml': VALID_SCENARIO_WITH_SCENE_YAML },
+    }));
+    expect(() => loadPack(dir)).not.toThrow();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/pack-loader/tests/loader.test.ts
+++ b/packages/pack-loader/tests/loader.test.ts
@@ -304,13 +304,13 @@ private_persona: {}
   });
 
   it('throws INVALID_YAML when a file contains invalid YAML syntax', () => {
-    const dir = track(makeTempPackDir({ manifestYaml: ': broken: yaml:' }));
+    // '{' is an unclosed flow mapping — js-yaml throws a YAMLException on parse.
+    const dir = track(makeTempPackDir({ manifestYaml: '{' }));
     expect(() => loadPack(dir)).toThrowError(PackLoaderError);
     try {
       loadPack(dir);
     } catch (e) {
-      const code = (e as PackLoaderError).code;
-      expect(['INVALID_YAML', 'SCHEMA_VALIDATION']).toContain(code);
+      expect((e as PackLoaderError).code).toBe('INVALID_YAML');
     }
   });
 
@@ -330,6 +330,18 @@ private_persona: {}
     const dir = track(makeTempPackDir({
       sceneYaml: VALID_SCENE_YAML + 'background: ../../outside.png\n',
       scenarioYamls: { 'scenario_with_scene.yaml': VALID_SCENARIO_WITH_SCENE_YAML },
+    }));
+    expect(() => loadPack(dir)).toThrowError(PackLoaderError);
+    try {
+      loadPack(dir);
+    } catch (e) {
+      expect((e as PackLoaderError).code).toBe('PATH_TRAVERSAL');
+    }
+  });
+
+  it('throws PATH_TRAVERSAL when an entry_scenario path escapes the pack root', () => {
+    const dir = track(makeTempPackDir({
+      manifestYaml: VALID_MANIFEST_YAML + 'entry_scenarios:\n  - ../../evil_scenario.yaml\n',
     }));
     expect(() => loadPack(dir)).toThrowError(PackLoaderError);
     try {

--- a/packages/pack-loader/tests/loader.test.ts
+++ b/packages/pack-loader/tests/loader.test.ts
@@ -262,6 +262,31 @@ private_persona: {}
       expect(['INVALID_YAML', 'SCHEMA_VALIDATION']).toContain(code);
     }
   });
+
+  it('throws PATH_TRAVERSAL when an NPC portrait path escapes the pack root', () => {
+    const dir = makeTempPackDir({
+      npcYaml: VALID_NPC_YAML + 'portrait: ../../outside.png\n',
+    });
+    expect(() => loadPack(dir)).toThrowError(PackLoaderError);
+    try {
+      loadPack(dir);
+    } catch (e) {
+      expect((e as PackLoaderError).code).toBe('PATH_TRAVERSAL');
+    }
+  });
+
+  it('throws PATH_TRAVERSAL when a scene background path escapes the pack root', () => {
+    const dir = makeTempPackDir({
+      sceneYaml: VALID_SCENE_YAML + 'background: ../../outside.png\n',
+      scenarioYamls: { 'scenario_with_scene.yaml': VALID_SCENARIO_WITH_SCENE_YAML },
+    });
+    expect(() => loadPack(dir)).toThrowError(PackLoaderError);
+    try {
+      loadPack(dir);
+    } catch (e) {
+      expect((e as PackLoaderError).code).toBe('PATH_TRAVERSAL');
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/pack-loader/tests/loader.test.ts
+++ b/packages/pack-loader/tests/loader.test.ts
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, afterEach } from 'vitest';
 import { loadPack, resolveBundle, loadPacksFromRoots } from '../src/loader.js';
 import { PackLoaderError } from '../src/types.js';
 import {
@@ -16,13 +16,22 @@ import {
   VALID_SCENE_YAML,
 } from './fixtures.js';
 
+const _tempDirs: string[] = [];
+afterEach(() => {
+  _tempDirs.splice(0).forEach((d) => rmSync(d, { recursive: true, force: true }));
+});
+function track(dir: string): string {
+  _tempDirs.push(dir);
+  return dir;
+}
+
 // ---------------------------------------------------------------------------
 // Happy-path: valid pack
 // ---------------------------------------------------------------------------
 
 describe('loadPack — valid pack', () => {
   it('loads a minimal pack without errors', () => {
-    const dir = makeTempPackDir();
+    const dir = track(makeTempPackDir());
     const pack = loadPack(dir, 'official');
     expect(pack.manifest.pack_id).toBe('test.minimal_pack');
     expect(pack.manifest.version).toBe('0.1.0');
@@ -30,14 +39,14 @@ describe('loadPack — valid pack', () => {
   });
 
   it('loads the scenario list', () => {
-    const dir = makeTempPackDir();
+    const dir = track(makeTempPackDir());
     const pack = loadPack(dir);
     expect(pack.scenarios).toHaveLength(1);
     expect(pack.scenarios[0]?.data.scenario_id).toBe('test_scenario');
   });
 
   it('loads the NPC referenced by the scenario', () => {
-    const dir = makeTempPackDir();
+    const dir = track(makeTempPackDir());
     const pack = loadPack(dir);
     expect(pack.npcs.size).toBe(1);
     const [npc] = [...pack.npcs.values()];
@@ -46,7 +55,7 @@ describe('loadPack — valid pack', () => {
   });
 
   it('loads the rubric referenced by the scenario', () => {
-    const dir = makeTempPackDir();
+    const dir = track(makeTempPackDir());
     const pack = loadPack(dir);
     expect(pack.rubrics.size).toBe(1);
     const [rubric] = [...pack.rubrics.values()];
@@ -54,17 +63,17 @@ describe('loadPack — valid pack', () => {
   });
 
   it('resolves the safety policy', () => {
-    const dir = makeTempPackDir();
+    const dir = track(makeTempPackDir());
     const pack = loadPack(dir);
     expect(pack.safety.policy_id).toBe('test_safety');
     expect(pack.safety.content_rating_cap).toBe('PG');
   });
 
   it('resolves an optional scene ref', () => {
-    const dir = makeTempPackDir({
+    const dir = track(makeTempPackDir({
       sceneYaml: VALID_SCENE_YAML,
       scenarioYamls: { 'scenario_with_scene.yaml': VALID_SCENARIO_WITH_SCENE_YAML },
-    });
+    }));
     const pack = loadPack(dir);
     expect(pack.scenes.size).toBe(1);
     const [scene] = [...pack.scenes.values()];
@@ -76,12 +85,12 @@ describe('loadPack — valid pack', () => {
       .replace('scenario_id: test_scenario', 'scenario_id: test_scenario_two')
       .replace('title: Test Scenario', 'title: Test Scenario Two');
 
-    const dir = makeTempPackDir({
+    const dir = track(makeTempPackDir({
       scenarioYamls: {
         'test_scenario.yaml': VALID_SCENARIO_YAML,
         'test_scenario_two.yaml': SECOND_SCENARIO,
       },
-    });
+    }));
     const pack = loadPack(dir);
     expect(pack.scenarios).toHaveLength(2);
   });
@@ -93,10 +102,10 @@ describe('loadPack — valid pack', () => {
 
 describe('resolveBundle', () => {
   it('returns a fully resolved bundle for a valid scenario', () => {
-    const dir = makeTempPackDir({
+    const dir = track(makeTempPackDir({
       sceneYaml: VALID_SCENE_YAML,
       scenarioYamls: { 'scenario.yaml': VALID_SCENARIO_WITH_SCENE_YAML },
-    });
+    }));
     const pack = loadPack(dir);
     const bundle = resolveBundle(pack, 'test_scenario_scene');
     expect(bundle.scenarioId).toBe('test_scenario_scene');
@@ -108,14 +117,14 @@ describe('resolveBundle', () => {
   });
 
   it('returns scene=null when the scenario has no scene ref', () => {
-    const dir = makeTempPackDir();
+    const dir = track(makeTempPackDir());
     const pack = loadPack(dir);
     const bundle = resolveBundle(pack, 'test_scenario');
     expect(bundle.scene).toBeNull();
   });
 
   it('throws MISSING_FILE for an unknown scenario_id', () => {
-    const dir = makeTempPackDir();
+    const dir = track(makeTempPackDir());
     const pack = loadPack(dir);
     expect(() => resolveBundle(pack, 'nonexistent')).toThrow(PackLoaderError);
     try {
@@ -132,7 +141,7 @@ describe('resolveBundle', () => {
 
 describe('loadPack — error cases', () => {
   it('throws MISSING_FILE when manifest.yaml is absent', () => {
-    const emptyDir = mkdtempSync(join(tmpdir(), 'convsim-empty-'));
+    const emptyDir = track(mkdtempSync(join(tmpdir(), 'convsim-empty-')));
     mkdirSync(join(emptyDir, 'scenarios'));
 
     expect(() => loadPack(emptyDir)).toThrowError(PackLoaderError);
@@ -144,14 +153,14 @@ describe('loadPack — error cases', () => {
   });
 
   it('throws MISSING_FILE when the referenced NPC file is absent', () => {
-    const dir = makeTempPackDir({
+    const dir = track(makeTempPackDir({
       scenarioYamls: {
         'test_scenario.yaml': VALID_SCENARIO_YAML.replace(
           'ref: ../npcs/test_npc.yaml',
           'ref: ../npcs/nonexistent_npc.yaml',
         ),
       },
-    });
+    }));
     expect(() => loadPack(dir)).toThrowError(PackLoaderError);
     try {
       loadPack(dir);
@@ -161,12 +170,12 @@ describe('loadPack — error cases', () => {
   });
 
   it('throws MISSING_FILE when the safety policy file is absent', () => {
-    const dir = makeTempPackDir({
+    const dir = track(makeTempPackDir({
       manifestYaml: VALID_MANIFEST_YAML.replace(
         'policy: safety/policy.yaml',
         'policy: safety/nonexistent.yaml',
       ),
-    });
+    }));
     expect(() => loadPack(dir)).toThrowError(PackLoaderError);
     try {
       loadPack(dir);
@@ -176,14 +185,14 @@ describe('loadPack — error cases', () => {
   });
 
   it('throws PATH_TRAVERSAL when a ref tries to escape the pack root', () => {
-    const dir = makeTempPackDir({
+    const dir = track(makeTempPackDir({
       scenarioYamls: {
         'test_scenario.yaml': VALID_SCENARIO_YAML.replace(
           'ref: ../npcs/test_npc.yaml',
           'ref: ../../outside/npc.yaml',
         ),
       },
-    });
+    }));
     expect(() => loadPack(dir)).toThrowError(PackLoaderError);
     try {
       loadPack(dir);
@@ -193,12 +202,34 @@ describe('loadPack — error cases', () => {
   });
 
   it('throws DUPLICATE_ID when two scenarios share the same scenario_id', () => {
-    const dir = makeTempPackDir({
+    const dir = track(makeTempPackDir({
       scenarioYamls: {
         'test_scenario.yaml': VALID_SCENARIO_YAML,
         'test_scenario_copy.yaml': VALID_SCENARIO_YAML,
       },
-    });
+    }));
+    expect(() => loadPack(dir)).toThrowError(PackLoaderError);
+    try {
+      loadPack(dir);
+    } catch (e) {
+      expect((e as PackLoaderError).code).toBe('DUPLICATE_ID');
+    }
+  });
+
+  it('throws DUPLICATE_ID when two NPC files share the same npc_id', () => {
+    const scenario2 = VALID_SCENARIO_YAML
+      .replace('scenario_id: test_scenario', 'scenario_id: test_scenario_two')
+      .replace('title: Test Scenario', 'title: Test Scenario Two')
+      .replace('ref: ../npcs/test_npc.yaml', 'ref: ../npcs/test_npc2.yaml');
+    const dir = track(makeTempPackDir({
+      scenarioYamls: {
+        'test_scenario.yaml': VALID_SCENARIO_YAML,
+        'test_scenario_two.yaml': scenario2,
+      },
+      extraFiles: {
+        'npcs/test_npc2.yaml': VALID_NPC_YAML, // same npc_id: test_npc
+      },
+    }));
     expect(() => loadPack(dir)).toThrowError(PackLoaderError);
     try {
       loadPack(dir);
@@ -208,9 +239,9 @@ describe('loadPack — error cases', () => {
   });
 
   it('throws UNSUPPORTED_VERSION when schema_version is not "0.1"', () => {
-    const dir = makeTempPackDir({
+    const dir = track(makeTempPackDir({
       manifestYaml: VALID_MANIFEST_YAML.replace('schema_version: "0.1"', 'schema_version: "9.9"'),
-    });
+    }));
     expect(() => loadPack(dir)).toThrowError(PackLoaderError);
     try {
       loadPack(dir);
@@ -221,7 +252,7 @@ describe('loadPack — error cases', () => {
 
   it('throws SCHEMA_VALIDATION when the manifest is missing a required field', () => {
     const invalidManifest = VALID_MANIFEST_YAML.replace(/^content_rating:.*\n/m, '');
-    const dir = makeTempPackDir({ manifestYaml: invalidManifest });
+    const dir = track(makeTempPackDir({ manifestYaml: invalidManifest }));
     expect(() => loadPack(dir)).toThrowError(PackLoaderError);
     try {
       loadPack(dir);
@@ -243,7 +274,7 @@ public_persona:
   demeanor: Neutral
 private_persona: {}
 `;
-    const dir = makeTempPackDir({ npcYaml: badNpc });
+    const dir = track(makeTempPackDir({ npcYaml: badNpc }));
     expect(() => loadPack(dir)).toThrowError(PackLoaderError);
     try {
       loadPack(dir);
@@ -253,7 +284,7 @@ private_persona: {}
   });
 
   it('throws INVALID_YAML when a file contains invalid YAML syntax', () => {
-    const dir = makeTempPackDir({ manifestYaml: ': broken: yaml:' });
+    const dir = track(makeTempPackDir({ manifestYaml: ': broken: yaml:' }));
     expect(() => loadPack(dir)).toThrowError(PackLoaderError);
     try {
       loadPack(dir);
@@ -264,9 +295,9 @@ private_persona: {}
   });
 
   it('throws PATH_TRAVERSAL when an NPC portrait path escapes the pack root', () => {
-    const dir = makeTempPackDir({
+    const dir = track(makeTempPackDir({
       npcYaml: VALID_NPC_YAML + 'portrait: ../../outside.png\n',
-    });
+    }));
     expect(() => loadPack(dir)).toThrowError(PackLoaderError);
     try {
       loadPack(dir);
@@ -276,10 +307,10 @@ private_persona: {}
   });
 
   it('throws PATH_TRAVERSAL when a scene background path escapes the pack root', () => {
-    const dir = makeTempPackDir({
+    const dir = track(makeTempPackDir({
       sceneYaml: VALID_SCENE_YAML + 'background: ../../outside.png\n',
       scenarioYamls: { 'scenario_with_scene.yaml': VALID_SCENARIO_WITH_SCENE_YAML },
-    });
+    }));
     expect(() => loadPack(dir)).toThrowError(PackLoaderError);
     try {
       loadPack(dir);
@@ -314,7 +345,7 @@ function makePackSubdir(parentDir: string, manifestYaml: string = VALID_MANIFEST
 
 describe('loadPacksFromRoots', () => {
   it('loads packs from an official root', () => {
-    const officialRoot = mkdtempSync(join(tmpdir(), 'convsim-official-root-'));
+    const officialRoot = track(mkdtempSync(join(tmpdir(), 'convsim-official-root-')));
     const manifestA = VALID_MANIFEST_YAML.replace('pack_id: test.minimal_pack', 'pack_id: official.pack_a');
     const manifestB = VALID_MANIFEST_YAML.replace('pack_id: test.minimal_pack', 'pack_id: official.pack_b');
     makePackSubdir(officialRoot, manifestA);
@@ -330,7 +361,7 @@ describe('loadPacksFromRoots', () => {
   });
 
   it('collects errors for invalid packs without throwing', () => {
-    const localDevRoot = mkdtempSync(join(tmpdir(), 'convsim-local-root-'));
+    const localDevRoot = track(mkdtempSync(join(tmpdir(), 'convsim-local-root-')));
     makePackSubdir(localDevRoot);
     mkdirSync(join(localDevRoot, 'broken-pack'), { recursive: true }); // empty dir, no manifest
 
@@ -351,8 +382,8 @@ describe('loadPacksFromRoots', () => {
   });
 
   it('loads from multiple roots and tags packs with their root kind', () => {
-    const officialRoot = mkdtempSync(join(tmpdir(), 'convsim-multi-official-'));
-    const communityRoot = mkdtempSync(join(tmpdir(), 'convsim-multi-community-'));
+    const officialRoot = track(mkdtempSync(join(tmpdir(), 'convsim-multi-official-')));
+    const communityRoot = track(mkdtempSync(join(tmpdir(), 'convsim-multi-community-')));
     makePackSubdir(officialRoot, VALID_MANIFEST_YAML.replace('pack_id: test.minimal_pack', 'pack_id: official.one'));
     makePackSubdir(communityRoot, VALID_MANIFEST_YAML.replace('pack_id: test.minimal_pack', 'pack_id: community.one'));
 

--- a/packages/pack-loader/tests/loader.test.ts
+++ b/packages/pack-loader/tests/loader.test.ts
@@ -156,6 +156,22 @@ describe('resolveBundle', () => {
       expect((e as PackLoaderError).code).toBe('MISSING_FILE');
     }
   });
+
+  it('throws MISSING_FILE when pack.scenes is missing a scene that the scenario references', () => {
+    const dir = track(makeTempPackDir({
+      sceneYaml: VALID_SCENE_YAML,
+      scenarioYamls: { 'scenario.yaml': VALID_SCENARIO_WITH_SCENE_YAML },
+    }));
+    const pack = loadPack(dir);
+    // Simulate a stale/corrupted LoadedPack where scenes weren't loaded.
+    pack.scenes.clear();
+    expect(() => resolveBundle(pack, 'test_scenario_scene')).toThrow(PackLoaderError);
+    try {
+      resolveBundle(pack, 'test_scenario_scene');
+    } catch (e) {
+      expect((e as PackLoaderError).code).toBe('MISSING_FILE');
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/pack-loader/tests/loader.test.ts
+++ b/packages/pack-loader/tests/loader.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it, afterEach } from 'vitest';
 import { loadPack, resolveBundle, loadPacksFromRoots } from '../src/loader.js';
+import { resolveRef } from '../src/resolver.js';
 import { PackLoaderError } from '../src/types.js';
 import {
   makeTempPackDir,
@@ -318,6 +319,7 @@ private_persona: {}
       expect((e as PackLoaderError).code).toBe('PATH_TRAVERSAL');
     }
   });
+
 });
 
 // ---------------------------------------------------------------------------
@@ -395,5 +397,34 @@ describe('loadPacksFromRoots', () => {
     const community = result.packs.find((p) => p.manifest.pack_id === 'community.one');
     expect(official?.packRootKind).toBe('official');
     expect(community?.packRootKind).toBe('community');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveRef unit tests
+// ---------------------------------------------------------------------------
+
+describe('resolveRef', () => {
+  it('throws PATH_TRAVERSAL for a ref containing a null byte', () => {
+    expect(() => resolveRef('/tmp/pack/scenarios', '/tmp/pack', 'npc\x00.evil')).toThrow(PackLoaderError);
+    try {
+      resolveRef('/tmp/pack/scenarios', '/tmp/pack', 'npc\x00.evil');
+    } catch (e) {
+      expect((e as PackLoaderError).code).toBe('PATH_TRAVERSAL');
+    }
+  });
+
+  it('resolves a safe relative ref without throwing', () => {
+    const result = resolveRef('/tmp/pack/scenarios', '/tmp/pack', '../npcs/npc.yaml');
+    expect(result).toBe('/tmp/pack/npcs/npc.yaml');
+  });
+
+  it('throws PATH_TRAVERSAL for a ref that escapes via ..', () => {
+    expect(() => resolveRef('/tmp/pack/scenarios', '/tmp/pack', '../../outside.yaml')).toThrow(PackLoaderError);
+    try {
+      resolveRef('/tmp/pack/scenarios', '/tmp/pack', '../../outside.yaml');
+    } catch (e) {
+      expect((e as PackLoaderError).code).toBe('PATH_TRAVERSAL');
+    }
   });
 });

--- a/packages/pack-loader/tests/loader.test.ts
+++ b/packages/pack-loader/tests/loader.test.ts
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: Apache-2.0
+import { mkdtempSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { loadPack, resolveBundle } from '../src/loader.js';
+import { PackLoaderError } from '../src/types.js';
+import {
+  makeTempPackDir,
+  VALID_MANIFEST_YAML,
+  VALID_SCENARIO_YAML,
+  VALID_SCENARIO_WITH_SCENE_YAML,
+  VALID_SCENE_YAML,
+} from './fixtures.js';
+
+// ---------------------------------------------------------------------------
+// Happy-path: valid pack
+// ---------------------------------------------------------------------------
+
+describe('loadPack — valid pack', () => {
+  it('loads a minimal pack without errors', () => {
+    const dir = makeTempPackDir();
+    const pack = loadPack(dir, 'official');
+    expect(pack.manifest.pack_id).toBe('test.minimal_pack');
+    expect(pack.manifest.version).toBe('0.1.0');
+    expect(pack.packRootKind).toBe('official');
+  });
+
+  it('loads the scenario list', () => {
+    const dir = makeTempPackDir();
+    const pack = loadPack(dir);
+    expect(pack.scenarios).toHaveLength(1);
+    expect(pack.scenarios[0]?.data.scenario_id).toBe('test_scenario');
+  });
+
+  it('loads the NPC referenced by the scenario', () => {
+    const dir = makeTempPackDir();
+    const pack = loadPack(dir);
+    expect(pack.npcs.size).toBe(1);
+    const [npc] = [...pack.npcs.values()];
+    expect(npc?.npc_id).toBe('test_npc');
+    expect(npc?.fictional).toBe(true);
+  });
+
+  it('loads the rubric referenced by the scenario', () => {
+    const dir = makeTempPackDir();
+    const pack = loadPack(dir);
+    expect(pack.rubrics.size).toBe(1);
+    const [rubric] = [...pack.rubrics.values()];
+    expect(rubric?.rubric_id).toBe('test_rubric');
+  });
+
+  it('resolves the safety policy', () => {
+    const dir = makeTempPackDir();
+    const pack = loadPack(dir);
+    expect(pack.safety.policy_id).toBe('test_safety');
+    expect(pack.safety.content_rating_cap).toBe('PG');
+  });
+
+  it('resolves an optional scene ref', () => {
+    const dir = makeTempPackDir({
+      sceneYaml: VALID_SCENE_YAML,
+      scenarioYamls: { 'scenario_with_scene.yaml': VALID_SCENARIO_WITH_SCENE_YAML },
+    });
+    const pack = loadPack(dir);
+    expect(pack.scenes.size).toBe(1);
+    const [scene] = [...pack.scenes.values()];
+    expect(scene?.scene_id).toBe('test_scene');
+  });
+
+  it('handles packs with multiple scenarios', () => {
+    const SECOND_SCENARIO = VALID_SCENARIO_YAML
+      .replace('scenario_id: test_scenario', 'scenario_id: test_scenario_two')
+      .replace('title: Test Scenario', 'title: Test Scenario Two');
+
+    const dir = makeTempPackDir({
+      scenarioYamls: {
+        'test_scenario.yaml': VALID_SCENARIO_YAML,
+        'test_scenario_two.yaml': SECOND_SCENARIO,
+      },
+    });
+    const pack = loadPack(dir);
+    expect(pack.scenarios).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveBundle
+// ---------------------------------------------------------------------------
+
+describe('resolveBundle', () => {
+  it('returns a fully resolved bundle for a valid scenario', () => {
+    const dir = makeTempPackDir({
+      sceneYaml: VALID_SCENE_YAML,
+      scenarioYamls: { 'scenario.yaml': VALID_SCENARIO_WITH_SCENE_YAML },
+    });
+    const pack = loadPack(dir);
+    const bundle = resolveBundle(pack, 'test_scenario_scene');
+    expect(bundle.scenarioId).toBe('test_scenario_scene');
+    expect(bundle.packId).toBe('test.minimal_pack');
+    expect(bundle.npc.npc_id).toBe('test_npc');
+    expect(bundle.rubric.rubric_id).toBe('test_rubric');
+    expect(bundle.scene?.scene_id).toBe('test_scene');
+    expect(bundle.safety.policy_id).toBe('test_safety');
+  });
+
+  it('returns scene=null when the scenario has no scene ref', () => {
+    const dir = makeTempPackDir();
+    const pack = loadPack(dir);
+    const bundle = resolveBundle(pack, 'test_scenario');
+    expect(bundle.scene).toBeNull();
+  });
+
+  it('throws MISSING_FILE for an unknown scenario_id', () => {
+    const dir = makeTempPackDir();
+    const pack = loadPack(dir);
+    expect(() => resolveBundle(pack, 'nonexistent')).toThrow(PackLoaderError);
+    try {
+      resolveBundle(pack, 'nonexistent');
+    } catch (e) {
+      expect((e as PackLoaderError).code).toBe('MISSING_FILE');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error cases
+// ---------------------------------------------------------------------------
+
+describe('loadPack — error cases', () => {
+  it('throws MISSING_FILE when manifest.yaml is absent', () => {
+    const emptyDir = mkdtempSync(join(tmpdir(), 'convsim-empty-'));
+    mkdirSync(join(emptyDir, 'scenarios'));
+
+    expect(() => loadPack(emptyDir)).toThrowError(PackLoaderError);
+    try {
+      loadPack(emptyDir);
+    } catch (e) {
+      expect((e as PackLoaderError).code).toBe('MISSING_FILE');
+    }
+  });
+
+  it('throws MISSING_FILE when the referenced NPC file is absent', () => {
+    const dir = makeTempPackDir({
+      scenarioYamls: {
+        'test_scenario.yaml': VALID_SCENARIO_YAML.replace(
+          'ref: ../npcs/test_npc.yaml',
+          'ref: ../npcs/nonexistent_npc.yaml',
+        ),
+      },
+    });
+    expect(() => loadPack(dir)).toThrowError(PackLoaderError);
+    try {
+      loadPack(dir);
+    } catch (e) {
+      expect((e as PackLoaderError).code).toBe('MISSING_FILE');
+    }
+  });
+
+  it('throws MISSING_FILE when the safety policy file is absent', () => {
+    const dir = makeTempPackDir({
+      manifestYaml: VALID_MANIFEST_YAML.replace(
+        'policy: safety/policy.yaml',
+        'policy: safety/nonexistent.yaml',
+      ),
+    });
+    expect(() => loadPack(dir)).toThrowError(PackLoaderError);
+    try {
+      loadPack(dir);
+    } catch (e) {
+      expect((e as PackLoaderError).code).toBe('MISSING_FILE');
+    }
+  });
+
+  it('throws PATH_TRAVERSAL when a ref tries to escape the pack root', () => {
+    const dir = makeTempPackDir({
+      scenarioYamls: {
+        'test_scenario.yaml': VALID_SCENARIO_YAML.replace(
+          'ref: ../npcs/test_npc.yaml',
+          'ref: ../../outside/npc.yaml',
+        ),
+      },
+    });
+    expect(() => loadPack(dir)).toThrowError(PackLoaderError);
+    try {
+      loadPack(dir);
+    } catch (e) {
+      expect((e as PackLoaderError).code).toBe('PATH_TRAVERSAL');
+    }
+  });
+
+  it('throws DUPLICATE_ID when two scenarios share the same scenario_id', () => {
+    const dir = makeTempPackDir({
+      scenarioYamls: {
+        'test_scenario.yaml': VALID_SCENARIO_YAML,
+        'test_scenario_copy.yaml': VALID_SCENARIO_YAML,
+      },
+    });
+    expect(() => loadPack(dir)).toThrowError(PackLoaderError);
+    try {
+      loadPack(dir);
+    } catch (e) {
+      expect((e as PackLoaderError).code).toBe('DUPLICATE_ID');
+    }
+  });
+
+  it('throws UNSUPPORTED_VERSION when schema_version is not "0.1"', () => {
+    const dir = makeTempPackDir({
+      manifestYaml: VALID_MANIFEST_YAML.replace('schema_version: "0.1"', 'schema_version: "9.9"'),
+    });
+    expect(() => loadPack(dir)).toThrowError(PackLoaderError);
+    try {
+      loadPack(dir);
+    } catch (e) {
+      expect((e as PackLoaderError).code).toBe('UNSUPPORTED_VERSION');
+    }
+  });
+
+  it('throws SCHEMA_VALIDATION when the manifest is missing a required field', () => {
+    const invalidManifest = VALID_MANIFEST_YAML.replace(/^content_rating:.*\n/m, '');
+    const dir = makeTempPackDir({ manifestYaml: invalidManifest });
+    expect(() => loadPack(dir)).toThrowError(PackLoaderError);
+    try {
+      loadPack(dir);
+    } catch (e) {
+      expect((e as PackLoaderError).code).toBe('SCHEMA_VALIDATION');
+    }
+  });
+
+  it('throws SCHEMA_VALIDATION when an NPC has fictional: false', () => {
+    const badNpc = `schema_version: "0.1"
+npc_id: bad_npc
+display_name: Bad NPC
+archetype: tester
+fictional: false
+age_band: adult
+public_persona:
+  occupation: A test
+  speaking_style: Direct
+  demeanor: Neutral
+private_persona: {}
+`;
+    const dir = makeTempPackDir({ npcYaml: badNpc });
+    expect(() => loadPack(dir)).toThrowError(PackLoaderError);
+    try {
+      loadPack(dir);
+    } catch (e) {
+      expect((e as PackLoaderError).code).toBe('SCHEMA_VALIDATION');
+    }
+  });
+
+  it('throws INVALID_YAML when a file contains invalid YAML syntax', () => {
+    const dir = makeTempPackDir({ manifestYaml: ': broken: yaml:' });
+    expect(() => loadPack(dir)).toThrowError(PackLoaderError);
+    try {
+      loadPack(dir);
+    } catch (e) {
+      const code = (e as PackLoaderError).code;
+      expect(['INVALID_YAML', 'SCHEMA_VALIDATION']).toContain(code);
+    }
+  });
+});

--- a/packages/pack-loader/tests/loader.test.ts
+++ b/packages/pack-loader/tests/loader.test.ts
@@ -96,20 +96,22 @@ describe('loadPack — valid pack', () => {
     expect(pack.scenarios).toHaveLength(2);
   });
 
-  it('accepts a portrait path using ../ relative to the NPC file directory', () => {
-    // npcs/test_npc.yaml with portrait: ../assets/portrait.png
+  it('accepts a portrait path relative to the pack root', () => {
+    // Portrait paths are pack-root-relative per the NPC schema ("within the pack").
+    // npcs/test_npc.yaml with portrait: assets/portrait.png
     // resolves to <packRoot>/assets/portrait.png — inside the pack root.
     const dir = track(makeTempPackDir({
-      npcYaml: VALID_NPC_YAML + 'portrait: ../assets/portrait.png\n',
+      npcYaml: VALID_NPC_YAML + 'portrait: assets/portrait.png\n',
     }));
     expect(() => loadPack(dir)).not.toThrow();
   });
 
-  it('accepts a scene background path using ../ relative to the scene file directory', () => {
-    // scenes/test_scene.yaml with background: ../assets/bg.png
+  it('accepts a scene background path relative to the pack root', () => {
+    // Background paths are pack-root-relative per the scene schema ("within the pack assets directory").
+    // scenes/test_scene.yaml with background: assets/bg.png
     // resolves to <packRoot>/assets/bg.png — inside the pack root.
     const dir = track(makeTempPackDir({
-      sceneYaml: VALID_SCENE_YAML + 'background: ../assets/bg.png\n',
+      sceneYaml: VALID_SCENE_YAML + 'background: assets/bg.png\n',
       scenarioYamls: { 'scenario_with_scene.yaml': VALID_SCENARIO_WITH_SCENE_YAML },
     }));
     expect(() => loadPack(dir)).not.toThrow();

--- a/packages/pack-loader/tests/roots.test.ts
+++ b/packages/pack-loader/tests/roots.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it, beforeEach, afterEach } from 'vitest';
@@ -79,5 +79,24 @@ describe('loadPacksFromRoots — version selection', () => {
     const result = loadPacksFromRoots({ officialRoot, communityRoot, localDevRoot: localRoot });
     expect(result.packs).toHaveLength(1);
     expect(result.packs[0]?.manifest.version).toBe('1.1.0');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Root-level inaccessible entries
+// ---------------------------------------------------------------------------
+
+describe('loadPacksFromRoots — inaccessible entries in root', () => {
+  it('loads valid packs even when the root contains a broken symlink', () => {
+    const localRoot = join(rootsDir, 'local');
+    mkdirSync(localRoot);
+    makePackInDir(localRoot, 'valid-pack', { manifestYaml: VALID_MANIFEST_YAML });
+    // A symlink pointing to a non-existent target: statSync throws ENOENT on it.
+    symlinkSync(join(localRoot, 'no-such-target'), join(localRoot, 'broken-link'));
+
+    const result = loadPacksFromRoots({ localDevRoot: localRoot });
+    expect(result.packs).toHaveLength(1);
+    expect(result.packs[0]?.manifest.pack_id).toBe('test.minimal_pack');
+    expect(result.errors).toHaveLength(0);
   });
 });

--- a/packages/pack-loader/tests/roots.test.ts
+++ b/packages/pack-loader/tests/roots.test.ts
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { loadPacksFromRoots } from '../src/loader.js';
+import { makePackInDir, VALID_MANIFEST_YAML } from './fixtures.js';
+
+let rootsDir: string;
+
+beforeEach(() => {
+  rootsDir = mkdtempSync(join(tmpdir(), 'convsim-roots-test-'));
+});
+
+afterEach(() => {
+  rmSync(rootsDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Version selection — highest semver wins when the same pack_id spans roots
+// ---------------------------------------------------------------------------
+
+describe('loadPacksFromRoots — version selection', () => {
+  it('selects the highest version when the same pack_id appears in multiple roots', () => {
+    const officialRoot = join(rootsDir, 'official');
+    const localRoot = join(rootsDir, 'local');
+    mkdirSync(officialRoot);
+    mkdirSync(localRoot);
+
+    makePackInDir(officialRoot, 'test-pack', {
+      manifestYaml: VALID_MANIFEST_YAML, // version: 0.1.0
+    });
+    makePackInDir(localRoot, 'test-pack', {
+      manifestYaml: VALID_MANIFEST_YAML.replace('version: 0.1.0', 'version: 0.2.0'),
+    });
+
+    const result = loadPacksFromRoots({ officialRoot, localDevRoot: localRoot });
+    expect(result.packs).toHaveLength(1);
+    expect(result.packs[0]?.manifest.version).toBe('0.2.0');
+  });
+
+  it('selects the higher version regardless of which root is listed first', () => {
+    const officialRoot = join(rootsDir, 'official');
+    const localRoot = join(rootsDir, 'local');
+    mkdirSync(officialRoot);
+    mkdirSync(localRoot);
+
+    // Newer version in the FIRST root (official) — must not be overridden by the older local version
+    makePackInDir(officialRoot, 'test-pack', {
+      manifestYaml: VALID_MANIFEST_YAML.replace('version: 0.1.0', 'version: 2.0.0'),
+    });
+    makePackInDir(localRoot, 'test-pack', {
+      manifestYaml: VALID_MANIFEST_YAML.replace('version: 0.1.0', 'version: 0.9.0'),
+    });
+
+    const result = loadPacksFromRoots({ officialRoot, localDevRoot: localRoot });
+    expect(result.packs).toHaveLength(1);
+    expect(result.packs[0]?.manifest.version).toBe('2.0.0');
+  });
+
+  it('returns a single pack when three roots all contain the same pack_id', () => {
+    const officialRoot = join(rootsDir, 'official');
+    const communityRoot = join(rootsDir, 'community');
+    const localRoot = join(rootsDir, 'local');
+    mkdirSync(officialRoot);
+    mkdirSync(communityRoot);
+    mkdirSync(localRoot);
+
+    makePackInDir(officialRoot, 'p', {
+      manifestYaml: VALID_MANIFEST_YAML.replace('version: 0.1.0', 'version: 1.0.0'),
+    });
+    makePackInDir(communityRoot, 'p', {
+      manifestYaml: VALID_MANIFEST_YAML.replace('version: 0.1.0', 'version: 1.1.0'),
+    });
+    makePackInDir(localRoot, 'p', {
+      manifestYaml: VALID_MANIFEST_YAML.replace('version: 0.1.0', 'version: 0.9.0'),
+    });
+
+    const result = loadPacksFromRoots({ officialRoot, communityRoot, localDevRoot: localRoot });
+    expect(result.packs).toHaveLength(1);
+    expect(result.packs[0]?.manifest.version).toBe('1.1.0');
+  });
+});

--- a/packages/pack-loader/tsconfig.json
+++ b/packages/pack-loader/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,34 @@ importers:
         specifier: ^2.1.9
         version: 2.1.9(@types/node@22.20.0)(@vitest/ui@2.1.9)(jsdom@25.0.1)
 
+  packages/pack-loader:
+    dependencies:
+      ajv:
+        specifier: ^8.17.1
+        version: 8.20.0
+      better-sqlite3:
+        specifier: ^11.5.0
+        version: 11.10.0
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.3.0
+    devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.11
+        version: 7.6.13
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.20.0
+      typescript:
+        specifier: ^5.5.0
+        version: 5.6.3
+      vitest:
+        specifier: ^2.0.0
+        version: 2.1.9(@types/node@22.20.0)(@vitest/ui@2.1.9)(jsdom@25.0.1)
+
   packages/scenario-schema:
     dependencies:
       ajv:
@@ -877,6 +905,9 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/better-sqlite3@7.6.13':
+    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
+
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
@@ -1095,10 +1126,22 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.10.40:
     resolution: {integrity: sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  better-sqlite3@11.10.0:
+    resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
   brace-expansion@1.1.15:
     resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
@@ -1111,6 +1154,9 @@ packages:
     resolution: {integrity: sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -1145,6 +1191,9 @@ packages:
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -1200,6 +1249,10 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
   deep-eql@4.1.4:
     resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
     engines: {node: '>=6'}
@@ -1207,6 +1260,10 @@ packages:
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -1218,6 +1275,10 @@ packages:
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
 
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
@@ -1235,6 +1296,9 @@ packages:
 
   electron-to-chromium@1.5.381:
     resolution: {integrity: sha512-n9Wa6yB+vDsGuA8AKbl/0z7HbvWqt5jxIdvr1IUicd0ryPrk7/xzwqLv8D9AbbvZ6avVNtXYLTfmgFHkwkyelg==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
@@ -1341,6 +1405,10 @@ packages:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
@@ -1391,6 +1459,9 @@ packages:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
   find-my-way@9.6.0:
     resolution: {integrity: sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==}
     engines: {node: '>=20'}
@@ -1409,6 +1480,9 @@ packages:
   form-data@4.0.6:
     resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1436,6 +1510,9 @@ packages:
   get-stream@8.0.1:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
     engines: {node: '>=16'}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
@@ -1489,6 +1566,9 @@ packages:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -1508,6 +1588,12 @@ packages:
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   ipaddr.js@2.4.0:
     resolution: {integrity: sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==}
@@ -1638,6 +1724,10 @@ packages:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -1648,6 +1738,12 @@ packages:
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
@@ -1664,8 +1760,15 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  node-abi@3.93.0:
+    resolution: {integrity: sha512-Cu6yUpX5Iavugm8BeX7c0wgU9CvOqfd1yM6A1d2q2ZMjym7GjpASv2GdRcTq3Fx+Sb5OgBkEEpw4VnAbY6Y5RA==}
+    engines: {node: '>=10'}
 
   node-releases@2.0.50:
     resolution: {integrity: sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==}
@@ -1681,6 +1784,9 @@ packages:
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   onetime@6.0.0:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
@@ -1758,6 +1864,12 @@ packages:
     resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -1776,12 +1888,19 @@ packages:
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
 
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
@@ -1814,6 +1933,10 @@ packages:
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
 
   real-require@0.2.0:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
@@ -1855,6 +1978,9 @@ packages:
 
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safe-regex2@5.1.1:
     resolution: {integrity: sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==}
@@ -1904,6 +2030,12 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
@@ -1925,6 +2057,9 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
   strip-final-newline@3.0.0:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
     engines: {node: '>=12'}
@@ -1932,6 +2067,10 @@ packages:
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
+
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -1946,6 +2085,13 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  tar-fs@2.1.5:
+    resolution: {integrity: sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
 
   thread-stream@4.2.0:
     resolution: {integrity: sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==}
@@ -2015,6 +2161,9 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -2049,6 +2198,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   vite-node@1.6.1:
     resolution: {integrity: sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==}
@@ -2175,6 +2327,9 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   ws@8.21.0:
     resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
@@ -2757,6 +2912,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
+  '@types/better-sqlite3@7.6.13':
+    dependencies:
+      '@types/node': 22.20.0
+
   '@types/estree@1.0.9': {}
 
   '@types/js-yaml@4.0.9': {}
@@ -3026,7 +3185,24 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.10.40: {}
+
+  better-sqlite3@11.10.0:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   brace-expansion@1.1.15:
     dependencies:
@@ -3044,6 +3220,11 @@ snapshots:
       electron-to-chromium: 1.5.381
       node-releases: 2.0.50
       update-browserslist-db: 1.2.3(browserslist@4.28.4)
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   cac@6.7.14: {}
 
@@ -3084,6 +3265,8 @@ snapshots:
       get-func-name: 2.0.2
 
   check-error@2.1.3: {}
+
+  chownr@1.1.4: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -3129,17 +3312,25 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
   deep-eql@4.1.4:
     dependencies:
       type-detect: 4.1.0
 
   deep-eql@5.0.2: {}
 
+  deep-extend@0.6.0: {}
+
   deep-is@0.1.4: {}
 
   delayed-stream@1.0.0: {}
 
   dequal@2.0.3: {}
+
+  detect-libc@2.1.2: {}
 
   diff-sequences@29.6.3: {}
 
@@ -3154,6 +3345,10 @@ snapshots:
       gopd: 1.2.0
 
   electron-to-chromium@1.5.381: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   entities@6.0.1: {}
 
@@ -3325,6 +3520,8 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
 
+  expand-template@2.0.3: {}
+
   expect-type@1.4.0: {}
 
   fast-decode-uri-component@1.0.1: {}
@@ -3384,6 +3581,8 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
+  file-uri-to-path@1.0.0: {}
+
   find-my-way@9.6.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -3409,6 +3608,8 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.4
       mime-types: 2.1.35
+
+  fs-constants@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
@@ -3438,6 +3639,8 @@ snapshots:
       es-object-atoms: 1.1.2
 
   get-stream@8.0.1: {}
+
+  github-from-package@0.0.0: {}
 
   glob-parent@6.0.2:
     dependencies:
@@ -3485,6 +3688,8 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  ieee754@1.2.1: {}
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -3497,6 +3702,10 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
+
+  inherits@2.0.4: {}
+
+  ini@1.3.8: {}
 
   ipaddr.js@2.4.0: {}
 
@@ -3624,6 +3833,8 @@ snapshots:
 
   mimic-fn@4.0.0: {}
 
+  mimic-response@3.1.0: {}
+
   min-indent@1.0.1: {}
 
   minimatch@10.2.5:
@@ -3633,6 +3844,10 @@ snapshots:
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.15
+
+  minimist@1.2.8: {}
+
+  mkdirp-classic@0.5.3: {}
 
   mlly@1.8.2:
     dependencies:
@@ -3647,7 +3862,13 @@ snapshots:
 
   nanoid@3.3.15: {}
 
+  napi-build-utils@2.0.0: {}
+
   natural-compare@1.4.0: {}
+
+  node-abi@3.93.0:
+    dependencies:
+      semver: 7.8.5
 
   node-releases@2.0.50: {}
 
@@ -3658,6 +3879,10 @@ snapshots:
   nwsapi@2.2.24: {}
 
   on-exit-leak-free@2.1.2: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   onetime@6.0.0:
     dependencies:
@@ -3742,6 +3967,21 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.93.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.5
+      tunnel-agent: 0.6.0
+
   prelude-ls@1.2.1: {}
 
   pretty-format@27.5.1:
@@ -3760,9 +4000,21 @@ snapshots:
 
   process-warning@5.0.0: {}
 
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
   punycode@2.3.1: {}
 
   quick-format-unescaped@4.0.4: {}
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
 
   react-dom@18.3.1(react@18.3.1):
     dependencies:
@@ -3791,6 +4043,12 @@ snapshots:
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
 
   real-require@0.2.0: {}
 
@@ -3846,6 +4104,8 @@ snapshots:
 
   rrweb-cssom@0.8.0: {}
 
+  safe-buffer@5.2.1: {}
+
   safe-regex2@5.1.1:
     dependencies:
       ret: 0.5.0
@@ -3880,6 +4140,14 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
   sirv@3.0.2:
     dependencies:
       '@polka/url': 1.0.0-next.29
@@ -3898,11 +4166,17 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   strip-final-newline@3.0.0: {}
 
   strip-indent@3.0.0:
     dependencies:
       min-indent: 1.0.1
+
+  strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
 
@@ -3915,6 +4189,21 @@ snapshots:
       has-flag: 4.0.0
 
   symbol-tree@3.2.4: {}
+
+  tar-fs@2.1.5:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   thread-stream@4.2.0:
     dependencies:
@@ -3967,6 +4256,10 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -3999,6 +4292,8 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  util-deprecate@1.0.2: {}
 
   vite-node@1.6.1(@types/node@22.20.0):
     dependencies:
@@ -4144,6 +4439,8 @@ snapshots:
       stackback: 0.0.2
 
   word-wrap@1.2.5: {}
+
+  wrappy@1.0.2: {}
 
   ws@8.21.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,14 +120,14 @@ importers:
         specifier: ^8.17.1
         version: 8.20.0
       better-sqlite3:
-        specifier: ^11.5.0
-        version: 11.10.0
+        specifier: ^12.11.1
+        version: 12.11.1
       js-yaml:
         specifier: ^4.1.0
         version: 4.3.0
     devDependencies:
       '@types/better-sqlite3':
-        specifier: ^7.6.11
+        specifier: ^7.6.13
         version: 7.6.13
       '@types/js-yaml':
         specifier: ^4.0.9
@@ -1139,9 +1139,6 @@ packages:
     resolution: {integrity: sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
-
-  better-sqlite3@11.10.0:
-    resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
 
   better-sqlite3@12.11.1:
     resolution: {integrity: sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==}
@@ -3198,11 +3195,6 @@ snapshots:
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.40: {}
-
-  better-sqlite3@11.10.0:
-    dependencies:
-      bindings: 1.5.0
-      prebuild-install: 7.1.3
 
   better-sqlite3@12.11.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1140,6 +1140,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  better-sqlite3@11.10.0:
+    resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
+
   better-sqlite3@12.11.1:
     resolution: {integrity: sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==}
     engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
@@ -3195,6 +3198,11 @@ snapshots:
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.40: {}
+
+  better-sqlite3@11.10.0:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
 
   better-sqlite3@12.11.1:
     dependencies:


### PR DESCRIPTION
## Summary

Adds `packages/pack-loader`, a new TypeScript workspace package with five core modules for loading, validating, and indexing scenario packs:

- **`loader.ts`** — Provides `loadPack()` to read a pack's `manifest.yaml` and all scenario YAMLs from `scenarios/`, resolving each scenario's `npc`, `rubric`, `scene`, and `safety.policy` references, validating all files against JSON schemas (v0.1), and rejecting packs with duplicate IDs or unsupported versions. Provides `resolveBundle()` to return a fully assembled scenario bundle ready for the conversation runtime. Provides `loadPacksFromRoots()` to scan official, community, and local-dev pack roots, selecting highest-version packs when the same `pack_id` appears in multiple roots.

- **`resolver.ts`** — Provides `resolveRef()` to resolve relative file references from a base directory while enforcing that the resolved path stays within the pack root (rejects path traversal, including via `..`, absolute paths, and null-byte injection). Provides `readPackFile()` to read files as UTF-8, throwing a typed `MISSING_FILE` error for absent files.

- **`validator.ts`** — Uses AJV to parse YAML text with `js-yaml` safe-load and validate against the existing JSON schemas (pack, scenario, npc, rubric, safety, scene v0.1). Never executes pack code; catches YAML syntax errors, schema violations, and unsupported schema versions.

- **`db.ts`** — Provides `PackIndex` class wrapping `better-sqlite3` for persistent pack metadata and scenario indexing. Supports `importPack()` (atomic upsert with scenario list replacement), `removePack()` (cascade delete), `listPacks()`, `listScenarios()` (with optional pack_id filter), and `getPack()`.

- **`types.ts`** — Exports raw YAML shapes for all file types (`RawManifest`, `RawScenario`, `RawNpc`, `RawRubric`, `RawSafety`, `RawScene`), loader output types, SQLite row shapes, and the `PackLoaderError` class with typed error codes.

## What is validated and rejected

- Missing files (`MISSING_FILE`)
- YAML syntax errors (`INVALID_YAML`)
- Schema validation failures (`SCHEMA_VALIDATION`)
- Refs that escape the pack root via `..`, absolute paths, or null bytes (`PATH_TRAVERSAL`)
- Duplicate `scenario_id` or `npc_id` values (`DUPLICATE_ID`)
- Unsupported `schema_version` values (`UNSUPPORTED_VERSION`)
- Invalid `entry_scenarios` references (path traversal, missing scenarios)

## How it was tested

50+ tests across three test files:

- **`tests/loader.test.ts`** — Unit tests for valid packs (manifest, scenarios, NPCs, rubrics, scenes, safety, bundles, scene-less bundles, multi-scenario packs) and comprehensive error conditions (missing manifest, missing NPC, missing safety, path traversal, duplicate IDs, unsupported version, bad YAML, missing required field, `fictional: false` NPC, NPC portrait traversal, scene background traversal, entry_scenarios path traversal/missing). Also tests `resolveRef()` directly for null-byte and `..` injection.

- **`tests/db.test.ts`** — Integration tests creating real SQLite databases in temp directories: import, replace (metadata and scenario list update), remove (with cascade), cross-pack `listScenarios()`, and scenario count accuracy.

- **`tests/roots.test.ts`** — Version selection tests ensuring highest-version packs are selected when duplicates appear across roots, and resilience tests confirming invalid packs or broken symlinks in a root don't prevent loading other packs in that root.

- All 50+ tests pass (`vitest run`).
- Smoke-tested against the real `packs/official/job-interview-basic` pack end-to-end.

Closes #26