### PR TITLE
Add convsim CLI with validate-pack, test-pack, import-pack, and export-pack commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,14 @@ jobs:
         run: |
           echo "Local: pnpm --filter @convsim/web test"
           pnpm --filter @convsim/web test
+      - name: Run pack-loader tests
+        run: |
+          echo "Local: pnpm --filter @convsim/pack-loader test"
+          pnpm --filter @convsim/pack-loader test
+      - name: Run CLI tests
+        run: |
+          echo "Local: pnpm --filter @convsim/cli test"
+          pnpm --filter @convsim/cli test
 
   schemas:
     name: Schema validation tests

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "./scripts/dev.sh",
     "test:schemas": "node packages/scenario-schema/tests/load-schemas.js && node packages/scenario-schema/tests/validate-schemas.js",
     "test:packs": "node packages/scenario-schema/tests/validate-packs.js packs/official",
-    "test:types": "pnpm --filter @convsim/shared-types check && pnpm --filter @convsim/scenario-schema check && pnpm --filter @convsim/ui check"
+    "test:types": "pnpm --filter @convsim/shared-types check && pnpm --filter @convsim/scenario-schema check && pnpm --filter @convsim/ui check && pnpm --filter @convsim/cli check"
   },
   "engines": {
     "node": ">=18"

--- a/packages/convsim-cli/package.json
+++ b/packages/convsim-cli/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@convsim/cli",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "convsim": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "check": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@convsim/pack-loader": "workspace:*",
+    "adm-zip": "^0.5.16"
+  },
+  "devDependencies": {
+    "@types/adm-zip": "^0.5.7",
+    "@types/node": "^22.0.0",
+    "typescript": "^5.5.0",
+    "vitest": "^2.0.0"
+  }
+}

--- a/packages/convsim-cli/package.json
+++ b/packages/convsim-cli/package.json
@@ -7,7 +7,7 @@
     "convsim": "./dist/index.js"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "check": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/packages/convsim-cli/src/commands/export-pack.ts
+++ b/packages/convsim-cli/src/commands/export-pack.ts
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+import { statSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+import AdmZip from 'adm-zip';
+import { loadPack, PackLoaderError } from '@convsim/pack-loader';
+import { writeJson, writeLine, writeErrorLine, formatBytes } from '../output.js';
+
+// ---------------------------------------------------------------------------
+// Result shape
+// ---------------------------------------------------------------------------
+
+export type ExportPackResult =
+  | {
+      status: 'ok';
+      pack_id: string;
+      name: string;
+      version: string;
+      output: string;
+      size_bytes: number;
+    }
+  | {
+      status: 'error';
+      error: {
+        code: string;
+        message: string;
+        file?: string;
+      };
+    };
+
+// ---------------------------------------------------------------------------
+// Command
+// ---------------------------------------------------------------------------
+
+/**
+ * Export a pack directory to a .zip archive.
+ *
+ * The pack is validated before archiving, so the output is guaranteed to be
+ * a valid pack.  All paths inside the zip are relative to the pack root —
+ * no absolute paths leak into the archive.
+ *
+ * `outputPath` defaults to `<cwd>/<pack_id>-<version>.zip`.
+ *
+ * Exit codes:
+ *   0 — archive created successfully
+ *   1 — pack is invalid
+ *   3 — unexpected system error
+ */
+export function runExportPack(
+  packPath: string,
+  json: boolean,
+  outputPath?: string,
+): number {
+  const absPackPath = resolve(packPath);
+
+  try {
+    // Validate the pack before archiving (runs security scan + schema validation).
+    const pack = loadPack(absPackPath, 'local-dev');
+
+    const safeName = pack.manifest.pack_id.replace(/[^a-zA-Z0-9._-]/g, '_');
+    const filename = `${safeName}-${pack.manifest.version}.zip`;
+    const dest = outputPath ? resolve(outputPath) : join(process.cwd(), filename);
+
+    // Build the zip with paths relative to the pack root.
+    // addLocalFolder(localPath, zipPath='') places files at the zip root with
+    // their path relative to localPath — no absolute or parent-directory refs.
+    const zip = new AdmZip();
+    zip.addLocalFolder(absPackPath, '');
+    zip.writeZip(dest);
+
+    const sizeBytes = statSync(dest).size;
+
+    const result: ExportPackResult = {
+      status: 'ok',
+      pack_id: pack.manifest.pack_id,
+      name: pack.manifest.name,
+      version: pack.manifest.version,
+      output: dest,
+      size_bytes: sizeBytes,
+    };
+
+    if (json) {
+      writeJson(result);
+    } else {
+      writeLine(
+        `✓ Pack exported: ${pack.manifest.name} (${pack.manifest.pack_id}) v${pack.manifest.version}`,
+      );
+      writeLine(`  Archive: ${dest} (${formatBytes(sizeBytes)})`);
+    }
+
+    return 0;
+  } catch (e) {
+    if (e instanceof PackLoaderError) {
+      const result: ExportPackResult = {
+        status: 'error',
+        error: {
+          code: e.code,
+          message: e.message,
+          ...(e.filePath !== undefined ? { file: e.filePath } : {}),
+        },
+      };
+
+      if (json) {
+        writeJson(result);
+      } else {
+        writeErrorLine(`✗ Export failed: ${e.code}`);
+        writeErrorLine(`  ${e.message}`);
+        if (e.filePath !== undefined) {
+          writeErrorLine(`  File: ${e.filePath}`);
+        }
+      }
+
+      return 1;
+    }
+
+    const msg = e instanceof Error ? e.message : String(e);
+    if (json) {
+      writeJson({ status: 'error', error: { code: 'UNEXPECTED_ERROR', message: msg } });
+    } else {
+      writeErrorLine(`✗ Unexpected error: ${msg}`);
+    }
+    return 3;
+  }
+}

--- a/packages/convsim-cli/src/commands/import-pack.ts
+++ b/packages/convsim-cli/src/commands/import-pack.ts
@@ -134,9 +134,13 @@ export function runImportPack(
     const destDir = join(packsDir, pack.manifest.pack_id);
 
     // Atomically replace any previous installation.
+    // Guard against self-import: if the source is already the installed location
+    // (packDir === destDir), rmSync would delete the source before cpSync runs.
     mkdirSync(packsDir, { recursive: true });
-    rmSync(destDir, { recursive: true, force: true });
-    cpSync(packDir, destDir, { recursive: true });
+    if (resolve(packDir) !== resolve(destDir)) {
+      rmSync(destDir, { recursive: true, force: true });
+      cpSync(packDir, destDir, { recursive: true });
+    }
 
     // Register in the SQLite index from the installed location.
     const dbPath = dataDir ? join(dataDir, 'index.db') : getDbPath();

--- a/packages/convsim-cli/src/commands/import-pack.ts
+++ b/packages/convsim-cli/src/commands/import-pack.ts
@@ -37,11 +37,15 @@ function detectSourceKind(absPath: string): 'zip' | 'dir' {
   try {
     st = statSync(absPath);
   } catch {
-    throw new Error(`Path does not exist: ${absPath}`);
+    throw new PackLoaderError('MISSING_FILE', `Path does not exist: ${absPath}`, absPath);
   }
   if (st.isDirectory()) return 'dir';
   if (st.isFile() && extname(absPath).toLowerCase() === '.zip') return 'zip';
-  throw new Error(`Source must be a directory or a .zip file: ${absPath}`);
+  throw new PackLoaderError(
+    'INVALID_SOURCE',
+    `Source must be a directory or a .zip file: ${absPath}`,
+    absPath,
+  );
 }
 
 /**

--- a/packages/convsim-cli/src/commands/import-pack.ts
+++ b/packages/convsim-cli/src/commands/import-pack.ts
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+import { statSync, mkdirSync, cpSync, rmSync, mkdtempSync, readdirSync } from 'node:fs';
+import { resolve, join, extname, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import AdmZip from 'adm-zip';
+import { loadPack, PackIndex, PackLoaderError } from '@convsim/pack-loader';
+import { getPacksDir, getDbPath } from '../paths.js';
+import { writeJson, writeLine, writeErrorLine } from '../output.js';
+
+// ---------------------------------------------------------------------------
+// Result shape
+// ---------------------------------------------------------------------------
+
+export type ImportPackResult =
+  | {
+      status: 'ok';
+      pack_id: string;
+      name: string;
+      version: string;
+      dest: string;
+    }
+  | {
+      status: 'error';
+      error: {
+        code: string;
+        message: string;
+        file?: string;
+      };
+    };
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function detectSourceKind(absPath: string): 'zip' | 'dir' {
+  let st;
+  try {
+    st = statSync(absPath);
+  } catch {
+    throw new Error(`Path does not exist: ${absPath}`);
+  }
+  if (st.isDirectory()) return 'dir';
+  if (st.isFile() && extname(absPath).toLowerCase() === '.zip') return 'zip';
+  throw new Error(`Source must be a directory or a .zip file: ${absPath}`);
+}
+
+/**
+ * If the extracted zip contains exactly one top-level directory, return it.
+ * This handles zips created with `zip -r pack-name.zip my-pack/`.
+ */
+function unwrapSingleSubdir(dir: string): string {
+  const entries = readdirSync(dir);
+  if (entries.length === 1) {
+    const first = entries[0];
+    if (first !== undefined) {
+      const candidate = join(dir, first);
+      if (statSync(candidate).isDirectory()) return candidate;
+    }
+  }
+  return dir;
+}
+
+// ---------------------------------------------------------------------------
+// Command
+// ---------------------------------------------------------------------------
+
+/**
+ * Import (copy) a pack into the user data directory and register it in the index.
+ *
+ * Accepts either a directory or a .zip file.  The pack is fully validated
+ * (including the security scan in loadPack) before any files are written.
+ *
+ * `dataDir` overrides the default data root — useful for tests and CI.
+ *
+ * Exit codes:
+ *   0 — pack imported successfully
+ *   1 — pack is invalid or unsafe
+ *   3 — unexpected system error
+ */
+export function runImportPack(
+  source: string,
+  json: boolean,
+  dataDir?: string,
+): number {
+  const absSource = resolve(source);
+  let tempDir: string | null = null;
+
+  try {
+    let packDir: string;
+    const kind = detectSourceKind(absSource);
+
+    if (kind === 'zip') {
+      tempDir = mkdtempSync(join(tmpdir(), 'convsim-import-'));
+      const zip = new AdmZip(absSource);
+      zip.extractAllTo(tempDir, /* overwrite */ true);
+      packDir = unwrapSingleSubdir(tempDir);
+    } else {
+      packDir = absSource;
+    }
+
+    // Validate (runs security scan + schema validation) — reads only, no writes yet.
+    const pack = loadPack(packDir, 'community');
+
+    const packsDir = dataDir ? join(dataDir, 'packs') : getPacksDir();
+    const destDir = join(packsDir, pack.manifest.pack_id);
+
+    // Atomically replace any previous installation.
+    mkdirSync(packsDir, { recursive: true });
+    rmSync(destDir, { recursive: true, force: true });
+    cpSync(packDir, destDir, { recursive: true });
+
+    // Register in the SQLite index from the installed location.
+    const dbPath = dataDir ? join(dataDir, 'index.db') : getDbPath();
+    mkdirSync(dirname(dbPath), { recursive: true });
+    const index = PackIndex.open(dbPath);
+    try {
+      const installedPack = loadPack(destDir, 'community');
+      index.importPack(installedPack);
+    } finally {
+      index.close();
+    }
+
+    const result: ImportPackResult = {
+      status: 'ok',
+      pack_id: pack.manifest.pack_id,
+      name: pack.manifest.name,
+      version: pack.manifest.version,
+      dest: destDir,
+    };
+
+    if (json) {
+      writeJson(result);
+    } else {
+      writeLine(
+        `✓ Pack imported: ${pack.manifest.name} (${pack.manifest.pack_id}) v${pack.manifest.version}`,
+      );
+      writeLine(`  Installed to: ${destDir}`);
+    }
+
+    return 0;
+  } catch (e) {
+    if (e instanceof PackLoaderError) {
+      const result: ImportPackResult = {
+        status: 'error',
+        error: {
+          code: e.code,
+          message: e.message,
+          ...(e.filePath !== undefined ? { file: e.filePath } : {}),
+        },
+      };
+
+      if (json) {
+        writeJson(result);
+      } else {
+        writeErrorLine(`✗ Import rejected: ${e.code}`);
+        writeErrorLine(`  ${e.message}`);
+        if (e.filePath !== undefined) {
+          writeErrorLine(`  File: ${e.filePath}`);
+        }
+      }
+
+      return 1;
+    }
+
+    const msg = e instanceof Error ? e.message : String(e);
+    if (json) {
+      writeJson({ status: 'error', error: { code: 'UNEXPECTED_ERROR', message: msg } });
+    } else {
+      writeErrorLine(`✗ Unexpected error: ${msg}`);
+    }
+    return 3;
+  } finally {
+    if (tempDir !== null) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  }
+}

--- a/packages/convsim-cli/src/commands/import-pack.ts
+++ b/packages/convsim-cli/src/commands/import-pack.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { statSync, mkdirSync, cpSync, rmSync, mkdtempSync, readdirSync } from 'node:fs';
-import { resolve, join, extname, dirname } from 'node:path';
+import { resolve, join, extname, dirname, isAbsolute } from 'node:path';
 import { tmpdir } from 'node:os';
 import AdmZip from 'adm-zip';
 import { loadPack, PackIndex, PackLoaderError } from '@convsim/pack-loader';
@@ -42,6 +42,30 @@ function detectSourceKind(absPath: string): 'zip' | 'dir' {
   if (st.isDirectory()) return 'dir';
   if (st.isFile() && extname(absPath).toLowerCase() === '.zip') return 'zip';
   throw new Error(`Source must be a directory or a .zip file: ${absPath}`);
+}
+
+/**
+ * Reject zip entries that would escape the extraction root (zip-slip).
+ * AdmZip does not sanitise entry names, so a crafted zip could write to
+ * arbitrary filesystem locations before loadPack's security scan runs.
+ * Throws PackLoaderError so the caller treats it as a user-facing rejection
+ * (exit code 1) rather than an unexpected error (exit code 3).
+ */
+function assertNoZipSlip(zip: AdmZip): void {
+  for (const entry of zip.getEntries()) {
+    const name = entry.entryName;
+    if (isAbsolute(name)) {
+      throw new PackLoaderError('UNSAFE_ZIP', `Zip entry has absolute path: "${name}"`, name);
+    }
+    const parts = name.split(/[\\/]/);
+    if (parts.some((p) => p === '..')) {
+      throw new PackLoaderError(
+        'UNSAFE_ZIP',
+        `Zip entry attempts path traversal: "${name}"`,
+        name,
+      );
+    }
+  }
 }
 
 /**
@@ -92,6 +116,7 @@ export function runImportPack(
     if (kind === 'zip') {
       tempDir = mkdtempSync(join(tmpdir(), 'convsim-import-'));
       const zip = new AdmZip(absSource);
+      assertNoZipSlip(zip);
       zip.extractAllTo(tempDir, /* overwrite */ true);
       packDir = unwrapSingleSubdir(tempDir);
     } else {

--- a/packages/convsim-cli/src/commands/test-pack.ts
+++ b/packages/convsim-cli/src/commands/test-pack.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+import { writeJson, writeErrorLine } from '../output.js';
+
+// ---------------------------------------------------------------------------
+// Result shape
+// ---------------------------------------------------------------------------
+
+export interface TestPackResult {
+  status: 'not_implemented';
+  message: string;
+}
+
+// ---------------------------------------------------------------------------
+// Command
+// ---------------------------------------------------------------------------
+
+/**
+ * Stub for the future pack test runner.
+ *
+ * Exit codes:
+ *   1 — not implemented (lets CI pipelines catch that this was a no-op)
+ */
+export function runTestPack(_packPath: string, json: boolean): number {
+  const msg =
+    'The automated test runner is not yet available. ' +
+    'Use validate-pack to check your pack for schema and content errors in the meantime.';
+
+  if (json) {
+    writeJson({ status: 'not_implemented', message: msg } satisfies TestPackResult);
+  } else {
+    writeErrorLine('⚠ test-pack: The automated test runner is not yet implemented.');
+    writeErrorLine('  Use validate-pack to check pack schema and content instead.');
+  }
+
+  return 1;
+}

--- a/packages/convsim-cli/src/commands/validate-pack.ts
+++ b/packages/convsim-cli/src/commands/validate-pack.ts
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+import { resolve } from 'node:path';
+import { loadPack, PackLoaderError } from '@convsim/pack-loader';
+import { writeJson, writeLine, writeErrorLine } from '../output.js';
+
+// ---------------------------------------------------------------------------
+// Result shape (stable contract for --json mode and CI)
+// ---------------------------------------------------------------------------
+
+export type ValidatePackResult =
+  | {
+      status: 'ok';
+      pack_id: string;
+      name: string;
+      version: string;
+      scenario_count: number;
+      npc_count: number;
+      rubric_count: number;
+    }
+  | {
+      status: 'error';
+      error: {
+        code: string;
+        message: string;
+        file?: string;
+      };
+    };
+
+// ---------------------------------------------------------------------------
+// Command
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate a pack directory and report the result.
+ *
+ * Exit codes:
+ *   0 — pack is valid
+ *   1 — pack has validation errors
+ *   3 — unexpected system error (e.g. path does not exist)
+ */
+export function runValidatePack(packPath: string, json: boolean): number {
+  const absPath = resolve(packPath);
+
+  try {
+    const pack = loadPack(absPath, 'local-dev');
+
+    const result: ValidatePackResult = {
+      status: 'ok',
+      pack_id: pack.manifest.pack_id,
+      name: pack.manifest.name,
+      version: pack.manifest.version,
+      scenario_count: pack.scenarios.length,
+      npc_count: pack.npcs.size,
+      rubric_count: pack.rubrics.size,
+    };
+
+    if (json) {
+      writeJson(result);
+    } else {
+      writeLine(
+        `✓ Pack valid: ${pack.manifest.name} (${pack.manifest.pack_id}) v${pack.manifest.version}`,
+      );
+      const parts = [
+        `${pack.scenarios.length} scenario${pack.scenarios.length !== 1 ? 's' : ''}`,
+        `${pack.npcs.size} NPC${pack.npcs.size !== 1 ? 's' : ''}`,
+        `${pack.rubrics.size} rubric${pack.rubrics.size !== 1 ? 's' : ''}`,
+      ];
+      if (pack.scenes.size > 0) {
+        parts.push(`${pack.scenes.size} scene${pack.scenes.size !== 1 ? 's' : ''}`);
+      }
+      writeLine(`  ${parts.join(' · ')}`);
+    }
+
+    return 0;
+  } catch (e) {
+    if (e instanceof PackLoaderError) {
+      const result: ValidatePackResult = {
+        status: 'error',
+        error: {
+          code: e.code,
+          message: e.message,
+          ...(e.filePath !== undefined ? { file: e.filePath } : {}),
+        },
+      };
+
+      if (json) {
+        writeJson(result);
+      } else {
+        writeErrorLine(`✗ Pack validation failed: ${e.code}`);
+        writeErrorLine(`  ${e.message}`);
+        if (e.filePath !== undefined) {
+          writeErrorLine(`  File: ${e.filePath}`);
+        }
+      }
+
+      return 1;
+    }
+
+    const msg = e instanceof Error ? e.message : String(e);
+    if (json) {
+      writeJson({ status: 'error', error: { code: 'UNEXPECTED_ERROR', message: msg } });
+    } else {
+      writeErrorLine(`✗ Unexpected error: ${msg}`);
+    }
+    return 3;
+  }
+}

--- a/packages/convsim-cli/src/commands/validate-pack.ts
+++ b/packages/convsim-cli/src/commands/validate-pack.ts
@@ -36,8 +36,8 @@ export type ValidatePackResult =
  *
  * Exit codes:
  *   0 — pack is valid
- *   1 — pack has validation errors
- *   3 — unexpected system error (e.g. path does not exist)
+ *   1 — pack is invalid or cannot be found (PackLoaderError)
+ *   3 — unexpected system error (OS error, out of memory, etc.)
  */
 export function runValidatePack(packPath: string, json: boolean): number {
   const absPath = resolve(packPath);

--- a/packages/convsim-cli/src/commands/validate-pack.ts
+++ b/packages/convsim-cli/src/commands/validate-pack.ts
@@ -16,6 +16,7 @@ export type ValidatePackResult =
       scenario_count: number;
       npc_count: number;
       rubric_count: number;
+      scene_count: number;
     }
   | {
       status: 'error';
@@ -52,6 +53,7 @@ export function runValidatePack(packPath: string, json: boolean): number {
       scenario_count: pack.scenarios.length,
       npc_count: pack.npcs.size,
       rubric_count: pack.rubrics.size,
+      scene_count: pack.scenes.size,
     };
 
     if (json) {

--- a/packages/convsim-cli/src/index.ts
+++ b/packages/convsim-cli/src/index.ts
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+import { parseArgs } from 'node:util';
+import { runValidatePack } from './commands/validate-pack.js';
+import { runTestPack } from './commands/test-pack.js';
+import { runImportPack } from './commands/import-pack.js';
+import { runExportPack } from './commands/export-pack.js';
+import { writeErrorLine } from './output.js';
+
+// ---------------------------------------------------------------------------
+// Help text
+// ---------------------------------------------------------------------------
+
+const HELP = `
+convsim — Conversation Simulator pack management CLI
+
+Usage:
+  convsim <command> [options] <path>
+
+Commands:
+  validate-pack <path>      Validate a pack directory (schema + security checks)
+  test-pack     <path>      Run the automated test suite for a pack (not yet available)
+  import-pack   <path>      Import a pack directory or .zip into the user data directory
+  export-pack   <path>      Export a pack directory to a .zip archive
+
+Options:
+  --json                    Output machine-readable JSON instead of human text
+  --output <file>           (export-pack) Write zip to this path instead of <pack_id>-<version>.zip
+  --data-dir <dir>          (import-pack) Use this directory as the convsim data root
+
+Exit codes:
+  0   Success
+  1   Validation or import error
+  2   Invalid usage (bad arguments)
+  3   Unexpected system error
+`.trim();
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+function main(): void {
+  const { values, positionals } = parseArgs({
+    allowPositionals: true,
+    strict: false,
+    options: {
+      json: { type: 'boolean', default: false },
+      output: { type: 'string' },
+      'data-dir': { type: 'string' },
+      help: { type: 'boolean', default: false },
+    },
+    args: process.argv.slice(2),
+  });
+
+  if (values['help'] === true || positionals.length === 0) {
+    process.stdout.write(HELP + '\n');
+    process.exit(positionals.length === 0 ? 2 : 0);
+  }
+
+  const command = positionals[0];
+  const json = values['json'] === true;
+
+  switch (command) {
+    case 'validate-pack': {
+      const packPath = positionals[1];
+      if (!packPath) {
+        writeErrorLine('Usage: convsim validate-pack [--json] <pack-directory>');
+        process.exit(2);
+      }
+      process.exit(runValidatePack(packPath, json));
+    }
+
+    case 'test-pack': {
+      const packPath = positionals[1];
+      if (!packPath) {
+        writeErrorLine('Usage: convsim test-pack [--json] <pack-directory>');
+        process.exit(2);
+      }
+      process.exit(runTestPack(packPath, json));
+    }
+
+    case 'import-pack': {
+      const source = positionals[1];
+      if (!source) {
+        writeErrorLine('Usage: convsim import-pack [--json] [--data-dir <dir>] <path-or-zip>');
+        process.exit(2);
+      }
+      const dataDirVal = values['data-dir'];
+      const dataDir = typeof dataDirVal === 'string' ? dataDirVal : undefined;
+      process.exit(runImportPack(source, json, dataDir));
+    }
+
+    case 'export-pack': {
+      const packPath = positionals[1];
+      if (!packPath) {
+        writeErrorLine('Usage: convsim export-pack [--json] [--output <file>] <pack-directory>');
+        process.exit(2);
+      }
+      const outputVal = values['output'];
+      const outputPath = typeof outputVal === 'string' ? outputVal : undefined;
+      process.exit(runExportPack(packPath, json, outputPath));
+    }
+
+    default:
+      writeErrorLine(`Unknown command: ${command}`);
+      writeErrorLine('Run "convsim --help" for usage.');
+      process.exit(2);
+  }
+}
+
+main();

--- a/packages/convsim-cli/src/index.ts
+++ b/packages/convsim-cli/src/index.ts
@@ -54,7 +54,7 @@ function main(): void {
 
   if (values['help'] === true || positionals.length === 0) {
     process.stdout.write(HELP + '\n');
-    process.exit(positionals.length === 0 ? 2 : 0);
+    process.exit(values['help'] === true ? 0 : 2);
   }
 
   const command = positionals[0];

--- a/packages/convsim-cli/src/output.ts
+++ b/packages/convsim-cli/src/output.ts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Write a JSON value to stdout as the sole output.  Used in --json mode.
+ */
+export function writeJson(data: unknown): void {
+  process.stdout.write(JSON.stringify(data, null, 2) + '\n');
+}
+
+/**
+ * Write a line to stdout (human-readable mode).
+ */
+export function writeLine(text: string): void {
+  process.stdout.write(text + '\n');
+}
+
+/**
+ * Write a line to stderr (human-readable mode).
+ */
+export function writeErrorLine(text: string): void {
+  process.stderr.write(text + '\n');
+}
+
+/**
+ * Format a file size in bytes as a human-friendly string.
+ */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/packages/convsim-cli/src/paths.ts
+++ b/packages/convsim-cli/src/paths.ts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * Return the root data directory for convsim user data.
+ * Prefer CONVSIM_DATA_DIR so tests and CI can point to a temp directory.
+ */
+export function getDataDir(): string {
+  const override = process.env['CONVSIM_DATA_DIR'];
+  if (override) return override;
+
+  const home = homedir();
+  if (process.platform === 'darwin') {
+    return join(home, 'Library', 'Application Support', 'convsim');
+  }
+  if (process.platform === 'win32') {
+    const appData = process.env['APPDATA'] ?? join(home, 'AppData', 'Roaming');
+    return join(appData, 'convsim');
+  }
+  const xdgData = process.env['XDG_DATA_HOME'] ?? join(home, '.local', 'share');
+  return join(xdgData, 'convsim');
+}
+
+export function getPacksDir(): string {
+  return join(getDataDir(), 'packs');
+}
+
+export function getDbPath(): string {
+  return join(getDataDir(), 'index.db');
+}

--- a/packages/convsim-cli/tests/cli.test.ts
+++ b/packages/convsim-cli/tests/cli.test.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync, statSync, existsSync } from 'node:fs';
-import { join, basename } from 'node:path';
+import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import AdmZip from 'adm-zip';

--- a/packages/convsim-cli/tests/cli.test.ts
+++ b/packages/convsim-cli/tests/cli.test.ts
@@ -580,7 +580,7 @@ describe('export-pack', () => {
     runExportPack(packDir, false, outputPath);
     const zip = new AdmZip(outputPath);
     const entries = zip.getEntries().map((e) => e.entryName);
-    expect(entries.some((e) => e === 'manifest.yaml' || e.endsWith('/manifest.yaml'))).toBe(true);
+    expect(entries).toContain('manifest.yaml');
     // No entry should start with '/' or contain an absolute Windows path
     for (const e of entries) {
       expect(e.startsWith('/')).toBe(false);

--- a/packages/convsim-cli/tests/cli.test.ts
+++ b/packages/convsim-cli/tests/cli.test.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync, statSync, existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, basename } from 'node:path';
 import { tmpdir } from 'node:os';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import AdmZip from 'adm-zip';
@@ -291,10 +291,26 @@ describe('validate-pack — broken pack', () => {
 });
 
 describe('validate-pack — path handling', () => {
-  it('resolves paths relative to process.cwd()', () => {
-    // Use an absolute path — the function must resolve it regardless of cwd.
+  it('accepts an absolute path', () => {
     const packDir = track(makeValidPackDir());
     const code = runValidatePack(packDir, true);
+    expect(code).toBe(0);
+  });
+
+  it('resolves a relative path against process.cwd()', () => {
+    // Create a temp dir and put the pack inside it as a subdirectory named
+    // 'pack' (makeValidPackDir with a parent always uses that name).
+    const tmp = track(mkdtempSync(join(tmpdir(), 'convsim-relpath-')));
+    track(makeValidPackDir(tmp));
+    // Point cwd at tmp so that 'pack' resolves to tmp/pack.
+    const origCwd = process.cwd;
+    process.cwd = () => tmp;
+    let code = -1;
+    try {
+      code = runValidatePack('pack', false);
+    } finally {
+      process.cwd = origCwd;
+    }
     expect(code).toBe(0);
   });
 
@@ -548,6 +564,23 @@ describe('import-pack — installation verification', () => {
     expect(existsSync(sentinelPath)).toBe(false);
     // The manifest should still be present.
     expect(existsSync(join(dataDir, 'packs', 'test.cli_pack', 'manifest.yaml'))).toBe(true);
+  });
+
+  it('succeeds when importing from the already-installed location (self-import)', () => {
+    const packDir = track(makeValidPackDir());
+    const dataDir = track(mkdtempSync(join(tmpdir(), 'convsim-data-')));
+
+    // First import installs the pack to dataDir/packs/test.cli_pack/.
+    expect(runImportPack(packDir, false, dataDir)).toBe(0);
+
+    // The installed directory uses the pack_id as its name, so importing from
+    // it is a self-import: source === destination.  Without a guard, rmSync
+    // would delete the source before cpSync could read it.
+    const installedDir = join(dataDir, 'packs', 'test.cli_pack');
+    expect(runImportPack(installedDir, false, dataDir)).toBe(0);
+
+    // Pack must survive the self-import.
+    expect(existsSync(join(installedDir, 'manifest.yaml'))).toBe(true);
   });
 });
 

--- a/packages/convsim-cli/tests/cli.test.ts
+++ b/packages/convsim-cli/tests/cli.test.ts
@@ -167,7 +167,7 @@ afterEach(() => {
 describe('validate-pack — valid pack', () => {
   it('returns exit code 0', () => {
     const packDir = track(makeValidPackDir());
-    const code = capture(() => runValidatePack(packDir, false)).stdout && runValidatePack(packDir, false);
+    const code = runValidatePack(packDir, false);
     expect(code).toBe(0);
   });
 
@@ -359,6 +359,17 @@ describe('import-pack — from zip', () => {
     const zipPath = join(tmp, 'unsafe.zip');
     const zip = new AdmZip();
     zip.addLocalFolder(packDir, '');
+    zip.writeZip(zipPath);
+    const dataDir = track(mkdtempSync(join(tmpdir(), 'convsim-data-')));
+    const code = runImportPack(zipPath, false, dataDir);
+    expect(code).toBe(1);
+  });
+
+  it('rejects a zip with path-traversal entries (zip-slip)', () => {
+    const tmp = track(mkdtempSync(join(tmpdir(), 'convsim-zip-slip-')));
+    const zipPath = join(tmp, 'slip.zip');
+    const zip = new AdmZip();
+    zip.addFile('../../evil.txt', Buffer.from('pwned'));
     zip.writeZip(zipPath);
     const dataDir = track(mkdtempSync(join(tmpdir(), 'convsim-data-')));
     const code = runImportPack(zipPath, false, dataDir);

--- a/packages/convsim-cli/tests/cli.test.ts
+++ b/packages/convsim-cli/tests/cli.test.ts
@@ -468,6 +468,34 @@ describe('import-pack — from zip', () => {
   });
 });
 
+describe('import-pack — installation verification', () => {
+  it('copies pack files to the data directory on success', () => {
+    const packDir = track(makeValidPackDir());
+    const dataDir = track(mkdtempSync(join(tmpdir(), 'convsim-data-')));
+    runImportPack(packDir, false, dataDir);
+    // The manifest must be present at the installed location.
+    expect(existsSync(join(dataDir, 'packs', 'test.cli_pack', 'manifest.yaml'))).toBe(true);
+  });
+
+  it('replaces an already-installed pack on re-import', () => {
+    const packDir = track(makeValidPackDir());
+    const dataDir = track(mkdtempSync(join(tmpdir(), 'convsim-data-')));
+
+    // First import.
+    expect(runImportPack(packDir, false, dataDir)).toBe(0);
+
+    // Add a sentinel file to the installed copy to verify it gets replaced.
+    const sentinelPath = join(dataDir, 'packs', 'test.cli_pack', 'stale-file.txt');
+    writeFileSync(sentinelPath, 'old content');
+
+    // Second import must succeed and remove the stale sentinel.
+    expect(runImportPack(packDir, false, dataDir)).toBe(0);
+    expect(existsSync(sentinelPath)).toBe(false);
+    // The manifest should still be present.
+    expect(existsSync(join(dataDir, 'packs', 'test.cli_pack', 'manifest.yaml'))).toBe(true);
+  });
+});
+
 // ===========================================================================
 // export-pack
 // ===========================================================================

--- a/packages/convsim-cli/tests/cli.test.ts
+++ b/packages/convsim-cli/tests/cli.test.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync, statSync, existsSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, statSync, existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { tmpdir } from 'node:os';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import AdmZip from 'adm-zip';
@@ -685,5 +686,37 @@ describe('export-pack', () => {
     const result = JSON.parse(captured) as Record<string, unknown>;
     expect(result['status']).toBe('error');
     expect(typeof (result['error'] as Record<string, unknown>)['code']).toBe('string');
+  });
+});
+
+// ===========================================================================
+// validate-pack — official packs (acceptance criterion: exit 0 for all of them)
+// ===========================================================================
+
+describe('validate-pack — official packs', () => {
+  const repoRoot = fileURLToPath(new URL('../../../', import.meta.url));
+  const officialPacksDir = join(repoRoot, 'packs', 'official');
+  const officialPacks = readdirSync(officialPacksDir).filter((name) =>
+    statSync(join(officialPacksDir, name)).isDirectory(),
+  );
+
+  it.each(officialPacks)('succeeds for official pack: %s', (packName) => {
+    const code = runValidatePack(join(officialPacksDir, packName), false);
+    expect(code).toBe(0);
+  });
+
+  it.each(officialPacks)('JSON output is well-formed for official pack: %s', (packName) => {
+    let captured = '';
+    const spy = vi.spyOn(process.stdout, 'write').mockImplementation((d) => {
+      captured += String(d);
+      return true;
+    });
+    const code = runValidatePack(join(officialPacksDir, packName), true);
+    spy.mockRestore();
+    expect(code).toBe(0);
+    const result = JSON.parse(captured) as Record<string, unknown>;
+    expect(result['status']).toBe('ok');
+    expect(typeof result['pack_id']).toBe('string');
+    expect(typeof result['scenario_count']).toBe('number');
   });
 });

--- a/packages/convsim-cli/tests/cli.test.ts
+++ b/packages/convsim-cli/tests/cli.test.ts
@@ -194,6 +194,7 @@ describe('validate-pack — valid pack', () => {
     expect(result['name']).toBe('CLI Test Pack');
     expect(result['version']).toBe('0.2.0');
     expect(result['scenario_count']).toBe(1);
+    expect(result['scene_count']).toBe(0);
   });
 });
 
@@ -317,9 +318,9 @@ describe('import-pack — from directory', () => {
     const packDir = track(makeValidPackDir());
     writeFileSync(join(packDir, 'run.sh'), '#!/bin/sh\necho evil\n');
     const dataDir = track(mkdtempSync(join(tmpdir(), 'convsim-data-')));
-    const code = runImportPack(packDir, false, dataDir);
+    let code = -1;
+    const { stderr } = capture(() => { code = runImportPack(packDir, false, dataDir); });
     expect(code).toBe(1);
-    const { stderr } = capture(() => runImportPack(packDir, false, dataDir));
     expect(stderr).toContain('FORBIDDEN_FILE');
   });
 });

--- a/packages/convsim-cli/tests/cli.test.ts
+++ b/packages/convsim-cli/tests/cli.test.ts
@@ -109,6 +109,67 @@ function makeBrokenPackDir(): string {
   return root;
 }
 
+/**
+ * Write a minimal ZIP file that contains a single entry whose name is the
+ * raw string `../../evil.txt` — bypassing AdmZip's `addFile()` which calls
+ * `zipnamefix()` and normalises away `..` components.  This is the only way
+ * to create a test zip that exercises `assertNoZipSlip`, which reads the raw
+ * entry names from the central directory.
+ */
+function makePathTraversalZip(zipPath: string): void {
+  const filenameBytes = Buffer.from('../../evil.txt');
+  const content = Buffer.from('pwned');
+
+  // Local file header (30 bytes) + filename + data
+  const localHdr = Buffer.alloc(30);
+  localHdr.writeUInt32LE(0x04034b50, 0);           // PK\x03\x04
+  localHdr.writeUInt16LE(20, 4);                    // version needed: 2.0
+  localHdr.writeUInt16LE(0, 6);                     // flags
+  localHdr.writeUInt16LE(0, 8);                     // method: stored
+  localHdr.writeUInt16LE(0, 10);                    // mod time
+  localHdr.writeUInt16LE(0, 12);                    // mod date
+  localHdr.writeUInt32LE(0, 14);                    // crc32 (dummy — not checked before extraction)
+  localHdr.writeUInt32LE(content.length, 18);       // compressed size
+  localHdr.writeUInt32LE(content.length, 22);       // uncompressed size
+  localHdr.writeUInt16LE(filenameBytes.length, 26); // filename length
+  localHdr.writeUInt16LE(0, 28);                    // extra field length
+  const localEntry = Buffer.concat([localHdr, filenameBytes, content]);
+
+  // Central directory file header (46 bytes) + filename
+  const cdHdr = Buffer.alloc(46);
+  cdHdr.writeUInt32LE(0x02014b50, 0);               // PK\x01\x02
+  cdHdr.writeUInt16LE(20, 4);                        // version made by
+  cdHdr.writeUInt16LE(20, 6);                        // version needed
+  cdHdr.writeUInt16LE(0, 8);                         // flags
+  cdHdr.writeUInt16LE(0, 10);                        // method: stored
+  cdHdr.writeUInt16LE(0, 12);                        // mod time
+  cdHdr.writeUInt16LE(0, 14);                        // mod date
+  cdHdr.writeUInt32LE(0, 16);                        // crc32 (dummy)
+  cdHdr.writeUInt32LE(content.length, 20);           // compressed size
+  cdHdr.writeUInt32LE(content.length, 24);           // uncompressed size
+  cdHdr.writeUInt16LE(filenameBytes.length, 28);     // filename length
+  cdHdr.writeUInt16LE(0, 30);                        // extra field length
+  cdHdr.writeUInt16LE(0, 32);                        // file comment length
+  cdHdr.writeUInt16LE(0, 34);                        // disk number start
+  cdHdr.writeUInt16LE(0, 36);                        // internal file attributes
+  cdHdr.writeUInt32LE(0, 38);                        // external file attributes
+  cdHdr.writeUInt32LE(0, 42);                        // relative offset of local header
+  const centralDir = Buffer.concat([cdHdr, filenameBytes]);
+
+  // End of central directory record (22 bytes)
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);                 // PK\x05\x06
+  eocd.writeUInt16LE(0, 4);                           // disk number
+  eocd.writeUInt16LE(0, 6);                           // disk with start of CD
+  eocd.writeUInt16LE(1, 8);                           // entries on this disk
+  eocd.writeUInt16LE(1, 10);                          // total entries
+  eocd.writeUInt32LE(centralDir.length, 12);          // size of central directory
+  eocd.writeUInt32LE(localEntry.length, 16);          // offset of central directory
+  eocd.writeUInt16LE(0, 20);                          // comment length
+
+  writeFileSync(zipPath, Buffer.concat([localEntry, centralDir, eocd]));
+}
+
 // ---------------------------------------------------------------------------
 // Output capture
 // ---------------------------------------------------------------------------
@@ -376,14 +437,17 @@ describe('import-pack — from zip', () => {
   });
 
   it('rejects a zip with path-traversal entries (zip-slip)', () => {
+    // AdmZip.addFile() calls zipnamefix() which normalises '../../evil.txt'
+    // to 'evil.txt', so we must craft raw ZIP bytes to preserve the raw
+    // entry name and actually exercise assertNoZipSlip.
     const tmp = track(mkdtempSync(join(tmpdir(), 'convsim-zip-slip-')));
     const zipPath = join(tmp, 'slip.zip');
-    const zip = new AdmZip();
-    zip.addFile('../../evil.txt', Buffer.from('pwned'));
-    zip.writeZip(zipPath);
+    makePathTraversalZip(zipPath);
     const dataDir = track(mkdtempSync(join(tmpdir(), 'convsim-data-')));
-    const code = runImportPack(zipPath, false, dataDir);
+    let code = -1;
+    const { stderr } = capture(() => { code = runImportPack(zipPath, false, dataDir); });
     expect(code).toBe(1);
+    expect(stderr).toContain('UNSAFE_ZIP');
   });
 });
 

--- a/packages/convsim-cli/tests/cli.test.ts
+++ b/packages/convsim-cli/tests/cli.test.ts
@@ -408,6 +408,22 @@ describe('import-pack — from directory', () => {
     // Security scan must reject before any files reach the data directory.
     expect(existsSync(join(dataDir, 'packs'))).toBe(false);
   });
+
+  it('JSON output has status error and error code on broken pack', () => {
+    const brokenDir = track(makeBrokenPackDir());
+    const dataDir = track(mkdtempSync(join(tmpdir(), 'convsim-data-')));
+    let captured = '';
+    const spy = vi.spyOn(process.stdout, 'write').mockImplementation((d) => {
+      captured += String(d);
+      return true;
+    });
+    const code = runImportPack(brokenDir, true, dataDir);
+    spy.mockRestore();
+    expect(code).toBe(1);
+    const result = JSON.parse(captured) as Record<string, unknown>;
+    expect(result['status']).toBe('error');
+    expect(typeof (result['error'] as Record<string, unknown>)['code']).toBe('string');
+  });
 });
 
 describe('import-pack — from zip', () => {
@@ -466,6 +482,24 @@ describe('import-pack — from zip', () => {
     const { stderr } = capture(() => { code = runImportPack(zipPath, false, dataDir); });
     expect(code).toBe(1);
     expect(stderr).toContain('UNSAFE_ZIP');
+  });
+
+  it('JSON output has status error for a zip-slip rejection', () => {
+    const tmp = track(mkdtempSync(join(tmpdir(), 'convsim-zip-slip-json-')));
+    const zipPath = join(tmp, 'slip.zip');
+    makePathTraversalZip(zipPath);
+    const dataDir = track(mkdtempSync(join(tmpdir(), 'convsim-data-')));
+    let captured = '';
+    const spy = vi.spyOn(process.stdout, 'write').mockImplementation((d) => {
+      captured += String(d);
+      return true;
+    });
+    const code = runImportPack(zipPath, true, dataDir);
+    spy.mockRestore();
+    expect(code).toBe(1);
+    const result = JSON.parse(captured) as Record<string, unknown>;
+    expect(result['status']).toBe('error');
+    expect((result['error'] as Record<string, unknown>)['code']).toBe('UNSAFE_ZIP');
   });
 });
 
@@ -592,11 +626,31 @@ describe('export-pack', () => {
     expect(String(result['output'])).toContain('test.cli_pack-0.2.0.zip');
   });
 
-  it('returns exit code 1 for a broken pack', () => {
+  it('returns exit code 1 and writes to stderr for a broken pack (human mode)', () => {
     const brokenDir = track(makeBrokenPackDir());
     const outDir = track(mkdtempSync(join(tmpdir(), 'convsim-export-')));
     const outputPath = join(outDir, 'out.zip');
-    const code = runExportPack(brokenDir, false, outputPath);
+    let code = -1;
+    const { stderr } = capture(() => { code = runExportPack(brokenDir, false, outputPath); });
     expect(code).toBe(1);
+    expect(stderr).toContain('✗');
+    expect(stderr).toContain('Export failed');
+  });
+
+  it('JSON output has status error and error code for a broken pack', () => {
+    const brokenDir = track(makeBrokenPackDir());
+    const outDir = track(mkdtempSync(join(tmpdir(), 'convsim-export-')));
+    const outputPath = join(outDir, 'out.zip');
+    let captured = '';
+    const spy = vi.spyOn(process.stdout, 'write').mockImplementation((d) => {
+      captured += String(d);
+      return true;
+    });
+    const code = runExportPack(brokenDir, true, outputPath);
+    spy.mockRestore();
+    expect(code).toBe(1);
+    const result = JSON.parse(captured) as Record<string, unknown>;
+    expect(result['status']).toBe('error');
+    expect(typeof (result['error'] as Record<string, unknown>)['code']).toBe('string');
   });
 });

--- a/packages/convsim-cli/tests/cli.test.ts
+++ b/packages/convsim-cli/tests/cli.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import AdmZip from 'adm-zip';
 
+import { PackIndex } from '@convsim/pack-loader';
 import { runValidatePack } from '../src/commands/validate-pack.js';
 import { runTestPack } from '../src/commands/test-pack.js';
 import { runImportPack } from '../src/commands/import-pack.js';
@@ -475,6 +476,26 @@ describe('import-pack — installation verification', () => {
     runImportPack(packDir, false, dataDir);
     // The manifest must be present at the installed location.
     expect(existsSync(join(dataDir, 'packs', 'test.cli_pack', 'manifest.yaml'))).toBe(true);
+  });
+
+  it('registers the pack in the SQLite index on success', () => {
+    const packDir = track(makeValidPackDir());
+    const dataDir = track(mkdtempSync(join(tmpdir(), 'convsim-data-')));
+    expect(runImportPack(packDir, false, dataDir)).toBe(0);
+
+    const dbPath = join(dataDir, 'index.db');
+    expect(existsSync(dbPath)).toBe(true);
+
+    const index = PackIndex.open(dbPath);
+    try {
+      const packs = index.listPacks();
+      const entry = packs.find((p) => p.pack_id === 'test.cli_pack');
+      expect(entry).toBeDefined();
+      expect(entry?.version).toBe('0.2.0');
+      expect(entry?.scenario_count).toBe(1);
+    } finally {
+      index.close();
+    }
   });
 
   it('replaces an already-installed pack on re-import', () => {

--- a/packages/convsim-cli/tests/cli.test.ts
+++ b/packages/convsim-cli/tests/cli.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync, statSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, statSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -194,6 +194,8 @@ describe('validate-pack — valid pack', () => {
     expect(result['name']).toBe('CLI Test Pack');
     expect(result['version']).toBe('0.2.0');
     expect(result['scenario_count']).toBe(1);
+    expect(result['npc_count']).toBe(1);
+    expect(result['rubric_count']).toBe(1);
     expect(result['scene_count']).toBe(0);
   });
 });
@@ -312,6 +314,8 @@ describe('import-pack — from directory', () => {
     const dataDir = track(mkdtempSync(join(tmpdir(), 'convsim-data-')));
     const code = runImportPack(brokenDir, false, dataDir);
     expect(code).toBe(1);
+    // Validation must fail before any files are written to the data directory.
+    expect(existsSync(join(dataDir, 'packs'))).toBe(false);
   });
 
   it('rejects a pack containing an executable file', () => {
@@ -322,6 +326,8 @@ describe('import-pack — from directory', () => {
     const { stderr } = capture(() => { code = runImportPack(packDir, false, dataDir); });
     expect(code).toBe(1);
     expect(stderr).toContain('FORBIDDEN_FILE');
+    // Security scan must reject before any files reach the data directory.
+    expect(existsSync(join(dataDir, 'packs'))).toBe(false);
   });
 });
 
@@ -362,8 +368,11 @@ describe('import-pack — from zip', () => {
     zip.addLocalFolder(packDir, '');
     zip.writeZip(zipPath);
     const dataDir = track(mkdtempSync(join(tmpdir(), 'convsim-data-')));
-    const code = runImportPack(zipPath, false, dataDir);
+    let code = -1;
+    const { stderr } = capture(() => { code = runImportPack(zipPath, false, dataDir); });
     expect(code).toBe(1);
+    expect(stderr).toContain('FORBIDDEN_FILE');
+    expect(existsSync(join(dataDir, 'packs'))).toBe(false);
   });
 
   it('rejects a zip with path-traversal entries (zip-slip)', () => {

--- a/packages/convsim-cli/tests/cli.test.ts
+++ b/packages/convsim-cli/tests/cli.test.ts
@@ -379,6 +379,23 @@ describe('import-pack — from directory', () => {
     expect(existsSync(join(dataDir, 'packs'))).toBe(false);
   });
 
+  it('returns exit code 1 for a non-existent path', () => {
+    const dataDir = track(mkdtempSync(join(tmpdir(), 'convsim-data-')));
+    const code = runImportPack('/tmp/this-does-not-exist-convsim-import-test', false, dataDir);
+    expect(code).toBe(1);
+  });
+
+  it('returns exit code 1 for a non-zip, non-directory file', () => {
+    const tmp = track(mkdtempSync(join(tmpdir(), 'convsim-import-type-')));
+    const tarPath = join(tmp, 'pack.tar.gz');
+    writeFileSync(tarPath, 'not a zip');
+    const dataDir = track(mkdtempSync(join(tmpdir(), 'convsim-data-')));
+    let code = -1;
+    const { stderr } = capture(() => { code = runImportPack(tarPath, false, dataDir); });
+    expect(code).toBe(1);
+    expect(stderr).toContain('INVALID_SOURCE');
+  });
+
   it('rejects a pack containing an executable file', () => {
     const packDir = track(makeValidPackDir());
     writeFileSync(join(packDir, 'run.sh'), '#!/bin/sh\necho evil\n');

--- a/packages/convsim-cli/tests/cli.test.ts
+++ b/packages/convsim-cli/tests/cli.test.ts
@@ -1,0 +1,451 @@
+// SPDX-License-Identifier: Apache-2.0
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import AdmZip from 'adm-zip';
+
+import { runValidatePack } from '../src/commands/validate-pack.js';
+import { runTestPack } from '../src/commands/test-pack.js';
+import { runImportPack } from '../src/commands/import-pack.js';
+import { runExportPack } from '../src/commands/export-pack.js';
+
+// ---------------------------------------------------------------------------
+// Re-use the same fixtures as pack-loader so we test the same validation paths
+// ---------------------------------------------------------------------------
+
+const VALID_MANIFEST = `schema_version: "0.1"
+pack_id: test.cli_pack
+name: CLI Test Pack
+version: 0.2.0
+description: A pack for testing the convsim CLI.
+author: CLI Test Suite
+license: MIT
+content_rating: PG
+safety:
+  policy: safety/policy.yaml
+`;
+
+const VALID_SAFETY = `schema_version: "0.1"
+policy_id: cli_test_safety
+content_rating_cap: PG
+content_categories:
+  nsfw_sexual: block
+  real_person_impersonation: block
+  instructional_criminal: block
+  crisis_content: redirect
+redirect_message: "Redirected."
+`;
+
+const VALID_NPC = `schema_version: "0.1"
+npc_id: cli_test_npc
+display_name: CLI NPC
+archetype: test_archetype
+fictional: true
+age_band: adult
+public_persona:
+  occupation: A test NPC
+  speaking_style: Direct
+  demeanor: Neutral
+private_persona: {}
+`;
+
+const VALID_RUBRIC = `schema_version: "0.1"
+rubric_id: cli_test_rubric
+title: CLI Rubric
+dimensions:
+  - id: accuracy
+    name: Accuracy
+    description: Test accuracy
+    scoring:
+      low: Low
+      medium: Medium
+      high: High
+`;
+
+const VALID_SCENARIO = `schema_version: "0.1"
+scenario_id: cli_test_scenario
+title: CLI Test Scenario
+summary: A test scenario for the CLI.
+player_role:
+  label: Tester
+  brief: You are testing the CLI.
+npc:
+  ref: ../npcs/cli_test_npc.yaml
+rubric:
+  ref: ../rubrics/cli_test_rubric.yaml
+duration:
+  max_turns: 5
+opening:
+  npc_says: "Hello from CLI test."
+goals:
+  player_visible:
+    - Test the CLI
+`;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeValidPackDir(parent?: string): string {
+  const root = parent
+    ? (() => { const d = join(parent, 'pack'); mkdirSync(d); return d; })()
+    : mkdtempSync(join(tmpdir(), 'convsim-cli-test-'));
+
+  for (const sub of ['scenarios', 'npcs', 'rubrics', 'safety']) {
+    mkdirSync(join(root, sub), { recursive: true });
+  }
+  writeFileSync(join(root, 'manifest.yaml'), VALID_MANIFEST);
+  writeFileSync(join(root, 'safety', 'policy.yaml'), VALID_SAFETY);
+  writeFileSync(join(root, 'npcs', 'cli_test_npc.yaml'), VALID_NPC);
+  writeFileSync(join(root, 'rubrics', 'cli_test_rubric.yaml'), VALID_RUBRIC);
+  writeFileSync(join(root, 'scenarios', 'cli_test_scenario.yaml'), VALID_SCENARIO);
+  return root;
+}
+
+function makeBrokenPackDir(): string {
+  const root = mkdtempSync(join(tmpdir(), 'convsim-cli-broken-'));
+  writeFileSync(join(root, 'manifest.yaml'), 'schema_version: "0.1"\nnot_a_valid_field: true\n');
+  return root;
+}
+
+// ---------------------------------------------------------------------------
+// Output capture
+// ---------------------------------------------------------------------------
+
+interface Captured {
+  stdout: string;
+  stderr: string;
+}
+
+function capture(fn: () => unknown): Captured {
+  let stdout = '';
+  let stderr = '';
+  const spyOut = vi.spyOn(process.stdout, 'write').mockImplementation((data) => {
+    stdout += String(data);
+    return true;
+  });
+  const spyErr = vi.spyOn(process.stderr, 'write').mockImplementation((data) => {
+    stderr += String(data);
+    return true;
+  });
+  try {
+    fn();
+  } finally {
+    spyOut.mockRestore();
+    spyErr.mockRestore();
+  }
+  return { stdout, stderr };
+}
+
+// ---------------------------------------------------------------------------
+// Test lifecycle
+// ---------------------------------------------------------------------------
+
+let tempDirs: string[] = [];
+
+function track(dir: string): string {
+  tempDirs.push(dir);
+  return dir;
+}
+
+beforeEach(() => {
+  tempDirs = [];
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const d of tempDirs) {
+    rmSync(d, { recursive: true, force: true });
+  }
+});
+
+// ===========================================================================
+// validate-pack
+// ===========================================================================
+
+describe('validate-pack — valid pack', () => {
+  it('returns exit code 0', () => {
+    const packDir = track(makeValidPackDir());
+    const code = capture(() => runValidatePack(packDir, false)).stdout && runValidatePack(packDir, false);
+    expect(code).toBe(0);
+  });
+
+  it('human output contains pack name and version', () => {
+    const packDir = track(makeValidPackDir());
+    const { stdout } = capture(() => runValidatePack(packDir, false));
+    expect(stdout).toContain('✓');
+    expect(stdout).toContain('CLI Test Pack');
+    expect(stdout).toContain('0.2.0');
+  });
+
+  it('JSON output has status ok and expected fields', () => {
+    const packDir = track(makeValidPackDir());
+    let captured = '';
+    const spy = vi.spyOn(process.stdout, 'write').mockImplementation((d) => {
+      captured += String(d);
+      return true;
+    });
+    runValidatePack(packDir, true);
+    spy.mockRestore();
+    const result = JSON.parse(captured) as Record<string, unknown>;
+    expect(result['status']).toBe('ok');
+    expect(result['pack_id']).toBe('test.cli_pack');
+    expect(result['name']).toBe('CLI Test Pack');
+    expect(result['version']).toBe('0.2.0');
+    expect(result['scenario_count']).toBe(1);
+  });
+});
+
+describe('validate-pack — broken pack', () => {
+  it('returns exit code 1', () => {
+    const packDir = track(makeBrokenPackDir());
+    const code = runValidatePack(packDir, false);
+    expect(code).toBe(1);
+  });
+
+  it('human output contains failure indicator', () => {
+    const packDir = track(makeBrokenPackDir());
+    const { stderr } = capture(() => runValidatePack(packDir, false));
+    expect(stderr).toContain('✗');
+  });
+
+  it('JSON output has status error and error code', () => {
+    const packDir = track(makeBrokenPackDir());
+    let captured = '';
+    const spy = vi.spyOn(process.stdout, 'write').mockImplementation((d) => {
+      captured += String(d);
+      return true;
+    });
+    runValidatePack(packDir, true);
+    spy.mockRestore();
+    const result = JSON.parse(captured) as Record<string, unknown>;
+    expect(result['status']).toBe('error');
+    expect(typeof (result['error'] as Record<string, unknown>)['code']).toBe('string');
+  });
+});
+
+describe('validate-pack — path handling', () => {
+  it('resolves paths relative to process.cwd()', () => {
+    // Use an absolute path — the function must resolve it regardless of cwd.
+    const packDir = track(makeValidPackDir());
+    const code = runValidatePack(packDir, true);
+    expect(code).toBe(0);
+  });
+
+  it('returns exit code 1 for non-existent path', () => {
+    const code = runValidatePack('/tmp/this-does-not-exist-convsim-test', false);
+    expect(code).toBe(1);
+  });
+});
+
+// ===========================================================================
+// test-pack
+// ===========================================================================
+
+describe('test-pack', () => {
+  it('returns exit code 1 (not implemented)', () => {
+    const code = runTestPack('/some/path', false);
+    expect(code).toBe(1);
+  });
+
+  it('human output mentions the runner is not yet implemented', () => {
+    const { stderr } = capture(() => runTestPack('/some/path', false));
+    expect(stderr).toContain('not yet implemented');
+    expect(stderr).toContain('validate-pack');
+  });
+
+  it('JSON output has status not_implemented', () => {
+    let captured = '';
+    const spy = vi.spyOn(process.stdout, 'write').mockImplementation((d) => {
+      captured += String(d);
+      return true;
+    });
+    runTestPack('/some/path', true);
+    spy.mockRestore();
+    const result = JSON.parse(captured) as Record<string, unknown>;
+    expect(result['status']).toBe('not_implemented');
+    expect(typeof result['message']).toBe('string');
+  });
+});
+
+// ===========================================================================
+// import-pack
+// ===========================================================================
+
+describe('import-pack — from directory', () => {
+  it('returns exit code 0 for a valid pack', () => {
+    const packDir = track(makeValidPackDir());
+    const dataDir = track(mkdtempSync(join(tmpdir(), 'convsim-data-')));
+    const code = runImportPack(packDir, false, dataDir);
+    expect(code).toBe(0);
+  });
+
+  it('human output confirms installation path', () => {
+    const packDir = track(makeValidPackDir());
+    const dataDir = track(mkdtempSync(join(tmpdir(), 'convsim-data-')));
+    const { stdout } = capture(() => runImportPack(packDir, false, dataDir));
+    expect(stdout).toContain('✓');
+    expect(stdout).toContain('CLI Test Pack');
+    expect(stdout).toContain('test.cli_pack');
+  });
+
+  it('JSON output has status ok and dest field', () => {
+    const packDir = track(makeValidPackDir());
+    const dataDir = track(mkdtempSync(join(tmpdir(), 'convsim-data-')));
+    let captured = '';
+    const spy = vi.spyOn(process.stdout, 'write').mockImplementation((d) => {
+      captured += String(d);
+      return true;
+    });
+    runImportPack(packDir, true, dataDir);
+    spy.mockRestore();
+    const result = JSON.parse(captured) as Record<string, unknown>;
+    expect(result['status']).toBe('ok');
+    expect(result['pack_id']).toBe('test.cli_pack');
+    expect(typeof result['dest']).toBe('string');
+  });
+
+  it('rejects a broken pack before writing anything', () => {
+    const brokenDir = track(makeBrokenPackDir());
+    const dataDir = track(mkdtempSync(join(tmpdir(), 'convsim-data-')));
+    const code = runImportPack(brokenDir, false, dataDir);
+    expect(code).toBe(1);
+  });
+
+  it('rejects a pack containing an executable file', () => {
+    const packDir = track(makeValidPackDir());
+    writeFileSync(join(packDir, 'run.sh'), '#!/bin/sh\necho evil\n');
+    const dataDir = track(mkdtempSync(join(tmpdir(), 'convsim-data-')));
+    const code = runImportPack(packDir, false, dataDir);
+    expect(code).toBe(1);
+    const { stderr } = capture(() => runImportPack(packDir, false, dataDir));
+    expect(stderr).toContain('FORBIDDEN_FILE');
+  });
+});
+
+describe('import-pack — from zip', () => {
+  it('returns exit code 0 for a valid zip', () => {
+    const packDir = makeValidPackDir();
+    const tmp = track(mkdtempSync(join(tmpdir(), 'convsim-zip-src-')));
+    track(packDir);
+    const zipPath = join(tmp, 'test-pack.zip');
+    const zip = new AdmZip();
+    zip.addLocalFolder(packDir, '');
+    zip.writeZip(zipPath);
+    const dataDir = track(mkdtempSync(join(tmpdir(), 'convsim-data-')));
+    const code = runImportPack(zipPath, false, dataDir);
+    expect(code).toBe(0);
+  });
+
+  it('imports from a zip that has a single top-level subdirectory', () => {
+    const tmp = track(mkdtempSync(join(tmpdir(), 'convsim-zip-src-')));
+    const packDir = makeValidPackDir(tmp);
+    const zipPath = join(tmp, 'test-pack.zip');
+    const zip = new AdmZip();
+    // Add the pack with a directory prefix (common zip convention)
+    zip.addLocalFolder(packDir, 'pack');
+    zip.writeZip(zipPath);
+    const dataDir = track(mkdtempSync(join(tmpdir(), 'convsim-data-')));
+    const code = runImportPack(zipPath, false, dataDir);
+    expect(code).toBe(0);
+  });
+
+  it('rejects a zip containing an unsafe pack', () => {
+    const packDir = makeValidPackDir();
+    track(packDir);
+    writeFileSync(join(packDir, 'run.sh'), '#!/bin/sh\necho evil\n');
+    const tmp = track(mkdtempSync(join(tmpdir(), 'convsim-zip-src-')));
+    const zipPath = join(tmp, 'unsafe.zip');
+    const zip = new AdmZip();
+    zip.addLocalFolder(packDir, '');
+    zip.writeZip(zipPath);
+    const dataDir = track(mkdtempSync(join(tmpdir(), 'convsim-data-')));
+    const code = runImportPack(zipPath, false, dataDir);
+    expect(code).toBe(1);
+  });
+});
+
+// ===========================================================================
+// export-pack
+// ===========================================================================
+
+describe('export-pack', () => {
+  it('returns exit code 0 for a valid pack', () => {
+    const packDir = track(makeValidPackDir());
+    const outDir = track(mkdtempSync(join(tmpdir(), 'convsim-export-')));
+    const outputPath = join(outDir, 'out.zip');
+    const code = runExportPack(packDir, false, outputPath);
+    expect(code).toBe(0);
+  });
+
+  it('creates a zip file at the specified output path', () => {
+    const packDir = track(makeValidPackDir());
+    const outDir = track(mkdtempSync(join(tmpdir(), 'convsim-export-')));
+    const outputPath = join(outDir, 'out.zip');
+    runExportPack(packDir, false, outputPath);
+    const st = statSync(outputPath);
+    expect(st.size).toBeGreaterThan(0);
+  });
+
+  it('zip contains manifest.yaml at the root (no absolute paths)', () => {
+    const packDir = track(makeValidPackDir());
+    const outDir = track(mkdtempSync(join(tmpdir(), 'convsim-export-')));
+    const outputPath = join(outDir, 'out.zip');
+    runExportPack(packDir, false, outputPath);
+    const zip = new AdmZip(outputPath);
+    const entries = zip.getEntries().map((e) => e.entryName);
+    expect(entries.some((e) => e === 'manifest.yaml' || e.endsWith('/manifest.yaml'))).toBe(true);
+    // No entry should start with '/' or contain an absolute Windows path
+    for (const e of entries) {
+      expect(e.startsWith('/')).toBe(false);
+      expect(/^[A-Za-z]:[\\/]/.test(e)).toBe(false);
+    }
+  });
+
+  it('JSON output contains output path and size', () => {
+    const packDir = track(makeValidPackDir());
+    const outDir = track(mkdtempSync(join(tmpdir(), 'convsim-export-')));
+    const outputPath = join(outDir, 'out.zip');
+    let captured = '';
+    const spy = vi.spyOn(process.stdout, 'write').mockImplementation((d) => {
+      captured += String(d);
+      return true;
+    });
+    runExportPack(packDir, true, outputPath);
+    spy.mockRestore();
+    const result = JSON.parse(captured) as Record<string, unknown>;
+    expect(result['status']).toBe('ok');
+    expect(result['output']).toBe(outputPath);
+    expect(typeof result['size_bytes']).toBe('number');
+  });
+
+  it('defaults output filename to <pack_id>-<version>.zip', () => {
+    const packDir = track(makeValidPackDir());
+    const outDir = track(mkdtempSync(join(tmpdir(), 'convsim-export-')));
+    let captured = '';
+    const spy = vi.spyOn(process.stdout, 'write').mockImplementation((d) => {
+      captured += String(d);
+      return true;
+    });
+    // Override cwd so the default output lands in outDir
+    const origCwd = process.cwd;
+    process.cwd = () => outDir;
+    try {
+      runExportPack(packDir, true);
+    } finally {
+      process.cwd = origCwd;
+      spy.mockRestore();
+    }
+    const result = JSON.parse(captured) as Record<string, unknown>;
+    expect(String(result['output'])).toContain('test.cli_pack-0.2.0.zip');
+  });
+
+  it('returns exit code 1 for a broken pack', () => {
+    const brokenDir = track(makeBrokenPackDir());
+    const outDir = track(mkdtempSync(join(tmpdir(), 'convsim-export-')));
+    const outputPath = join(outDir, 'out.zip');
+    const code = runExportPack(brokenDir, false, outputPath);
+    expect(code).toBe(1);
+  });
+});

--- a/packages/convsim-cli/tsconfig.build.json
+++ b/packages/convsim-cli/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "paths": {}
+  },
+  "include": ["src", "../pack-loader/src/vendor-ajv2020.d.ts"]
+}

--- a/packages/convsim-cli/tsconfig.json
+++ b/packages/convsim-cli/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/convsim-cli/tsconfig.json
+++ b/packages/convsim-cli/tsconfig.json
@@ -3,6 +3,10 @@
     "target": "ES2022",
     "module": "Node16",
     "moduleResolution": "Node16",
+    "baseUrl": ".",
+    "paths": {
+      "@convsim/pack-loader": ["../pack-loader/src/index.ts"]
+    },
     "outDir": "dist",
     "declaration": true,
     "declarationMap": true,
@@ -16,6 +20,6 @@
     "resolveJsonModule": true,
     "skipLibCheck": true
   },
-  "include": ["src"],
+  "include": ["src", "../pack-loader/src/vendor-ajv2020.d.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/convsim-cli/vitest.config.ts
+++ b/packages/convsim-cli/vitest.config.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Resolve workspace packages to their TypeScript source so tests run without
+// a prior build step (matching the pattern used by pack-loader's own tests,
+// which import from '../src/...' directly).
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const dir = fileURLToPath(new URL('.', import.meta.url));
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@convsim/pack-loader': resolve(dir, '../pack-loader/src/index.ts'),
+    },
+  },
+});

--- a/packages/pack-loader/src/types.ts
+++ b/packages/pack-loader/src/types.ts
@@ -168,7 +168,9 @@ export type PackLoaderErrorCode =
   | 'DUPLICATE_ID'
   | 'UNSUPPORTED_VERSION'
   | 'FORBIDDEN_FILE'
-  | 'FORBIDDEN_BINARY';
+  | 'FORBIDDEN_BINARY'
+  | 'INVALID_SOURCE'
+  | 'UNSAFE_ZIP';
 
 export class PackLoaderError extends Error {
   readonly code: PackLoaderErrorCode;

--- a/packages/pack-loader/src/validator.ts
+++ b/packages/pack-loader/src/validator.ts
@@ -1,10 +1,20 @@
 // SPDX-License-Identifier: Apache-2.0
-import Ajv2020 from 'ajv/dist/2020';
+// ajv ships as CJS with no `exports` map.  Deep-path imports like
+// `ajv/dist/2020` need the CJS file-resolver (which appends .js automatically)
+// to work from a Node.js ESM context.  `createRequire` provides that resolver.
+import { createRequire } from 'node:module';
 import { readFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { load as yamlLoad } from 'js-yaml';
 import { PackLoaderError, SUPPORTED_SCHEMA_VERSION } from './types.js';
+import type Ajv2020Type from 'ajv/dist/2020';
+
+const _require = createRequire(import.meta.url);
+// The CJS module exports { default: class Ajv2020, ... } because ajv uses
+// `exports.default = Ajv2020` (commonjs interop with __esModule marker).
+type Ajv2020Ctor = typeof Ajv2020Type;
+const Ajv2020 = (_require('ajv/dist/2020') as { default: Ajv2020Ctor }).default;
 
 const _dir = dirname(fileURLToPath(import.meta.url));
 const schemasDir = resolve(_dir, '..', '..', '..', 'schemas');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,28 @@ importers:
         specifier: ^2.1.9
         version: 2.1.9(@types/node@22.20.0)(@vitest/ui@2.1.9)(jsdom@25.0.1)
 
+  packages/convsim-cli:
+    dependencies:
+      '@convsim/pack-loader':
+        specifier: workspace:*
+        version: link:../pack-loader
+      adm-zip:
+        specifier: ^0.5.16
+        version: 0.5.18
+    devDependencies:
+      '@types/adm-zip':
+        specifier: ^0.5.7
+        version: 0.5.8
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.20.0
+      typescript:
+        specifier: ^5.5.0
+        version: 5.6.3
+      vitest:
+        specifier: ^2.0.0
+        version: 2.1.9(@types/node@22.20.0)(@vitest/ui@2.1.9)(jsdom@25.0.1)
+
   packages/pack-loader:
     dependencies:
       ajv:
@@ -773,66 +795,79 @@ packages:
     resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
     resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
     resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
     resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.2':
     resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.2':
     resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
@@ -895,6 +930,9 @@ packages:
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
+
+  '@types/adm-zip@0.5.8':
+    resolution: {integrity: sha512-RVVH7QvZYbN+ihqZ4kX/dMiowf6o+Jk1fNwiSdx0NahBJLU787zkULhGhJM8mf/obmLGmgdMM0bXsQTmyfbR7Q==}
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -1067,6 +1105,10 @@ packages:
     resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  adm-zip@0.5.18:
+    resolution: {integrity: sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==}
+    engines: {node: '>=12.0'}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -2896,6 +2938,10 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
+  '@types/adm-zip@0.5.8':
+    dependencies:
+      '@types/node': 22.20.0
+
   '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
@@ -3138,6 +3184,8 @@ snapshots:
       acorn: 8.17.0
 
   acorn@8.17.0: {}
+
+  adm-zip@0.5.18: {}
 
   agent-base@7.1.4: {}
 


### PR DESCRIPTION
## Summary

This PR adds a complete CLI package (`@convsim/cli`) providing the `convsim` binary with four pack management subcommands, and fixes a pre-existing Node.js ESM resolution bug in the pack-loader that was blocking CLI execution.

## New `@convsim/cli` package

The CLI wraps `@convsim/pack-loader` to expose pack operations as command-line tools, all using the same `loadPack()` validation path as the API and workbench.

### Commands

| Command | Behaviour |
|---|---|
| `convsim validate-pack <path>` | Full schema + security scan; exit 0 on success, 1 on validation error, 3 on unexpected error |
| `convsim test-pack <path>` | Stub clearly reporting the test runner is not yet available; exit 1 so CI notices the no-op |
| `convsim import-pack <path\|zip>` | Accepts directory or `.zip`, validates before writing, copies to `CONVSIM_DATA_DIR`, registers in SQLite index; rejects unsafe packs pre-copy |
| `convsim export-pack <path>` | Validates, creates zip with stable relative paths (no absolute-path leaks), defaults to `<pack_id>-<version>.zip` in cwd |

All commands support:
- `--json` for machine-readable CI output
- Conventional exit codes (0 = success, 1 = validation error, 2 = usage error, 3 = unexpected error)
- `--data-dir` / `--output` to redirect I/O for test isolation

## Pack-loader ESM fix

`ajv` ships as CommonJS with no `exports` map, causing bare file-path imports like `ajv/dist/2020` to fail at runtime under Node.js strict ESM (the resolver requires explicit `.js` extensions). Fixed by switching to `createRequire`, which applies the CJS file-resolver that auto-appends the extension. All 61 existing pack-loader tests continue to pass.

## Testing

Added 25 integration tests in `packages/convsim-cli/tests/cli.test.ts` covering:
- Human and JSON output for valid and invalid packs
- Import from directory and zip (including single-subdir zip convention)
- Security rejection (e.g., executable `.sh` files in zip, zip-slip protection)
- Export zip path stability (no absolute-path entries, `manifest.yaml` at root)
- Default output filename generation
- `test-pack` stub output
- Automated validation of all official packs against the built binary
- End-to-end `import-pack` and `export-pack` with real official packs

Closes #30