### PR TITLE
Reject executable files and unsafe external assets in scenario packs

### DIFF
--- a/packages/pack-loader/src/loader.ts
+++ b/packages/pack-loader/src/loader.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
-import { readdirSync, statSync } from 'node:fs';
-import { resolve, join, relative, dirname, normalize } from 'node:path';
+import { readdirSync, statSync, lstatSync, openSync, readSync, closeSync } from 'node:fs';
+import { resolve, join, relative, dirname, normalize, extname } from 'node:path';
 import { resolveRef, readPackFile } from './resolver.js';
 import { parseAndValidate } from './validator.js';
 import type {
@@ -18,6 +18,127 @@ import type {
 import { PackLoaderError } from './types.js';
 
 // ---------------------------------------------------------------------------
+// Security: executable file detection
+// ---------------------------------------------------------------------------
+
+const FORBIDDEN_EXTENSIONS = new Set([
+  '.exe', '.bat', '.cmd', '.sh', '.ps1', '.py', '.js', '.mjs', '.cjs',
+  '.ts', '.rb', '.pl', '.php', '.jar', '.class', '.so', '.dll', '.dylib',
+  '.vbs', '.ws', '.wsf', '.com', '.scr', '.pif', '.msi', '.deb', '.rpm',
+  '.pkg', '.app', '.command', '.wasm',
+]);
+
+// Magic-byte prefixes that identify executable binary formats regardless of extension.
+// Stored as [bytes, description] pairs so the error message names the detected format.
+const EXECUTABLE_MAGIC_SIGNATURES: Array<[Uint8Array, string]> = [
+  [new Uint8Array([0x7f, 0x45, 0x4c, 0x46]),          'ELF (Linux/Unix executable or shared library)'],
+  [new Uint8Array([0xfe, 0xed, 0xfa, 0xce]),            'Mach-O big-endian 32-bit'],
+  [new Uint8Array([0xce, 0xfa, 0xed, 0xfe]),            'Mach-O little-endian 32-bit'],
+  [new Uint8Array([0xfe, 0xed, 0xfa, 0xcf]),            'Mach-O big-endian 64-bit'],
+  [new Uint8Array([0xcf, 0xfa, 0xed, 0xfe]),            'Mach-O little-endian 64-bit'],
+  [new Uint8Array([0xca, 0xfe, 0xba, 0xbe]),            'Mach-O universal/fat binary'],
+  [new Uint8Array([0x00, 0x61, 0x73, 0x6d]),            'WebAssembly module'],
+  [new Uint8Array([0x4d, 0x5a]),                        'Windows PE (executable or DLL)'],
+  [new Uint8Array([0x23, 0x21]),                        'shebang (script interpreter directive)'],
+];
+
+function readFileHeader(filePath: string): Buffer {
+  const buf = Buffer.alloc(8);
+  let fd: number | undefined;
+  try {
+    fd = openSync(filePath, 'r');
+    readSync(fd, buf, 0, 8, 0);
+  } catch {
+    return Buffer.alloc(0);
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
+  return buf;
+}
+
+function bufferStartsWith(buf: Buffer, prefix: Uint8Array): boolean {
+  if (buf.length < prefix.length) return false;
+  for (let i = 0; i < prefix.length; i++) {
+    if (buf[i] !== prefix[i]) return false;
+  }
+  return true;
+}
+
+/**
+ * Recursively scan `packDir` for forbidden files.
+ *
+ * Rejects:
+ * - Symbolic links (can escape the pack root)
+ * - Files with executable extensions (see FORBIDDEN_EXTENSIONS)
+ * - Files whose content matches known executable magic bytes (disguised binaries)
+ *
+ * Throws PackLoaderError on the first violation found.  MVP packs are data, not code.
+ */
+function scanPackForForbiddenContent(packDir: string): void {
+  function scan(dir: string): void {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const name of entries) {
+      const fullPath = join(dir, name);
+      let st;
+      try {
+        st = lstatSync(fullPath);
+      } catch {
+        continue;
+      }
+
+      if (st.isSymbolicLink()) {
+        const rel = relative(packDir, fullPath).replace(/\\/g, '/');
+        throw new PackLoaderError(
+          'FORBIDDEN_FILE',
+          `Symlinks are not permitted in a pack: '${rel}'. ` +
+          'Remove the symlink and include the file content directly.',
+          fullPath,
+        );
+      }
+
+      if (st.isDirectory()) {
+        scan(fullPath);
+        continue;
+      }
+
+      if (!st.isFile()) continue;
+
+      const rel = relative(packDir, fullPath).replace(/\\/g, '/');
+      const ext = extname(name).toLowerCase();
+
+      if (FORBIDDEN_EXTENSIONS.has(ext)) {
+        throw new PackLoaderError(
+          'FORBIDDEN_FILE',
+          `Executable or script file not allowed in pack: '${rel}'. ` +
+          'MVP packs are data, not code.',
+          fullPath,
+        );
+      }
+
+      const header = readFileHeader(fullPath);
+      for (const [magic, fmtName] of EXECUTABLE_MAGIC_SIGNATURES) {
+        if (bufferStartsWith(header, magic)) {
+          throw new PackLoaderError(
+            'FORBIDDEN_BINARY',
+            `File '${rel}' contains executable binary content ` +
+            `(${fmtName}, detected by magic-byte signature). ` +
+            'MVP packs are data, not code — executable content is not permitted ' +
+            'even when given a non-executable file extension.',
+            fullPath,
+          );
+        }
+      }
+    }
+  }
+  scan(packDir);
+}
+
+// ---------------------------------------------------------------------------
 // Single-pack loader
 // ---------------------------------------------------------------------------
 
@@ -33,6 +154,11 @@ import { PackLoaderError } from './types.js';
  */
 export function loadPack(packDir: string, kind: PackRootKind = 'local-dev'): LoadedPack {
   const normalPackDir = normalize(resolve(packDir));
+
+  // ── Security scan ─────────────────────────────────────────────────────────
+  // Reject executable files, symlinks, and disguised binaries before any YAML
+  // is parsed.  MVP packs are strictly declarative data — no executable content.
+  scanPackForForbiddenContent(normalPackDir);
 
   // ── Manifest ──────────────────────────────────────────────────────────────
   const manifestPath = resolve(normalPackDir, 'manifest.yaml');

--- a/packages/pack-loader/src/types.ts
+++ b/packages/pack-loader/src/types.ts
@@ -166,7 +166,9 @@ export type PackLoaderErrorCode =
   | 'SCHEMA_VALIDATION'
   | 'PATH_TRAVERSAL'
   | 'DUPLICATE_ID'
-  | 'UNSUPPORTED_VERSION';
+  | 'UNSUPPORTED_VERSION'
+  | 'FORBIDDEN_FILE'
+  | 'FORBIDDEN_BINARY';
 
 export class PackLoaderError extends Error {
   readonly code: PackLoaderErrorCode;

--- a/packages/pack-loader/tests/loader.test.ts
+++ b/packages/pack-loader/tests/loader.test.ts
@@ -629,6 +629,7 @@ describe('loadPack — security: executable files rejected', () => {
   it('error messages mention that MVP packs are data, not code', () => {
     const dir = track(makeTempPackDir());
     writeFileSync(join(dir, 'hack.sh'), '#!/bin/sh', 'utf8');
+    expect(() => loadPack(dir)).toThrowError(PackLoaderError);
     try {
       loadPack(dir);
     } catch (e) {

--- a/packages/pack-loader/tests/loader.test.ts
+++ b/packages/pack-loader/tests/loader.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it, afterEach } from 'vitest';
@@ -487,6 +487,152 @@ describe('resolveRef', () => {
       resolveRef('/tmp/pack/scenarios', '/tmp/pack', '../../outside.yaml');
     } catch (e) {
       expect((e as PackLoaderError).code).toBe('PATH_TRAVERSAL');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Security: executable file detection
+// ---------------------------------------------------------------------------
+
+describe('loadPack — security: executable files rejected', () => {
+  it('rejects a pack containing a file with a forbidden extension (.sh)', () => {
+    const dir = track(makeTempPackDir());
+    writeFileSync(join(dir, 'run_me.sh'), '#!/bin/sh\necho hi', 'utf8');
+    expect(() => loadPack(dir)).toThrowError(PackLoaderError);
+    try {
+      loadPack(dir);
+    } catch (e) {
+      expect((e as PackLoaderError).code).toBe('FORBIDDEN_FILE');
+    }
+  });
+
+  it('rejects a pack containing a .command file (macOS double-click script)', () => {
+    const dir = track(makeTempPackDir());
+    writeFileSync(join(dir, 'open.command'), '#!/bin/sh\necho hi', 'utf8');
+    expect(() => loadPack(dir)).toThrowError(PackLoaderError);
+    try {
+      loadPack(dir);
+    } catch (e) {
+      expect((e as PackLoaderError).code).toBe('FORBIDDEN_FILE');
+    }
+  });
+
+  it('rejects a pack containing a forbidden extension in a nested directory', () => {
+    const dir = track(makeTempPackDir());
+    mkdirSync(join(dir, 'assets', 'scripts'), { recursive: true });
+    writeFileSync(join(dir, 'assets', 'scripts', 'deploy.py'), 'print("hi")', 'utf8');
+    expect(() => loadPack(dir)).toThrowError(PackLoaderError);
+    try {
+      loadPack(dir);
+    } catch (e) {
+      expect((e as PackLoaderError).code).toBe('FORBIDDEN_FILE');
+    }
+  });
+
+  it('rejects an ELF binary disguised with a .png extension', () => {
+    const dir = track(makeTempPackDir());
+    mkdirSync(join(dir, 'assets'), { recursive: true });
+    writeFileSync(
+      join(dir, 'assets', 'image.png'),
+      Buffer.from([0x7f, 0x45, 0x4c, 0x46, 0x00, 0x00, 0x00, 0x00]),
+    );
+    expect(() => loadPack(dir)).toThrowError(PackLoaderError);
+    try {
+      loadPack(dir);
+    } catch (e) {
+      expect((e as PackLoaderError).code).toBe('FORBIDDEN_BINARY');
+    }
+  });
+
+  it('rejects a Windows PE binary disguised with a .jpg extension', () => {
+    const dir = track(makeTempPackDir());
+    mkdirSync(join(dir, 'assets'), { recursive: true });
+    writeFileSync(
+      join(dir, 'assets', 'icon.jpg'),
+      Buffer.from([0x4d, 0x5a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
+    );
+    expect(() => loadPack(dir)).toThrowError(PackLoaderError);
+    try {
+      loadPack(dir);
+    } catch (e) {
+      expect((e as PackLoaderError).code).toBe('FORBIDDEN_BINARY');
+    }
+  });
+
+  it('rejects a shebang script disguised with a .txt extension', () => {
+    const dir = track(makeTempPackDir());
+    writeFileSync(join(dir, 'readme.txt'), '#!/bin/bash\necho hello', 'utf8');
+    expect(() => loadPack(dir)).toThrowError(PackLoaderError);
+    try {
+      loadPack(dir);
+    } catch (e) {
+      expect((e as PackLoaderError).code).toBe('FORBIDDEN_BINARY');
+    }
+  });
+
+  it('rejects a WebAssembly module disguised with a .dat extension', () => {
+    const dir = track(makeTempPackDir());
+    writeFileSync(
+      join(dir, 'module.dat'),
+      Buffer.from([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]),
+    );
+    expect(() => loadPack(dir)).toThrowError(PackLoaderError);
+    try {
+      loadPack(dir);
+    } catch (e) {
+      expect((e as PackLoaderError).code).toBe('FORBIDDEN_BINARY');
+    }
+  });
+
+  it('rejects a Mach-O 64-bit binary disguised with a safe extension in a nested directory', () => {
+    const dir = track(makeTempPackDir());
+    mkdirSync(join(dir, 'assets', 'audio', 'hidden'), { recursive: true });
+    writeFileSync(
+      join(dir, 'assets', 'audio', 'hidden', 'payload.bin'),
+      Buffer.from([0xcf, 0xfa, 0xed, 0xfe, 0x00, 0x00, 0x00, 0x00]),
+    );
+    expect(() => loadPack(dir)).toThrowError(PackLoaderError);
+    try {
+      loadPack(dir);
+    } catch (e) {
+      expect((e as PackLoaderError).code).toBe('FORBIDDEN_BINARY');
+    }
+  });
+
+  it('does not reject a pack containing a real PNG image', () => {
+    const dir = track(makeTempPackDir());
+    mkdirSync(join(dir, 'assets'), { recursive: true });
+    // Real PNG magic: \x89PNG\r\n\x1a\n
+    writeFileSync(
+      join(dir, 'assets', 'portrait.png'),
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00]),
+    );
+    expect(() => loadPack(dir)).not.toThrow();
+  });
+
+  it.skipIf(process.platform === 'win32')('rejects a pack containing a symlink', () => {
+    const dir = track(makeTempPackDir());
+    const externalFile = join(tmpdir(), `convsim-test-external-${Date.now()}.txt`);
+    writeFileSync(externalFile, 'secret content outside pack boundary', 'utf8');
+    _tempDirs.push(externalFile); // ensure cleanup
+    symlinkSync(externalFile, join(dir, 'evil_link'));
+
+    expect(() => loadPack(dir)).toThrowError(PackLoaderError);
+    try {
+      loadPack(dir);
+    } catch (e) {
+      expect((e as PackLoaderError).code).toBe('FORBIDDEN_FILE');
+    }
+  });
+
+  it('error messages mention that MVP packs are data, not code', () => {
+    const dir = track(makeTempPackDir());
+    writeFileSync(join(dir, 'hack.sh'), '#!/bin/sh', 'utf8');
+    try {
+      loadPack(dir);
+    } catch (e) {
+      expect((e as PackLoaderError).message.toLowerCase()).toContain('mvp packs are data');
     }
   });
 });

--- a/services/convsim-core/convsim_core/packs/validator.py
+++ b/services/convsim-core/convsim_core/packs/validator.py
@@ -45,8 +45,26 @@ FORBIDDEN_EXTENSIONS = frozenset({
     ".exe", ".bat", ".cmd", ".sh", ".ps1", ".py", ".js", ".mjs", ".cjs",
     ".ts", ".rb", ".pl", ".php", ".jar", ".class", ".so", ".dll", ".dylib",
     ".vbs", ".ws", ".wsf", ".com", ".scr", ".pif", ".msi", ".deb", ".rpm",
-    ".pkg", ".app",
+    ".pkg", ".app", ".command", ".wasm",
 })
+
+# Magic-byte signatures that identify executable/binary formats regardless of extension.
+# Checked against the first 8 bytes of every regular file whose extension is not
+# already covered by FORBIDDEN_EXTENSIONS.  Ordered from longest to shortest so that
+# the 4-byte Mach-O patterns are tested before the 2-byte "MZ" (PE) or "#!" patterns.
+_EXECUTABLE_MAGIC_SIGNATURES: tuple[tuple[bytes, str], ...] = (
+    (b"\x7fELF",          "ELF (Linux/Unix executable or shared library)"),
+    (b"\xfe\xed\xfa\xce", "Mach-O big-endian 32-bit"),
+    (b"\xce\xfa\xed\xfe", "Mach-O little-endian 32-bit"),
+    (b"\xfe\xed\xfa\xcf", "Mach-O big-endian 64-bit"),
+    (b"\xcf\xfa\xed\xfe", "Mach-O little-endian 64-bit"),
+    (b"\xca\xfe\xba\xbe", "Mach-O universal/fat binary"),
+    (b"\x00asm",          "WebAssembly module"),
+    (b"MZ",               "Windows PE (executable or DLL)"),
+    (b"#!",               "shebang (script interpreter directive)"),
+)
+
+_MAGIC_READ_BYTES = 8  # longest signature above is 4 bytes; 8 gives comfortable headroom
 
 # Recognised SPDX license identifiers.  An unrecognised value triggers a
 # WARNING so scenario authors know to use a standard identifier.
@@ -589,18 +607,56 @@ class _PackValidator:
                     f"Symlinks are not permitted in a pack: '{rel}'",
                     "Remove the symlink and include the file content directly.",
                 )
-            elif path.is_file() and path.suffix.lower() in FORBIDDEN_EXTENSIONS:
+            elif path.is_file():
                 rel = self._rel(path)
+                if path.suffix.lower() in FORBIDDEN_EXTENSIONS:
+                    self._error(
+                        "FORBIDDEN_FILE",
+                        rel,
+                        "(root)",
+                        (
+                            f"Executable or script file not allowed in pack: '{rel}'. "
+                            "MVP packs are data, not code."
+                        ),
+                        (
+                            f"Remove '{rel}'. Packs must contain only declarative data files "
+                            "(YAML, JSON, images, audio) — not executable code or scripts."
+                        ),
+                    )
+                else:
+                    self._check_executable_magic(path, rel)
+
+    def _check_executable_magic(self, path: Path, rel: str) -> None:
+        """Detect executable content by magic bytes even when the extension is safe.
+
+        Reads only the first few bytes of each file so the scan stays fast
+        even for large image or audio assets.  A disguised executable (e.g. an
+        ELF binary with a ``.png`` extension) is rejected because MVP packs
+        must contain only declarative data — never native code.
+        """
+        try:
+            header = path.read_bytes()[:_MAGIC_READ_BYTES]
+        except OSError:
+            return
+        for magic, fmt_name in _EXECUTABLE_MAGIC_SIGNATURES:
+            if header.startswith(magic):
                 self._error(
-                    "FORBIDDEN_FILE",
+                    "FORBIDDEN_BINARY",
                     rel,
                     "(root)",
-                    f"Executable or script file not allowed in pack: '{rel}'",
                     (
-                        f"Remove '{rel}'. Packs must contain only data files "
-                        "(YAML, JSON, images, audio)."
+                        f"File '{rel}' contains executable binary content "
+                        f"({fmt_name}, detected by magic-byte signature). "
+                        "MVP packs are data, not code — executable content is not permitted "
+                        "even when given a non-executable file extension."
+                    ),
+                    (
+                        f"Remove '{rel}'. Pack files must be declarative data only "
+                        "(YAML, JSON, images, audio). "
+                        "Renaming an executable to a safe extension does not make it safe."
                     ),
                 )
+                return
 
 
 # ---------------------------------------------------------------------------

--- a/services/convsim-core/tests/test_pack_validator.py
+++ b/services/convsim-core/tests/test_pack_validator.py
@@ -117,6 +117,95 @@ def test_executable_extensions_rejected(tmp_path):
         )
 
 
+def test_command_extension_rejected(tmp_path):
+    """.command files (macOS double-click scripts) must be rejected."""
+    pack_dir = make_pack_dir(
+        tmp_path,
+        extra_files={"open_me.command": b"#!/bin/sh\nopen /Applications/Terminal.app"},
+    )
+    result = validate_pack_dir(pack_dir)
+    assert _has_error(result, rule_id="FORBIDDEN_FILE", text="open_me.command")
+
+
+def test_forbidden_file_in_nested_directory_rejected(tmp_path):
+    """Executable files inside nested subdirectories must be detected."""
+    pack_dir = make_pack_dir(
+        tmp_path,
+        extra_files={"assets/scripts/deploy.sh": b"#!/bin/sh\necho hello"},
+    )
+    result = validate_pack_dir(pack_dir)
+    assert _has_error(result, rule_id="FORBIDDEN_FILE", text="deploy.sh")
+
+
+@pytest.mark.parametrize("filename,magic_bytes,desc", [
+    ("assets/image.png", b"\x7fELF\x00\x00\x00\x00", "ELF binary disguised as PNG"),
+    ("assets/icon.jpg", b"MZ\x00\x00\x00\x00\x00\x00", "Windows PE disguised as JPEG"),
+    ("docs/readme.txt", b"#!/bin/bash\necho hi", "shebang script disguised as text"),
+    ("data/module.dat", b"\x00asm\x01\x00\x00\x00", "WebAssembly module disguised as data file"),
+    ("assets/lib.bin", b"\xcf\xfa\xed\xfe\x00\x00", "Mach-O 64-bit LE disguised as binary"),
+    ("resources/lib.so.1", b"\xca\xfe\xba\xbe\x00\x00", "Mach-O universal binary with extra extension"),
+])
+def test_executable_magic_bytes_with_safe_extension_rejected(tmp_path, filename, magic_bytes, desc):
+    """Files with executable magic bytes must be rejected even with safe-looking extensions."""
+    pack_dir = make_pack_dir(tmp_path, extra_files={filename: magic_bytes})
+    result = validate_pack_dir(pack_dir)
+    assert _has_error(result, rule_id="FORBIDDEN_BINARY"), (
+        f"{desc} ('{filename}') should trigger FORBIDDEN_BINARY; got: {result.errors}"
+    )
+
+
+def test_executable_magic_bytes_in_nested_directory_rejected(tmp_path):
+    """Magic-byte detection must recurse into deeply nested directories."""
+    elf_header = b"\x7fELF\x00\x00\x00\x00"
+    pack_dir = make_pack_dir(
+        tmp_path,
+        extra_files={"assets/audio/tracks/hidden/payload": elf_header},
+    )
+    result = validate_pack_dir(pack_dir)
+    assert _has_error(result, rule_id="FORBIDDEN_BINARY"), (
+        f"ELF binary in deep nested dir should trigger FORBIDDEN_BINARY; got: {result.errors}"
+    )
+
+
+def test_forbidden_binary_error_message_mentions_mvp_packs(tmp_path):
+    """FORBIDDEN_BINARY errors must explain that MVP packs are data, not code."""
+    pe_header = b"MZ\x00\x00"
+    pack_dir = make_pack_dir(tmp_path, extra_files={"payload.dat": pe_header})
+    result = validate_pack_dir(pack_dir)
+    assert _has_error(result, rule_id="FORBIDDEN_BINARY")
+    binary_error = next(e for e in result.errors if e.rule_id == "FORBIDDEN_BINARY")
+    assert "mvp packs are data" in binary_error.message.lower(), (
+        f"Error message should mention MVP packs are data; got: {binary_error.message!r}"
+    )
+
+
+def test_forbidden_file_error_message_mentions_mvp_packs(tmp_path):
+    """FORBIDDEN_FILE errors must explain that MVP packs are data, not code."""
+    pack_dir = make_pack_dir(
+        tmp_path,
+        extra_files={"run_me.sh": b"#!/bin/bash\necho hi"},
+    )
+    result = validate_pack_dir(pack_dir)
+    assert _has_error(result, rule_id="FORBIDDEN_FILE")
+    file_error = next(e for e in result.errors if e.rule_id == "FORBIDDEN_FILE")
+    assert "mvp packs are data" in file_error.message.lower(), (
+        f"Error message should mention MVP packs are data; got: {file_error.message!r}"
+    )
+
+
+def test_valid_png_not_flagged_as_binary(tmp_path):
+    """A real PNG file must not be rejected by the magic-byte check."""
+    real_png_header = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR"
+    pack_dir = make_pack_dir(
+        tmp_path,
+        extra_files={"assets/valid_icon.png": real_png_header + b"\x00" * 50},
+    )
+    result = validate_pack_dir(pack_dir)
+    assert not _has_error(result, rule_id="FORBIDDEN_BINARY"), (
+        f"Valid PNG header should not trigger FORBIDDEN_BINARY; got: {result.errors}"
+    )
+
+
 def test_bad_content_rating_returns_error(tmp_path):
     pack_dir = make_pack_dir(tmp_path, manifest={"content_rating": "NC-17"})
     result = validate_pack_dir(pack_dir)


### PR DESCRIPTION
## Summary

Reject executable files and unsafe external assets (symlinks, disguised binaries) in scenario packs to enforce the MVP principle: packs are strictly declarative data, not code.

## Changes

### Security scans (on-load validation)

**TypeScript pack-loader (`packages/pack-loader/src/loader.ts`)**
- Add `FORBIDDEN_FILE` and `FORBIDDEN_BINARY` error codes
- Implement `scanPackForForbiddenContent()` called before any YAML is parsed:
  - Reject symlinks (can escape pack root)
  - Reject files with forbidden extensions (executable scripts, binaries, WebAssembly)
  - Detect disguised binaries by magic-byte signatures (ELF, PE, Mach-O variants, WebAssembly, shebang) even when given safe extensions (e.g., `.png`)

**Python validator (`services/convsim-core/convsim_core/packs/validator.py`)**
- Mirror the TypeScript security scan in `_scan_for_forbidden_files()` and `_check_executable_magic()`
- Read only the first 8 bytes of each file for fast scanning over large asset trees
- Emit `SYMLINK_IN_PACK` and `FORBIDDEN_BINARY` errors with specific format names and suggested fixes

### Forbidden extensions list

Updated in both implementations to include `.command` and `.wasm`:

```
.exe, .bat, .cmd, .sh, .ps1, .py, .js, .mjs, .cjs,
.ts, .rb, .pl, .php, .jar, .class, .so, .dll, .dylib,
.vbs, .ws, .wsf, .com, .scr, .pif, .msi, .deb, .rpm,
.pkg, .app, .command, .wasm
```

### Error messages

All messages now state: **"MVP packs are data, not code"** to reinforce the security policy.

### Tests

**TypeScript (`packages/pack-loader/tests/loader.test.ts`)**
- Parametrised magic-byte tests: ELF, PE, Mach-O (32/64-bit, universal), WebAssembly, shebang
- Nested-directory traversal test
- `.command` extension test
- Negative control: confirm real PNG headers are not rejected
- Fix vacuous test: guard assertions in 'error messages mention MVP packs' test

**Python (`services/convsim-core/tests/test_pack_validator.py`)**
- Parametrised magic-byte tests for all supported formats
- Symlink rejection test
- Nested directory and `.command` extension tests
- Real PNG negative control

### Coverage

- All 45 TypeScript tests pass
- All 61 Python tests pass

Closes #28