### PR TITLE
Add llama-server sidecar download script and managed process lifecycle

### DIFF
--- a/runtimes/llama_cpp/README.md
+++ b/runtimes/llama_cpp/README.md
@@ -52,14 +52,16 @@ curl -X POST http://127.0.0.1:7355/api/sidecar/start \
 
 Optional request fields:
 
-| Field             | Type    | Default | Description                          |
-|-------------------|---------|---------|--------------------------------------|
-| `model_path`      | string  | —       | Absolute path to the GGUF file       |
-| `executable`      | string  | auto    | Path to llama-server binary          |
-| `context_length`  | int     | null    | Context window size (`--ctx-size`)   |
-| `threads`         | int     | null    | CPU thread count (`--threads`)       |
-| `gpu_layers`      | int     | null    | GPU layers (`--n-gpu-layers`)        |
-| `startup_timeout` | float   | 120.0   | Seconds to wait for /health          |
+| Field             | Type    | Default       | Description                          |
+|-------------------|---------|---------------|--------------------------------------|
+| `model_path`      | string  | —             | Absolute path to the GGUF file       |
+| `executable`      | string  | auto          | Path to llama-server binary          |
+| `host`            | string  | `127.0.0.1`   | Interface for llama-server to bind   |
+| `port`            | int     | `7356`        | Port for llama-server to bind        |
+| `context_length`  | int     | null          | Context window size (`--ctx-size`)   |
+| `threads`         | int     | null          | CPU thread count (`--threads`)       |
+| `gpu_layers`      | int     | null          | GPU layers (`--n-gpu-layers`)        |
+| `startup_timeout` | float   | 120.0         | Seconds to wait for /health          |
 
 Stop with `POST /api/sidecar/stop`. Query state with `GET /api/sidecar/status`.
 

--- a/runtimes/llama_cpp/README.md
+++ b/runtimes/llama_cpp/README.md
@@ -3,17 +3,90 @@
 
 Integration layer for llama.cpp — the primary local LLM runtime.
 
-**Status:** Not yet implemented. Planned in Milestone 1 (text-only simulator).
+The llama-server process binds to `http://127.0.0.1:7356` by default.
+Runtime logs are written to `~/.convsim/logs/runtime.log`.
 
-This directory will contain:
-- Scripts to download platform-specific llama.cpp binaries
-- Configuration helpers for llama-server startup
-- The `ChatRuntime` adapter that speaks to llama-server's OpenAI-compatible API
+## Quickstart
 
-The llama-server process runs at `http://127.0.0.1:7356` in dev mode.
+### 1 — Get a llama-server binary
+
+**Option A — Download script (Linux / macOS)**
+
+```sh
+./runtimes/llama_cpp/download-runtime.sh
+# Binary lands at ~/.convsim/bin/llama-server
+# Follow the printed PATH instructions.
+```
+
+**Option B — Manual install**
+
+- Download a release from <https://github.com/ggml-org/llama.cpp/releases>
+- Extract `llama-server` (or `llama-server.exe` on Windows) and place it in a
+  directory on your PATH.
+
+**Option C — Build from source**
+
+```sh
+git clone https://github.com/ggml-org/llama.cpp
+cd llama.cpp && cmake -B build && cmake --build build --config Release
+# Binary: build/bin/llama-server
+```
+
+### 2 — Get a GGUF model
+
+Download a GGUF model file.  The [model registry](../../model-registry/registry.yaml)
+lists recommended models.  A starter model (≈2.6 GB):
+
+```
+https://huggingface.co/Qwen/Qwen3-4B-Instruct-GGUF
+```
+
+### 3 — Start via the sidecar API (managed mode)
+
+```sh
+# POST /api/sidecar/start
+curl -X POST http://127.0.0.1:7355/api/sidecar/start \
+  -H "Content-Type: application/json" \
+  -d '{"model_path": "/path/to/model.gguf"}'
+```
+
+Optional request fields:
+
+| Field             | Type    | Default | Description                          |
+|-------------------|---------|---------|--------------------------------------|
+| `model_path`      | string  | —       | Absolute path to the GGUF file       |
+| `executable`      | string  | auto    | Path to llama-server binary          |
+| `context_length`  | int     | null    | Context window size (`--ctx-size`)   |
+| `threads`         | int     | null    | CPU thread count (`--threads`)       |
+| `gpu_layers`      | int     | null    | GPU layers (`--n-gpu-layers`)        |
+| `startup_timeout` | float   | 120.0   | Seconds to wait for /health          |
+
+Stop with `POST /api/sidecar/stop`. Query state with `GET /api/sidecar/status`.
+
+### 4 — External server (advanced)
+
+If you already run your own llama-server, do **not** call `/api/sidecar/start`.
+Set the runtime to `llama_cpp` via `POST /api/models/use` — the adapter will
+connect to whatever is listening on `CONVSIM_LLAMA_CPP_BASE_URL`
+(default `http://127.0.0.1:7356`).
+
+## Error handling
+
+| Situation             | API response                       |
+|-----------------------|------------------------------------|
+| Port already in use   | 503 `SIDECAR_START_FAILED` with actionable message |
+| Executable not found  | 503 `SIDECAR_START_FAILED`         |
+| Startup timeout       | 503 `SIDECAR_START_FAILED`         |
+| Process crash         | state transitions to `crashed`; check `log_path` |
+| Already running       | 409 `SIDECAR_ALREADY_RUNNING`      |
+
+## Log location
+
+`~/.convsim/logs/runtime.log` — contains llama-server stdout/stderr.
+Transcript content is **never** written there; only server diagnostic output.
 
 ## References
 
-- llama.cpp: https://github.com/ggml-org/llama.cpp
-- llama-server exposes an OpenAI-compatible chat completions endpoint
-- GGUF model format is the target; models are downloaded by the user
+- llama.cpp: <https://github.com/ggml-org/llama.cpp>
+- GGUF format: <https://github.com/ggml-org/ggml/blob/master/docs/gguf.md>
+- OpenAI-compatible API: `llama-server` exposes `/v1/chat/completions` (SSE streaming)

--- a/runtimes/llama_cpp/download-runtime.sh
+++ b/runtimes/llama_cpp/download-runtime.sh
@@ -107,7 +107,6 @@ fi
 #   llama-{tag}-bin-{platform}-{cuda/metal/cpu}.zip
 # We prefer the plain CPU build for portability.
 
-VERSION_SHORT="${RELEASE_TAG#b}"  # strip leading 'b' if present (e.g. b5148 -> 5148)
 ASSET_NAME="llama-${RELEASE_TAG}-bin-${PLATFORM}-cpu.zip"
 DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${RELEASE_TAG}/${ASSET_NAME}"
 

--- a/runtimes/llama_cpp/download-runtime.sh
+++ b/runtimes/llama_cpp/download-runtime.sh
@@ -23,6 +23,15 @@
 
 set -euo pipefail
 
+# ── Early --help / -h (platform-agnostic) ────────────────────────────────────
+
+for _arg in "$@"; do
+  if [[ "$_arg" == "--help" || "$_arg" == "-h" ]]; then
+    sed -n '2,/^set /p' "$0" | grep '^#' | sed 's/^# \?//'
+    exit 0
+  fi
+done
+
 RELEASE_TAG="${LLAMA_CPP_VERSION:-}"  # empty = auto-detect latest
 DEST_DIR="${LLAMA_CPP_DEST:-$HOME/.convsim/bin}"
 BINARY_NAME="llama-server"
@@ -73,10 +82,6 @@ while [[ $# -gt 0 ]]; do
     --dest)
       DEST_DIR="$2"
       shift 2
-      ;;
-    --help|-h)
-      sed -n '2,/^set /p' "$0" | grep '^#' | sed 's/^# \?//'
-      exit 0
       ;;
     *)
       echo "Unknown option: $1" >&2
@@ -144,7 +149,7 @@ echo "Extracting..."
 unzip -q "$ZIP_PATH" -d "$TMP_DIR/extracted"
 
 # The binary may be at the root or in a subdirectory
-EXTRACTED_BIN="$(find "$TMP_DIR/extracted" -name "llama-server" -o -name "llama-server.exe" | head -1)"
+EXTRACTED_BIN="$(find "$TMP_DIR/extracted" \( -name "llama-server" -o -name "llama-server.exe" \) -type f | head -1)"
 if [[ -z "$EXTRACTED_BIN" ]]; then
   echo "llama-server binary not found in archive. Contents:" >&2
   find "$TMP_DIR/extracted" -type f >&2

--- a/runtimes/llama_cpp/download-runtime.sh
+++ b/runtimes/llama_cpp/download-runtime.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# download-runtime.sh — Download a pre-built llama-server binary for this platform.
+#
+# Usage:
+#   ./runtimes/llama_cpp/download-runtime.sh [--version TAG] [--dest DIR]
+#
+# Options:
+#   --version TAG   llama.cpp release tag to download (default: latest)
+#   --dest DIR      directory to place the binary (default: ~/.convsim/bin)
+#
+# After the download, add the destination to PATH or pass its full path to
+# POST /api/sidecar/start as the "executable" field.
+#
+# Supported platforms:
+#   Linux  x86_64  — linux-x64
+#   Linux  aarch64 — linux-arm64
+#   macOS  arm64   — macos-arm64   (Apple Silicon)
+#   macOS  x86_64  — macos-x64     (Intel Mac)
+#
+# Windows users: install via WSL2 (use the Linux binary) or build from source:
+#   https://github.com/ggml-org/llama.cpp#build
+
+set -euo pipefail
+
+RELEASE_TAG="${LLAMA_CPP_VERSION:-}"  # empty = auto-detect latest
+DEST_DIR="${LLAMA_CPP_DEST:-$HOME/.convsim/bin}"
+BINARY_NAME="llama-server"
+REPO="ggml-org/llama.cpp"
+
+# ── Platform detection ────────────────────────────────────────────────────────
+
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+
+case "$OS" in
+  Linux)
+    case "$ARCH" in
+      x86_64)  PLATFORM="linux-x64" ;;
+      aarch64) PLATFORM="linux-arm64" ;;
+      *)
+        echo "Unsupported Linux architecture: $ARCH" >&2
+        echo "Build from source: https://github.com/ggml-org/llama.cpp#build" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+  Darwin)
+    case "$ARCH" in
+      arm64)  PLATFORM="macos-arm64" ;;
+      x86_64) PLATFORM="macos-x64" ;;
+      *)
+        echo "Unsupported macOS architecture: $ARCH" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+  *)
+    echo "Unsupported OS: $OS" >&2
+    echo "Windows users: use WSL2 (Linux binary) or build from source." >&2
+    exit 1
+    ;;
+esac
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)
+      RELEASE_TAG="$2"
+      shift 2
+      ;;
+    --dest)
+      DEST_DIR="$2"
+      shift 2
+      ;;
+    --help|-h)
+      sed -n '2,/^set /p' "$0" | grep '^#' | sed 's/^# \?//'
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# ── Resolve latest tag if not specified ───────────────────────────────────────
+
+if [[ -z "$RELEASE_TAG" ]]; then
+  echo "Fetching latest llama.cpp release tag..."
+  if command -v curl &>/dev/null; then
+    RELEASE_TAG="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+      | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')"
+  elif command -v wget &>/dev/null; then
+    RELEASE_TAG="$(wget -qO- "https://api.github.com/repos/${REPO}/releases/latest" \
+      | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')"
+  else
+    echo "curl or wget is required to fetch the latest release." >&2
+    exit 1
+  fi
+  echo "Latest release: ${RELEASE_TAG}"
+fi
+
+# ── Build download URL ────────────────────────────────────────────────────────
+# llama.cpp release assets follow this naming convention:
+#   llama-{tag}-bin-{platform}-{cuda/metal/cpu}.zip
+# We prefer the plain CPU build for portability.
+
+VERSION_SHORT="${RELEASE_TAG#b}"  # strip leading 'b' if present (e.g. b5148 -> 5148)
+ASSET_NAME="llama-${RELEASE_TAG}-bin-${PLATFORM}-cpu.zip"
+DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${RELEASE_TAG}/${ASSET_NAME}"
+
+echo ""
+echo "Platform : ${PLATFORM}"
+echo "Version  : ${RELEASE_TAG}"
+echo "Asset    : ${ASSET_NAME}"
+echo "Dest     : ${DEST_DIR}"
+echo ""
+
+# ── Download and extract ──────────────────────────────────────────────────────
+
+mkdir -p "$DEST_DIR"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+ZIP_PATH="${TMP_DIR}/${ASSET_NAME}"
+
+echo "Downloading ${DOWNLOAD_URL} ..."
+if command -v curl &>/dev/null; then
+  curl -fL --progress-bar -o "$ZIP_PATH" "$DOWNLOAD_URL" || {
+    echo "" >&2
+    echo "Download failed. Check that ${RELEASE_TAG} has a ${ASSET_NAME} asset." >&2
+    echo "Browse releases: https://github.com/${REPO}/releases" >&2
+    exit 1
+  }
+elif command -v wget &>/dev/null; then
+  wget -q --show-progress -O "$ZIP_PATH" "$DOWNLOAD_URL" || {
+    echo "Download failed." >&2
+    exit 1
+  }
+fi
+
+echo "Extracting..."
+unzip -q "$ZIP_PATH" -d "$TMP_DIR/extracted"
+
+# The binary may be at the root or in a subdirectory
+EXTRACTED_BIN="$(find "$TMP_DIR/extracted" -name "llama-server" -o -name "llama-server.exe" | head -1)"
+if [[ -z "$EXTRACTED_BIN" ]]; then
+  echo "llama-server binary not found in archive. Contents:" >&2
+  find "$TMP_DIR/extracted" -type f >&2
+  exit 1
+fi
+
+cp "$EXTRACTED_BIN" "${DEST_DIR}/${BINARY_NAME}"
+chmod +x "${DEST_DIR}/${BINARY_NAME}"
+
+echo ""
+echo "Installed: ${DEST_DIR}/${BINARY_NAME}"
+echo ""
+echo "Add to PATH (add this to ~/.bashrc or ~/.zshrc):"
+echo "  export PATH=\"${DEST_DIR}:\$PATH\""
+echo ""
+echo "Or pass the full path to the sidecar API:"
+echo "  POST /api/sidecar/start  { \"executable\": \"${DEST_DIR}/${BINARY_NAME}\", ... }"

--- a/runtimes/llama_cpp/download-runtime.sh
+++ b/runtimes/llama_cpp/download-runtime.sh
@@ -131,18 +131,18 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 ZIP_PATH="${TMP_DIR}/${ASSET_NAME}"
 
 echo "Downloading ${DOWNLOAD_URL} ..."
+_DOWNLOAD_FAILED_MSG() {
+  echo "" >&2
+  echo "Download failed. Check that ${RELEASE_TAG} has a ${ASSET_NAME} asset." >&2
+  echo "Browse releases: https://github.com/${REPO}/releases" >&2
+}
 if command -v curl &>/dev/null; then
-  curl -fL --progress-bar -o "$ZIP_PATH" "$DOWNLOAD_URL" || {
-    echo "" >&2
-    echo "Download failed. Check that ${RELEASE_TAG} has a ${ASSET_NAME} asset." >&2
-    echo "Browse releases: https://github.com/${REPO}/releases" >&2
-    exit 1
-  }
+  curl -fL --progress-bar -o "$ZIP_PATH" "$DOWNLOAD_URL" || { _DOWNLOAD_FAILED_MSG; exit 1; }
 elif command -v wget &>/dev/null; then
-  wget -q --show-progress -O "$ZIP_PATH" "$DOWNLOAD_URL" || {
-    echo "Download failed." >&2
-    exit 1
-  }
+  wget -q --show-progress -O "$ZIP_PATH" "$DOWNLOAD_URL" || { _DOWNLOAD_FAILED_MSG; exit 1; }
+else
+  echo "curl or wget is required to download the binary." >&2
+  exit 1
 fi
 
 echo "Extracting..."

--- a/services/convsim-core/convsim_core/app.py
+++ b/services/convsim-core/convsim_core/app.py
@@ -12,7 +12,7 @@ from convsim_core.errors import (
     request_validation_error_handler,
 )
 from convsim_core.logging_setup import configure_logging
-from convsim_core.routers import diag as diag_router, health, models as models_router, packs as packs_router, sessions as sessions_router, settings as settings_router, stt as stt_router
+from convsim_core.routers import diag as diag_router, health, models as models_router, packs as packs_router, sessions as sessions_router, settings as settings_router, sidecar as sidecar_router, stt as stt_router
 from convsim_core.runtime import build_runtime
 from convsim_core.runtime.sidecar import LlamaCppSidecar
 from convsim_core.storage.database import Database
@@ -48,6 +48,7 @@ def create_app(config: ServiceConfig | None = None) -> FastAPI:
     app.include_router(settings_router.router)
     app.include_router(diag_router.router)
     app.include_router(models_router.router)
+    app.include_router(sidecar_router.router)
     app.include_router(stt_router.router)
     app.include_router(packs_router.router)
     app.include_router(sessions_router.router)

--- a/services/convsim-core/convsim_core/app.py
+++ b/services/convsim-core/convsim_core/app.py
@@ -12,8 +12,9 @@ from convsim_core.errors import (
     request_validation_error_handler,
 )
 from convsim_core.logging_setup import configure_logging
-from convsim_core.routers import diag as diag_router, health, models as models_router, packs as packs_router, settings as settings_router, stt as stt_router
+from convsim_core.routers import diag as diag_router, health, models as models_router, packs as packs_router, settings as settings_router, sidecar as sidecar_router, stt as stt_router
 from convsim_core.runtime import build_runtime
+from convsim_core.runtime.sidecar import LlamaCppSidecar
 from convsim_core.storage.database import Database
 from convsim_core.storage.repositories.settings_repo import load_settings
 
@@ -32,7 +33,9 @@ def create_app(config: ServiceConfig | None = None) -> FastAPI:
         app.state.db = db
         app.state.app_settings = load_settings(db.connection(), config.data_dir, config.log_dir)
         app.state.runtime = build_runtime(config.runtime_id)
+        app.state.sidecar = LlamaCppSidecar(log_dir=config.log_dir)
         yield
+        await app.state.sidecar.stop()
         db.close()
 
     app = FastAPI(title="convsim-core", version="0.1.0", lifespan=lifespan)
@@ -47,5 +50,6 @@ def create_app(config: ServiceConfig | None = None) -> FastAPI:
     app.include_router(models_router.router)
     app.include_router(stt_router.router)
     app.include_router(packs_router.router)
+    app.include_router(sidecar_router.router)
 
     return app

--- a/services/convsim-core/convsim_core/app.py
+++ b/services/convsim-core/convsim_core/app.py
@@ -13,7 +13,9 @@ from convsim_core.errors import (
 )
 from convsim_core.logging_setup import configure_logging
 from convsim_core.routers import diag as diag_router, health, models as models_router, settings as settings_router, stt as stt_router
+from convsim_core.routers import sidecar as sidecar_router
 from convsim_core.runtime import build_runtime
+from convsim_core.runtime.sidecar import LlamaCppSidecar
 from convsim_core.storage.database import Database
 from convsim_core.storage.repositories.settings_repo import load_settings
 
@@ -32,7 +34,9 @@ def create_app(config: ServiceConfig | None = None) -> FastAPI:
         app.state.db = db
         app.state.app_settings = load_settings(db.connection(), config.data_dir, config.log_dir)
         app.state.runtime = build_runtime(config.runtime_id)
+        app.state.sidecar = LlamaCppSidecar(log_dir=config.log_dir)
         yield
+        await app.state.sidecar.stop()
         db.close()
 
     app = FastAPI(title="convsim-core", version="0.1.0", lifespan=lifespan)
@@ -46,5 +50,6 @@ def create_app(config: ServiceConfig | None = None) -> FastAPI:
     app.include_router(diag_router.router)
     app.include_router(models_router.router)
     app.include_router(stt_router.router)
+    app.include_router(sidecar_router.router)
 
     return app

--- a/services/convsim-core/convsim_core/routers/sidecar.py
+++ b/services/convsim-core/convsim_core/routers/sidecar.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0
+"""REST API for managed llama-server sidecar lifecycle.
+
+Endpoints allow the UI (or advanced users) to start/stop a local
+llama-server process managed by the app. Users who run their own
+llama-server externally can ignore these endpoints entirely.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import APIRouter, Request
+from pydantic import BaseModel
+
+from convsim_core.errors import ConvsimError
+from convsim_core.runtime.sidecar import LlamaCppSidecar, SidecarState
+
+router = APIRouter()
+
+
+class SidecarStartRequest(BaseModel):
+    model_path: str
+    executable: Optional[str] = None
+    context_length: Optional[int] = None
+    threads: Optional[int] = None
+    gpu_layers: Optional[int] = None
+    startup_timeout: float = 120.0
+
+
+class SidecarStartResponse(BaseModel):
+    state: str
+    pid: Optional[int] = None
+    model_path: Optional[str] = None
+    log_path: str
+    host: str
+    port: int
+    started_at: Optional[str] = None
+
+
+class SidecarStopResponse(BaseModel):
+    state: str
+    message: str
+
+
+class SidecarStatusResponse(BaseModel):
+    state: str
+    pid: Optional[int] = None
+    model_path: Optional[str] = None
+    error: Optional[str] = None
+    log_path: str
+    host: str
+    port: int
+    started_at: Optional[str] = None
+
+
+@router.post("/api/sidecar/start", response_model=SidecarStartResponse)
+async def start_sidecar(request: Request, body: SidecarStartRequest) -> SidecarStartResponse:
+    """Start the managed llama-server with the specified GGUF model.
+
+    Returns 409 if a sidecar is already running. Returns 503 on port conflict,
+    missing executable, or startup failure (with a descriptive message).
+    """
+    sidecar: LlamaCppSidecar = request.app.state.sidecar
+
+    if sidecar.state == SidecarState.RUNNING:
+        raise ConvsimError(
+            code="SIDECAR_ALREADY_RUNNING",
+            message="A managed llama-server is already running. Stop it first via POST /api/sidecar/stop.",
+            status_code=409,
+        )
+
+    try:
+        await sidecar.start(
+            body.model_path,
+            executable=body.executable,
+            context_length=body.context_length,
+            threads=body.threads,
+            gpu_layers=body.gpu_layers,
+            startup_timeout=body.startup_timeout,
+        )
+    except RuntimeError as exc:
+        current = sidecar.get_status()
+        raise ConvsimError(
+            code="SIDECAR_START_FAILED",
+            message=str(exc),
+            status_code=503,
+        ) from exc
+
+    status = sidecar.get_status()
+    return SidecarStartResponse(
+        state=status["state"],
+        pid=status["pid"],
+        model_path=status["model_path"],
+        log_path=status["log_path"],
+        host=status["host"],
+        port=status["port"],
+        started_at=status["started_at"],
+    )
+
+
+@router.post("/api/sidecar/stop", response_model=SidecarStopResponse)
+async def stop_sidecar(request: Request) -> SidecarStopResponse:
+    """Stop the managed llama-server process.
+
+    No-op (200) if no sidecar is running.
+    """
+    sidecar: LlamaCppSidecar = request.app.state.sidecar
+
+    if sidecar.state not in (SidecarState.RUNNING, SidecarState.STARTING):
+        return SidecarStopResponse(
+            state=sidecar.state.value,
+            message="No managed llama-server is running.",
+        )
+
+    await sidecar.stop()
+    return SidecarStopResponse(
+        state=SidecarState.STOPPED.value,
+        message="Managed llama-server stopped.",
+    )
+
+
+@router.get("/api/sidecar/status", response_model=SidecarStatusResponse)
+async def sidecar_status(request: Request) -> SidecarStatusResponse:
+    """Return the current state of the managed sidecar process."""
+    sidecar: LlamaCppSidecar = request.app.state.sidecar
+    status = sidecar.get_status()
+    return SidecarStatusResponse(**status)

--- a/services/convsim-core/convsim_core/routers/sidecar.py
+++ b/services/convsim-core/convsim_core/routers/sidecar.py
@@ -105,17 +105,12 @@ async def stop_sidecar(request: Request) -> SidecarStopResponse:
     """
     sidecar: LlamaCppSidecar = request.app.state.sidecar
 
-    if sidecar.state not in (SidecarState.RUNNING, SidecarState.STARTING):
-        return SidecarStopResponse(
-            state=sidecar.state.value,
-            message="No managed llama-server is running.",
-        )
-
+    was_running = sidecar.state in (SidecarState.RUNNING, SidecarState.STARTING)
     await sidecar.stop()
-    return SidecarStopResponse(
-        state=SidecarState.STOPPED.value,
-        message="Managed llama-server stopped.",
-    )
+
+    if was_running:
+        return SidecarStopResponse(state=SidecarState.STOPPED.value, message="Managed llama-server stopped.")
+    return SidecarStopResponse(state=SidecarState.STOPPED.value, message="No managed llama-server is running.")
 
 
 @router.get("/api/sidecar/status", response_model=SidecarStatusResponse)

--- a/services/convsim-core/convsim_core/routers/sidecar.py
+++ b/services/convsim-core/convsim_core/routers/sidecar.py
@@ -78,8 +78,7 @@ async def start_sidecar(request: Request, body: SidecarStartRequest) -> SidecarS
             gpu_layers=body.gpu_layers,
             startup_timeout=body.startup_timeout,
         )
-    except RuntimeError as exc:
-        current = sidecar.get_status()
+    except (RuntimeError, TimeoutError) as exc:
         raise ConvsimError(
             code="SIDECAR_START_FAILED",
             message=str(exc),

--- a/services/convsim-core/convsim_core/routers/sidecar.py
+++ b/services/convsim-core/convsim_core/routers/sidecar.py
@@ -21,6 +21,8 @@ router = APIRouter()
 class SidecarStartRequest(BaseModel):
     model_path: str
     executable: Optional[str] = None
+    host: str = "127.0.0.1"
+    port: int = 7356
     context_length: Optional[int] = None
     threads: Optional[int] = None
     gpu_layers: Optional[int] = None
@@ -73,6 +75,8 @@ async def start_sidecar(request: Request, body: SidecarStartRequest) -> SidecarS
         await sidecar.start(
             body.model_path,
             executable=body.executable,
+            host=body.host,
+            port=body.port,
             context_length=body.context_length,
             threads=body.threads,
             gpu_layers=body.gpu_layers,

--- a/services/convsim-core/convsim_core/routers/sidecar.py
+++ b/services/convsim-core/convsim_core/routers/sidecar.py
@@ -62,10 +62,10 @@ async def start_sidecar(request: Request, body: SidecarStartRequest) -> SidecarS
     """
     sidecar: LlamaCppSidecar = request.app.state.sidecar
 
-    if sidecar.state == SidecarState.RUNNING:
+    if sidecar.state in (SidecarState.RUNNING, SidecarState.STARTING):
         raise ConvsimError(
             code="SIDECAR_ALREADY_RUNNING",
-            message="A managed llama-server is already running. Stop it first via POST /api/sidecar/stop.",
+            message="A managed llama-server is already running or starting. Stop it first via POST /api/sidecar/stop.",
             status_code=409,
         )
 

--- a/services/convsim-core/convsim_core/runtime/sidecar.py
+++ b/services/convsim-core/convsim_core/runtime/sidecar.py
@@ -236,14 +236,17 @@ class LlamaCppSidecar:
     async def stop(self) -> None:
         """Terminate the managed process and release resources."""
         if self._state not in (SidecarState.RUNNING, SidecarState.STARTING):
+            self._process = None
             self._state = SidecarState.STOPPED
             self._error = None
+            self._model_path = None
             self._started_at = None
             return
         await self._terminate_process()
         self._close_log()
         self._state = SidecarState.STOPPED
         self._error = None
+        self._model_path = None
         self._started_at = None
 
     @property

--- a/services/convsim-core/convsim_core/runtime/sidecar.py
+++ b/services/convsim-core/convsim_core/runtime/sidecar.py
@@ -1,0 +1,284 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Managed llama-server sidecar process lifecycle.
+
+Handles launching, health-polling, log capture, and graceful shutdown of a
+local llama-server process. External llama.cpp users can skip this entirely;
+the LlamaCppRuntime HTTP adapter works against any reachable llama-server.
+"""
+from __future__ import annotations
+
+import asyncio
+import shutil
+import socket
+import subprocess
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import IO
+
+
+class SidecarState(str, Enum):
+    STOPPED = "stopped"
+    STARTING = "starting"
+    RUNNING = "running"
+    CRASHED = "crashed"
+    PORT_CONFLICT = "port_conflict"
+
+
+_DEFAULT_HOST = "127.0.0.1"
+_DEFAULT_PORT = 7356
+_STARTUP_TIMEOUT = 120.0
+_HEALTH_POLL_INTERVAL = 0.5
+_TERMINATE_TIMEOUT = 5.0
+
+
+def build_command(
+    executable: str,
+    model_path: str,
+    *,
+    host: str = _DEFAULT_HOST,
+    port: int = _DEFAULT_PORT,
+    context_length: int | None = None,
+    threads: int | None = None,
+    gpu_layers: int | None = None,
+) -> list[str]:
+    """Build the llama-server argument list from the given parameters.
+
+    Kept as a module-level function so command construction can be unit-tested
+    without touching the process or file system.
+    """
+    cmd: list[str] = [
+        executable,
+        "--model", model_path,
+        "--host", host,
+        "--port", str(port),
+    ]
+    if context_length is not None:
+        cmd.extend(["--ctx-size", str(context_length)])
+    if threads is not None:
+        cmd.extend(["--threads", str(threads)])
+    if gpu_layers is not None:
+        cmd.extend(["--n-gpu-layers", str(gpu_layers)])
+    return cmd
+
+
+def find_executable() -> str | None:
+    """Return the path to llama-server if found in PATH, else None."""
+    return shutil.which("llama-server") or shutil.which("llama_server")
+
+
+def _is_port_in_use(host: str, port: int) -> bool:
+    """Return True if something is already listening on host:port."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(0.5)
+        return sock.connect_ex((host, port)) == 0
+
+
+async def _wait_for_ready(
+    process: asyncio.subprocess.Process,
+    health_url: str,
+    timeout: float,
+    log_path: Path,
+) -> None:
+    """Poll health_url until 200 OK, or raise on process crash or timeout."""
+    import httpx
+
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    last_error: Exception | None = None
+
+    while loop.time() < deadline:
+        if process.returncode is not None:
+            raise RuntimeError(
+                f"llama-server exited early (code {process.returncode}). "
+                f"Check log: {log_path}"
+            )
+
+        try:
+            async with httpx.AsyncClient(timeout=2.0) as client:
+                resp = await client.get(health_url)
+                if resp.status_code == 200:
+                    return
+                # 503 = model still loading; keep polling
+        except (httpx.ConnectError, httpx.TimeoutException) as exc:
+            last_error = exc
+
+        await asyncio.sleep(_HEALTH_POLL_INTERVAL)
+
+    raise TimeoutError(
+        f"llama-server did not become ready within {timeout}s. "
+        f"Last error: {last_error}. Check log: {log_path}"
+    )
+
+
+class LlamaCppSidecar:
+    """Owns the lifecycle of a single managed llama-server child process.
+
+    One instance lives on ``app.state.sidecar`` for the duration of the
+    server process. External llama.cpp users never call start(); the
+    LlamaCppRuntime HTTP adapter connects directly to their server.
+    """
+
+    def __init__(self, log_dir: str) -> None:
+        self._log_dir = Path(log_dir)
+        self._log_path = self._log_dir / "runtime.log"
+        self._log_fh: IO[bytes] | None = None
+        self._process: asyncio.subprocess.Process | None = None
+        self._state = SidecarState.STOPPED
+        self._error: str | None = None
+        self._model_path: str | None = None
+        self._host: str = _DEFAULT_HOST
+        self._port: int = _DEFAULT_PORT
+        self._started_at: str | None = None
+
+    async def start(
+        self,
+        model_path: str,
+        *,
+        executable: str | None = None,
+        host: str = _DEFAULT_HOST,
+        port: int = _DEFAULT_PORT,
+        context_length: int | None = None,
+        threads: int | None = None,
+        gpu_layers: int | None = None,
+        startup_timeout: float = _STARTUP_TIMEOUT,
+    ) -> None:
+        """Launch llama-server and block until the /health endpoint is ready.
+
+        Raises RuntimeError on port conflict, missing executable, or startup
+        failure. Raises TimeoutError if startup_timeout elapses before /health
+        returns 200.
+        """
+        if self._state == SidecarState.RUNNING:
+            return
+
+        exe = executable or find_executable()
+        if exe is None:
+            raise RuntimeError(
+                "llama-server executable not found in PATH. "
+                "Install llama.cpp or set the 'executable' field in the request."
+            )
+
+        if _is_port_in_use(host, port):
+            self._state = SidecarState.PORT_CONFLICT
+            self._error = (
+                f"Port {port} on {host} is already in use. "
+                "Stop the existing process or configure a different port."
+            )
+            raise RuntimeError(self._error)
+
+        cmd = build_command(
+            exe, model_path,
+            host=host, port=port,
+            context_length=context_length,
+            threads=threads,
+            gpu_layers=gpu_layers,
+        )
+
+        self._log_dir.mkdir(parents=True, exist_ok=True)
+        self._log_path = self._log_dir / "runtime.log"
+        log_fh: IO[bytes] = open(self._log_path, "ab")  # noqa: WPS515
+        self._log_fh = log_fh
+
+        self._state = SidecarState.STARTING
+        self._error = None
+        self._model_path = model_path
+        self._host = host
+        self._port = port
+        self._started_at = datetime.now(timezone.utc).isoformat()
+
+        header = (
+            f"\n--- llama-server start {self._started_at} ---\n"
+            f"cmd: {' '.join(cmd)}\n"
+        ).encode()
+        log_fh.write(header)
+        log_fh.flush()
+
+        try:
+            self._process = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=log_fh,
+                stderr=subprocess.STDOUT,
+            )
+        except (FileNotFoundError, PermissionError) as exc:
+            self._state = SidecarState.CRASHED
+            self._error = f"Failed to start llama-server: {exc}"
+            self._close_log()
+            raise RuntimeError(self._error) from exc
+
+        health_url = f"http://{host}:{port}/health"
+        try:
+            await _wait_for_ready(self._process, health_url, startup_timeout, self._log_path)
+        except Exception as exc:
+            self._state = SidecarState.CRASHED
+            self._error = str(exc)
+            await self._terminate_process()
+            self._close_log()
+            raise
+
+        self._state = SidecarState.RUNNING
+
+    async def stop(self) -> None:
+        """Terminate the managed process and release resources."""
+        if self._state not in (SidecarState.RUNNING, SidecarState.STARTING):
+            self._state = SidecarState.STOPPED
+            return
+        await self._terminate_process()
+        self._close_log()
+        self._state = SidecarState.STOPPED
+        self._started_at = None
+
+    @property
+    def state(self) -> SidecarState:
+        """Current sidecar state; detects crash by polling process returncode."""
+        if (
+            self._state == SidecarState.RUNNING
+            and self._process is not None
+            and self._process.returncode is not None
+        ):
+            self._state = SidecarState.CRASHED
+            self._error = (
+                f"llama-server exited unexpectedly with code {self._process.returncode}. "
+                f"Check log: {self._log_path}"
+            )
+        return self._state
+
+    def get_status(self) -> dict:
+        """Return a serialisable snapshot of the current sidecar state."""
+        current_state = self.state
+        return {
+            "state": current_state.value,
+            "pid": (
+                self._process.pid
+                if self._process is not None and current_state == SidecarState.RUNNING
+                else None
+            ),
+            "model_path": self._model_path,
+            "error": self._error,
+            "log_path": str(self._log_path),
+            "host": self._host,
+            "port": self._port,
+            "started_at": self._started_at,
+        }
+
+    async def _terminate_process(self) -> None:
+        if self._process is None:
+            return
+        try:
+            self._process.terminate()
+            try:
+                await asyncio.wait_for(self._process.wait(), timeout=_TERMINATE_TIMEOUT)
+            except asyncio.TimeoutError:
+                self._process.kill()
+                await self._process.wait()
+        except ProcessLookupError:
+            pass
+        self._process = None
+
+    def _close_log(self) -> None:
+        if self._log_fh is not None:
+            try:
+                self._log_fh.close()
+            except OSError:
+                pass
+            self._log_fh = None

--- a/services/convsim-core/convsim_core/runtime/sidecar.py
+++ b/services/convsim-core/convsim_core/runtime/sidecar.py
@@ -86,6 +86,7 @@ async def _wait_for_ready(
     loop = asyncio.get_running_loop()
     deadline = loop.time() + timeout
     last_error: Exception | None = None
+    last_status: int | None = None
 
     while loop.time() < deadline:
         if process.returncode is not None:
@@ -100,14 +101,23 @@ async def _wait_for_ready(
                 if resp.status_code == 200:
                     return
                 # 503 = model still loading; keep polling
+                last_status = resp.status_code
+                last_error = None
         except httpx.TransportError as exc:
             last_error = exc
+            last_status = None
 
         await asyncio.sleep(_HEALTH_POLL_INTERVAL)
 
+    if last_error is not None:
+        detail = f"Last error: {last_error}"
+    elif last_status is not None:
+        detail = f"Last HTTP status: {last_status} (server may still be loading the model)"
+    else:
+        detail = "no response received"
     raise TimeoutError(
         f"llama-server did not become ready within {timeout}s. "
-        f"Last error: {last_error}. Check log: {log_path}"
+        f"{detail}. Check log: {log_path}"
     )
 
 

--- a/services/convsim-core/convsim_core/runtime/sidecar.py
+++ b/services/convsim-core/convsim_core/runtime/sidecar.py
@@ -177,7 +177,12 @@ class LlamaCppSidecar:
 
         self._log_dir.mkdir(parents=True, exist_ok=True)
         self._log_path = self._log_dir / "runtime.log"
-        log_fh: IO[bytes] = open(self._log_path, "ab")  # noqa: WPS515
+        try:
+            log_fh: IO[bytes] = open(self._log_path, "ab")  # noqa: WPS515
+        except OSError as exc:
+            self._state = SidecarState.CRASHED
+            self._error = f"Failed to open log file {self._log_path}: {exc}"
+            raise RuntimeError(self._error) from exc
         self._log_fh = log_fh
 
         self._state = SidecarState.STARTING

--- a/services/convsim-core/convsim_core/runtime/sidecar.py
+++ b/services/convsim-core/convsim_core/runtime/sidecar.py
@@ -200,7 +200,7 @@ class LlamaCppSidecar:
                 stdout=log_fh,
                 stderr=subprocess.STDOUT,
             )
-        except (FileNotFoundError, PermissionError) as exc:
+        except OSError as exc:
             self._state = SidecarState.CRASHED
             self._error = f"Failed to start llama-server: {exc}"
             self._close_log()

--- a/services/convsim-core/convsim_core/runtime/sidecar.py
+++ b/services/convsim-core/convsim_core/runtime/sidecar.py
@@ -222,6 +222,7 @@ class LlamaCppSidecar:
         """Terminate the managed process and release resources."""
         if self._state not in (SidecarState.RUNNING, SidecarState.STARTING):
             self._state = SidecarState.STOPPED
+            self._started_at = None
             return
         await self._terminate_process()
         self._close_log()

--- a/services/convsim-core/convsim_core/runtime/sidecar.py
+++ b/services/convsim-core/convsim_core/runtime/sidecar.py
@@ -149,7 +149,7 @@ class LlamaCppSidecar:
         failure. Raises TimeoutError if startup_timeout elapses before /health
         returns 200.
         """
-        if self.state == SidecarState.RUNNING:
+        if self.state in (SidecarState.RUNNING, SidecarState.STARTING):
             return
 
         exe = executable or find_executable()

--- a/services/convsim-core/convsim_core/runtime/sidecar.py
+++ b/services/convsim-core/convsim_core/runtime/sidecar.py
@@ -237,11 +237,13 @@ class LlamaCppSidecar:
         """Terminate the managed process and release resources."""
         if self._state not in (SidecarState.RUNNING, SidecarState.STARTING):
             self._state = SidecarState.STOPPED
+            self._error = None
             self._started_at = None
             return
         await self._terminate_process()
         self._close_log()
         self._state = SidecarState.STOPPED
+        self._error = None
         self._started_at = None
 
     @property

--- a/services/convsim-core/convsim_core/runtime/sidecar.py
+++ b/services/convsim-core/convsim_core/runtime/sidecar.py
@@ -100,7 +100,7 @@ async def _wait_for_ready(
                 if resp.status_code == 200:
                     return
                 # 503 = model still loading; keep polling
-        except (httpx.ConnectError, httpx.TimeoutException) as exc:
+        except httpx.TransportError as exc:
             last_error = exc
 
         await asyncio.sleep(_HEALTH_POLL_INTERVAL)

--- a/services/convsim-core/convsim_core/runtime/sidecar.py
+++ b/services/convsim-core/convsim_core/runtime/sidecar.py
@@ -149,7 +149,7 @@ class LlamaCppSidecar:
         failure. Raises TimeoutError if startup_timeout elapses before /health
         returns 200.
         """
-        if self._state == SidecarState.RUNNING:
+        if self.state == SidecarState.RUNNING:
             return
 
         exe = executable or find_executable()
@@ -241,6 +241,7 @@ class LlamaCppSidecar:
                 f"llama-server exited unexpectedly with code {self._process.returncode}. "
                 f"Check log: {self._log_path}"
             )
+            self._close_log()
         return self._state
 
     def get_status(self) -> dict:

--- a/services/convsim-core/tests/test_sidecar.py
+++ b/services/convsim-core/tests/test_sidecar.py
@@ -291,12 +291,14 @@ def test_sidecar_stop_when_crashed_returns_stopped(client):
     assert status["state"] == "stopped"
     assert status["started_at"] is None
     assert status["error"] is None
+    assert status["model_path"] is None
 
 
 def test_sidecar_stop_when_port_conflict_returns_stopped(client):
     """POST /api/sidecar/stop must return state=stopped and clear error for PORT_CONFLICT."""
     client.app.state.sidecar._state = SidecarState.PORT_CONFLICT
     client.app.state.sidecar._error = "Port 7356 on 127.0.0.1 is already in use."
+    client.app.state.sidecar._model_path = "/some/model.gguf"
 
     resp = client.post("/api/sidecar/stop")
     assert resp.status_code == 200
@@ -304,6 +306,7 @@ def test_sidecar_stop_when_port_conflict_returns_stopped(client):
 
     status = client.get("/api/sidecar/status").json()
     assert status["error"] is None
+    assert status["model_path"] is None
 
 
 def test_sidecar_start_missing_executable_returns_503(client):
@@ -518,7 +521,45 @@ async def test_start_and_stop_with_fake_executable(tmp_path):
     await sidecar.stop()
 
     assert sidecar.state == SidecarState.STOPPED
-    assert sidecar.get_status()["pid"] is None
+    status = sidecar.get_status()
+    assert status["pid"] is None
+    assert status["model_path"] is None
+    assert status["error"] is None
+    assert status["started_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_stop_clears_model_path_after_crash(tmp_path):
+    """stop() must clear model_path regardless of whether the sidecar crashed.
+
+    The state property transitions _state to CRASHED but does not touch
+    _model_path. stop() must clear it so that GET /api/sidecar/status returns
+    model_path=null after the sidecar is stopped, not the stale path.
+    Also verifies that _process is set to None (resource cleanup).
+    """
+    import signal
+
+    exe = _write_fake_server(tmp_path)
+    port = _free_port()
+    sidecar = LlamaCppSidecar(log_dir=str(tmp_path / "logs"))
+
+    await sidecar.start("crash-model.gguf", executable=exe, port=port, startup_timeout=15.0)
+    assert sidecar.state == SidecarState.RUNNING
+
+    # Kill externally to trigger spontaneous crash, then read .state so the
+    # property updates _state = CRASHED (the early-return path in stop()).
+    os.kill(sidecar.get_status()["pid"], signal.SIGKILL)
+    await asyncio.sleep(0.3)
+    assert sidecar.state == SidecarState.CRASHED
+
+    await sidecar.stop()
+
+    assert sidecar.state == SidecarState.STOPPED
+    status = sidecar.get_status()
+    assert status["model_path"] is None
+    assert status["error"] is None
+    assert status["started_at"] is None
+    assert sidecar._process is None
 
 
 @pytest.mark.asyncio

--- a/services/convsim-core/tests/test_sidecar.py
+++ b/services/convsim-core/tests/test_sidecar.py
@@ -249,6 +249,34 @@ def test_sidecar_start_timeout_returns_503(client):
     assert resp.json()["error"]["code"] == "SIDECAR_START_FAILED"
 
 
+def test_sidecar_start_returns_409_when_already_running(client):
+    """POST /api/sidecar/start must return 409 if the sidecar is RUNNING."""
+    client.app.state.sidecar._state = SidecarState.RUNNING
+
+    resp = client.post(
+        "/api/sidecar/start",
+        json={"model_path": "/path/to/model.gguf"},
+    )
+    assert resp.status_code == 409
+    assert resp.json()["error"]["code"] == "SIDECAR_ALREADY_RUNNING"
+
+
+def test_sidecar_start_returns_409_when_starting(client):
+    """POST /api/sidecar/start must return 409 if the sidecar is still STARTING.
+
+    Without this guard, a second concurrent request would slip through the RUNNING
+    check, spawn a second process, and overwrite the open log file handle.
+    """
+    client.app.state.sidecar._state = SidecarState.STARTING
+
+    resp = client.post(
+        "/api/sidecar/start",
+        json={"model_path": "/path/to/model.gguf"},
+    )
+    assert resp.status_code == 409
+    assert resp.json()["error"]["code"] == "SIDECAR_ALREADY_RUNNING"
+
+
 # ---------------------------------------------------------------------------
 # Integration test — real fake executable
 # ---------------------------------------------------------------------------

--- a/services/convsim-core/tests/test_sidecar.py
+++ b/services/convsim-core/tests/test_sidecar.py
@@ -208,6 +208,30 @@ async def test_start_raises_on_generic_oserror(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_start_raises_on_log_open_oserror(tmp_path):
+    """OSError from opening the log file must produce state=CRASHED and RuntimeError.
+
+    open(log_path, "ab") can fail with PermissionError, EMFILE, or similar.
+    Before the fix these propagated as raw OSError, bypassing the router's
+    (RuntimeError, TimeoutError) handler and returning 500 instead of 503.
+    """
+    from unittest.mock import patch
+
+    sidecar = LlamaCppSidecar(log_dir=str(tmp_path / "logs"))
+
+    with patch("builtins.open", side_effect=OSError(13, "Permission denied")):
+        with pytest.raises(RuntimeError, match="Failed to open log file"):
+            await sidecar.start(
+                "fake.gguf",
+                executable="/bin/true",
+                port=_free_port(),
+            )
+
+    assert sidecar.state == SidecarState.CRASHED
+    assert sidecar._log_fh is None
+
+
+@pytest.mark.asyncio
 async def test_stop_when_not_running_is_noop(tmp_path):
     sidecar = LlamaCppSidecar(log_dir=str(tmp_path / "logs"))
     await sidecar.stop()  # must not raise

--- a/services/convsim-core/tests/test_sidecar.py
+++ b/services/convsim-core/tests/test_sidecar.py
@@ -357,6 +357,52 @@ def _write_fake_server(tmp_path: Path) -> str:
 
 
 @pytest.mark.asyncio
+async def test_wait_for_ready_retries_on_read_error(tmp_path):
+    """_wait_for_ready must retry on ReadError, not raise an unhandled exception.
+
+    ConnectError and TimeoutException were already caught. ReadError (connection
+    reset mid-response) and RemoteProtocolError were not, which would have
+    propagated through start() as a non-RuntimeError/TimeoutError type, bypassing
+    the router's exception handler and producing a 500 instead of 503.
+    Catching httpx.TransportError covers all transport-layer failures.
+    """
+    import httpx
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from convsim_core.runtime.sidecar import _wait_for_ready
+
+    fake_process = MagicMock()
+    fake_process.returncode = None
+
+    call_count = 0
+
+    async def _raise_read_error(*_a, **_kw):
+        nonlocal call_count
+        call_count += 1
+        raise httpx.ReadError("connection reset by peer")
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    mock_client.get = _raise_read_error
+
+    # timeout=1.5s, poll_interval=0.5s → at least 2 calls before deadline
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        with pytest.raises(TimeoutError):
+            await _wait_for_ready(
+                fake_process,
+                "http://127.0.0.1:9999/health",
+                timeout=1.5,
+                log_path=tmp_path / "runtime.log",
+            )
+
+    # Must have retried at least twice — if ReadError propagated immediately there
+    # would be exactly 1 call and the assertion above would be a RuntimeError, not
+    # a TimeoutError.
+    assert call_count >= 2
+
+
+@pytest.mark.asyncio
 async def test_start_and_stop_with_fake_executable(tmp_path):
     exe = _write_fake_server(tmp_path)
     port = _free_port()

--- a/services/convsim-core/tests/test_sidecar.py
+++ b/services/convsim-core/tests/test_sidecar.py
@@ -1,0 +1,350 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the llama-server sidecar process manager.
+
+Unit tests cover command construction and state logic without spawning processes.
+The integration test at the bottom spawns a real fake executable written to a
+temp directory; it is marked asyncio and relies on a free port found at runtime.
+"""
+from __future__ import annotations
+
+import os
+import socket
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from convsim_core.runtime.sidecar import (
+    LlamaCppSidecar,
+    SidecarState,
+    _is_port_in_use,
+    build_command,
+    find_executable,
+)
+
+
+# ---------------------------------------------------------------------------
+# build_command — pure unit tests, no I/O
+# ---------------------------------------------------------------------------
+
+
+def test_build_command_minimal():
+    cmd = build_command("/usr/bin/llama-server", "/models/foo.gguf")
+    assert cmd[0] == "/usr/bin/llama-server"
+    assert "--model" in cmd
+    assert "/models/foo.gguf" in cmd
+    assert "--host" in cmd
+    assert "127.0.0.1" in cmd
+    assert "--port" in cmd
+    assert "7356" in cmd
+
+
+def test_build_command_custom_host_port():
+    cmd = build_command("/bin/llama-server", "model.gguf", host="0.0.0.0", port=9999)
+    assert "0.0.0.0" in cmd
+    assert "9999" in cmd
+
+
+def test_build_command_context_length():
+    cmd = build_command("/bin/llama-server", "m.gguf", context_length=8192)
+    idx = cmd.index("--ctx-size")
+    assert cmd[idx + 1] == "8192"
+
+
+def test_build_command_threads():
+    cmd = build_command("/bin/llama-server", "m.gguf", threads=4)
+    idx = cmd.index("--threads")
+    assert cmd[idx + 1] == "4"
+
+
+def test_build_command_gpu_layers():
+    cmd = build_command("/bin/llama-server", "m.gguf", gpu_layers=32)
+    idx = cmd.index("--n-gpu-layers")
+    assert cmd[idx + 1] == "32"
+
+
+def test_build_command_all_options():
+    cmd = build_command(
+        "/bin/llama-server", "m.gguf",
+        host="127.0.0.1", port=7356,
+        context_length=4096, threads=8, gpu_layers=0,
+    )
+    assert "--ctx-size" in cmd
+    assert "--threads" in cmd
+    assert "--n-gpu-layers" in cmd
+    assert "4096" in cmd
+    assert "8" in cmd
+    assert "0" in cmd
+
+
+def test_build_command_omits_optional_flags_when_none():
+    cmd = build_command("/bin/llama-server", "m.gguf")
+    assert "--ctx-size" not in cmd
+    assert "--threads" not in cmd
+    assert "--n-gpu-layers" not in cmd
+
+
+def test_build_command_port_is_string_not_int():
+    cmd = build_command("/bin/llama-server", "m.gguf", port=7356)
+    port_idx = cmd.index("--port")
+    assert isinstance(cmd[port_idx + 1], str)
+
+
+# ---------------------------------------------------------------------------
+# Initial state
+# ---------------------------------------------------------------------------
+
+
+def test_initial_state_is_stopped(tmp_path):
+    sidecar = LlamaCppSidecar(log_dir=str(tmp_path / "logs"))
+    assert sidecar.state == SidecarState.STOPPED
+
+
+def test_get_status_initial_fields(tmp_path):
+    sidecar = LlamaCppSidecar(log_dir=str(tmp_path / "logs"))
+    status = sidecar.get_status()
+    assert status["state"] == "stopped"
+    assert status["pid"] is None
+    assert status["model_path"] is None
+    assert status["error"] is None
+    assert status["started_at"] is None
+    assert "127.0.0.1" == status["host"]
+    assert 7356 == status["port"]
+
+
+# ---------------------------------------------------------------------------
+# Port conflict detection
+# ---------------------------------------------------------------------------
+
+
+def test_is_port_in_use_free_port():
+    # A port we just discovered to be free should report as not in use
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        port = s.getsockname()[1]
+    # Port is now closed; should be free
+    assert not _is_port_in_use("127.0.0.1", port)
+
+
+def test_is_port_in_use_occupied_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        s.bind(("127.0.0.1", 0))
+        s.listen(1)
+        port = s.getsockname()[1]
+        assert _is_port_in_use("127.0.0.1", port)
+
+
+@pytest.mark.asyncio
+async def test_start_raises_on_port_conflict(tmp_path):
+    sidecar = LlamaCppSidecar(log_dir=str(tmp_path / "logs"))
+    # Bind a real socket to occupy the port
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        s.bind(("127.0.0.1", 0))
+        s.listen(1)
+        occupied_port = s.getsockname()[1]
+
+        with pytest.raises(RuntimeError, match="already in use"):
+            await sidecar.start(
+                "fake.gguf",
+                executable="/bin/true",
+                port=occupied_port,
+            )
+
+    assert sidecar.state == SidecarState.PORT_CONFLICT
+    assert sidecar.get_status()["error"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Missing executable
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_raises_when_executable_missing(tmp_path):
+    sidecar = LlamaCppSidecar(log_dir=str(tmp_path / "logs"))
+    with pytest.raises(RuntimeError, match="Failed to start"):
+        await sidecar.start(
+            "fake.gguf",
+            executable="/nonexistent/llama-server",
+            port=_free_port(),
+            startup_timeout=2.0,
+        )
+    assert sidecar.state == SidecarState.CRASHED
+
+
+# ---------------------------------------------------------------------------
+# Stop when already stopped
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stop_when_not_running_is_noop(tmp_path):
+    sidecar = LlamaCppSidecar(log_dir=str(tmp_path / "logs"))
+    await sidecar.stop()  # must not raise
+    assert sidecar.state == SidecarState.STOPPED
+
+
+# ---------------------------------------------------------------------------
+# find_executable — smoke test (may return None in CI)
+# ---------------------------------------------------------------------------
+
+
+def test_find_executable_returns_none_or_str():
+    result = find_executable()
+    assert result is None or isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# API endpoint tests via TestClient
+# ---------------------------------------------------------------------------
+
+
+def test_sidecar_status_endpoint_initial(client):
+    resp = client.get("/api/sidecar/status")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["state"] == "stopped"
+    assert data["pid"] is None
+    assert "log_path" in data
+
+
+def test_sidecar_stop_when_not_running_returns_200(client):
+    resp = client.post("/api/sidecar/stop")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["state"] == "stopped"
+    assert "No managed" in data["message"]
+
+
+def test_sidecar_start_missing_executable_returns_503(client):
+    resp = client.post(
+        "/api/sidecar/start",
+        json={
+            "model_path": "/nonexistent/model.gguf",
+            "executable": "/nonexistent/llama-server",
+            "startup_timeout": 2.0,
+        },
+    )
+    assert resp.status_code == 503
+    body = resp.json()
+    assert body["error"]["code"] == "SIDECAR_START_FAILED"
+
+
+# ---------------------------------------------------------------------------
+# Integration test — real fake executable
+# ---------------------------------------------------------------------------
+
+
+_FAKE_LLAMA_SERVER = textwrap.dedent("""\
+    #!/usr/bin/env python3
+    \"\"\"Minimal fake llama-server for sidecar integration testing.\"\"\"
+    import http.server
+    import sys
+
+    port = 7356
+    args = sys.argv[1:]
+    for i, arg in enumerate(args):
+        if arg == "--port" and i + 1 < len(args):
+            port = int(args[i + 1])
+            break
+
+    class _H(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            if self.path == "/health":
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(b'{"status":"ok"}')
+            else:
+                self.send_response(404)
+                self.end_headers()
+        def log_message(self, *_a, **_kw):
+            pass
+
+    with http.server.HTTPServer(("127.0.0.1", port), _H) as srv:
+        srv.serve_forever()
+""")
+
+
+def _free_port() -> int:
+    """Return a currently free TCP port on loopback."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _write_fake_server(tmp_path: Path) -> str:
+    """Write the fake llama-server script and return its path."""
+    exe = tmp_path / "fake-llama-server"
+    exe.write_text(_FAKE_LLAMA_SERVER)
+    exe.chmod(0o755)
+    return str(exe)
+
+
+@pytest.mark.asyncio
+async def test_start_and_stop_with_fake_executable(tmp_path):
+    exe = _write_fake_server(tmp_path)
+    port = _free_port()
+    sidecar = LlamaCppSidecar(log_dir=str(tmp_path / "logs"))
+
+    await sidecar.start(
+        "fake-model.gguf",
+        executable=exe,
+        port=port,
+        startup_timeout=15.0,
+    )
+
+    assert sidecar.state == SidecarState.RUNNING
+    status = sidecar.get_status()
+    assert status["pid"] is not None
+    assert status["model_path"] == "fake-model.gguf"
+    assert status["port"] == port
+    assert status["error"] is None
+    log_path = Path(status["log_path"])
+    assert log_path.exists()
+
+    await sidecar.stop()
+
+    assert sidecar.state == SidecarState.STOPPED
+    assert sidecar.get_status()["pid"] is None
+
+
+@pytest.mark.asyncio
+async def test_start_crash_detected_on_immediate_exit(tmp_path):
+    crasher = tmp_path / "crash-server"
+    crasher.write_text("#!/usr/bin/env python3\nimport sys\nsys.exit(1)\n")
+    crasher.chmod(0o755)
+
+    port = _free_port()
+    sidecar = LlamaCppSidecar(log_dir=str(tmp_path / "logs"))
+
+    with pytest.raises(Exception):
+        await sidecar.start(
+            "m.gguf",
+            executable=str(crasher),
+            port=port,
+            startup_timeout=5.0,
+        )
+
+    assert sidecar.state == SidecarState.CRASHED
+    assert sidecar.get_status()["error"] is not None
+
+
+@pytest.mark.asyncio
+async def test_start_twice_when_already_running_is_noop(tmp_path):
+    exe = _write_fake_server(tmp_path)
+    port = _free_port()
+    sidecar = LlamaCppSidecar(log_dir=str(tmp_path / "logs"))
+
+    await sidecar.start("fake.gguf", executable=exe, port=port, startup_timeout=15.0)
+    assert sidecar.state == SidecarState.RUNNING
+    pid_before = sidecar.get_status()["pid"]
+
+    # Second call should be a no-op (same process)
+    await sidecar.start("other.gguf", executable=exe, port=port, startup_timeout=15.0)
+    assert sidecar.get_status()["pid"] == pid_before
+
+    await sidecar.stop()

--- a/services/convsim-core/tests/test_sidecar.py
+++ b/services/convsim-core/tests/test_sidecar.py
@@ -271,13 +271,15 @@ def test_sidecar_stop_when_not_running_returns_200(client):
 
 
 def test_sidecar_stop_when_crashed_returns_stopped(client):
-    """POST /api/sidecar/stop must return state=stopped even when sidecar has crashed.
+    """POST /api/sidecar/stop must return state=stopped and clear error when sidecar crashed.
 
-    Without this, the endpoint returned state="crashed" — contradicting the
-    "No managed llama-server is running" message and leaving the sidecar in a
-    non-STOPPED state that prevented clean status queries.
+    Without the state fix, the endpoint returned state="crashed" — contradicting
+    the "No managed llama-server is running" message.
+    Without the error fix, GET /api/sidecar/status would still report the crash
+    error message after stop, which is confusing when state=stopped.
     """
     client.app.state.sidecar._state = SidecarState.CRASHED
+    client.app.state.sidecar._error = "llama-server exited unexpectedly with code 1."
 
     resp = client.post("/api/sidecar/stop")
     assert resp.status_code == 200
@@ -288,15 +290,20 @@ def test_sidecar_stop_when_crashed_returns_stopped(client):
     status = client.get("/api/sidecar/status").json()
     assert status["state"] == "stopped"
     assert status["started_at"] is None
+    assert status["error"] is None
 
 
 def test_sidecar_stop_when_port_conflict_returns_stopped(client):
-    """POST /api/sidecar/stop must return state=stopped for PORT_CONFLICT state."""
+    """POST /api/sidecar/stop must return state=stopped and clear error for PORT_CONFLICT."""
     client.app.state.sidecar._state = SidecarState.PORT_CONFLICT
+    client.app.state.sidecar._error = "Port 7356 on 127.0.0.1 is already in use."
 
     resp = client.post("/api/sidecar/stop")
     assert resp.status_code == 200
     assert resp.json()["state"] == "stopped"
+
+    status = client.get("/api/sidecar/status").json()
+    assert status["error"] is None
 
 
 def test_sidecar_start_missing_executable_returns_503(client):

--- a/services/convsim-core/tests/test_sidecar.py
+++ b/services/convsim-core/tests/test_sidecar.py
@@ -578,3 +578,78 @@ async def test_log_file_closed_after_spontaneous_crash(tmp_path):
     assert sidecar.state == SidecarState.CRASHED
     assert sidecar._log_fh is None
     assert log_fh.closed
+
+
+# ---------------------------------------------------------------------------
+# No executable in PATH (executable=None, find_executable returns None)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_raises_when_no_executable_in_path(tmp_path):
+    """start() with executable=None and nothing in PATH must raise RuntimeError.
+
+    This exercises the find_executable() → None → RuntimeError("not found in PATH")
+    path, which is distinct from the explicit-bad-path path (FileNotFoundError from
+    create_subprocess_exec). State must remain STOPPED since no state changes happen
+    before this early-return error.
+    """
+    from unittest.mock import patch
+
+    sidecar = LlamaCppSidecar(log_dir=str(tmp_path / "logs"))
+
+    with patch("convsim_core.runtime.sidecar.find_executable", return_value=None):
+        with pytest.raises(RuntimeError, match="executable not found in PATH"):
+            await sidecar.start("fake.gguf", port=_free_port())
+
+    # No state change — sidecar was never touched
+    assert sidecar.state == SidecarState.STOPPED
+    assert sidecar._log_fh is None
+
+
+# ---------------------------------------------------------------------------
+# Timeout message includes HTTP status when server returns non-200 responses
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_wait_for_ready_timeout_message_includes_http_status(tmp_path):
+    """Timeout message must report last HTTP status, not 'Last error: None'.
+
+    When llama-server starts but keeps returning HTTP 503 (model still loading)
+    and the startup timeout elapses, the old code produced:
+        'Last error: None. Check log: ...'
+    which is not actionable. The fixed code must include the HTTP status code
+    so users know the server was reachable but still loading.
+    """
+    import httpx
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from convsim_core.runtime.sidecar import _wait_for_ready
+
+    fake_process = MagicMock()
+    fake_process.returncode = None
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 503
+
+    async def _return_503(*_a, **_kw):
+        return mock_resp
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    mock_client.get = _return_503
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        with pytest.raises(TimeoutError) as exc_info:
+            await _wait_for_ready(
+                fake_process,
+                "http://127.0.0.1:9999/health",
+                timeout=1.2,
+                log_path=tmp_path / "runtime.log",
+            )
+
+    assert "503" in str(exc_info.value), (
+        "Timeout message should include the last HTTP status (503), not 'Last error: None'"
+    )

--- a/services/convsim-core/tests/test_sidecar.py
+++ b/services/convsim-core/tests/test_sidecar.py
@@ -363,6 +363,39 @@ def test_sidecar_start_returns_409_when_starting(client):
     assert resp.json()["error"]["code"] == "SIDECAR_ALREADY_RUNNING"
 
 
+def test_sidecar_start_forwards_custom_host_and_port(client):
+    """POST /api/sidecar/start must forward host and port to sidecar.start().
+
+    The port-conflict error message tells users to "configure a different port",
+    so the API must actually accept host/port fields and forward them.
+    """
+    from unittest.mock import AsyncMock, patch
+
+    captured = {}
+
+    async def _mock_start(model_path, *, host, port, **kwargs):
+        captured["host"] = host
+        captured["port"] = port
+
+    with patch.object(client.app.state.sidecar, "start", _mock_start):
+        with patch.object(
+            client.app.state.sidecar, "get_status",
+            return_value={
+                "state": "running", "pid": 42, "model_path": "/m.gguf",
+                "log_path": "/tmp/runtime.log", "host": "0.0.0.0", "port": 9000,
+                "error": None, "started_at": "2026-01-01T00:00:00+00:00",
+            },
+        ):
+            resp = client.post(
+                "/api/sidecar/start",
+                json={"model_path": "/m.gguf", "host": "0.0.0.0", "port": 9000},
+            )
+
+    assert resp.status_code == 200
+    assert captured["host"] == "0.0.0.0"
+    assert captured["port"] == 9000
+
+
 # ---------------------------------------------------------------------------
 # Integration test — real fake executable
 # ---------------------------------------------------------------------------

--- a/services/convsim-core/tests/test_sidecar.py
+++ b/services/convsim-core/tests/test_sidecar.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import asyncio
 import os
 import socket
-import sys
 import textwrap
 from pathlib import Path
 
@@ -218,6 +217,35 @@ def test_sidecar_stop_when_not_running_returns_200(client):
     data = resp.json()
     assert data["state"] == "stopped"
     assert "No managed" in data["message"]
+
+
+def test_sidecar_stop_when_crashed_returns_stopped(client):
+    """POST /api/sidecar/stop must return state=stopped even when sidecar has crashed.
+
+    Without this, the endpoint returned state="crashed" — contradicting the
+    "No managed llama-server is running" message and leaving the sidecar in a
+    non-STOPPED state that prevented clean status queries.
+    """
+    client.app.state.sidecar._state = SidecarState.CRASHED
+
+    resp = client.post("/api/sidecar/stop")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["state"] == "stopped"
+    assert "No managed" in data["message"]
+
+    status = client.get("/api/sidecar/status").json()
+    assert status["state"] == "stopped"
+    assert status["started_at"] is None
+
+
+def test_sidecar_stop_when_port_conflict_returns_stopped(client):
+    """POST /api/sidecar/stop must return state=stopped for PORT_CONFLICT state."""
+    client.app.state.sidecar._state = SidecarState.PORT_CONFLICT
+
+    resp = client.post("/api/sidecar/stop")
+    assert resp.status_code == 200
+    assert resp.json()["state"] == "stopped"
 
 
 def test_sidecar_start_missing_executable_returns_503(client):

--- a/services/convsim-core/tests/test_sidecar.py
+++ b/services/convsim-core/tests/test_sidecar.py
@@ -181,6 +181,33 @@ async def test_start_raises_when_executable_missing(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_start_raises_on_generic_oserror(tmp_path):
+    """Any OSError from create_subprocess_exec must leave state=CRASHED, not STARTING.
+
+    FileNotFoundError and PermissionError were already handled; other OSError
+    subclasses (e.g. EMFILE — too many open files) were not caught, which left
+    _state=STARTING with an open log handle and caused 500 instead of 503.
+    """
+    from unittest.mock import patch
+
+    sidecar = LlamaCppSidecar(log_dir=str(tmp_path / "logs"))
+
+    async def _raise_emfile(*_a, **_kw):
+        raise OSError(24, "Too many open files")
+
+    with patch("asyncio.create_subprocess_exec", _raise_emfile):
+        with pytest.raises(RuntimeError, match="Failed to start"):
+            await sidecar.start(
+                "fake.gguf",
+                executable="/bin/true",
+                port=_free_port(),
+            )
+
+    assert sidecar.state == SidecarState.CRASHED
+    assert sidecar._log_fh is None  # log handle must be closed, not leaked
+
+
+@pytest.mark.asyncio
 async def test_stop_when_not_running_is_noop(tmp_path):
     sidecar = LlamaCppSidecar(log_dir=str(tmp_path / "logs"))
     await sidecar.stop()  # must not raise

--- a/services/convsim-core/tests/test_sidecar.py
+++ b/services/convsim-core/tests/test_sidecar.py
@@ -233,6 +233,21 @@ def test_sidecar_start_missing_executable_returns_503(client):
     assert body["error"]["code"] == "SIDECAR_START_FAILED"
 
 
+def test_sidecar_start_timeout_returns_503(client):
+    """Startup timeout (TimeoutError, not RuntimeError) must map to 503, not 500."""
+    async def _raise_timeout(*_args, **_kwargs):
+        raise TimeoutError("llama-server did not become ready within 1s")
+
+    client.app.state.sidecar.start = _raise_timeout
+
+    resp = client.post(
+        "/api/sidecar/start",
+        json={"model_path": "/fake/model.gguf", "startup_timeout": 1.0},
+    )
+    assert resp.status_code == 503
+    assert resp.json()["error"]["code"] == "SIDECAR_START_FAILED"
+
+
 # ---------------------------------------------------------------------------
 # Integration test — real fake executable
 # ---------------------------------------------------------------------------

--- a/services/convsim-core/tests/test_sidecar.py
+++ b/services/convsim-core/tests/test_sidecar.py
@@ -7,6 +7,7 @@ temp directory; it is marked asyncio and relies on a free port found at runtime.
 """
 from __future__ import annotations
 
+import asyncio
 import os
 import socket
 import sys
@@ -363,3 +364,64 @@ async def test_start_twice_when_already_running_is_noop(tmp_path):
     assert sidecar.get_status()["pid"] == pid_before
 
     await sidecar.stop()
+
+
+@pytest.mark.asyncio
+async def test_restart_after_spontaneous_crash(tmp_path):
+    """start() must restart a crashed sidecar, not silently no-op.
+
+    Regression test: start() was checking self._state (raw field) instead of
+    self.state (property). A spontaneously crashed process leaves _state as
+    RUNNING until the property is called, so start() would return early without
+    restarting.
+    """
+    import signal
+
+    exe = _write_fake_server(tmp_path)
+    port1 = _free_port()
+    sidecar = LlamaCppSidecar(log_dir=str(tmp_path / "logs"))
+
+    await sidecar.start("fake.gguf", executable=exe, port=port1, startup_timeout=15.0)
+    assert sidecar.state == SidecarState.RUNNING
+    pid = sidecar.get_status()["pid"]
+
+    # Kill the child externally, bypassing stop()
+    os.kill(pid, signal.SIGKILL)
+    await asyncio.sleep(0.3)
+
+    # Calling start() directly (without first reading .state) must detect the
+    # crash via the property and proceed to restart, not silently return.
+    port2 = _free_port()
+    await sidecar.start("fake.gguf", executable=exe, port=port2, startup_timeout=15.0)
+
+    assert sidecar.state == SidecarState.RUNNING
+    assert sidecar.get_status()["pid"] != pid
+
+    await sidecar.stop()
+
+
+@pytest.mark.asyncio
+async def test_log_file_closed_after_spontaneous_crash(tmp_path):
+    """state property must close _log_fh when it detects a crash.
+
+    Regression test: the log file handle was leaked when a process exited
+    spontaneously because _close_log() was only called in the startup-failure
+    path, not in the state property's crash-detection branch.
+    """
+    import signal
+
+    exe = _write_fake_server(tmp_path)
+    port = _free_port()
+    sidecar = LlamaCppSidecar(log_dir=str(tmp_path / "logs"))
+
+    await sidecar.start("fake.gguf", executable=exe, port=port, startup_timeout=15.0)
+    log_fh = sidecar._log_fh
+    assert log_fh is not None
+
+    os.kill(sidecar.get_status()["pid"], signal.SIGKILL)
+    await asyncio.sleep(0.3)
+
+    # Accessing .state triggers crash detection; the log handle must be closed.
+    assert sidecar.state == SidecarState.CRASHED
+    assert sidecar._log_fh is None
+    assert log_fh.closed


### PR DESCRIPTION
## What changed

Implements the llama.cpp runtime sidecar management requested in #52. The app can now launch, health-poll, log, and stop a local `llama-server` child process on behalf of users who do not run an external provider.

### New files

- **`services/convsim-core/convsim_core/runtime/sidecar.py`** — `LlamaCppSidecar` class:
  - `build_command()` pure function constructs the `llama-server` CLI args (testable in isolation)
  - `start()` checks for port conflicts, spawns the subprocess, captures stdout+stderr to `~/.convsim/logs/runtime.log`, and polls `/health` until the server is ready or a configurable timeout elapses
  - `stop()` terminates gracefully (SIGTERM → SIGKILL after 5 s)
  - `state` property detects crashes by polling `process.returncode`
  - Runtime log never contains transcript content

- **`services/convsim-core/convsim_core/routers/sidecar.py`** — three REST endpoints:
  - `POST /api/sidecar/start` — starts the managed sidecar with the specified GGUF path; returns 409 if already running, 503 with actionable messages for port conflicts, missing executable, or startup timeout
  - `POST /api/sidecar/stop` — stops the sidecar; 200 no-op if not running
  - `GET /api/sidecar/status` — returns state, PID, model path, error, log path, host/port

- **`runtimes/llama_cpp/download-runtime.sh`** — platform-aware Bash script that fetches a pre-built `llama-server` binary from the llama.cpp GitHub releases page (Linux x86_64/aarch64, macOS arm64/x86_64; Windows users directed to WSL2 or source build)

- **`services/convsim-core/tests/test_sidecar.py`** — 22 tests:
  - Unit tests for `build_command()` covering all optional flags
  - Port-conflict and missing-executable guard tests
  - API endpoint tests via `TestClient`
  - Integration test that spawns a real fake HTTP server executable and verifies the full start → running → stop lifecycle
  - Crash detection and idempotent re-start tests

### Modified files

- **`services/convsim-core/convsim_core/app.py`** — creates `LlamaCppSidecar` on `app.state.sidecar` in the FastAPI lifespan and stops it cleanly on shutdown; registers the sidecar router
- **`runtimes/llama_cpp/README.md`** — full quickstart (download script, manual install, build from source), sidecar API reference, error table, and external-server guidance

## External-server mode

Users who already run their own `llama-server` skip the sidecar entirely. Selecting `llama_cpp` via `POST /api/models/use` connects the existing `LlamaCppRuntime` HTTP adapter to whichever server is listening on `CONVSIM_LLAMA_CPP_BASE_URL` — no duplicate sidecar is launched.

## How it was tested

- All 22 new sidecar tests pass, including a real integration test that spawns a fake Python HTTP server as the executable
- Full test suite passes with no regressions

Closes #52