### PR TITLE
Implement pack and scenario library API with local FTS search and filters

### DIFF
--- a/services/convsim-core/convsim_core/app.py
+++ b/services/convsim-core/convsim_core/app.py
@@ -12,7 +12,7 @@ from convsim_core.errors import (
     request_validation_error_handler,
 )
 from convsim_core.logging_setup import configure_logging
-from convsim_core.routers import diag as diag_router, health, models as models_router, packs as packs_router, sessions as sessions_router, settings as settings_router, sidecar as sidecar_router, stt as stt_router
+from convsim_core.routers import diag as diag_router, health, models as models_router, packs as packs_router, scenarios as scenarios_router, sessions as sessions_router, settings as settings_router, sidecar as sidecar_router, stt as stt_router
 from convsim_core.runtime import build_runtime
 from convsim_core.runtime.sidecar import LlamaCppSidecar
 from convsim_core.storage.database import Database

--- a/services/convsim-core/convsim_core/app.py
+++ b/services/convsim-core/convsim_core/app.py
@@ -12,7 +12,7 @@ from convsim_core.errors import (
     request_validation_error_handler,
 )
 from convsim_core.logging_setup import configure_logging
-from convsim_core.routers import diag as diag_router, health, models as models_router, packs as packs_router, sessions as sessions_router, settings as settings_router, stt as stt_router
+from convsim_core.routers import diag as diag_router, health, models as models_router, packs as packs_router, scenarios as scenarios_router, sessions as sessions_router, settings as settings_router, stt as stt_router
 from convsim_core.runtime import build_runtime
 from convsim_core.storage.database import Database
 from convsim_core.storage.repositories.settings_repo import load_settings
@@ -47,6 +47,7 @@ def create_app(config: ServiceConfig | None = None) -> FastAPI:
     app.include_router(models_router.router)
     app.include_router(stt_router.router)
     app.include_router(packs_router.router)
+    app.include_router(scenarios_router.router)
     app.include_router(sessions_router.router)
 
     return app

--- a/services/convsim-core/convsim_core/app.py
+++ b/services/convsim-core/convsim_core/app.py
@@ -12,7 +12,7 @@ from convsim_core.errors import (
     request_validation_error_handler,
 )
 from convsim_core.logging_setup import configure_logging
-from convsim_core.routers import diag as diag_router, health, models as models_router, packs as packs_router, settings as settings_router, stt as stt_router
+from convsim_core.routers import diag as diag_router, health, models as models_router, packs as packs_router, scenarios as scenarios_router, settings as settings_router, stt as stt_router
 from convsim_core.runtime import build_runtime
 from convsim_core.storage.database import Database
 from convsim_core.storage.repositories.settings_repo import load_settings
@@ -47,5 +47,6 @@ def create_app(config: ServiceConfig | None = None) -> FastAPI:
     app.include_router(models_router.router)
     app.include_router(stt_router.router)
     app.include_router(packs_router.router)
+    app.include_router(scenarios_router.router)
 
     return app

--- a/services/convsim-core/convsim_core/app.py
+++ b/services/convsim-core/convsim_core/app.py
@@ -51,7 +51,7 @@ def create_app(config: ServiceConfig | None = None) -> FastAPI:
     app.include_router(sidecar_router.router)
     app.include_router(stt_router.router)
     app.include_router(packs_router.router)
-    app.include_router(sessions_router.router)
     app.include_router(scenarios_router.router)
+    app.include_router(sessions_router.router)
 
     return app

--- a/services/convsim-core/convsim_core/app.py
+++ b/services/convsim-core/convsim_core/app.py
@@ -12,7 +12,7 @@ from convsim_core.errors import (
     request_validation_error_handler,
 )
 from convsim_core.logging_setup import configure_logging
-from convsim_core.routers import diag as diag_router, health, models as models_router, packs as packs_router, sessions as sessions_router, settings as settings_router, sidecar as sidecar_router, stt as stt_router
+from convsim_core.routers import diag as diag_router, health, models as models_router, packs as packs_router, scenarios as scenarios_router, sessions as sessions_router, settings as settings_router, sidecar as sidecar_router, stt as stt_router
 from convsim_core.runtime import build_runtime
 from convsim_core.runtime.sidecar import LlamaCppSidecar
 from convsim_core.storage.database import Database
@@ -52,5 +52,6 @@ def create_app(config: ServiceConfig | None = None) -> FastAPI:
     app.include_router(stt_router.router)
     app.include_router(packs_router.router)
     app.include_router(sessions_router.router)
+    app.include_router(scenarios_router.router)
 
     return app

--- a/services/convsim-core/convsim_core/packs/asset_indexer.py
+++ b/services/convsim-core/convsim_core/packs/asset_indexer.py
@@ -27,7 +27,7 @@ def _classify_asset(path: Path) -> str:
         return "image"
     if ext in (".mp3", ".ogg", ".wav", ".flac", ".aac"):
         return "audio"
-    if path.name == "pack.json":
+    if path.name in ("pack.json", "manifest.yaml"):
         return "manifest"
     if ext in (".yaml", ".yml", ".json"):
         return "data"

--- a/services/convsim-core/convsim_core/packs/importer.py
+++ b/services/convsim-core/convsim_core/packs/importer.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Safe pack import from folder or zip archive with atomic rollback on failure."""
 import io
+import json
 import logging
 import shutil
 import sqlite3
@@ -8,10 +9,13 @@ import stat
 import tempfile
 import zipfile
 from pathlib import Path
+from typing import Optional
+
+import yaml
 
 from convsim_core.errors import ConvsimError
 from convsim_core.packs.asset_indexer import index_pack_assets
-from convsim_core.packs.models import ImportResult, PackManifest
+from convsim_core.packs.models import ImportResult, PackManifest, ScenarioInsertData
 from convsim_core.packs.validator import validate_pack_dir
 from convsim_core.storage.repositories.pack_repo import get_pack_by_slug, insert_pack, insert_scenario
 
@@ -88,15 +92,11 @@ def safe_extract_zip(zip_bytes: bytes, dest: Path) -> None:
             status_code=422,
         ) from exc
     except Exception as exc:
-        # Truncated archives, negative-seek errors, and other unexpected I/O failures
-        # from the zipfile module must produce a 422 rather than a 500.
         raise ConvsimError(
             "INVALID_ZIP",
             f"Could not read zip archive: {type(exc).__name__}: {exc}",
             status_code=422,
         ) from exc
-    # Defense-in-depth: verify actual bytes written, because a malicious archive can set
-    # file_size to 0 in the central directory to bypass the pre-check above.
     actual_size = sum(f.stat().st_size for f in dest.rglob("*") if f.is_file())
     if actual_size > _MAX_UNCOMPRESSED_BYTES:
         raise ConvsimError(
@@ -107,29 +107,85 @@ def safe_extract_zip(zip_bytes: bytes, dest: Path) -> None:
         )
 
 
-def _discover_scenarios(pack_dir: Path, manifest: PackManifest) -> list[tuple[str, str]]:
-    """Return (slug, name) pairs for scenario files found in the pack."""
+def _parse_scenario_yaml(path: Path) -> dict:
+    """Load a scenario YAML file, returning {} on any parse error."""
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+        return raw if isinstance(raw, dict) else {}
+    except Exception:
+        return {}
+
+
+def _discover_scenarios(
+    pack_dir: Path,
+    manifest: PackManifest,
+) -> list[ScenarioInsertData]:
+    """Return ScenarioInsertData list for scenario files found in the pack."""
     seen: set[str] = set()
-    scenarios: list[tuple[str, str]] = []
+    scenarios: list[ScenarioInsertData] = []
+
+    def _process_file(path: Path, rel_path: str) -> None:
+        slug = path.stem
+        if slug in seen:
+            return
+        seen.add(slug)
+        raw = _parse_scenario_yaml(path)
+        scenarios.append(_scenario_data_from_raw(raw, slug, rel_path, manifest))
 
     for ref in manifest.entry_scenarios:
         path = pack_dir / ref
         if path.is_file():
-            slug = path.stem
-            if slug not in seen:
-                seen.add(slug)
-                scenarios.append((slug, _slug_to_name(slug)))
+            rel = ref.replace("\\", "/")
+            _process_file(path, rel)
 
     scenarios_dir = pack_dir / "scenarios"
     if scenarios_dir.is_dir():
         for f in sorted(scenarios_dir.iterdir()):
             if f.is_file() and f.suffix.lower() in (".yaml", ".yml", ".json"):
-                slug = f.stem
-                if slug not in seen:
-                    seen.add(slug)
-                    scenarios.append((slug, _slug_to_name(slug)))
+                rel = "scenarios/" + f.name
+                _process_file(f, rel)
 
     return scenarios
+
+
+def _scenario_data_from_raw(
+    raw: dict,
+    slug: str,
+    rel_path: str,
+    manifest: PackManifest,
+) -> ScenarioInsertData:
+    """Build a ScenarioInsertData from parsed YAML content and pack manifest."""
+    title: Optional[str] = raw.get("title")
+    summary: Optional[str] = raw.get("summary")
+
+    duration = raw.get("duration") or {}
+    max_turns: Optional[int] = duration.get("max_turns")
+    soft_time_limit: Optional[int] = duration.get("soft_time_limit_minutes")
+
+    difficulty = raw.get("difficulty") or {}
+    difficulty_default: Optional[str] = difficulty.get("default")
+
+    requirements = raw.get("requirements") or manifest.requirements or {}
+    voice_support: bool = bool(requirements.get("voice_support", False))
+    model_recommendation: Optional[str] = requirements.get("model_recommendation")
+
+    return ScenarioInsertData(
+        slug=slug,
+        name=_slug_to_name(slug),
+        title=title,
+        summary=summary,
+        content_rating=manifest.content_rating,
+        difficulty_default=difficulty_default,
+        max_turns=max_turns,
+        soft_time_limit_minutes=soft_time_limit,
+        tags_json=json.dumps(manifest.tags) if manifest.tags else None,
+        voice_support=voice_support,
+        model_recommendation=model_recommendation,
+        rel_path=rel_path,
+        pack_name=manifest.name,
+        pack_description=manifest.description,
+        pack_tags=manifest.tags,
+    )
 
 
 def _slug_to_name(slug: str) -> str:
@@ -157,9 +213,6 @@ def _install_from_dir(
     if manifest is None:
         raise ConvsimError("PACK_INVALID", "Pack manifest could not be loaded.", status_code=422)
 
-    # Safety: ensure the computed install path stays within packs_base_dir and is not
-    # equal to packs_base_dir itself (which would happen with an empty safe_name, causing
-    # shutil.rmtree to wipe the entire packs directory before the atomic move).
     safe_name = manifest.pack_id.replace("/", "_").replace("\\", "_")
     if not safe_name:
         raise ConvsimError(
@@ -183,8 +236,6 @@ def _install_from_dir(
             status_code=422,
         )
 
-    # Conflict: any existing pack with the same id blocks import regardless of version.
-    # A pack directory is keyed by id, so a different version would silently overwrite it.
     existing = get_pack_by_slug(conn, manifest.pack_id)
     if existing is not None:
         raise PackConflictError(manifest.pack_id, existing.version)
@@ -198,14 +249,12 @@ def _install_from_dir(
 
         pack_db_id = insert_pack(conn, manifest, str(pack_dest))
 
-        scenarios = _discover_scenarios(tmp_dest, manifest)
+        scenario_list = _discover_scenarios(tmp_dest, manifest)
         slug_to_scenario_id: dict[str, int] = {}
-        for slug, name in scenarios:
-            scenario_db_id = insert_scenario(conn, pack_db_id, slug, name)
-            slug_to_scenario_id[slug] = scenario_db_id
+        for scenario_data in scenario_list:
+            scenario_db_id = insert_scenario(conn, pack_db_id, scenario_data)
+            slug_to_scenario_id[scenario_data.slug] = scenario_db_id
 
-        # Move staging copy to final destination before indexing so that
-        # absolute file_path values stored in asset_index reflect the real location.
         if pack_dest.exists():
             shutil.rmtree(pack_dest)
         pack_dest.parent.mkdir(parents=True, exist_ok=True)
@@ -218,14 +267,14 @@ def _install_from_dir(
             "Installed pack '%s' v%s (%d scenarios, %d assets)",
             manifest.pack_id,
             manifest.version,
-            len(scenarios),
+            len(scenario_list),
             assets_count,
         )
         return ImportResult(
             pack_slug=manifest.pack_id,
             pack_name=manifest.name,
             pack_version=manifest.version,
-            scenarios_indexed=len(scenarios),
+            scenarios_indexed=len(scenario_list),
             assets_indexed=assets_count,
         )
 
@@ -233,11 +282,6 @@ def _install_from_dir(
         conn.rollback()
         if tmp_dest.exists():
             shutil.rmtree(tmp_dest, ignore_errors=True)
-        # If the move already completed, undo it to leave no partial install.
-        # Compare resolved paths: source_dir arrives resolved from the router but
-        # pack_dest is constructed from an unresolved config path, so a plain ==
-        # comparison fails on systems where packs_dir contains a symlink (e.g.
-        # macOS /tmp → /private/tmp), incorrectly deleting the source directory.
         if pack_dest.exists() and not (source_dir.resolve() == pack_dest.resolve()):
             shutil.rmtree(pack_dest, ignore_errors=True)
         raise

--- a/services/convsim-core/convsim_core/packs/importer.py
+++ b/services/convsim-core/convsim_core/packs/importer.py
@@ -92,11 +92,15 @@ def safe_extract_zip(zip_bytes: bytes, dest: Path) -> None:
             status_code=422,
         ) from exc
     except Exception as exc:
+        # Truncated archives, negative-seek errors, and other unexpected I/O failures
+        # from the zipfile module must produce a 422 rather than a 500.
         raise ConvsimError(
             "INVALID_ZIP",
             f"Could not read zip archive: {type(exc).__name__}: {exc}",
             status_code=422,
         ) from exc
+    # Defense-in-depth: verify actual bytes written, because a malicious archive can set
+    # file_size to 0 in the central directory to bypass the pre-check above.
     actual_size = sum(f.stat().st_size for f in dest.rglob("*") if f.is_file())
     if actual_size > _MAX_UNCOMPRESSED_BYTES:
         raise ConvsimError(
@@ -214,6 +218,9 @@ def _install_from_dir(
         raise ConvsimError("PACK_INVALID", "Pack manifest could not be loaded.", status_code=422)
     manifest = validation.manifest
 
+    # Safety: ensure the computed install path stays within packs_base_dir and is not
+    # equal to packs_base_dir itself (which would happen with an empty safe_name, causing
+    # shutil.rmtree to wipe the entire packs directory before the atomic move).
     safe_name = manifest.pack_id.replace("/", "_").replace("\\", "_")
     if not safe_name:
         raise ConvsimError(
@@ -237,6 +244,8 @@ def _install_from_dir(
             status_code=422,
         )
 
+    # Conflict: any existing pack with the same id blocks import regardless of version.
+    # A pack directory is keyed by id, so a different version would silently overwrite it.
     existing = get_pack_by_slug(conn, manifest.pack_id)
     if existing is not None:
         raise PackConflictError(manifest.pack_id, existing.version)
@@ -256,6 +265,8 @@ def _install_from_dir(
             scenario_db_id = insert_scenario(conn, pack_db_id, scenario_data)
             slug_to_scenario_id[scenario_data.slug] = scenario_db_id
 
+        # Move staging copy to final destination before indexing so that
+        # absolute file_path values stored in asset_index reflect the real location.
         if pack_dest.exists():
             shutil.rmtree(pack_dest)
         pack_dest.parent.mkdir(parents=True, exist_ok=True)
@@ -283,6 +294,11 @@ def _install_from_dir(
         conn.rollback()
         if tmp_dest.exists():
             shutil.rmtree(tmp_dest, ignore_errors=True)
+        # If the move already completed, undo it to leave no partial install.
+        # Compare resolved paths: source_dir arrives resolved from the router but
+        # pack_dest is constructed from an unresolved config path, so a plain ==
+        # comparison fails on systems where packs_dir contains a symlink (e.g.
+        # macOS /tmp → /private/tmp), incorrectly deleting the source directory.
         if pack_dest.exists() and not (source_dir.resolve() == pack_dest.resolve()):
             shutil.rmtree(pack_dest, ignore_errors=True)
         raise

--- a/services/convsim-core/convsim_core/packs/importer.py
+++ b/services/convsim-core/convsim_core/packs/importer.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Safe pack import from folder or zip archive with atomic rollback on failure."""
 import io
+import json
 import logging
 import shutil
 import sqlite3
@@ -8,10 +9,13 @@ import stat
 import tempfile
 import zipfile
 from pathlib import Path
+from typing import Optional
+
+import yaml
 
 from convsim_core.errors import ConvsimError
 from convsim_core.packs.asset_indexer import index_pack_assets
-from convsim_core.packs.models import ImportResult, PackManifest
+from convsim_core.packs.models import ImportResult, PackManifest, ScenarioInsertData
 from convsim_core.packs.validator import validate_pack_dir
 from convsim_core.storage.repositories.pack_repo import get_pack_by_slug, insert_pack, insert_scenario
 
@@ -88,15 +92,11 @@ def safe_extract_zip(zip_bytes: bytes, dest: Path) -> None:
             status_code=422,
         ) from exc
     except Exception as exc:
-        # Truncated archives, negative-seek errors, and other unexpected I/O failures
-        # from the zipfile module must produce a 422 rather than a 500.
         raise ConvsimError(
             "INVALID_ZIP",
             f"Could not read zip archive: {type(exc).__name__}: {exc}",
             status_code=422,
         ) from exc
-    # Defense-in-depth: verify actual bytes written, because a malicious archive can set
-    # file_size to 0 in the central directory to bypass the pre-check above.
     actual_size = sum(f.stat().st_size for f in dest.rglob("*") if f.is_file())
     if actual_size > _MAX_UNCOMPRESSED_BYTES:
         raise ConvsimError(
@@ -107,29 +107,85 @@ def safe_extract_zip(zip_bytes: bytes, dest: Path) -> None:
         )
 
 
-def _discover_scenarios(pack_dir: Path, manifest: PackManifest) -> list[tuple[str, str]]:
-    """Return (slug, name) pairs for scenario files found in the pack."""
+def _parse_scenario_yaml(path: Path) -> dict:
+    """Load a scenario YAML file, returning {} on any parse error."""
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+        return raw if isinstance(raw, dict) else {}
+    except Exception:
+        return {}
+
+
+def _discover_scenarios(
+    pack_dir: Path,
+    manifest: PackManifest,
+) -> list[ScenarioInsertData]:
+    """Return ScenarioInsertData list for scenario files found in the pack."""
     seen: set[str] = set()
-    scenarios: list[tuple[str, str]] = []
+    scenarios: list[ScenarioInsertData] = []
+
+    def _process_file(path: Path, rel_path: str) -> None:
+        slug = path.stem
+        if slug in seen:
+            return
+        seen.add(slug)
+        raw = _parse_scenario_yaml(path)
+        scenarios.append(_scenario_data_from_raw(raw, slug, rel_path, manifest))
 
     for ref in manifest.entry_scenarios:
         path = pack_dir / ref
         if path.is_file():
-            slug = path.stem
-            if slug not in seen:
-                seen.add(slug)
-                scenarios.append((slug, _slug_to_name(slug)))
+            rel = ref.replace("\\", "/")
+            _process_file(path, rel)
 
     scenarios_dir = pack_dir / "scenarios"
     if scenarios_dir.is_dir():
         for f in sorted(scenarios_dir.iterdir()):
             if f.is_file() and f.suffix.lower() in (".yaml", ".yml", ".json"):
-                slug = f.stem
-                if slug not in seen:
-                    seen.add(slug)
-                    scenarios.append((slug, _slug_to_name(slug)))
+                rel = "scenarios/" + f.name
+                _process_file(f, rel)
 
     return scenarios
+
+
+def _scenario_data_from_raw(
+    raw: dict,
+    slug: str,
+    rel_path: str,
+    manifest: PackManifest,
+) -> ScenarioInsertData:
+    """Build a ScenarioInsertData from parsed YAML content and pack manifest."""
+    title: Optional[str] = raw.get("title")
+    summary: Optional[str] = raw.get("summary")
+
+    duration = raw.get("duration") or {}
+    max_turns: Optional[int] = duration.get("max_turns")
+    soft_time_limit: Optional[int] = duration.get("soft_time_limit_minutes")
+
+    difficulty = raw.get("difficulty") or {}
+    difficulty_default: Optional[str] = difficulty.get("default")
+
+    requirements = raw.get("requirements") or manifest.requirements or {}
+    voice_support: bool = bool(requirements.get("voice_support", False))
+    model_recommendation: Optional[str] = requirements.get("model_recommendation")
+
+    return ScenarioInsertData(
+        slug=slug,
+        name=_slug_to_name(slug),
+        title=title,
+        summary=summary,
+        content_rating=manifest.content_rating,
+        difficulty_default=difficulty_default,
+        max_turns=max_turns,
+        soft_time_limit_minutes=soft_time_limit,
+        tags_json=json.dumps(manifest.tags) if manifest.tags else None,
+        voice_support=voice_support,
+        model_recommendation=model_recommendation,
+        rel_path=rel_path,
+        pack_name=manifest.name,
+        pack_description=manifest.description,
+        pack_tags=manifest.tags,
+    )
 
 
 def _slug_to_name(slug: str) -> str:
@@ -158,9 +214,6 @@ def _install_from_dir(
         raise ConvsimError("PACK_INVALID", "Pack manifest could not be loaded.", status_code=422)
     manifest = validation.manifest
 
-    # Safety: ensure the computed install path stays within packs_base_dir and is not
-    # equal to packs_base_dir itself (which would happen with an empty safe_name, causing
-    # shutil.rmtree to wipe the entire packs directory before the atomic move).
     safe_name = manifest.pack_id.replace("/", "_").replace("\\", "_")
     if not safe_name:
         raise ConvsimError(
@@ -184,8 +237,6 @@ def _install_from_dir(
             status_code=422,
         )
 
-    # Conflict: any existing pack with the same id blocks import regardless of version.
-    # A pack directory is keyed by id, so a different version would silently overwrite it.
     existing = get_pack_by_slug(conn, manifest.pack_id)
     if existing is not None:
         raise PackConflictError(manifest.pack_id, existing.version)
@@ -199,14 +250,12 @@ def _install_from_dir(
 
         pack_db_id = insert_pack(conn, manifest, str(pack_dest))
 
-        scenarios = _discover_scenarios(tmp_dest, manifest)
+        scenario_list = _discover_scenarios(tmp_dest, manifest)
         slug_to_scenario_id: dict[str, int] = {}
-        for slug, name in scenarios:
-            scenario_db_id = insert_scenario(conn, pack_db_id, slug, name)
-            slug_to_scenario_id[slug] = scenario_db_id
+        for scenario_data in scenario_list:
+            scenario_db_id = insert_scenario(conn, pack_db_id, scenario_data)
+            slug_to_scenario_id[scenario_data.slug] = scenario_db_id
 
-        # Move staging copy to final destination before indexing so that
-        # absolute file_path values stored in asset_index reflect the real location.
         if pack_dest.exists():
             shutil.rmtree(pack_dest)
         pack_dest.parent.mkdir(parents=True, exist_ok=True)
@@ -219,14 +268,14 @@ def _install_from_dir(
             "Installed pack '%s' v%s (%d scenarios, %d assets)",
             manifest.pack_id,
             manifest.version,
-            len(scenarios),
+            len(scenario_list),
             assets_count,
         )
         return ImportResult(
             pack_slug=manifest.pack_id,
             pack_name=manifest.name,
             pack_version=manifest.version,
-            scenarios_indexed=len(scenarios),
+            scenarios_indexed=len(scenario_list),
             assets_indexed=assets_count,
         )
 
@@ -234,11 +283,6 @@ def _install_from_dir(
         conn.rollback()
         if tmp_dest.exists():
             shutil.rmtree(tmp_dest, ignore_errors=True)
-        # If the move already completed, undo it to leave no partial install.
-        # Compare resolved paths: source_dir arrives resolved from the router but
-        # pack_dest is constructed from an unresolved config path, so a plain ==
-        # comparison fails on systems where packs_dir contains a symlink (e.g.
-        # macOS /tmp → /private/tmp), incorrectly deleting the source directory.
         if pack_dest.exists() and not (source_dir.resolve() == pack_dest.resolve()):
             shutil.rmtree(pack_dest, ignore_errors=True)
         raise

--- a/services/convsim-core/convsim_core/packs/importer.py
+++ b/services/convsim-core/convsim_core/packs/importer.py
@@ -92,11 +92,15 @@ def safe_extract_zip(zip_bytes: bytes, dest: Path) -> None:
             status_code=422,
         ) from exc
     except Exception as exc:
+        # Truncated archives, negative-seek errors, and other unexpected I/O failures
+        # from the zipfile module must produce a 422 rather than a 500.
         raise ConvsimError(
             "INVALID_ZIP",
             f"Could not read zip archive: {type(exc).__name__}: {exc}",
             status_code=422,
         ) from exc
+    # Defense-in-depth: verify actual bytes written, because a malicious archive can set
+    # file_size to 0 in the central directory to bypass the pre-check above.
     actual_size = sum(f.stat().st_size for f in dest.rglob("*") if f.is_file())
     if actual_size > _MAX_UNCOMPRESSED_BYTES:
         raise ConvsimError(
@@ -213,6 +217,9 @@ def _install_from_dir(
     if manifest is None:
         raise ConvsimError("PACK_INVALID", "Pack manifest could not be loaded.", status_code=422)
 
+    # Safety: ensure the computed install path stays within packs_base_dir and is not
+    # equal to packs_base_dir itself (which would happen with an empty safe_name, causing
+    # shutil.rmtree to wipe the entire packs directory before the atomic move).
     safe_name = manifest.pack_id.replace("/", "_").replace("\\", "_")
     if not safe_name:
         raise ConvsimError(
@@ -236,6 +243,8 @@ def _install_from_dir(
             status_code=422,
         )
 
+    # Conflict: any existing pack with the same id blocks import regardless of version.
+    # A pack directory is keyed by id, so a different version would silently overwrite it.
     existing = get_pack_by_slug(conn, manifest.pack_id)
     if existing is not None:
         raise PackConflictError(manifest.pack_id, existing.version)
@@ -255,6 +264,8 @@ def _install_from_dir(
             scenario_db_id = insert_scenario(conn, pack_db_id, scenario_data)
             slug_to_scenario_id[scenario_data.slug] = scenario_db_id
 
+        # Move staging copy to final destination before indexing so that
+        # absolute file_path values stored in asset_index reflect the real location.
         if pack_dest.exists():
             shutil.rmtree(pack_dest)
         pack_dest.parent.mkdir(parents=True, exist_ok=True)
@@ -282,6 +293,11 @@ def _install_from_dir(
         conn.rollback()
         if tmp_dest.exists():
             shutil.rmtree(tmp_dest, ignore_errors=True)
+        # If the move already completed, undo it to leave no partial install.
+        # Compare resolved paths: source_dir arrives resolved from the router but
+        # pack_dest is constructed from an unresolved config path, so a plain ==
+        # comparison fails on systems where packs_dir contains a symlink (e.g.
+        # macOS /tmp → /private/tmp), incorrectly deleting the source directory.
         if pack_dest.exists() and not (source_dir.resolve() == pack_dest.resolve()):
             shutil.rmtree(pack_dest, ignore_errors=True)
         raise

--- a/services/convsim-core/convsim_core/packs/models.py
+++ b/services/convsim-core/convsim_core/packs/models.py
@@ -75,6 +75,7 @@ class ValidationResult(BaseModel):
     version: Optional[str] = None
     errors: list[ValidationIssue] = []
     warnings: list[ValidationIssue] = []
+    rule_ids: list[str] = []
     manifest: Optional[PackManifest] = None
 
 

--- a/services/convsim-core/convsim_core/packs/models.py
+++ b/services/convsim-core/convsim_core/packs/models.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Optional
 
@@ -50,8 +51,13 @@ class PackSummary(BaseModel):
     description: Optional[str] = None
     author: Optional[str] = None
     license: Optional[str] = None
+    content_rating: Optional[str] = None
+    supported_languages: list[str] = []
+    tags: list[str] = []
     source_path: Optional[str] = None
     installed_at: str
+    validation_status: str = "unknown"
+    last_validated_at: Optional[str] = None
 
 
 class ValidationResult(BaseModel):
@@ -80,3 +86,70 @@ class ImportResult(BaseModel):
     pack_version: str
     scenarios_indexed: int
     assets_indexed: int
+
+
+class PlayerRoleInfo(BaseModel):
+    """Player role details for a scenario."""
+
+    label: str
+    brief: Optional[str] = None
+
+
+class ScenarioCard(BaseModel):
+    """Summary of a scenario suitable for a library card view."""
+
+    scenario_id: str
+    pack_id: str
+    pack_name: str
+    title: str
+    summary: Optional[str] = None
+    tags: list[str] = []
+    content_rating: Optional[str] = None
+    difficulty_default: Optional[str] = None
+    max_turns: Optional[int] = None
+    estimated_length_minutes: Optional[int] = None
+    voice_support: bool = False
+    model_recommendation: Optional[str] = None
+
+
+class ScenarioDetail(BaseModel):
+    """Full scenario metadata without hidden agenda."""
+
+    scenario_id: str
+    pack_id: str
+    pack_name: str
+    title: str
+    summary: Optional[str] = None
+    tags: list[str] = []
+    content_rating: Optional[str] = None
+    difficulty_default: Optional[str] = None
+    difficulty_options: dict = {}
+    max_turns: Optional[int] = None
+    estimated_length_minutes: Optional[int] = None
+    voice_support: bool = False
+    model_recommendation: Optional[str] = None
+    player_role: Optional[PlayerRoleInfo] = None
+    opening_npc_says: Optional[str] = None
+    player_visible_goals: list[str] = []
+    hidden_goals: Optional[list[str]] = None
+
+
+@dataclass
+class ScenarioInsertData:
+    """Metadata for inserting a scenario record and its FTS entry."""
+
+    slug: str
+    name: str
+    title: Optional[str] = None
+    summary: Optional[str] = None
+    content_rating: Optional[str] = None
+    difficulty_default: Optional[str] = None
+    max_turns: Optional[int] = None
+    soft_time_limit_minutes: Optional[int] = None
+    tags_json: Optional[str] = None
+    voice_support: bool = False
+    model_recommendation: Optional[str] = None
+    rel_path: Optional[str] = None
+    pack_name: str = ""
+    pack_description: Optional[str] = None
+    pack_tags: list[str] = field(default_factory=list)

--- a/services/convsim-core/convsim_core/packs/models.py
+++ b/services/convsim-core/convsim_core/packs/models.py
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
+from dataclasses import dataclass, field
 from typing import Optional
 
 from pydantic import BaseModel
 
 
 class PackManifest(BaseModel):
-    """Parsed contents of a pack's pack.json manifest file."""
+    """Parsed contents of a pack's pack.json or manifest.yaml manifest file."""
 
     schema_version: str
     pack_id: str
@@ -33,8 +34,13 @@ class PackSummary(BaseModel):
     description: Optional[str] = None
     author: Optional[str] = None
     license: Optional[str] = None
+    content_rating: Optional[str] = None
+    supported_languages: list[str] = []
+    tags: list[str] = []
     source_path: Optional[str] = None
     installed_at: str
+    validation_status: str = "unknown"
+    last_validated_at: Optional[str] = None
 
 
 class ValidationResult(BaseModel):
@@ -45,6 +51,7 @@ class ValidationResult(BaseModel):
     name: Optional[str] = None
     version: Optional[str] = None
     errors: list[str] = []
+    rule_ids: list[str] = []
 
 
 class ImportResult(BaseModel):
@@ -55,3 +62,70 @@ class ImportResult(BaseModel):
     pack_version: str
     scenarios_indexed: int
     assets_indexed: int
+
+
+class PlayerRoleInfo(BaseModel):
+    """Player role details for a scenario."""
+
+    label: str
+    brief: Optional[str] = None
+
+
+class ScenarioCard(BaseModel):
+    """Summary of a scenario suitable for a library card view."""
+
+    scenario_id: str
+    pack_id: str
+    pack_name: str
+    title: str
+    summary: Optional[str] = None
+    tags: list[str] = []
+    content_rating: Optional[str] = None
+    difficulty_default: Optional[str] = None
+    max_turns: Optional[int] = None
+    estimated_length_minutes: Optional[int] = None
+    voice_support: bool = False
+    model_recommendation: Optional[str] = None
+
+
+class ScenarioDetail(BaseModel):
+    """Full scenario metadata without hidden agenda."""
+
+    scenario_id: str
+    pack_id: str
+    pack_name: str
+    title: str
+    summary: Optional[str] = None
+    tags: list[str] = []
+    content_rating: Optional[str] = None
+    difficulty_default: Optional[str] = None
+    difficulty_options: dict = {}
+    max_turns: Optional[int] = None
+    estimated_length_minutes: Optional[int] = None
+    voice_support: bool = False
+    model_recommendation: Optional[str] = None
+    player_role: Optional[PlayerRoleInfo] = None
+    opening_npc_says: Optional[str] = None
+    player_visible_goals: list[str] = []
+    hidden_goals: Optional[list[str]] = None
+
+
+@dataclass
+class ScenarioInsertData:
+    """Metadata for inserting a scenario record and its FTS entry."""
+
+    slug: str
+    name: str
+    title: Optional[str] = None
+    summary: Optional[str] = None
+    content_rating: Optional[str] = None
+    difficulty_default: Optional[str] = None
+    max_turns: Optional[int] = None
+    soft_time_limit_minutes: Optional[int] = None
+    tags_json: Optional[str] = None
+    voice_support: bool = False
+    model_recommendation: Optional[str] = None
+    rel_path: Optional[str] = None
+    pack_name: str = ""
+    pack_description: Optional[str] = None
+    pack_tags: list[str] = field(default_factory=list)

--- a/services/convsim-core/convsim_core/packs/validator.py
+++ b/services/convsim-core/convsim_core/packs/validator.py
@@ -36,11 +36,11 @@ RULE_SYMLINK_DETECTED = "SYMLINK_DETECTED"
 RULE_FORBIDDEN_EXTENSION = "FORBIDDEN_EXTENSION"
 
 
-def _fmt_schema_err(exc: jsonschema.ValidationError) -> str:
+def _fmt_schema_err(exc: jsonschema.ValidationError, filename: str = "pack.json") -> str:
     path = list(exc.absolute_path)
     if path:
-        return f"pack.json [{'.'.join(str(p) for p in path)}]: {exc.message}"
-    return f"pack.json: {exc.message}"
+        return f"{filename} [{'.'.join(str(p) for p in path)}]: {exc.message}"
+    return f"{filename}: {exc.message}"
 
 
 def errors_to_rule_ids(errors: list[str]) -> list[str]:
@@ -54,7 +54,7 @@ def errors_to_rule_ids(errors: list[str]) -> list[str]:
             ids.add(RULE_INVALID_MANIFEST_JSON)
         elif "not valid yaml" in el or "must be a yaml mapping" in el:
             ids.add(RULE_INVALID_MANIFEST_YAML)
-        elif "pack.json [" in el or "pack.json:" in el or "schema" in el:
+        elif "pack.json [" in el or "pack.json:" in el or "manifest.yaml [" in el or "manifest.yaml:" in el or "schema" in el:
             ids.add(RULE_SCHEMA_VIOLATION)
         elif "content_rating" in el:
             ids.add(RULE_INVALID_CONTENT_RATING)
@@ -87,12 +87,14 @@ def load_manifest(pack_dir: Path) -> tuple[Optional[PackManifest], list[str]]:
     json_path = pack_dir / "pack.json"
     yaml_path = pack_dir / "manifest.yaml"
 
+    manifest_filename = "pack.json"
     if json_path.exists():
         try:
             raw = json.loads(json_path.read_text(encoding="utf-8"))
         except json.JSONDecodeError as exc:
             return None, [f"pack.json is not valid JSON: {exc}"]
     elif yaml_path.exists():
+        manifest_filename = "manifest.yaml"
         try:
             raw = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
         except yaml.YAMLError as exc:
@@ -103,12 +105,12 @@ def load_manifest(pack_dir: Path) -> tuple[Optional[PackManifest], list[str]]:
         return None, ["Missing pack.json or manifest.yaml at pack root"]
 
     # Validate against the authoritative JSON Schema.
-    schema_errs = [_fmt_schema_err(e) for e in _PACK_SCHEMA_VALIDATOR.iter_errors(raw)]
+    schema_errs = [_fmt_schema_err(e, manifest_filename) for e in _PACK_SCHEMA_VALIDATOR.iter_errors(raw)]
 
     try:
         manifest = PackManifest.model_validate(raw)
     except Exception as exc:
-        return None, schema_errs + [f"pack.json failed schema validation: {exc}"]
+        return None, schema_errs + [f"{manifest_filename} failed schema validation: {exc}"]
 
     return manifest, schema_errs
 

--- a/services/convsim-core/convsim_core/packs/validator.py
+++ b/services/convsim-core/convsim_core/packs/validator.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Optional
 
 import jsonschema
+import yaml
 
 from convsim_core.packs.models import PackManifest
 from convsim_core.schema_paths import get_schema
@@ -22,6 +23,18 @@ FORBIDDEN_EXTENSIONS = frozenset({
     ".pkg", ".app",
 })
 
+# Rule ID constants (also used by CLI tools for parity).
+RULE_MISSING_MANIFEST = "MISSING_MANIFEST"
+RULE_INVALID_MANIFEST_JSON = "INVALID_MANIFEST_JSON"
+RULE_INVALID_MANIFEST_YAML = "INVALID_MANIFEST_YAML"
+RULE_SCHEMA_VIOLATION = "SCHEMA_VIOLATION"
+RULE_INVALID_CONTENT_RATING = "INVALID_CONTENT_RATING"
+RULE_INVALID_PACK_ID = "INVALID_PACK_ID"
+RULE_UNSAFE_ENTRY_SCENARIO = "UNSAFE_ENTRY_SCENARIO"
+RULE_MISSING_ENTRY_SCENARIO = "MISSING_ENTRY_SCENARIO"
+RULE_SYMLINK_DETECTED = "SYMLINK_DETECTED"
+RULE_FORBIDDEN_EXTENSION = "FORBIDDEN_EXTENSION"
+
 
 def _fmt_schema_err(exc: jsonschema.ValidationError) -> str:
     path = list(exc.absolute_path)
@@ -30,23 +43,65 @@ def _fmt_schema_err(exc: jsonschema.ValidationError) -> str:
     return f"pack.json: {exc.message}"
 
 
-def load_manifest(pack_dir: Path) -> tuple[Optional[PackManifest], list[str]]:
-    """Parse pack.json from pack_dir. Returns (manifest_or_None, errors).
+def _errors_to_rule_ids(errors: list[str]) -> list[str]:
+    """Derive unique rule IDs from error message strings."""
+    ids: set[str] = set()
+    for e in errors:
+        el = e.lower()
+        if "missing" in el and ("pack.json" in el or "manifest" in el):
+            ids.add(RULE_MISSING_MANIFEST)
+        elif "not valid json" in el:
+            ids.add(RULE_INVALID_MANIFEST_JSON)
+        elif "not valid yaml" in el:
+            ids.add(RULE_INVALID_MANIFEST_YAML)
+        elif "pack.json [" in el or "pack.json:" in el or "schema" in el or "required" in el:
+            ids.add(RULE_SCHEMA_VIOLATION)
+        elif "content_rating" in el:
+            ids.add(RULE_INVALID_CONTENT_RATING)
+        elif "pack_id" in el and ("unsafe" in el or "empty" in el or "valid" in el or "separator" in el):
+            ids.add(RULE_INVALID_PACK_ID)
+        elif "unsafe" in el or ("escape" in el and "entry" in el):
+            ids.add(RULE_UNSAFE_ENTRY_SCENARIO)
+        elif "not found" in el or "file not found" in el:
+            ids.add(RULE_MISSING_ENTRY_SCENARIO)
+        elif "symlink" in el:
+            ids.add(RULE_SYMLINK_DETECTED)
+        elif "executable" in el or "not allowed" in el or "forbidden" in el:
+            ids.add(RULE_FORBIDDEN_EXTENSION)
+        elif "null byte" in el or "null" in el:
+            ids.add(RULE_INVALID_PACK_ID)
+        else:
+            ids.add(RULE_SCHEMA_VIOLATION)
+    return sorted(ids)
 
+
+def load_manifest(pack_dir: Path) -> tuple[Optional[PackManifest], list[str]]:
+    """Parse pack.json or manifest.yaml from pack_dir. Returns (manifest_or_None, errors).
+
+    Tries pack.json (JSON format) first, then falls back to manifest.yaml (YAML format).
     When the manifest can be parsed but fails the JSON Schema, the manifest is
     still returned so that validate_pack_dir can continue its path-safety and
     executable-rejection checks and surface ALL problems in one pass.
     """
-    manifest_path = pack_dir / "pack.json"
-    if not manifest_path.exists():
-        return None, ["Missing pack.json at pack root"]
+    json_path = pack_dir / "pack.json"
+    yaml_path = pack_dir / "manifest.yaml"
 
-    try:
-        raw = json.loads(manifest_path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError as exc:
-        return None, [f"pack.json is not valid JSON: {exc}"]
+    if json_path.exists():
+        try:
+            raw = json.loads(json_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            return None, [f"pack.json is not valid JSON: {exc}"]
+    elif yaml_path.exists():
+        try:
+            raw = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+        except yaml.YAMLError as exc:
+            return None, [f"manifest.yaml is not valid YAML: {exc}"]
+        if not isinstance(raw, dict):
+            return None, ["manifest.yaml must be a YAML mapping"]
+    else:
+        return None, ["Missing pack.json or manifest.yaml at pack root"]
 
-    # Validate against the authoritative JSON Schema (same pattern as model_registry_service).
+    # Validate against the authoritative JSON Schema.
     schema_errs = [_fmt_schema_err(e) for e in _PACK_SCHEMA_VALIDATOR.iter_errors(raw)]
 
     try:
@@ -54,7 +109,6 @@ def load_manifest(pack_dir: Path) -> tuple[Optional[PackManifest], list[str]]:
     except Exception as exc:
         return None, schema_errs + [f"pack.json failed schema validation: {exc}"]
 
-    # Return manifest + any schema errors; caller decides whether to halt.
     return manifest, schema_errs
 
 
@@ -70,26 +124,15 @@ def validate_pack_dir(pack_dir: Path) -> tuple[Optional[PackManifest], list[str]
     manifest, manifest_errors = load_manifest(pack_dir)
     errors.extend(manifest_errors)
     if manifest is None:
-        # JSON / Pydantic parse failed — no manifest to continue validating.
         return None, errors
     pack_dir_resolved = pack_dir.resolve()
 
-    # Content rating must be in the permitted set.
     if manifest.content_rating and manifest.content_rating not in CONTENT_RATINGS:
         errors.append(
             f"Invalid content_rating '{manifest.content_rating}'. "
             f"Allowed values: {', '.join(sorted(CONTENT_RATINGS))}"
         )
 
-    # pack_id must be non-empty and must not contain path-traversal, header-injection,
-    # null characters, or path separators.  Path separators (/ and \) are rejected because
-    # _install_from_dir maps pack_id directly to a directory name after stripping them; two
-    # different ids (e.g. "foo/bar" and "foo_bar") would collide to the same directory,
-    # causing the importer to silently overwrite the first pack's files with the second's.
-    # Null bytes (\x00) are included because os.path on POSIX silently truncates paths at
-    # the first null byte, which could redirect installs to an unintended directory.
-    # "." is rejected because Path(packs_dir) / "." resolves back to packs_dir itself,
-    # which would cause the importer to rmtree the entire packs directory.
     _PACK_ID_FORBIDDEN = {'"', "/", "\\", "\r", "\n", "\x00"}
     if not manifest.pack_id:
         errors.append("pack_id must not be empty")
@@ -98,7 +141,6 @@ def validate_pack_dir(pack_dir: Path) -> tuple[Optional[PackManifest], list[str]
     elif ".." in manifest.pack_id or any(c in manifest.pack_id for c in _PACK_ID_FORBIDDEN):
         errors.append(f"pack_id contains unsafe characters: {manifest.pack_id!r}")
 
-    # Each entry scenario must reference a file that exists within the pack dir.
     for ref in manifest.entry_scenarios:
         if "\x00" in ref:
             errors.append(f"Entry scenario path contains null byte: {ref!r}")
@@ -116,9 +158,6 @@ def validate_pack_dir(pack_dir: Path) -> tuple[Optional[PackManifest], list[str]
         if not resolved.is_file():
             errors.append(f"Entry scenario file not found: {ref!r}")
 
-    # Scan every entry for symlinks and forbidden extensions.
-    # Symlinks are rejected here (consistent with safe_extract_zip for zip archives)
-    # to prevent shutil.copytree from following them to files outside the pack dir.
     for file_path in pack_dir.rglob("*"):
         if file_path.is_symlink():
             rel = file_path.relative_to(pack_dir)

--- a/services/convsim-core/convsim_core/packs/validator.py
+++ b/services/convsim-core/convsim_core/packs/validator.py
@@ -43,7 +43,7 @@ def _fmt_schema_err(exc: jsonschema.ValidationError) -> str:
     return f"pack.json: {exc.message}"
 
 
-def _errors_to_rule_ids(errors: list[str]) -> list[str]:
+def errors_to_rule_ids(errors: list[str]) -> list[str]:
     """Derive unique rule IDs from error message strings."""
     ids: set[str] = set()
     for e in errors:
@@ -52,7 +52,7 @@ def _errors_to_rule_ids(errors: list[str]) -> list[str]:
             ids.add(RULE_MISSING_MANIFEST)
         elif "not valid json" in el:
             ids.add(RULE_INVALID_MANIFEST_JSON)
-        elif "not valid yaml" in el:
+        elif "not valid yaml" in el or "must be a yaml mapping" in el:
             ids.add(RULE_INVALID_MANIFEST_YAML)
         elif "pack.json [" in el or "pack.json:" in el or "schema" in el or "required" in el:
             ids.add(RULE_SCHEMA_VIOLATION)
@@ -68,8 +68,9 @@ def _errors_to_rule_ids(errors: list[str]) -> list[str]:
             ids.add(RULE_SYMLINK_DETECTED)
         elif "executable" in el or "not allowed" in el or "forbidden" in el:
             ids.add(RULE_FORBIDDEN_EXTENSION)
-        elif "null byte" in el or "null" in el:
-            ids.add(RULE_INVALID_PACK_ID)
+        elif "null byte" in el:
+            # Null bytes in entry scenario paths are an unsafe path error, not a pack_id error.
+            ids.add(RULE_UNSAFE_ENTRY_SCENARIO)
         else:
             ids.add(RULE_SCHEMA_VIOLATION)
     return sorted(ids)

--- a/services/convsim-core/convsim_core/packs/validator.py
+++ b/services/convsim-core/convsim_core/packs/validator.py
@@ -16,6 +16,7 @@ ERROR   — blocks import and contribution.
 WARNING — allows local development; blocks official-pack contribution.
 """
 import json
+import re as _re
 from pathlib import Path
 from typing import Optional
 
@@ -224,6 +225,7 @@ class _PackValidator:
     def _build_result(self, manifest: Optional[PackManifest]) -> ValidationResult:
         errors = [i for i in self._issues if i.severity == ValidationSeverity.ERROR]
         warnings = [i for i in self._issues if i.severity == ValidationSeverity.WARNING]
+        rule_ids = list(dict.fromkeys(e.rule_id for e in errors))
         return ValidationResult(
             valid=len(errors) == 0,
             pack_id=manifest.pack_id if manifest else None,
@@ -231,6 +233,7 @@ class _PackValidator:
             version=manifest.version if manifest else None,
             errors=errors,
             warnings=warnings,
+            rule_ids=rule_ids,
             manifest=manifest,
         )
 
@@ -592,7 +595,7 @@ class _PackValidator:
             elif path.is_file() and path.suffix.lower() in FORBIDDEN_EXTENSIONS:
                 rel = self._rel(path)
                 self._error(
-                    "FORBIDDEN_FILE",
+                    "FORBIDDEN_EXTENSION",
                     rel,
                     "(root)",
                     f"Executable or script file not allowed in pack: '{rel}'",
@@ -622,6 +625,48 @@ def validate_pack_dir(pack_dir: Path) -> ValidationResult:
         validation failures.
     """
     return _PackValidator(pack_dir).validate()
+
+
+def errors_to_rule_ids(errors: list[str]) -> list[str]:
+    """Map a list of error message strings to unique rule ID strings.
+
+    Classifies error messages (from string-based validation output or CLI tools)
+    into structured rule IDs for API and CLI responses.  Order is preserved;
+    duplicates are removed.
+    """
+    seen: set[str] = set()
+    result: list[str] = []
+    for error in errors:
+        rule_id = _classify_error_message(error)
+        if rule_id not in seen:
+            seen.add(rule_id)
+            result.append(rule_id)
+    return result
+
+
+def _classify_error_message(error: str) -> str:
+    """Return the rule ID for a single validation error message string."""
+    # Null byte in an entry scenario path — checked before generic path checks.
+    if "null byte" in error and (
+        "entry scenario" in error.lower() or "scenarios/" in error.lower()
+    ):
+        return "UNSAFE_ENTRY_SCENARIO"
+    # Manifest YAML must be a mapping (top-level element is not a dict).
+    if "must be a YAML mapping" in error:
+        return "INVALID_MANIFEST_YAML"
+    # Missing entry scenario file — checked BEFORE schema-violation patterns so
+    # that filenames containing the word 'required' are not misclassified.
+    if "Entry scenario file not found:" in error:
+        return "MISSING_ENTRY_SCENARIO"
+    # Forbidden file extension (executable/script in pack).
+    if "not allowed in pack" in error:
+        return "FORBIDDEN_EXTENSION"
+    # JSON Schema violations (e.g. "[field]: value does not match", "is a required property").
+    if "does not match" in error or _re.search(r"\[[\w_-]+\]:", error):
+        return "SCHEMA_VIOLATION"
+    if "is a required property" in error:
+        return "SCHEMA_VIOLATION"
+    return "UNKNOWN"
 
 
 # Module-level in-memory cache keyed by (resolved_path, version, max_mtime).

--- a/services/convsim-core/convsim_core/packs/validator.py
+++ b/services/convsim-core/convsim_core/packs/validator.py
@@ -54,7 +54,7 @@ def errors_to_rule_ids(errors: list[str]) -> list[str]:
             ids.add(RULE_INVALID_MANIFEST_JSON)
         elif "not valid yaml" in el or "must be a yaml mapping" in el:
             ids.add(RULE_INVALID_MANIFEST_YAML)
-        elif "pack.json [" in el or "pack.json:" in el or "schema" in el or "required" in el:
+        elif "pack.json [" in el or "pack.json:" in el or "schema" in el:
             ids.add(RULE_SCHEMA_VIOLATION)
         elif "content_rating" in el:
             ids.add(RULE_INVALID_CONTENT_RATING)
@@ -134,6 +134,15 @@ def validate_pack_dir(pack_dir: Path) -> tuple[Optional[PackManifest], list[str]
             f"Allowed values: {', '.join(sorted(CONTENT_RATINGS))}"
         )
 
+    # pack_id must be non-empty and must not contain path-traversal, header-injection,
+    # null characters, or path separators.  Path separators (/ and \) are rejected because
+    # _install_from_dir maps pack_id directly to a directory name after stripping them; two
+    # different ids (e.g. "foo/bar" and "foo_bar") would collide to the same directory,
+    # causing the importer to silently overwrite the first pack's files with the second's.
+    # Null bytes (\x00) are included because os.path on POSIX silently truncates paths at
+    # the first null byte, which could redirect installs to an unintended directory.
+    # "." is rejected because Path(packs_dir) / "." resolves back to packs_dir itself,
+    # which would cause the importer to rmtree the entire packs directory.
     _PACK_ID_FORBIDDEN = {'"', "/", "\\", "\r", "\n", "\x00"}
     if not manifest.pack_id:
         errors.append("pack_id must not be empty")
@@ -159,6 +168,9 @@ def validate_pack_dir(pack_dir: Path) -> tuple[Optional[PackManifest], list[str]
         if not resolved.is_file():
             errors.append(f"Entry scenario file not found: {ref!r}")
 
+    # Scan every entry for symlinks and forbidden extensions.
+    # Symlinks are rejected here (consistent with safe_extract_zip for zip archives)
+    # to prevent shutil.copytree from following them to files outside the pack dir.
     for file_path in pack_dir.rglob("*"):
         if file_path.is_symlink():
             rel = file_path.relative_to(pack_dir)

--- a/services/convsim-core/convsim_core/packs/validator.py
+++ b/services/convsim-core/convsim_core/packs/validator.py
@@ -614,7 +614,7 @@ class _PackValidator:
                 rel = self._rel(path)
                 if path.suffix.lower() in FORBIDDEN_EXTENSIONS:
                     self._error(
-                        "FORBIDDEN_FILE",
+                        "FORBIDDEN_EXTENSION",
                         rel,
                         "(root)",
                         (

--- a/services/convsim-core/convsim_core/routers/packs.py
+++ b/services/convsim-core/convsim_core/routers/packs.py
@@ -130,7 +130,7 @@ async def validate_pack(
         try:
             safe_extract_zip(zip_bytes, extract_dir)
         except ConvsimError as exc:
-            return _zip_error(exc.message)
+            return _zip_error(exc.message, rule_id=exc.code)
 
         top_level = list(extract_dir.iterdir())
         pack_source = (

--- a/services/convsim-core/convsim_core/routers/packs.py
+++ b/services/convsim-core/convsim_core/routers/packs.py
@@ -14,7 +14,7 @@ from convsim_core.errors import ConvsimError
 from convsim_core.packs.exporter import export_to_zip
 from convsim_core.packs.importer import safe_extract_zip, import_from_folder, import_from_zip
 from convsim_core.packs.models import ImportResult, PackSummary, ValidationResult
-from convsim_core.packs.validator import validate_pack_dir
+from convsim_core.packs.validator import validate_pack_dir, _errors_to_rule_ids
 from convsim_core.storage.repositories.pack_repo import list_packs
 
 router = APIRouter(prefix="/api/packs", tags=["packs"])
@@ -133,6 +133,7 @@ async def validate_pack(
         name=manifest.name if manifest else None,
         version=manifest.version if manifest else None,
         errors=errors,
+        rule_ids=_errors_to_rule_ids(errors),
     )
 
 

--- a/services/convsim-core/convsim_core/routers/packs.py
+++ b/services/convsim-core/convsim_core/routers/packs.py
@@ -110,6 +110,7 @@ async def validate_pack(
                 message=message,
                 suggested_fix="Provide a valid pack zip archive.",
             )],
+            rule_ids=[rule_id],
         )
 
     zip_bytes = await file.read()

--- a/services/convsim-core/convsim_core/routers/packs.py
+++ b/services/convsim-core/convsim_core/routers/packs.py
@@ -14,7 +14,7 @@ from convsim_core.errors import ConvsimError
 from convsim_core.packs.exporter import export_to_zip
 from convsim_core.packs.importer import safe_extract_zip, import_from_folder, import_from_zip
 from convsim_core.packs.models import ImportResult, PackSummary, ValidationResult
-from convsim_core.packs.validator import validate_pack_dir, _errors_to_rule_ids
+from convsim_core.packs.validator import validate_pack_dir, errors_to_rule_ids
 from convsim_core.storage.repositories.pack_repo import list_packs
 
 router = APIRouter(prefix="/api/packs", tags=["packs"])
@@ -133,7 +133,7 @@ async def validate_pack(
         name=manifest.name if manifest else None,
         version=manifest.version if manifest else None,
         errors=errors,
-        rule_ids=_errors_to_rule_ids(errors),
+        rule_ids=errors_to_rule_ids(errors),
     )
 
 

--- a/services/convsim-core/convsim_core/routers/scenarios.py
+++ b/services/convsim-core/convsim_core/routers/scenarios.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Scenario library endpoints: list with filters/FTS, and full scenario detail."""
+from typing import Annotated, Optional
+
+from fastapi import APIRouter, Query, Request
+from fastapi.responses import JSONResponse
+
+from convsim_core.errors import ConvsimError
+from convsim_core.packs.models import ScenarioCard, ScenarioDetail
+from convsim_core.storage.repositories.scenario_repo import get_scenario_by_id, list_scenarios
+
+router = APIRouter(prefix="/api/scenarios", tags=["scenarios"])
+
+
+@router.get("", response_model=list[ScenarioCard])
+async def get_scenarios(
+    request: Request,
+    q: Annotated[Optional[str], Query(description="Full-text search over title, summary, tags, and pack README")] = None,
+    pack: Annotated[Optional[str], Query(description="Filter by pack slug")] = None,
+    tag: Annotated[Optional[str], Query(description="Filter by tag")] = None,
+    language: Annotated[Optional[str], Query(description="Filter by supported language code")] = None,
+    content_rating: Annotated[Optional[str], Query(description="Filter by content rating (G, PG, PG-13)")] = None,
+    difficulty: Annotated[Optional[str], Query(description="Filter by default difficulty (easy, normal, hard)")] = None,
+    voice_support: Annotated[Optional[bool], Query(description="Filter to scenarios with voice support")] = None,
+) -> list[ScenarioCard]:
+    """List installed scenarios with optional filters and full-text search."""
+    conn = request.app.state.db.connection()
+    return list_scenarios(
+        conn,
+        q=q,
+        pack=pack,
+        tag=tag,
+        language=language,
+        content_rating=content_rating,
+        difficulty=difficulty,
+        voice_support=voice_support,
+    )
+
+
+@router.get("/{scenario_id}", response_model=ScenarioDetail)
+async def get_scenario(
+    scenario_id: str,
+    request: Request,
+    include_hidden: Annotated[bool, Query(description="Include hidden agenda (only honoured in dev mode)")] = False,
+) -> ScenarioDetail:
+    """Return full scenario metadata. Hidden agenda is excluded unless dev mode is active."""
+    conn = request.app.state.db.connection()
+    config = request.app.state.service_config
+    dev_mode: bool = getattr(config, "dev_debug", False)
+    reveal_hidden = include_hidden and dev_mode
+
+    detail = get_scenario_by_id(conn, scenario_id, include_hidden=reveal_hidden)
+    if detail is None:
+        raise ConvsimError("NOT_FOUND", f"Scenario '{scenario_id}' not found.", status_code=404)
+    return detail

--- a/services/convsim-core/convsim_core/storage/migrations.py
+++ b/services/convsim-core/convsim_core/storage/migrations.py
@@ -223,6 +223,14 @@ CREATE VIRTUAL TABLE scenario_fts USING fts5(
 CREATE VIRTUAL TABLE pack_readme_fts USING fts5(
     name, description
 );
+
+CREATE TRIGGER scenario_fts_delete AFTER DELETE ON scenarios BEGIN
+    DELETE FROM scenario_fts WHERE rowid = OLD.id;
+END;
+
+CREATE TRIGGER pack_readme_fts_delete AFTER DELETE ON packs BEGIN
+    DELETE FROM pack_readme_fts WHERE rowid = OLD.id;
+END;
 """
 
 MIGRATIONS: list[tuple[str, str]] = [

--- a/services/convsim-core/convsim_core/storage/migrations.py
+++ b/services/convsim-core/convsim_core/storage/migrations.py
@@ -168,11 +168,44 @@ ALTER TABLE asset_index ADD COLUMN pack_id INTEGER REFERENCES packs(id) ON DELET
 ALTER TABLE asset_index ADD COLUMN scenario_id INTEGER REFERENCES scenarios(id) ON DELETE SET NULL;
 """
 
+_SCENARIO_LIBRARY_API_SQL = """
+ALTER TABLE packs ADD COLUMN content_rating TEXT;
+ALTER TABLE packs ADD COLUMN supported_languages_json TEXT;
+ALTER TABLE packs ADD COLUMN validation_status TEXT NOT NULL DEFAULT 'unknown';
+ALTER TABLE packs ADD COLUMN last_validated_at TEXT;
+
+ALTER TABLE scenarios ADD COLUMN title TEXT;
+ALTER TABLE scenarios ADD COLUMN summary TEXT;
+ALTER TABLE scenarios ADD COLUMN content_rating TEXT;
+ALTER TABLE scenarios ADD COLUMN difficulty_default TEXT;
+ALTER TABLE scenarios ADD COLUMN max_turns INTEGER;
+ALTER TABLE scenarios ADD COLUMN soft_time_limit_minutes INTEGER;
+ALTER TABLE scenarios ADD COLUMN tags_json TEXT;
+ALTER TABLE scenarios ADD COLUMN voice_support INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE scenarios ADD COLUMN model_recommendation TEXT;
+ALTER TABLE scenarios ADD COLUMN rel_path TEXT;
+
+DROP TABLE scenario_fts;
+CREATE VIRTUAL TABLE scenario_fts USING fts5(title, summary, tags, pack_name, pack_readme);
+
+DROP TABLE pack_readme_fts;
+CREATE VIRTUAL TABLE pack_readme_fts USING fts5(name, description);
+
+CREATE TRIGGER scenario_fts_ad AFTER DELETE ON scenarios BEGIN
+    DELETE FROM scenario_fts WHERE rowid = old.id;
+END;
+
+CREATE TRIGGER pack_readme_fts_ad AFTER DELETE ON packs BEGIN
+    DELETE FROM pack_readme_fts WHERE rowid = old.id;
+END;
+"""
+
 MIGRATIONS: list[tuple[str, str]] = [
     ("0001_initial_schema", _INITIAL_SCHEMA_SQL),
     ("0002_model_registry_v2", _MODEL_REGISTRY_V2_SQL),
     ("0003_model_manager_api", _MODEL_MANAGER_API_SQL),
     ("0004_extend_pack_assets", _EXTEND_PACK_ASSETS_SQL),
+    ("0005_scenario_library_api", _SCENARIO_LIBRARY_API_SQL),
 ]
 
 

--- a/services/convsim-core/convsim_core/storage/migrations.py
+++ b/services/convsim-core/convsim_core/storage/migrations.py
@@ -239,6 +239,14 @@ DROP TABLE IF EXISTS scenario_fts;
 CREATE VIRTUAL TABLE scenario_fts USING fts5(
     title, summary, tags, pack_name, pack_readme
 );
+
+CREATE TRIGGER scenario_fts_delete AFTER DELETE ON scenarios BEGIN
+    DELETE FROM scenario_fts WHERE rowid = OLD.id;
+END;
+
+CREATE TRIGGER pack_readme_fts_delete AFTER DELETE ON packs BEGIN
+    DELETE FROM pack_readme_fts WHERE rowid = OLD.id;
+END;
 """
 
 MIGRATIONS: list[tuple[str, str]] = [

--- a/services/convsim-core/convsim_core/storage/migrations.py
+++ b/services/convsim-core/convsim_core/storage/migrations.py
@@ -218,6 +218,29 @@ CREATE VIRTUAL TABLE session_transcript_fts USING fts5(
 );
 """
 
+_PACK_SCENARIO_LIBRARY_SCHEMA_SQL = """
+ALTER TABLE packs ADD COLUMN content_rating TEXT;
+ALTER TABLE packs ADD COLUMN supported_languages_json TEXT;
+ALTER TABLE packs ADD COLUMN validation_status TEXT;
+ALTER TABLE packs ADD COLUMN last_validated_at TEXT;
+
+ALTER TABLE scenarios ADD COLUMN title TEXT;
+ALTER TABLE scenarios ADD COLUMN summary TEXT;
+ALTER TABLE scenarios ADD COLUMN content_rating TEXT;
+ALTER TABLE scenarios ADD COLUMN difficulty_default TEXT;
+ALTER TABLE scenarios ADD COLUMN max_turns INTEGER;
+ALTER TABLE scenarios ADD COLUMN soft_time_limit_minutes INTEGER;
+ALTER TABLE scenarios ADD COLUMN tags_json TEXT;
+ALTER TABLE scenarios ADD COLUMN voice_support INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE scenarios ADD COLUMN model_recommendation TEXT;
+ALTER TABLE scenarios ADD COLUMN rel_path TEXT;
+
+DROP TABLE IF EXISTS scenario_fts;
+CREATE VIRTUAL TABLE scenario_fts USING fts5(
+    title, summary, tags, pack_name, pack_readme
+);
+"""
+
 MIGRATIONS: list[tuple[str, str]] = [
     ("0001_initial_schema", _INITIAL_SCHEMA_SQL),
     ("0002_model_registry_v2", _MODEL_REGISTRY_V2_SQL),
@@ -225,6 +248,7 @@ MIGRATIONS: list[tuple[str, str]] = [
     ("0004_extend_pack_assets", _EXTEND_PACK_ASSETS_SQL),
     ("0005_turn_pipeline", _TURN_PIPELINE_SQL),
     ("0006_turn_transcript_and_events", _TURN_TRANSCRIPT_AND_EVENTS_SQL),
+    ("0007_pack_scenario_library_schema", _PACK_SCENARIO_LIBRARY_SCHEMA_SQL),
 ]
 
 

--- a/services/convsim-core/convsim_core/storage/migrations.py
+++ b/services/convsim-core/convsim_core/storage/migrations.py
@@ -196,12 +196,42 @@ CREATE TABLE turn_session_turns (
 );
 """
 
+_SCENARIO_LIBRARY_SQL = """
+ALTER TABLE packs ADD COLUMN content_rating TEXT;
+ALTER TABLE packs ADD COLUMN supported_languages_json TEXT;
+ALTER TABLE packs ADD COLUMN validation_status TEXT NOT NULL DEFAULT 'unknown';
+ALTER TABLE packs ADD COLUMN last_validated_at TEXT;
+
+ALTER TABLE scenarios ADD COLUMN title TEXT;
+ALTER TABLE scenarios ADD COLUMN summary TEXT;
+ALTER TABLE scenarios ADD COLUMN content_rating TEXT;
+ALTER TABLE scenarios ADD COLUMN difficulty_default TEXT;
+ALTER TABLE scenarios ADD COLUMN max_turns INTEGER;
+ALTER TABLE scenarios ADD COLUMN soft_time_limit_minutes INTEGER;
+ALTER TABLE scenarios ADD COLUMN tags_json TEXT;
+ALTER TABLE scenarios ADD COLUMN voice_support INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE scenarios ADD COLUMN model_recommendation TEXT;
+ALTER TABLE scenarios ADD COLUMN rel_path TEXT;
+
+DROP TABLE IF EXISTS scenario_fts;
+DROP TABLE IF EXISTS pack_readme_fts;
+
+CREATE VIRTUAL TABLE scenario_fts USING fts5(
+    title, summary, tags, pack_name, pack_readme
+);
+
+CREATE VIRTUAL TABLE pack_readme_fts USING fts5(
+    name, description
+);
+"""
+
 MIGRATIONS: list[tuple[str, str]] = [
     ("0001_initial_schema", _INITIAL_SCHEMA_SQL),
     ("0002_model_registry_v2", _MODEL_REGISTRY_V2_SQL),
     ("0003_model_manager_api", _MODEL_MANAGER_API_SQL),
     ("0004_extend_pack_assets", _EXTEND_PACK_ASSETS_SQL),
     ("0005_turn_pipeline", _TURN_PIPELINE_SQL),
+    ("0006_scenario_library", _SCENARIO_LIBRARY_SQL),
 ]
 
 

--- a/services/convsim-core/convsim_core/storage/migrations.py
+++ b/services/convsim-core/convsim_core/storage/migrations.py
@@ -218,6 +218,38 @@ CREATE VIRTUAL TABLE session_transcript_fts USING fts5(
 );
 """
 
+_SCENARIO_LIBRARY_API_SQL = """
+ALTER TABLE packs ADD COLUMN content_rating TEXT;
+ALTER TABLE packs ADD COLUMN supported_languages_json TEXT;
+ALTER TABLE packs ADD COLUMN validation_status TEXT NOT NULL DEFAULT 'unknown';
+ALTER TABLE packs ADD COLUMN last_validated_at TEXT;
+
+ALTER TABLE scenarios ADD COLUMN title TEXT;
+ALTER TABLE scenarios ADD COLUMN summary TEXT;
+ALTER TABLE scenarios ADD COLUMN content_rating TEXT;
+ALTER TABLE scenarios ADD COLUMN difficulty_default TEXT;
+ALTER TABLE scenarios ADD COLUMN max_turns INTEGER;
+ALTER TABLE scenarios ADD COLUMN soft_time_limit_minutes INTEGER;
+ALTER TABLE scenarios ADD COLUMN tags_json TEXT;
+ALTER TABLE scenarios ADD COLUMN voice_support INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE scenarios ADD COLUMN model_recommendation TEXT;
+ALTER TABLE scenarios ADD COLUMN rel_path TEXT;
+
+DROP TABLE scenario_fts;
+CREATE VIRTUAL TABLE scenario_fts USING fts5(title, summary, tags, pack_name, pack_readme);
+
+DROP TABLE pack_readme_fts;
+CREATE VIRTUAL TABLE pack_readme_fts USING fts5(name, description);
+
+CREATE TRIGGER scenario_fts_ad AFTER DELETE ON scenarios BEGIN
+    DELETE FROM scenario_fts WHERE rowid = old.id;
+END;
+
+CREATE TRIGGER pack_readme_fts_ad AFTER DELETE ON packs BEGIN
+    DELETE FROM pack_readme_fts WHERE rowid = old.id;
+END;
+"""
+
 MIGRATIONS: list[tuple[str, str]] = [
     ("0001_initial_schema", _INITIAL_SCHEMA_SQL),
     ("0002_model_registry_v2", _MODEL_REGISTRY_V2_SQL),
@@ -225,6 +257,7 @@ MIGRATIONS: list[tuple[str, str]] = [
     ("0004_extend_pack_assets", _EXTEND_PACK_ASSETS_SQL),
     ("0005_turn_pipeline", _TURN_PIPELINE_SQL),
     ("0006_turn_transcript_and_events", _TURN_TRANSCRIPT_AND_EVENTS_SQL),
+    ("0007_scenario_library_api", _SCENARIO_LIBRARY_API_SQL),
 ]
 
 

--- a/services/convsim-core/convsim_core/storage/migrations.py
+++ b/services/convsim-core/convsim_core/storage/migrations.py
@@ -246,6 +246,7 @@ CREATE VIRTUAL TABLE pack_readme_fts USING fts5(
     name, description
 );
 
+
 CREATE TRIGGER scenario_fts_delete AFTER DELETE ON scenarios BEGIN
     DELETE FROM scenario_fts WHERE rowid = OLD.id;
 END;

--- a/services/convsim-core/convsim_core/storage/migrations.py
+++ b/services/convsim-core/convsim_core/storage/migrations.py
@@ -228,6 +228,33 @@ CREATE TABLE session_debriefs (
 CREATE INDEX session_debriefs_session_id ON session_debriefs(session_id);
 """
 
+_SCENARIO_LIBRARY_SCHEMA_SQL = """
+ALTER TABLE packs ADD COLUMN content_rating TEXT;
+ALTER TABLE packs ADD COLUMN supported_languages_json TEXT;
+ALTER TABLE packs ADD COLUMN validation_status TEXT NOT NULL DEFAULT 'unknown';
+ALTER TABLE packs ADD COLUMN last_validated_at TEXT;
+
+ALTER TABLE scenarios ADD COLUMN title TEXT;
+ALTER TABLE scenarios ADD COLUMN summary TEXT;
+ALTER TABLE scenarios ADD COLUMN content_rating TEXT;
+ALTER TABLE scenarios ADD COLUMN difficulty_default TEXT;
+ALTER TABLE scenarios ADD COLUMN max_turns INTEGER;
+ALTER TABLE scenarios ADD COLUMN soft_time_limit_minutes INTEGER;
+ALTER TABLE scenarios ADD COLUMN tags_json TEXT;
+ALTER TABLE scenarios ADD COLUMN voice_support INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE scenarios ADD COLUMN model_recommendation TEXT;
+ALTER TABLE scenarios ADD COLUMN rel_path TEXT;
+
+DROP TABLE IF EXISTS scenario_fts;
+CREATE VIRTUAL TABLE scenario_fts USING fts5(
+    title, summary, tags, pack_name, pack_readme
+);
+
+CREATE TRIGGER scenario_fts_delete AFTER DELETE ON scenarios BEGIN
+    DELETE FROM scenario_fts WHERE rowid = OLD.id;
+END;
+"""
+
 MIGRATIONS: list[tuple[str, str]] = [
     ("0001_initial_schema", _INITIAL_SCHEMA_SQL),
     ("0002_model_registry_v2", _MODEL_REGISTRY_V2_SQL),
@@ -236,6 +263,7 @@ MIGRATIONS: list[tuple[str, str]] = [
     ("0005_turn_pipeline", _TURN_PIPELINE_SQL),
     ("0006_turn_transcript_and_events", _TURN_TRANSCRIPT_AND_EVENTS_SQL),
     ("0007_session_debriefs", _DEBRIEF_TABLE_SQL),
+    ("0008_scenario_library_schema", _SCENARIO_LIBRARY_SCHEMA_SQL),
 ]
 
 

--- a/services/convsim-core/convsim_core/storage/migrations.py
+++ b/services/convsim-core/convsim_core/storage/migrations.py
@@ -258,6 +258,35 @@ CREATE VIRTUAL TABLE scenario_fts USING fts5(
 CREATE TRIGGER scenario_fts_delete AFTER DELETE ON scenarios BEGIN
     DELETE FROM scenario_fts WHERE rowid = OLD.id;
 END;
+
+-- Backfill scenario_fts for any scenarios already in the DB before this migration.
+-- Uses name/description as fallbacks because title/summary are NULL on pre-existing rows.
+INSERT INTO scenario_fts(rowid, title, summary, tags, pack_name, pack_readme)
+SELECT s.id,
+       COALESCE(s.title, s.name, ''),
+       COALESCE(s.summary, s.description, ''),
+       '',
+       COALESCE(p.name, ''),
+       COALESCE(p.description, '')
+FROM scenarios s
+JOIN packs p ON s.pack_id = p.id;
+
+-- Keep pack_readme_fts in sync when packs are deleted.  The insert path (insert_pack)
+-- adds a row manually; we need a matching delete trigger so the FTS index doesn't
+-- accumulate ghost entries for removed packs.
+-- pack_readme_fts uses content='packs', so we must use the FTS5 'delete' command
+-- (providing the old column values) instead of a plain DELETE, because by the time
+-- an AFTER DELETE trigger fires the content-table row is already gone and SQLite
+-- can no longer read the indexed terms from it.
+CREATE TRIGGER pack_readme_fts_delete AFTER DELETE ON packs BEGIN
+    INSERT INTO pack_readme_fts(pack_readme_fts, rowid, name, description)
+    VALUES('delete', OLD.id, OLD.name, COALESCE(OLD.description, ''));
+END;
+
+-- Backfill pack_readme_fts for packs imported before this migration (the old
+-- insert_pack did not insert into pack_readme_fts).
+INSERT INTO pack_readme_fts(rowid, name, description)
+SELECT id, name, COALESCE(description, '') FROM packs;
 """
 
 MIGRATIONS: list[tuple[str, str]] = [

--- a/services/convsim-core/convsim_core/storage/migrations.py
+++ b/services/convsim-core/convsim_core/storage/migrations.py
@@ -235,19 +235,16 @@ ALTER TABLE scenarios ADD COLUMN voice_support INTEGER NOT NULL DEFAULT 0;
 ALTER TABLE scenarios ADD COLUMN model_recommendation TEXT;
 ALTER TABLE scenarios ADD COLUMN rel_path TEXT;
 
-DROP TABLE scenario_fts;
-CREATE VIRTUAL TABLE scenario_fts USING fts5(title, summary, tags, pack_name, pack_readme);
+DROP TABLE IF EXISTS scenario_fts;
+DROP TABLE IF EXISTS pack_readme_fts;
 
-DROP TABLE pack_readme_fts;
-CREATE VIRTUAL TABLE pack_readme_fts USING fts5(name, description);
+CREATE VIRTUAL TABLE scenario_fts USING fts5(
+    title, summary, tags, pack_name, pack_readme
+);
 
-CREATE TRIGGER scenario_fts_ad AFTER DELETE ON scenarios BEGIN
-    DELETE FROM scenario_fts WHERE rowid = old.id;
-END;
-
-CREATE TRIGGER pack_readme_fts_ad AFTER DELETE ON packs BEGIN
-    DELETE FROM pack_readme_fts WHERE rowid = old.id;
-END;
+CREATE VIRTUAL TABLE pack_readme_fts USING fts5(
+    name, description
+);
 """
 
 MIGRATIONS: list[tuple[str, str]] = [

--- a/services/convsim-core/convsim_core/storage/migrations.py
+++ b/services/convsim-core/convsim_core/storage/migrations.py
@@ -269,6 +269,7 @@ MIGRATIONS: list[tuple[str, str]] = [
     ("0006_turn_transcript_and_events", _TURN_TRANSCRIPT_AND_EVENTS_SQL),
     ("0007_session_debriefs", _DEBRIEF_TABLE_SQL),
     ("0008_session_debriefs_unique_idx", _DEBRIEF_UNIQUE_IDX_SQL),
+    ("0009_scenario_library_schema", _SCENARIO_LIBRARY_SCHEMA_SQL),
 ]
 
 

--- a/services/convsim-core/convsim_core/storage/migrations.py
+++ b/services/convsim-core/convsim_core/storage/migrations.py
@@ -245,6 +245,14 @@ CREATE VIRTUAL TABLE scenario_fts USING fts5(
 CREATE VIRTUAL TABLE pack_readme_fts USING fts5(
     name, description
 );
+
+CREATE TRIGGER scenario_fts_delete AFTER DELETE ON scenarios BEGIN
+    DELETE FROM scenario_fts WHERE rowid = OLD.id;
+END;
+
+CREATE TRIGGER pack_readme_fts_delete AFTER DELETE ON packs BEGIN
+    DELETE FROM pack_readme_fts WHERE rowid = OLD.id;
+END;
 """
 
 MIGRATIONS: list[tuple[str, str]] = [

--- a/services/convsim-core/convsim_core/storage/repositories/pack_repo.py
+++ b/services/convsim-core/convsim_core/storage/repositories/pack_repo.py
@@ -4,12 +4,14 @@ import json
 import sqlite3
 from typing import Optional
 
-from convsim_core.packs.models import PackManifest, PackSummary
+from convsim_core.packs.models import PackManifest, PackSummary, ScenarioInsertData
 
 
 def list_packs(conn: sqlite3.Connection) -> list[PackSummary]:
     rows = conn.execute(
-        "SELECT id, slug, name, version, description, author, license, source_path, installed_at"
+        "SELECT id, slug, name, version, description, author, license, content_rating,"
+        " supported_languages_json, tags_json, source_path, installed_at,"
+        " validation_status, last_validated_at"
         " FROM packs ORDER BY installed_at DESC"
     ).fetchall()
     return [_row_to_summary(row) for row in rows]
@@ -17,7 +19,9 @@ def list_packs(conn: sqlite3.Connection) -> list[PackSummary]:
 
 def get_pack_by_slug(conn: sqlite3.Connection, slug: str) -> Optional[PackSummary]:
     row = conn.execute(
-        "SELECT id, slug, name, version, description, author, license, source_path, installed_at"
+        "SELECT id, slug, name, version, description, author, license, content_rating,"
+        " supported_languages_json, tags_json, source_path, installed_at,"
+        " validation_status, last_validated_at"
         " FROM packs WHERE slug = ?",
         (slug,),
     ).fetchone()
@@ -29,11 +33,12 @@ def insert_pack(
     manifest: PackManifest,
     source_path: str,
 ) -> int:
-    """Insert a pack record. Returns the new pack DB id. Does not commit."""
+    """Insert a pack record and its FTS entry. Returns the new pack DB id. Does not commit."""
     cursor = conn.execute(
         """
-        INSERT INTO packs (slug, name, version, description, author, license, source_path, tags_json)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO packs (slug, name, version, description, author, license, content_rating,
+                           supported_languages_json, source_path, tags_json)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             manifest.pack_id,
@@ -42,26 +47,66 @@ def insert_pack(
             manifest.description,
             manifest.author,
             manifest.license,
+            manifest.content_rating,
+            json.dumps(manifest.supported_languages) if manifest.supported_languages else None,
             source_path,
             json.dumps(manifest.tags) if manifest.tags else None,
         ),
     )
-    return cursor.lastrowid  # type: ignore[return-value]
+    pack_db_id: int = cursor.lastrowid  # type: ignore[assignment]
+    conn.execute(
+        "INSERT INTO pack_readme_fts(rowid, name, description) VALUES (?, ?, ?)",
+        (pack_db_id, manifest.name, manifest.description or ""),
+    )
+    return pack_db_id
 
 
 def insert_scenario(
     conn: sqlite3.Connection,
     pack_db_id: int,
-    slug: str,
-    name: str,
-    description: Optional[str] = None,
+    data: ScenarioInsertData,
 ) -> int:
-    """Insert a scenario record. Returns the new scenario DB id. Does not commit."""
+    """Insert a scenario record and its FTS entry. Returns the new scenario DB id. Does not commit."""
     cursor = conn.execute(
-        "INSERT INTO scenarios (pack_id, slug, name, description) VALUES (?, ?, ?, ?)",
-        (pack_db_id, slug, name, description),
+        """
+        INSERT INTO scenarios
+            (pack_id, slug, name, title, summary, content_rating, difficulty_default,
+             max_turns, soft_time_limit_minutes, tags_json, voice_support,
+             model_recommendation, rel_path)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            pack_db_id,
+            data.slug,
+            data.name,
+            data.title,
+            data.summary,
+            data.content_rating,
+            data.difficulty_default,
+            data.max_turns,
+            data.soft_time_limit_minutes,
+            data.tags_json,
+            1 if data.voice_support else 0,
+            data.model_recommendation,
+            data.rel_path,
+        ),
     )
-    return cursor.lastrowid  # type: ignore[return-value]
+    scenario_db_id: int = cursor.lastrowid  # type: ignore[assignment]
+
+    pack_tags = " ".join(data.pack_tags) if data.pack_tags else ""
+    conn.execute(
+        "INSERT INTO scenario_fts(rowid, title, summary, tags, pack_name, pack_readme)"
+        " VALUES (?, ?, ?, ?, ?, ?)",
+        (
+            scenario_db_id,
+            data.title or data.name,
+            data.summary or "",
+            pack_tags,
+            data.pack_name,
+            data.pack_description or "",
+        ),
+    )
+    return scenario_db_id
 
 
 def _row_to_summary(row: sqlite3.Row) -> PackSummary:
@@ -73,6 +118,11 @@ def _row_to_summary(row: sqlite3.Row) -> PackSummary:
         description=row["description"],
         author=row["author"],
         license=row["license"],
+        content_rating=row["content_rating"],
+        supported_languages=json.loads(row["supported_languages_json"] or "[]"),
+        tags=json.loads(row["tags_json"] or "[]"),
         source_path=row["source_path"],
         installed_at=row["installed_at"],
+        validation_status=row["validation_status"] or "unknown",
+        last_validated_at=row["last_validated_at"],
     )

--- a/services/convsim-core/convsim_core/storage/repositories/scenario_repo.py
+++ b/services/convsim-core/convsim_core/storage/repositories/scenario_repo.py
@@ -191,7 +191,9 @@ def _load_scenario_yaml(pack_source_path: Optional[str], rel_path: Optional[str]
     if not pack_source_path or not rel_path:
         return {}
     try:
-        path = Path(pack_source_path) / rel_path
+        base = Path(pack_source_path).resolve()
+        path = (base / rel_path).resolve()
+        path.relative_to(base)  # raises ValueError if outside pack directory
         raw = yaml.safe_load(path.read_text(encoding="utf-8"))
         return raw if isinstance(raw, dict) else {}
     except Exception:

--- a/services/convsim-core/convsim_core/storage/repositories/scenario_repo.py
+++ b/services/convsim-core/convsim_core/storage/repositories/scenario_repo.py
@@ -1,0 +1,197 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Database queries for the scenario library: listing, filtering, FTS, and detail."""
+import json
+import sqlite3
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+from convsim_core.packs.models import PlayerRoleInfo, ScenarioCard, ScenarioDetail
+
+_SCENARIO_COLS = """
+    s.slug          AS scenario_id,
+    p.slug          AS pack_id,
+    p.name          AS pack_name,
+    COALESCE(s.title, s.name)  AS title,
+    s.summary,
+    p.tags_json,
+    COALESCE(s.content_rating, p.content_rating) AS content_rating,
+    s.difficulty_default,
+    s.max_turns,
+    s.soft_time_limit_minutes,
+    s.voice_support,
+    s.model_recommendation,
+    s.rel_path,
+    p.source_path   AS pack_source_path
+"""
+
+_BASE_QUERY = f"""
+    SELECT {_SCENARIO_COLS}
+    FROM scenarios s
+    JOIN packs p ON s.pack_id = p.id
+"""
+
+
+def _fts_query(q: str) -> str:
+    """Convert user search text to a safe FTS5 query with prefix matching."""
+    words = [w.replace('"', "").strip() for w in q.split() if w.strip()]
+    if not words:
+        return ""
+    return " ".join(f'"{w}"*' for w in words)
+
+
+def list_scenarios(
+    conn: sqlite3.Connection,
+    *,
+    q: Optional[str] = None,
+    pack: Optional[str] = None,
+    tag: Optional[str] = None,
+    language: Optional[str] = None,
+    content_rating: Optional[str] = None,
+    difficulty: Optional[str] = None,
+    voice_support: Optional[bool] = None,
+) -> list[ScenarioCard]:
+    """Return scenario cards, optionally filtered and/or FTS-searched."""
+    clauses: list[str] = []
+    params: list = []
+
+    if q:
+        fts = _fts_query(q)
+        if fts:
+            clauses.append(
+                "(s.id IN (SELECT rowid FROM scenario_fts WHERE scenario_fts MATCH ?))"
+            )
+            params.append(fts)
+
+    if pack:
+        clauses.append("p.slug = ?")
+        params.append(pack)
+
+    if tag:
+        clauses.append(
+            "p.tags_json IS NOT NULL AND"
+            " EXISTS(SELECT 1 FROM json_each(p.tags_json) jt WHERE jt.value = ?)"
+        )
+        params.append(tag)
+
+    if language:
+        clauses.append(
+            "p.supported_languages_json IS NOT NULL AND"
+            " EXISTS(SELECT 1 FROM json_each(p.supported_languages_json) jl WHERE jl.value = ?)"
+        )
+        params.append(language)
+
+    if content_rating:
+        clauses.append("COALESCE(s.content_rating, p.content_rating) = ?")
+        params.append(content_rating)
+
+    if difficulty:
+        clauses.append("s.difficulty_default = ?")
+        params.append(difficulty)
+
+    if voice_support is not None:
+        clauses.append("s.voice_support = ?")
+        params.append(1 if voice_support else 0)
+
+    sql = _BASE_QUERY
+    if clauses:
+        sql += " WHERE " + " AND ".join(clauses)
+    sql += " ORDER BY title"
+
+    rows = conn.execute(sql, params).fetchall()
+    return [_row_to_card(row) for row in rows]
+
+
+def get_scenario_by_id(
+    conn: sqlite3.Connection,
+    scenario_id: str,
+    *,
+    include_hidden: bool = False,
+) -> Optional[ScenarioDetail]:
+    """Return full scenario detail for a given scenario slug, or None if not found.
+
+    Hidden agenda (goals.hidden) is excluded unless include_hidden is True.
+    """
+    row = conn.execute(
+        _BASE_QUERY + " WHERE s.slug = ? LIMIT 1",
+        (scenario_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    return _row_to_detail(row, include_hidden=include_hidden)
+
+
+def _row_to_card(row: sqlite3.Row) -> ScenarioCard:
+    tags = json.loads(row["tags_json"] or "[]")
+    return ScenarioCard(
+        scenario_id=row["scenario_id"],
+        pack_id=row["pack_id"],
+        pack_name=row["pack_name"],
+        title=row["title"] or row["scenario_id"],
+        summary=row["summary"],
+        tags=tags,
+        content_rating=row["content_rating"],
+        difficulty_default=row["difficulty_default"],
+        max_turns=row["max_turns"],
+        estimated_length_minutes=row["soft_time_limit_minutes"],
+        voice_support=bool(row["voice_support"]),
+        model_recommendation=row["model_recommendation"],
+    )
+
+
+def _row_to_detail(row: sqlite3.Row, *, include_hidden: bool) -> ScenarioDetail:
+    tags = json.loads(row["tags_json"] or "[]")
+    yaml_data = _load_scenario_yaml(row["pack_source_path"], row["rel_path"])
+
+    player_role: Optional[PlayerRoleInfo] = None
+    pr_raw = yaml_data.get("player_role")
+    if isinstance(pr_raw, dict):
+        player_role = PlayerRoleInfo(
+            label=pr_raw.get("label", ""),
+            brief=pr_raw.get("brief"),
+        )
+
+    opening_npc_says: Optional[str] = None
+    opening = yaml_data.get("opening")
+    if isinstance(opening, dict):
+        opening_npc_says = opening.get("npc_says")
+
+    goals = yaml_data.get("goals") or {}
+    player_visible_goals: list[str] = goals.get("player_visible") or []
+    hidden_goals: Optional[list[str]] = goals.get("hidden") if include_hidden else None
+
+    difficulty_raw = yaml_data.get("difficulty") or {}
+    difficulty_options: dict = difficulty_raw.get("options") or {}
+
+    return ScenarioDetail(
+        scenario_id=row["scenario_id"],
+        pack_id=row["pack_id"],
+        pack_name=row["pack_name"],
+        title=row["title"] or row["scenario_id"],
+        summary=row["summary"],
+        tags=tags,
+        content_rating=row["content_rating"],
+        difficulty_default=row["difficulty_default"],
+        difficulty_options=difficulty_options,
+        max_turns=row["max_turns"],
+        estimated_length_minutes=row["soft_time_limit_minutes"],
+        voice_support=bool(row["voice_support"]),
+        model_recommendation=row["model_recommendation"],
+        player_role=player_role,
+        opening_npc_says=opening_npc_says,
+        player_visible_goals=player_visible_goals,
+        hidden_goals=hidden_goals,
+    )
+
+
+def _load_scenario_yaml(pack_source_path: Optional[str], rel_path: Optional[str]) -> dict:
+    """Load scenario YAML from disk. Returns {} if path is unavailable or parse fails."""
+    if not pack_source_path or not rel_path:
+        return {}
+    try:
+        path = Path(pack_source_path) / rel_path
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+        return raw if isinstance(raw, dict) else {}
+    except Exception:
+        return {}

--- a/services/convsim-core/convsim_core/storage/repositories/scenario_repo.py
+++ b/services/convsim-core/convsim_core/storage/repositories/scenario_repo.py
@@ -36,6 +36,7 @@ _BASE_QUERY = f"""
 def _fts_query(q: str) -> str:
     """Convert user search text to a safe FTS5 query with prefix matching."""
     words = [w.replace('"', "").strip() for w in q.split() if w.strip()]
+    words = [w for w in words if w]  # drop words that became empty after stripping quotes
     if not words:
         return ""
     return " ".join(f'"{w}"*' for w in words)

--- a/services/convsim-core/tests/helpers.py
+++ b/services/convsim-core/tests/helpers.py
@@ -122,8 +122,64 @@ def make_pack_dir(base: Path, manifest: dict | None = None, extra_files: dict | 
 
     scenarios_dir = pack_dir / "scenarios"
     scenarios_dir.mkdir(exist_ok=True)
-    (scenarios_dir / "intro.yaml").write_text("scenario_id: intro\ntitle: Intro\n", encoding="utf-8")
-    (scenarios_dir / "advanced.yaml").write_text("scenario_id: advanced\ntitle: Advanced\n", encoding="utf-8")
+    (scenarios_dir / "intro.yaml").write_text(
+        "schema_version: '0.1'\n"
+        "scenario_id: intro\n"
+        "title: Introduction Scenario\n"
+        "summary: Practice introductory conversation skills with a friendly partner.\n"
+        "player_role:\n"
+        "  label: Participant\n"
+        "  brief: You are attending a first meeting.\n"
+        "npc:\n"
+        "  ref: ../npcs/host.yaml\n"
+        "rubric:\n"
+        "  ref: ../rubrics/intro_rubric.yaml\n"
+        "duration:\n"
+        "  max_turns: 10\n"
+        "  soft_time_limit_minutes: 8\n"
+        "opening:\n"
+        "  npc_says: Hello! Welcome to the session.\n"
+        "goals:\n"
+        "  player_visible:\n"
+        "    - Build rapport with the host\n"
+        "    - Demonstrate active listening\n"
+        "  hidden:\n"
+        "    - Host is evaluating your communication style\n"
+        "difficulty:\n"
+        "  default: easy\n"
+        "  options:\n"
+        "    easy:\n"
+        "      npc_patience_modifier: 10\n"
+        "    normal:\n"
+        "      npc_patience_modifier: 0\n",
+        encoding="utf-8",
+    )
+    (scenarios_dir / "advanced.yaml").write_text(
+        "schema_version: '0.1'\n"
+        "scenario_id: advanced\n"
+        "title: Advanced Challenge\n"
+        "summary: A high-pressure scenario for experienced participants.\n"
+        "player_role:\n"
+        "  label: Senior Participant\n"
+        "  brief: You are the lead responder.\n"
+        "npc:\n"
+        "  ref: ../npcs/host.yaml\n"
+        "rubric:\n"
+        "  ref: ../rubrics/intro_rubric.yaml\n"
+        "duration:\n"
+        "  max_turns: 20\n"
+        "  soft_time_limit_minutes: 15\n"
+        "opening:\n"
+        "  npc_says: Let us begin the advanced session.\n"
+        "goals:\n"
+        "  player_visible:\n"
+        "    - Demonstrate expertise under pressure\n"
+        "  hidden:\n"
+        "    - Evaluating leadership qualities\n"
+        "difficulty:\n"
+        "  default: hard\n",
+        encoding="utf-8",
+    )
 
     portraits_dir = pack_dir / "assets" / "portraits"
     portraits_dir.mkdir(parents=True, exist_ok=True)

--- a/services/convsim-core/tests/helpers.py
+++ b/services/convsim-core/tests/helpers.py
@@ -36,8 +36,64 @@ def make_pack_dir(base: Path, manifest: dict | None = None, extra_files: dict | 
 
     scenarios_dir = pack_dir / "scenarios"
     scenarios_dir.mkdir(exist_ok=True)
-    (scenarios_dir / "intro.yaml").write_text("scenario_id: intro\ntitle: Intro\n", encoding="utf-8")
-    (scenarios_dir / "advanced.yaml").write_text("scenario_id: advanced\ntitle: Advanced\n", encoding="utf-8")
+    (scenarios_dir / "intro.yaml").write_text(
+        "schema_version: '0.1'\n"
+        "scenario_id: intro\n"
+        "title: Introduction Scenario\n"
+        "summary: Practice introductory conversation skills with a friendly partner.\n"
+        "player_role:\n"
+        "  label: Participant\n"
+        "  brief: You are attending a first meeting.\n"
+        "npc:\n"
+        "  ref: ../npcs/host.yaml\n"
+        "rubric:\n"
+        "  ref: ../rubrics/intro_rubric.yaml\n"
+        "duration:\n"
+        "  max_turns: 10\n"
+        "  soft_time_limit_minutes: 8\n"
+        "opening:\n"
+        "  npc_says: Hello! Welcome to the session.\n"
+        "goals:\n"
+        "  player_visible:\n"
+        "    - Build rapport with the host\n"
+        "    - Demonstrate active listening\n"
+        "  hidden:\n"
+        "    - Host is evaluating your communication style\n"
+        "difficulty:\n"
+        "  default: easy\n"
+        "  options:\n"
+        "    easy:\n"
+        "      npc_patience_modifier: 10\n"
+        "    normal:\n"
+        "      npc_patience_modifier: 0\n",
+        encoding="utf-8",
+    )
+    (scenarios_dir / "advanced.yaml").write_text(
+        "schema_version: '0.1'\n"
+        "scenario_id: advanced\n"
+        "title: Advanced Challenge\n"
+        "summary: A high-pressure scenario for experienced participants.\n"
+        "player_role:\n"
+        "  label: Senior Participant\n"
+        "  brief: You are the lead responder.\n"
+        "npc:\n"
+        "  ref: ../npcs/host.yaml\n"
+        "rubric:\n"
+        "  ref: ../rubrics/intro_rubric.yaml\n"
+        "duration:\n"
+        "  max_turns: 20\n"
+        "  soft_time_limit_minutes: 15\n"
+        "opening:\n"
+        "  npc_says: Let us begin the advanced session.\n"
+        "goals:\n"
+        "  player_visible:\n"
+        "    - Demonstrate expertise under pressure\n"
+        "  hidden:\n"
+        "    - Evaluating leadership qualities\n"
+        "difficulty:\n"
+        "  default: hard\n",
+        encoding="utf-8",
+    )
 
     portraits_dir = pack_dir / "assets" / "portraits"
     portraits_dir.mkdir(parents=True, exist_ok=True)

--- a/services/convsim-core/tests/test_migrations.py
+++ b/services/convsim-core/tests/test_migrations.py
@@ -101,6 +101,119 @@ def test_fts_tables_created(tmp_path):
         db.close()
 
 
+def test_scenario_fts_backfill_indexes_pre_existing_scenarios(tmp_path):
+    """Scenarios inserted before migration 0009 must appear in scenario_fts after migration."""
+    import sqlite3
+    from convsim_core.storage.migrations import MIGRATIONS, _BOOTSTRAP_SQL
+
+    # Apply all migrations up to but not including 0009.
+    db_path = str(tmp_path / "db" / "app.db")
+    (tmp_path / "db").mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+
+    cutoff = "0009_scenario_library_schema"
+    conn.executescript(_BOOTSTRAP_SQL)
+    for name, sql in MIGRATIONS:
+        if name == cutoff:
+            break
+        conn.executescript(
+            f"BEGIN;\n{sql}\nINSERT INTO schema_migrations(name) VALUES('{name}');\nCOMMIT;\n"
+        )
+
+    # Insert a pack and scenario using the pre-0009 schema (no title/summary columns yet).
+    conn.execute(
+        "INSERT INTO packs (slug, name, version, description) VALUES ('old.pack', 'Old Pack', '1.0.0', 'Old description')"
+    )
+    pack_id = conn.execute("SELECT id FROM packs WHERE slug='old.pack'").fetchone()[0]
+    conn.execute(
+        "INSERT INTO scenarios (pack_id, slug, name, description) VALUES (?, 'old_scenario', 'Old Scenario', 'Old summary')",
+        (pack_id,),
+    )
+    conn.commit()
+
+    # Now apply migration 0009, which should backfill scenario_fts.
+    name, sql = next((n, s) for n, s in MIGRATIONS if n == cutoff)
+    conn.executescript(
+        f"BEGIN;\n{sql}\nINSERT INTO schema_migrations(name) VALUES('{name}');\nCOMMIT;\n"
+    )
+
+    rows = conn.execute(
+        "SELECT rowid FROM scenario_fts WHERE scenario_fts MATCH '\"Old\"*'"
+    ).fetchall()
+    assert len(rows) > 0, "Pre-existing scenario must be indexed in scenario_fts after migration 0009"
+    conn.close()
+
+
+def test_pack_readme_fts_backfill_indexes_pre_existing_packs(tmp_path):
+    """Packs inserted before migration 0009 must appear in pack_readme_fts after migration."""
+    import sqlite3
+    from convsim_core.storage.migrations import MIGRATIONS, _BOOTSTRAP_SQL
+
+    db_path = str(tmp_path / "db" / "app.db")
+    (tmp_path / "db").mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+
+    cutoff = "0009_scenario_library_schema"
+    conn.executescript(_BOOTSTRAP_SQL)
+    for name, sql in MIGRATIONS:
+        if name == cutoff:
+            break
+        conn.executescript(
+            f"BEGIN;\n{sql}\nINSERT INTO schema_migrations(name) VALUES('{name}');\nCOMMIT;\n"
+        )
+
+    conn.execute(
+        "INSERT INTO packs (slug, name, version, description) VALUES ('legacy.pack', 'Legacy Pack', '1.0.0', 'A legacy description')"
+    )
+    conn.commit()
+
+    name, sql = next((n, s) for n, s in MIGRATIONS if n == cutoff)
+    conn.executescript(
+        f"BEGIN;\n{sql}\nINSERT INTO schema_migrations(name) VALUES('{name}');\nCOMMIT;\n"
+    )
+
+    rows = conn.execute(
+        "SELECT rowid FROM pack_readme_fts WHERE pack_readme_fts MATCH '\"Legacy\"*'"
+    ).fetchall()
+    assert len(rows) > 0, "Pre-existing pack must be indexed in pack_readme_fts after migration 0009"
+    conn.close()
+
+
+def test_pack_readme_fts_delete_trigger_removes_entry_on_pack_delete(tmp_path):
+    """Deleting a pack must remove its pack_readme_fts entry to avoid ghost FTS results."""
+    from convsim_core.storage.database import Database
+
+    db = Database.open(str(tmp_path / "db"))
+    try:
+        conn = db.connection()
+        conn.execute(
+            "INSERT INTO packs (slug, name, version) VALUES ('ghost.pack', 'Ghost Pack', '1.0.0')"
+        )
+        pack_id = conn.execute("SELECT id FROM packs WHERE slug='ghost.pack'").fetchone()[0]
+        conn.execute(
+            "INSERT INTO pack_readme_fts(rowid, name, description) VALUES (?, ?, ?)",
+            (pack_id, "Ghost Pack", ""),
+        )
+        conn.commit()
+
+        before = conn.execute(
+            "SELECT rowid FROM pack_readme_fts WHERE pack_readme_fts MATCH '\"Ghost\"*'"
+        ).fetchall()
+        assert len(before) == 1
+
+        conn.execute("DELETE FROM packs WHERE id = ?", (pack_id,))
+        conn.commit()
+
+        after = conn.execute(
+            "SELECT rowid FROM pack_readme_fts WHERE pack_readme_fts MATCH '\"Ghost\"*'"
+        ).fetchall()
+        assert len(after) == 0, "pack_readme_fts must not retain entries for deleted packs"
+    finally:
+        db.close()
+
+
 def test_settings_persist_across_restarts(tmp_path):
     """Settings written to the DB survive a close/reopen cycle."""
     db_dir = str(tmp_path / "db")

--- a/services/convsim-core/tests/test_pack_validator.py
+++ b/services/convsim-core/tests/test_pack_validator.py
@@ -21,7 +21,7 @@ def test_missing_manifest_returns_error(tmp_path):
     empty = tmp_path / "empty_pack"
     empty.mkdir()
     _, errors = validate_pack_dir(empty)
-    assert any("Missing pack.json" in e for e in errors)
+    assert any("missing" in e.lower() and ("pack.json" in e or "manifest" in e) for e in errors)
 
 
 def test_invalid_json_manifest_returns_error(tmp_path):

--- a/services/convsim-core/tests/test_pack_validator.py
+++ b/services/convsim-core/tests/test_pack_validator.py
@@ -104,7 +104,7 @@ def test_schema_violation_returns_error(tmp_path):
 def test_forbidden_extension_rejected(tmp_path):
     pack_dir = make_pack_dir(tmp_path, extra_files={"run_me.sh": b"#!/bin/bash\necho hi"})
     result = validate_pack_dir(pack_dir)
-    assert _has_error(result, rule_id="FORBIDDEN_FILE", text="run_me.sh")
+    assert _has_error(result, rule_id="FORBIDDEN_EXTENSION", text="run_me.sh")
 
 
 def test_executable_extensions_rejected(tmp_path):
@@ -112,8 +112,8 @@ def test_executable_extensions_rejected(tmp_path):
         sub = tmp_path / f"test_{ext.lstrip('.')}"
         pack_dir = make_pack_dir(sub, extra_files={f"bad{ext}": b""})
         result = validate_pack_dir(pack_dir)
-        assert _has_error(result, rule_id="FORBIDDEN_FILE"), (
-            f"Expected {ext!r} to trigger FORBIDDEN_FILE"
+        assert _has_error(result, rule_id="FORBIDDEN_EXTENSION"), (
+            f"Expected {ext!r} to trigger FORBIDDEN_EXTENSION"
         )
 
 
@@ -440,13 +440,13 @@ def test_multiple_errors_reported_in_one_pass(tmp_path):
             "content_rating": "Adult",                     # INVALID_CONTENT_RATING
             "entry_scenarios": ["scenarios/missing.yaml"],  # MISSING_FILE
         },
-        extra_files={"hack.sh": b"#!/bin/sh"},             # FORBIDDEN_FILE
+        extra_files={"hack.sh": b"#!/bin/sh"},             # FORBIDDEN_EXTENSION
     )
     result = validate_pack_dir(pack_dir)
     rule_ids = {e.rule_id for e in result.errors}
     assert "INVALID_CONTENT_RATING" in rule_ids
     assert "MISSING_FILE" in rule_ids
-    assert "FORBIDDEN_FILE" in rule_ids
+    assert "FORBIDDEN_EXTENSION" in rule_ids
 
 
 # ---------------------------------------------------------------------------

--- a/services/convsim-core/tests/test_pack_validator.py
+++ b/services/convsim-core/tests/test_pack_validator.py
@@ -124,7 +124,7 @@ def test_command_extension_rejected(tmp_path):
         extra_files={"open_me.command": b"#!/bin/sh\nopen /Applications/Terminal.app"},
     )
     result = validate_pack_dir(pack_dir)
-    assert _has_error(result, rule_id="FORBIDDEN_FILE", text="open_me.command")
+    assert _has_error(result, rule_id="FORBIDDEN_EXTENSION", text="open_me.command")
 
 
 def test_forbidden_file_in_nested_directory_rejected(tmp_path):
@@ -134,7 +134,7 @@ def test_forbidden_file_in_nested_directory_rejected(tmp_path):
         extra_files={"assets/scripts/deploy.sh": b"#!/bin/sh\necho hello"},
     )
     result = validate_pack_dir(pack_dir)
-    assert _has_error(result, rule_id="FORBIDDEN_FILE", text="deploy.sh")
+    assert _has_error(result, rule_id="FORBIDDEN_EXTENSION", text="deploy.sh")
 
 
 @pytest.mark.parametrize("filename,magic_bytes,desc", [
@@ -179,17 +179,17 @@ def test_forbidden_binary_error_message_mentions_mvp_packs(tmp_path):
     )
 
 
-def test_forbidden_file_error_message_mentions_mvp_packs(tmp_path):
-    """FORBIDDEN_FILE errors must explain that MVP packs are data, not code."""
+def test_forbidden_extension_error_message_mentions_mvp_packs(tmp_path):
+    """FORBIDDEN_EXTENSION errors must explain that MVP packs are data, not code."""
     pack_dir = make_pack_dir(
         tmp_path,
         extra_files={"run_me.sh": b"#!/bin/bash\necho hi"},
     )
     result = validate_pack_dir(pack_dir)
-    assert _has_error(result, rule_id="FORBIDDEN_FILE")
-    file_error = next(e for e in result.errors if e.rule_id == "FORBIDDEN_FILE")
-    assert "mvp packs are data" in file_error.message.lower(), (
-        f"Error message should mention MVP packs are data; got: {file_error.message!r}"
+    assert _has_error(result, rule_id="FORBIDDEN_EXTENSION")
+    ext_error = next(e for e in result.errors if e.rule_id == "FORBIDDEN_EXTENSION")
+    assert "mvp packs are data" in ext_error.message.lower(), (
+        f"Error message should mention MVP packs are data; got: {ext_error.message!r}"
     )
 
 

--- a/services/convsim-core/tests/test_scenarios_api.py
+++ b/services/convsim-core/tests/test_scenarios_api.py
@@ -356,6 +356,25 @@ def test_validate_yaml_mapping_error_returns_invalid_manifest_yaml_rule(client, 
     assert "SCHEMA_VIOLATION" not in rule_ids
 
 
+def test_validate_missing_entry_scenario_returns_missing_entry_scenario_rule(client, tmp_path):
+    """Missing entry scenario file must produce MISSING_ENTRY_SCENARIO, not SCHEMA_VIOLATION."""
+    from convsim_core.packs.validator import errors_to_rule_ids
+    errors = ["Entry scenario file not found: 'scenarios/intro.yaml'"]
+    rule_ids = errors_to_rule_ids(errors)
+    assert "MISSING_ENTRY_SCENARIO" in rule_ids
+    assert "SCHEMA_VIOLATION" not in rule_ids
+
+
+def test_validate_missing_entry_scenario_not_confused_by_required_in_filename(client, tmp_path):
+    """MISSING_ENTRY_SCENARIO must not be misclassified as SCHEMA_VIOLATION when the
+    filename happens to contain the word 'required'."""
+    from convsim_core.packs.validator import errors_to_rule_ids
+    errors = ["Entry scenario file not found: 'scenarios/required_intro.yaml'"]
+    rule_ids = errors_to_rule_ids(errors)
+    assert "MISSING_ENTRY_SCENARIO" in rule_ids
+    assert "SCHEMA_VIOLATION" not in rule_ids
+
+
 # ── manifest.yaml format ──────────────────────────────────────────────────────
 
 

--- a/services/convsim-core/tests/test_scenarios_api.py
+++ b/services/convsim-core/tests/test_scenarios_api.py
@@ -492,3 +492,11 @@ def test_pack_list_includes_tags(client, tmp_path):
     resp = client.get("/api/packs")
     packs = resp.json()
     assert "test" in packs[0]["tags"]
+
+
+def test_validate_yaml_manifest_schema_violation_returns_schema_violation_rule(client, tmp_path):
+    """Schema errors from a manifest.yaml pack must produce SCHEMA_VIOLATION, not fall through to other rules."""
+    from convsim_core.packs.validator import errors_to_rule_ids
+    errors = ["manifest.yaml [name]: 'Foo Bar' does not match '^[a-z]'"]
+    rule_ids = errors_to_rule_ids(errors)
+    assert "SCHEMA_VIOLATION" in rule_ids

--- a/services/convsim-core/tests/test_scenarios_api.py
+++ b/services/convsim-core/tests/test_scenarios_api.py
@@ -411,11 +411,46 @@ def test_import_manifest_yaml_pack(client, tmp_path):
         "scenario_id: yaml_intro\n"
         "title: YAML Intro\n"
         "summary: A scenario loaded from a manifest.yaml pack.\n"
+        "player_role:\n  label: Tester\n  brief: You are testing the YAML pack import.\n"
         "npc:\n  ref: ../npcs/host.yaml\n"
-        "rubric:\n  ref: ../rubrics/default.yaml\n"
+        "rubric:\n  ref: ../rubrics/intro_rubric.yaml\n"
         "duration:\n  max_turns: 5\n  soft_time_limit_minutes: 4\n"
         "opening:\n  npc_says: Hello from YAML pack.\n"
         "goals:\n  player_visible:\n    - Test YAML import\n",
+        encoding="utf-8",
+    )
+
+    npcs_dir = pack_dir / "npcs"
+    npcs_dir.mkdir()
+    (npcs_dir / "host.yaml").write_text(
+        "schema_version: '0.1'\n"
+        "npc_id: host\n"
+        "display_name: Host\n"
+        "archetype: generic\n"
+        "fictional: true\n"
+        "age_band: adult\n"
+        "public_persona:\n"
+        "  occupation: Test host for YAML pack\n"
+        "  speaking_style: Neutral and direct\n"
+        "  demeanor: Professional\n"
+        "private_persona: {}\n",
+        encoding="utf-8",
+    )
+
+    rubrics_dir = pack_dir / "rubrics"
+    rubrics_dir.mkdir()
+    (rubrics_dir / "intro_rubric.yaml").write_text(
+        "schema_version: '0.1'\n"
+        "rubric_id: intro_rubric\n"
+        "title: Intro Rubric\n"
+        "dimensions:\n"
+        "  - id: quality\n"
+        "    name: Response Quality\n"
+        "    description: How well the player responded\n"
+        "    scoring:\n"
+        "      low: Poor response\n"
+        "      medium: Adequate response\n"
+        "      high: Excellent response\n",
         encoding="utf-8",
     )
 

--- a/services/convsim-core/tests/test_scenarios_api.py
+++ b/services/convsim-core/tests/test_scenarios_api.py
@@ -338,6 +338,26 @@ def test_validate_invalid_pack_returns_rule_ids(client, tmp_path):
     assert "FORBIDDEN_EXTENSION" in body["rule_ids"]
 
 
+def test_validate_zip_slip_returns_zip_slip_rule_id(client, tmp_path):
+    """A zip with a path traversal entry must return rule_id ZIP_SLIP, not INVALID_ZIP."""
+    import io as _io
+    import zipfile as _zipfile
+
+    buf = _io.BytesIO()
+    with _zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("../escape.txt", "evil")
+    zip_bytes = buf.getvalue()
+
+    resp = client.post(
+        "/api/packs/validate",
+        files={"file": ("pack.zip", zip_bytes, "application/zip")},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["valid"] is False
+    assert body["rule_ids"] == ["ZIP_SLIP"]
+
+
 def test_validate_pack_with_null_byte_entry_scenario_returns_unsafe_rule(client, tmp_path):
     """Null byte in an entry scenario path must produce UNSAFE_ENTRY_SCENARIO, not INVALID_PACK_ID."""
     from convsim_core.packs.validator import errors_to_rule_ids

--- a/services/convsim-core/tests/test_scenarios_api.py
+++ b/services/convsim-core/tests/test_scenarios_api.py
@@ -1,0 +1,409 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Integration tests for the scenario library API."""
+import pytest
+from fastapi.testclient import TestClient
+
+from tests.helpers import make_pack_zip, make_pack_dir
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _import_pack(client: TestClient, tmp_path, manifest: dict | None = None) -> None:
+    zip_bytes = make_pack_zip(tmp_path, manifest=manifest)
+    resp = client.post(
+        "/api/packs/import/zip",
+        files={"file": ("pack.zip", zip_bytes, "application/zip")},
+    )
+    assert resp.status_code == 201, resp.text
+
+
+# ── no-pack state ─────────────────────────────────────────────────────────────
+
+
+def test_list_scenarios_empty_when_no_packs(client):
+    resp = client.get("/api/scenarios")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_get_scenario_404_when_no_packs(client):
+    resp = client.get("/api/scenarios/nonexistent")
+    assert resp.status_code == 404
+    assert resp.json()["error"]["code"] == "NOT_FOUND"
+
+
+# ── basic listing ─────────────────────────────────────────────────────────────
+
+
+def test_list_scenarios_returns_cards_after_import(client, tmp_path):
+    _import_pack(client, tmp_path)
+    resp = client.get("/api/scenarios")
+    assert resp.status_code == 200
+    scenarios = resp.json()
+    assert len(scenarios) >= 1
+    card = scenarios[0]
+    assert "scenario_id" in card
+    assert "pack_id" in card
+    assert "pack_name" in card
+    assert "title" in card
+
+
+def test_scenario_card_has_expected_fields(client, tmp_path):
+    _import_pack(client, tmp_path)
+    resp = client.get("/api/scenarios")
+    cards = resp.json()
+    assert len(cards) >= 1
+    card = cards[0]
+    required = {
+        "scenario_id", "pack_id", "pack_name", "title", "summary",
+        "tags", "content_rating", "difficulty_default", "max_turns",
+        "estimated_length_minutes", "voice_support", "model_recommendation",
+    }
+    assert required.issubset(card.keys())
+
+
+def test_scenario_card_includes_pack_metadata(client, tmp_path):
+    _import_pack(client, tmp_path)
+    resp = client.get("/api/scenarios")
+    card = resp.json()[0]
+    assert card["pack_id"] == "test.sample_pack"
+    assert card["pack_name"] == "Sample Pack"
+    assert card["content_rating"] == "G"
+    assert "test" in card["tags"]
+
+
+# ── scenario detail ───────────────────────────────────────────────────────────
+
+
+def test_get_scenario_detail_returns_full_metadata(client, tmp_path):
+    _import_pack(client, tmp_path)
+    resp = client.get("/api/scenarios")
+    scenario_id = resp.json()[0]["scenario_id"]
+
+    detail_resp = client.get(f"/api/scenarios/{scenario_id}")
+    assert detail_resp.status_code == 200
+    detail = detail_resp.json()
+
+    assert detail["scenario_id"] == scenario_id
+    assert "title" in detail
+    assert "player_role" in detail
+    assert "opening_npc_says" in detail
+    assert "player_visible_goals" in detail
+    assert isinstance(detail["player_visible_goals"], list)
+
+
+def test_get_scenario_detail_intro(client, tmp_path):
+    _import_pack(client, tmp_path)
+    resp = client.get("/api/scenarios/intro")
+    assert resp.status_code == 200
+    detail = resp.json()
+    assert detail["title"] == "Introduction Scenario"
+    assert detail["max_turns"] == 10
+    assert detail["estimated_length_minutes"] == 8
+    assert detail["difficulty_default"] == "easy"
+    assert detail["player_role"]["label"] == "Participant"
+    assert detail["opening_npc_says"] == "Hello! Welcome to the session."
+    assert "Build rapport with the host" in detail["player_visible_goals"]
+
+
+# ── hidden agenda security ────────────────────────────────────────────────────
+
+
+def test_hidden_goals_not_returned_by_default(client, tmp_path):
+    _import_pack(client, tmp_path)
+    resp = client.get("/api/scenarios/intro")
+    assert resp.status_code == 200
+    detail = resp.json()
+    assert detail.get("hidden_goals") is None
+
+
+def test_hidden_goals_not_returned_even_when_requested_without_dev_mode(client, tmp_path):
+    """include_hidden=1 must be ignored when dev_debug is False (the default)."""
+    _import_pack(client, tmp_path)
+    resp = client.get("/api/scenarios/intro?include_hidden=true")
+    assert resp.status_code == 200
+    detail = resp.json()
+    assert detail.get("hidden_goals") is None
+
+
+# ── filters ───────────────────────────────────────────────────────────────────
+
+
+def test_filter_by_pack(client, tmp_path):
+    _import_pack(client, tmp_path)
+    resp = client.get("/api/scenarios?pack=test.sample_pack")
+    assert resp.status_code == 200
+    scenarios = resp.json()
+    assert len(scenarios) >= 1
+    for s in scenarios:
+        assert s["pack_id"] == "test.sample_pack"
+
+
+def test_filter_by_nonexistent_pack_returns_empty(client, tmp_path):
+    _import_pack(client, tmp_path)
+    resp = client.get("/api/scenarios?pack=no_such_pack")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_filter_by_tag(client, tmp_path):
+    _import_pack(client, tmp_path)
+    resp = client.get("/api/scenarios?tag=test")
+    assert resp.status_code == 200
+    assert len(resp.json()) >= 1
+
+
+def test_filter_by_nonexistent_tag_returns_empty(client, tmp_path):
+    _import_pack(client, tmp_path)
+    resp = client.get("/api/scenarios?tag=nonexistent_tag_xyz")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_filter_by_language(client, tmp_path):
+    _import_pack(client, tmp_path)
+    resp = client.get("/api/scenarios?language=en")
+    assert resp.status_code == 200
+    assert len(resp.json()) >= 1
+
+
+def test_filter_by_language_not_supported_returns_empty(client, tmp_path):
+    _import_pack(client, tmp_path)
+    resp = client.get("/api/scenarios?language=jp")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_filter_by_content_rating(client, tmp_path):
+    _import_pack(client, tmp_path)
+    resp = client.get("/api/scenarios?content_rating=G")
+    assert resp.status_code == 200
+    assert len(resp.json()) >= 1
+
+
+def test_filter_by_content_rating_no_match(client, tmp_path):
+    _import_pack(client, tmp_path)
+    resp = client.get("/api/scenarios?content_rating=PG-13")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_filter_by_difficulty(client, tmp_path):
+    _import_pack(client, tmp_path)
+    resp = client.get("/api/scenarios?difficulty=easy")
+    assert resp.status_code == 200
+    scenarios = resp.json()
+    assert len(scenarios) >= 1
+    for s in scenarios:
+        assert s["difficulty_default"] == "easy"
+
+
+def test_filter_by_voice_support_false(client, tmp_path):
+    _import_pack(client, tmp_path)
+    resp = client.get("/api/scenarios?voice_support=false")
+    assert resp.status_code == 200
+    for s in resp.json():
+        assert s["voice_support"] is False
+
+
+def test_filter_by_voice_support_true_returns_empty_for_test_pack(client, tmp_path):
+    _import_pack(client, tmp_path)
+    resp = client.get("/api/scenarios?voice_support=true")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+# ── FTS search ────────────────────────────────────────────────────────────────
+
+
+def test_fts_search_by_title_word(client, tmp_path):
+    _import_pack(client, tmp_path)
+    resp = client.get("/api/scenarios?q=Introduction")
+    assert resp.status_code == 200
+    results = resp.json()
+    assert any(s["scenario_id"] == "intro" for s in results)
+
+
+def test_fts_search_by_summary_word(client, tmp_path):
+    _import_pack(client, tmp_path)
+    resp = client.get("/api/scenarios?q=introductory")
+    assert resp.status_code == 200
+    results = resp.json()
+    assert any(s["scenario_id"] == "intro" for s in results)
+
+
+def test_fts_search_by_pack_name(client, tmp_path):
+    _import_pack(client, tmp_path)
+    resp = client.get("/api/scenarios?q=Sample")
+    assert resp.status_code == 200
+    results = resp.json()
+    assert len(results) >= 1
+
+
+def test_fts_search_by_pack_description(client, tmp_path):
+    _import_pack(client, tmp_path)
+    resp = client.get("/api/scenarios?q=minimal")
+    assert resp.status_code == 200
+    results = resp.json()
+    assert len(results) >= 1
+
+
+def test_fts_search_no_match_returns_empty(client, tmp_path):
+    _import_pack(client, tmp_path)
+    resp = client.get("/api/scenarios?q=zzznomatchxxx")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_fts_search_works_without_network(client, tmp_path):
+    """FTS is local SQLite — it must not make any network calls (structural test)."""
+    _import_pack(client, tmp_path)
+    resp = client.get("/api/scenarios?q=pressure")
+    assert resp.status_code == 200
+
+
+# ── validation rule_ids ───────────────────────────────────────────────────────
+
+
+def test_validate_valid_pack_returns_rule_ids_empty(client, tmp_path):
+    zip_bytes = make_pack_zip(tmp_path)
+    resp = client.post(
+        "/api/packs/validate",
+        files={"file": ("pack.zip", zip_bytes, "application/zip")},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["valid"] is True
+    assert body["rule_ids"] == []
+
+
+def test_validate_invalid_pack_returns_rule_ids(client, tmp_path):
+    zip_bytes = make_pack_zip(tmp_path, extra_files={"bad.sh": b"#!/bin/sh\necho hi"})
+    resp = client.post(
+        "/api/packs/validate",
+        files={"file": ("pack.zip", zip_bytes, "application/zip")},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["valid"] is False
+    assert "FORBIDDEN_EXTENSION" in body["rule_ids"]
+
+
+# ── manifest.yaml format ──────────────────────────────────────────────────────
+
+
+def test_import_manifest_yaml_pack(client, tmp_path):
+    """Packs with manifest.yaml (YAML format) instead of pack.json must import successfully."""
+    pack_dir = tmp_path / "yaml_pack"
+    pack_dir.mkdir()
+
+    manifest_content = (
+        "schema_version: '0.1'\n"
+        "pack_id: test.yaml_pack\n"
+        "name: YAML Pack\n"
+        "version: 1.0.0\n"
+        "description: Pack using manifest.yaml format\n"
+        "author: Test Suite\n"
+        "license: CC BY 4.0\n"
+        "content_rating: G\n"
+        "tags:\n"
+        "  - yaml\n"
+        "  - test\n"
+        "supported_languages:\n"
+        "  - en\n"
+        "entry_scenarios:\n"
+        "  - scenarios/yaml_intro.yaml\n"
+        "safety:\n"
+        "  policy: safety/default.yaml\n"
+    )
+    (pack_dir / "manifest.yaml").write_text(manifest_content, encoding="utf-8")
+
+    scenarios_dir = pack_dir / "scenarios"
+    scenarios_dir.mkdir()
+    (scenarios_dir / "yaml_intro.yaml").write_text(
+        "schema_version: '0.1'\n"
+        "scenario_id: yaml_intro\n"
+        "title: YAML Intro\n"
+        "summary: A scenario loaded from a manifest.yaml pack.\n"
+        "npc:\n  ref: ../npcs/host.yaml\n"
+        "rubric:\n  ref: ../rubrics/default.yaml\n"
+        "duration:\n  max_turns: 5\n  soft_time_limit_minutes: 4\n"
+        "opening:\n  npc_says: Hello from YAML pack.\n"
+        "goals:\n  player_visible:\n    - Test YAML import\n",
+        encoding="utf-8",
+    )
+
+    safety_dir = pack_dir / "safety"
+    safety_dir.mkdir()
+    (safety_dir / "default.yaml").write_text(
+        "schema_version: '0.1'\n"
+        "policy_id: default\n"
+        "content_categories:\n"
+        "  nsfw_sexual: block\n"
+        "  real_person_impersonation: block\n"
+        "  instructional_criminal: block\n"
+        "  crisis_content: redirect\n"
+        "redirect_message: \"I can't help with that.\"\n"
+        "content_rating_cap: G\n",
+        encoding="utf-8",
+    )
+
+    import io as _io
+    import zipfile as _zipfile
+
+    buf = _io.BytesIO()
+    with _zipfile.ZipFile(buf, "w") as zf:
+        for f in sorted(pack_dir.rglob("*")):
+            if f.is_file():
+                arcname = "yaml_pack/" + str(f.relative_to(pack_dir)).replace("\\", "/")
+                zf.write(f, arcname)
+    zip_bytes = buf.getvalue()
+
+    resp = client.post(
+        "/api/packs/import/zip",
+        files={"file": ("yaml_pack.zip", zip_bytes, "application/zip")},
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["pack_slug"] == "test.yaml_pack"
+    assert body["scenarios_indexed"] >= 1
+
+    # Verify it shows up in scenarios list
+    scenarios_resp = client.get("/api/scenarios?pack=test.yaml_pack")
+    assert scenarios_resp.status_code == 200
+    assert len(scenarios_resp.json()) >= 1
+
+
+# ── packs list includes new fields ────────────────────────────────────────────
+
+
+def test_pack_list_includes_content_rating(client, tmp_path):
+    _import_pack(client, tmp_path)
+    resp = client.get("/api/packs")
+    assert resp.status_code == 200
+    packs = resp.json()
+    assert len(packs) == 1
+    assert packs[0]["content_rating"] == "G"
+
+
+def test_pack_list_includes_supported_languages(client, tmp_path):
+    _import_pack(client, tmp_path)
+    resp = client.get("/api/packs")
+    packs = resp.json()
+    assert packs[0]["supported_languages"] == ["en"]
+
+
+def test_pack_list_includes_validation_status(client, tmp_path):
+    _import_pack(client, tmp_path)
+    resp = client.get("/api/packs")
+    packs = resp.json()
+    assert "validation_status" in packs[0]
+    assert packs[0]["validation_status"] == "unknown"
+
+
+def test_pack_list_includes_tags(client, tmp_path):
+    _import_pack(client, tmp_path)
+    resp = client.get("/api/packs")
+    packs = resp.json()
+    assert "test" in packs[0]["tags"]

--- a/services/convsim-core/tests/test_scenarios_api.py
+++ b/services/convsim-core/tests/test_scenarios_api.py
@@ -302,6 +302,15 @@ def test_fts_search_works_without_network(client, tmp_path):
     assert resp.status_code == 200
 
 
+def test_fts_search_query_of_only_quotes_returns_all(client, tmp_path):
+    """A search query consisting only of quote characters should behave like no query."""
+    _import_pack(client, tmp_path)
+    resp = client.get('/api/scenarios?q="')
+    assert resp.status_code == 200
+    all_resp = client.get("/api/scenarios")
+    assert resp.json() == all_resp.json()
+
+
 # ── validation rule_ids ───────────────────────────────────────────────────────
 
 

--- a/services/convsim-core/tests/test_scenarios_api.py
+++ b/services/convsim-core/tests/test_scenarios_api.py
@@ -3,10 +3,29 @@
 import pytest
 from fastapi.testclient import TestClient
 
+from convsim_core.app import create_app
+from convsim_core.config import ServiceConfig
 from tests.helpers import make_pack_zip, make_pack_dir
 
 
 # ── helpers ───────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def dev_client(tmp_path):
+    config = ServiceConfig(
+        host="127.0.0.1",
+        port=7355,
+        data_dir=str(tmp_path / "data"),
+        log_dir=str(tmp_path / "logs"),
+        db_dir=str(tmp_path / "db"),
+        packs_dir=str(tmp_path / "packs"),
+        local_dev_packs_dir=str(tmp_path),
+        dev_debug=True,
+    )
+    app = create_app(config)
+    with TestClient(app) as c:
+        yield c
 
 
 def _import_pack(client: TestClient, tmp_path, manifest: dict | None = None) -> None:
@@ -122,6 +141,26 @@ def test_hidden_goals_not_returned_even_when_requested_without_dev_mode(client, 
     """include_hidden=1 must be ignored when dev_debug is False (the default)."""
     _import_pack(client, tmp_path)
     resp = client.get("/api/scenarios/intro?include_hidden=true")
+    assert resp.status_code == 200
+    detail = resp.json()
+    assert detail.get("hidden_goals") is None
+
+
+def test_hidden_goals_returned_in_dev_mode_with_flag(dev_client, tmp_path):
+    """Hidden agenda must be returned when dev_debug=True and include_hidden=true."""
+    _import_pack(dev_client, tmp_path)
+    resp = dev_client.get("/api/scenarios/intro?include_hidden=true")
+    assert resp.status_code == 200
+    detail = resp.json()
+    assert isinstance(detail.get("hidden_goals"), list)
+    assert len(detail["hidden_goals"]) > 0
+    assert "Host is evaluating your communication style" in detail["hidden_goals"]
+
+
+def test_hidden_goals_not_returned_in_dev_mode_without_flag(dev_client, tmp_path):
+    """In dev mode, hidden agenda must still be withheld unless include_hidden=true."""
+    _import_pack(dev_client, tmp_path)
+    resp = dev_client.get("/api/scenarios/intro")
     assert resp.status_code == 200
     detail = resp.json()
     assert detail.get("hidden_goals") is None
@@ -288,6 +327,24 @@ def test_validate_invalid_pack_returns_rule_ids(client, tmp_path):
     body = resp.json()
     assert body["valid"] is False
     assert "FORBIDDEN_EXTENSION" in body["rule_ids"]
+
+
+def test_validate_pack_with_null_byte_entry_scenario_returns_unsafe_rule(client, tmp_path):
+    """Null byte in an entry scenario path must produce UNSAFE_ENTRY_SCENARIO, not INVALID_PACK_ID."""
+    from convsim_core.packs.validator import errors_to_rule_ids
+    errors = ["Entry scenario path contains null byte: 'scenarios/foo\x00bar.yaml'"]
+    rule_ids = errors_to_rule_ids(errors)
+    assert "UNSAFE_ENTRY_SCENARIO" in rule_ids
+    assert "INVALID_PACK_ID" not in rule_ids
+
+
+def test_validate_yaml_mapping_error_returns_invalid_manifest_yaml_rule(client, tmp_path):
+    """'manifest.yaml must be a YAML mapping' must produce INVALID_MANIFEST_YAML, not SCHEMA_VIOLATION."""
+    from convsim_core.packs.validator import errors_to_rule_ids
+    errors = ["manifest.yaml must be a YAML mapping"]
+    rule_ids = errors_to_rule_ids(errors)
+    assert "INVALID_MANIFEST_YAML" in rule_ids
+    assert "SCHEMA_VIOLATION" not in rule_ids
 
 
 # ── manifest.yaml format ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Implements the scenario library API (`GET /api/scenarios`, `GET /api/scenarios/{scenario_id}`) with local SQLite FTS5 search and flexible filtering. Extends the packs endpoint to return library metadata (`content_rating`, `supported_languages`, `tags`, `validation_status`), and adds structured validation reporting via `rule_ids`. Supports importing packs via optional `manifest.yaml` files (YAML format) for compatibility with official pack structure.

## Changes

**Database (migrations 0008–0009):**
- Extended `packs` with `content_rating`, `supported_languages_json`, `validation_status`, `last_validated_at`, and `tags_json`.
- Extended `scenarios` with `title`, `summary`, `difficulty_default`, `max_turns`, `soft_time_limit_minutes`, `tags_json`, `voice_support`, `model_recommendation`, `rel_path`.
- Created self-managed FTS5 tables:
  - `scenario_fts(title, summary, tags, pack_name, pack_readme)` with delete triggers.
  - `pack_readme_fts(name, description)` with content='packs' and delete triggers for cleanup on pack removal.
- Migration 0009 backfills FTS entries for pre-existing scenarios and packs.

**Pack validator (`validator.py`):**
- Accepts `manifest.yaml` (YAML format) as a fallback when `pack.json` is absent, enabling import of packs that use YAML-only manifests.
- Added `rule_ids: list[str]` field to `ValidationResult`, derived from validation issue rule IDs for CLI parity and structured API responses.
- Restored `errors_to_rule_ids()` function for mapping validation errors to rule IDs.

**Importer (`importer.py`):**
- Parses scenario YAML files at import time, extracting `title`, `summary`, `tags`, `difficulty`, `voice_support`, `max_turns`, `model_recommendation`, and `player_role`.
- Populates new database columns for each scenario and denormalizes pack metadata into FTS entries for full-text search.
- Updated `insert_pack()` to populate pack-level `content_rating`, `supported_languages`, `tags`.

**Pack repository (`pack_repo.py`):**
- Extended `PackSummary` to include `content_rating`, `supported_languages`, `tags`, `validation_status`, `last_validated_at`.
- Updated `get_packs()` to return all extended fields.

**Scenario repository (`scenario_repo.py`, new):**
- `list_scenarios()`: Queries FTS index with optional full-text search (`q`), supports filters: `pack`, `tag`, `language`, `content_rating`, `difficulty`, `voice_support`.
- `get_scenario_by_id()`: Returns `ScenarioDetail` with player role, opening line, and player-visible goals; excludes hidden agenda by default, only revealed in dev mode when `include_hidden=true` is explicitly passed.

**Scenarios router (`routers/scenarios.py`, new):**
- `GET /api/scenarios`: List scenarios with FTS and filtering; returns `ScenarioCard` summary (title, summary, tags, difficulty, voice support, model recommendation).
- `GET /api/scenarios/{scenario_id}`: Return full scenario metadata; hides hidden agenda unless server is in dev mode and `include_hidden=true`.

**Pack models (`packs/models.py`):**
- Added `ScenarioCard` (library card view) and `ScenarioDetail` (full metadata view) Pydantic models.
- Added `PlayerRoleInfo` and `ScenarioInsertData` for metadata marshalling.

**Tests (`test_scenarios_api.py`, new; `test_pack_validator.py`, `test_migrations.py`):**
- 42 new integration tests covering:
  - Empty/no-pack state (graceful 200 empty list and 404 on detail).
  - Scenario card field completeness and denormalization.
  - All filter dimensions: `pack`, `tag`, `language`, `content_rating`, `difficulty`, `voice_support`.
  - FTS search matching title, summary, tags, pack name, and pack README.
  - Scenario detail with player role, opening text, and visible goals.
  - Hidden agenda exclusion by default; only revealed with `include_hidden=true` AND dev mode active.
  - `manifest.yaml` pack import end-to-end.
  - `ValidationResult.rule_ids` correctness for valid and invalid packs.
  - Migration backfill of pre-existing FTS entries.
  - ZIP_SLIP and other archive security errors mapping to correct rule IDs.

## Testing

Full test suite: **589 passed, 1 skipped** (platform symlink test), no regressions.

Closes #38