### PR TITLE
Build Creator Workbench with pack explorer and YAML/Markdown editor

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -10,6 +10,7 @@ import { scenarioRoutes } from './routes/scenarios.js';
 import { sessionRoutes } from './routes/sessions.js';
 import { sessionWsRoutes } from './routes/session-ws.js';
 import { privacyRoutes, setDataFolderPath } from './routes/privacy.js';
+import { workbenchRoutes, setWorkbenchRoots } from './routes/workbench.js';
 import { initDb } from './db.js';
 import { getListenConfig } from './config.js';
 
@@ -56,6 +57,10 @@ if (process.argv[1] === new URL(import.meta.url).pathname) {
   initDb(dbPath);
   setDataFolderPath(path.dirname(dbPath));
   setPacksDbPath(packsDbPath);
+  setWorkbenchRoots(
+    process.env['PACKS_OFFICIAL_ROOT'] ?? path.join(process.cwd(), 'packs', 'official'),
+    process.env['PACKS_LOCAL_DEV_ROOT'] ?? path.join(os.homedir(), '.convsim', 'packs', 'local-dev'),
+  );
   const app = await buildApp();
   await app.listen(listenConfig);
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -10,6 +10,7 @@ import { sessionRoutes } from './routes/sessions.js';
 import { sessionWsRoutes } from './routes/session-ws.js';
 import { privacyRoutes, setDataFolderPath } from './routes/privacy.js';
 import { packRoutes } from './routes/packs.js';
+import { workbenchRoutes, setWorkbenchRoots } from './routes/workbench.js';
 import { initDb } from './db.js';
 import { getListenConfig } from './config.js';
 
@@ -37,6 +38,7 @@ export async function buildApp() {
   await app.register(sessionWsRoutes);
   await app.register(privacyRoutes);
   await app.register(packRoutes);
+  await app.register(workbenchRoutes);
 
   return app;
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -9,6 +9,7 @@ import { scenarioRoutes } from './routes/scenarios.js';
 import { sessionRoutes } from './routes/sessions.js';
 import { sessionWsRoutes } from './routes/session-ws.js';
 import { privacyRoutes, setDataFolderPath } from './routes/privacy.js';
+import { workbenchRoutes, setWorkbenchRoots } from './routes/workbench.js';
 import { initDb } from './db.js';
 import { getListenConfig } from './config.js';
 
@@ -35,6 +36,7 @@ export async function buildApp() {
   await app.register(sessionRoutes);
   await app.register(sessionWsRoutes);
   await app.register(privacyRoutes);
+  await app.register(workbenchRoutes);
 
   return app;
 }
@@ -47,6 +49,17 @@ if (process.argv[1] === new URL(import.meta.url).pathname) {
   fs.mkdirSync(path.dirname(dbPath), { recursive: true });
   initDb(dbPath);
   setDataFolderPath(path.dirname(dbPath));
+
+  // Pack roots: official packs ship with the app; local-dev packs live in ~/.convsim
+  const thisDir = path.dirname(new URL(import.meta.url).pathname);
+  const officialRoot =
+    process.env['PACKS_OFFICIAL_ROOT'] ??
+    path.resolve(thisDir, '..', '..', '..', '..', 'packs', 'official');
+  const localDevRoot =
+    process.env['PACKS_LOCAL_DEV_ROOT'] ??
+    path.join(os.homedir(), '.convsim', 'packs', 'local-dev');
+  setWorkbenchRoots(officialRoot, localDevRoot);
+
   const app = await buildApp();
   await app.listen(listenConfig);
 }

--- a/apps/api/src/routes/workbench.test.ts
+++ b/apps/api/src/routes/workbench.test.ts
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { FastifyInstance } from 'fastify';
+import { buildApp } from '../index.js';
+import { setWorkbenchRoots } from './workbench.js';
+
+let app: FastifyInstance;
+let officialRoot: string;
+let localDevRoot: string;
+let tmpBase: string;
+
+function setupPack(root: string, slug: string, name: string, packId: string) {
+  const packDir = join(root, slug);
+  mkdirSync(join(packDir, 'scenarios'), { recursive: true });
+  mkdirSync(join(packDir, 'npcs'), { recursive: true });
+  writeFileSync(
+    join(packDir, 'manifest.yaml'),
+    `schema_version: "0.1"\npack_id: ${packId}\nname: ${name}\nversion: 0.1.0\ndescription: Test pack\nauthor: Test\nlicense: MIT\ncontent_rating: PG\nsafety:\n  policy: safety/default.yaml\n`,
+  );
+  writeFileSync(join(packDir, 'README.md'), `# ${name}\n\nA test pack.\n`);
+  writeFileSync(
+    join(packDir, 'scenarios', 'basic.yaml'),
+    `schema_version: "0.1"\nscenario_id: basic\ntitle: Basic Scenario\n`,
+  );
+  return packDir;
+}
+
+beforeEach(async () => {
+  tmpBase = join(tmpdir(), `workbench-test-${Math.random().toString(36).slice(2)}`);
+  officialRoot = join(tmpBase, 'official');
+  localDevRoot = join(tmpBase, 'local-dev');
+  mkdirSync(officialRoot, { recursive: true });
+  mkdirSync(localDevRoot, { recursive: true });
+
+  setupPack(officialRoot, 'sample-pack', 'Sample Pack', 'official.sample_pack');
+  setupPack(localDevRoot, 'my-pack', 'My Pack', 'local.my_pack');
+
+  setWorkbenchRoots(officialRoot, localDevRoot);
+  app = await buildApp();
+});
+
+afterEach(async () => {
+  await app.close();
+  try {
+    rmSync(tmpBase, { recursive: true, force: true });
+  } catch { /* ignore cleanup errors */ }
+});
+
+describe('GET /api/workbench/packs', () => {
+  it('lists packs from official and local-dev roots', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/workbench/packs' });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ kind: string; slug: string; editable: boolean }[]>();
+    expect(Array.isArray(body)).toBe(true);
+    expect(body.length).toBeGreaterThanOrEqual(2);
+
+    const official = body.find((p) => p.kind === 'official');
+    expect(official).toBeDefined();
+    expect(official?.slug).toBe('sample-pack');
+    expect(official?.editable).toBe(false);
+
+    const local = body.find((p) => p.kind === 'local-dev');
+    expect(local).toBeDefined();
+    expect(local?.slug).toBe('my-pack');
+    expect(local?.editable).toBe(true);
+  });
+
+  it('returns pack_id and name from manifest', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/workbench/packs' });
+    const body = res.json<{ kind: string; pack_id: string; name: string }[]>();
+    const official = body.find((p) => p.kind === 'official');
+    expect(official?.pack_id).toBe('official.sample_pack');
+    expect(official?.name).toBe('Sample Pack');
+  });
+});
+
+describe('GET /api/workbench/packs/:kind/:slug/files', () => {
+  it('returns file tree for an official pack', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/workbench/packs/official/sample-pack/files',
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ tree: { name: string; kind: string; path: string }[] }>();
+    expect(Array.isArray(body.tree)).toBe(true);
+
+    const manifest = body.tree.find((n) => n.name === 'manifest.yaml');
+    expect(manifest).toBeDefined();
+    expect(manifest?.kind).toBe('yaml');
+
+    const readme = body.tree.find((n) => n.name === 'README.md');
+    expect(readme).toBeDefined();
+    expect(readme?.kind).toBe('markdown');
+
+    const scenarios = body.tree.find((n) => n.name === 'scenarios');
+    expect(scenarios).toBeDefined();
+    expect(scenarios?.kind).toBe('dir');
+  });
+
+  it('returns 404 for unknown pack', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/workbench/packs/official/does-not-exist/files',
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('returns 400 for invalid kind', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/workbench/packs/community/sample-pack/files',
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe('GET /api/workbench/packs/:kind/:slug/file', () => {
+  it('returns file content for an official pack', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/workbench/packs/official/sample-pack/file?path=README.md',
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ content: string; editable: boolean }>();
+    expect(body.content).toContain('Sample Pack');
+    expect(body.editable).toBe(false);
+  });
+
+  it('returns editable:true for local-dev pack', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/workbench/packs/local-dev/my-pack/file?path=manifest.yaml',
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ content: string; editable: boolean }>();
+    expect(body.editable).toBe(true);
+  });
+
+  it('returns 400 when path param is missing', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/workbench/packs/official/sample-pack/file',
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 for path traversal attempt', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/workbench/packs/official/sample-pack/file?path=../../etc/passwd',
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 404 for non-existent file', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/workbench/packs/official/sample-pack/file?path=ghost.yaml',
+    });
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe('PUT /api/workbench/packs/:kind/:slug/file', () => {
+  it('writes file content for local-dev pack', async () => {
+    const newContent = 'schema_version: "0.1"\nname: Updated\n';
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/workbench/packs/local-dev/my-pack/file?path=manifest.yaml',
+      headers: { 'content-type': 'application/json' },
+      payload: JSON.stringify({ content: newContent }),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ ok: boolean }>();
+    expect(body.ok).toBe(true);
+
+    // Verify file was actually written
+    const readRes = await app.inject({
+      method: 'GET',
+      url: '/api/workbench/packs/local-dev/my-pack/file?path=manifest.yaml',
+    });
+    expect(readRes.json<{ content: string }>().content).toBe(newContent);
+  });
+
+  it('returns 403 when writing to official pack', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/workbench/packs/official/sample-pack/file?path=manifest.yaml',
+      headers: { 'content-type': 'application/json' },
+      payload: JSON.stringify({ content: 'evil' }),
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('returns 400 for non-editable file type', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/workbench/packs/local-dev/my-pack/file?path=image.png',
+      headers: { 'content-type': 'application/json' },
+      payload: JSON.stringify({ content: 'binary' }),
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 for path traversal attempt', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/workbench/packs/local-dev/my-pack/file?path=../../etc/cron.d/evil',
+      headers: { 'content-type': 'application/json' },
+      payload: JSON.stringify({ content: 'evil' }),
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe('POST /api/workbench/packs/:kind/:slug/copy-to-local', () => {
+  it('copies an official pack to local-dev', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/workbench/packs/official/sample-pack/copy-to-local',
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ kind: string; slug: string; editable: boolean }>();
+    expect(body.kind).toBe('local-dev');
+    expect(body.slug).toContain('sample-pack');
+    expect(body.editable).toBe(true);
+
+    // Verify the copy appears in the pack list
+    const listRes = await app.inject({ method: 'GET', url: '/api/workbench/packs' });
+    const packs = listRes.json<{ slug: string }[]>();
+    expect(packs.some((p) => p.slug === body.slug)).toBe(true);
+  });
+
+  it('returns 400 when trying to copy a local-dev pack', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/workbench/packs/local-dev/my-pack/copy-to-local',
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 404 for unknown pack', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/workbench/packs/official/does-not-exist/copy-to-local',
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('avoids slug collision when dest already exists', async () => {
+    // Copy once
+    const res1 = await app.inject({
+      method: 'POST',
+      url: '/api/workbench/packs/official/sample-pack/copy-to-local',
+    });
+    expect(res1.statusCode).toBe(200);
+    const slug1 = res1.json<{ slug: string }>().slug;
+
+    // Copy again — should get a different slug
+    const res2 = await app.inject({
+      method: 'POST',
+      url: '/api/workbench/packs/official/sample-pack/copy-to-local',
+    });
+    expect(res2.statusCode).toBe(200);
+    const slug2 = res2.json<{ slug: string }>().slug;
+
+    expect(slug1).not.toBe(slug2);
+  });
+});

--- a/apps/api/src/routes/workbench.test.ts
+++ b/apps/api/src/routes/workbench.test.ts
@@ -147,6 +147,14 @@ describe('GET /api/workbench/packs/:kind/:slug/file', () => {
     expect(res.statusCode).toBe(400);
   });
 
+  it('returns 400 when path resolves to a directory', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/workbench/packs/official/sample-pack/file?path=scenarios',
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
   it('returns 400 for path traversal attempt', async () => {
     const res = await app.inject({
       method: 'GET',

--- a/apps/api/src/routes/workbench.test.ts
+++ b/apps/api/src/routes/workbench.test.ts
@@ -155,6 +155,14 @@ describe('GET /api/workbench/packs/:kind/:slug/file', () => {
     expect(res.statusCode).toBe(400);
   });
 
+  it('returns 400 when path resolves to the pack root itself (dot-traversal)', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/workbench/packs/official/sample-pack/file?path=.',
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
   it('returns 404 for non-existent file', async () => {
     const res = await app.inject({
       method: 'GET',
@@ -211,6 +219,26 @@ describe('PUT /api/workbench/packs/:kind/:slug/file', () => {
       url: '/api/workbench/packs/local-dev/my-pack/file?path=../../etc/cron.d/evil',
       headers: { 'content-type': 'application/json' },
       payload: JSON.stringify({ content: 'evil' }),
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 when path param is missing', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/workbench/packs/local-dev/my-pack/file',
+      headers: { 'content-type': 'application/json' },
+      payload: JSON.stringify({ content: 'hello' }),
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 when path resolves to the pack root itself (dot-traversal)', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/workbench/packs/local-dev/my-pack/file?path=.',
+      headers: { 'content-type': 'application/json' },
+      payload: JSON.stringify({ content: 'hello' }),
     });
     expect(res.statusCode).toBe(400);
   });

--- a/apps/api/src/routes/workbench.ts
+++ b/apps/api/src/routes/workbench.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { FastifyInstance } from 'fastify';
 import fs from 'node:fs';
+import { randomBytes } from 'node:crypto';
 import path from 'node:path';
 
 let _officialRoot = '';
@@ -144,7 +145,7 @@ function getPackRoot(kind: PackKind, slug: string, reply: Reply): string {
 
 function resolveFilePath(packRoot: string, relPath: string, reply: Reply): string {
   const abs = path.normalize(path.resolve(packRoot, relPath));
-  if (!abs.startsWith(packRoot + path.sep) && abs !== packRoot) {
+  if (!abs.startsWith(packRoot + path.sep)) {
     reply.status(400);
     throw new Error('Path traversal not allowed');
   }
@@ -244,7 +245,14 @@ export async function workbenchRoutes(app: FastifyInstance): Promise<void> {
         throw new Error(`File type "${ext}" is not editable via the workbench`);
       }
       fs.mkdirSync(path.dirname(absPath), { recursive: true });
-      fs.writeFileSync(absPath, content, 'utf-8');
+      const tmpPath = `${absPath}.tmp.${randomBytes(4).toString('hex')}`;
+      try {
+        fs.writeFileSync(tmpPath, content, 'utf-8');
+        fs.renameSync(tmpPath, absPath);
+      } catch (err) {
+        try { fs.unlinkSync(tmpPath); } catch { /* ignore cleanup failure */ }
+        throw err;
+      }
       return { ok: true };
     },
   );

--- a/apps/api/src/routes/workbench.ts
+++ b/apps/api/src/routes/workbench.ts
@@ -204,9 +204,16 @@ export async function workbenchRoutes(app: FastifyInstance): Promise<void> {
       }
       const packRoot = getPackRoot(kind, slug, reply);
       const absPath = resolveFilePath(packRoot, relPath, reply);
-      if (!fs.existsSync(absPath)) {
+      let stat: fs.Stats;
+      try {
+        stat = fs.statSync(absPath);
+      } catch {
         reply.status(404);
         throw new Error(`File not found: ${relPath}`);
+      }
+      if (!stat.isFile()) {
+        reply.status(400);
+        throw new Error(`Path is not a file: ${relPath}`);
       }
       const content = fs.readFileSync(absPath, 'utf-8');
       return { content, editable: kind === 'local-dev' };

--- a/apps/api/src/routes/workbench.ts
+++ b/apps/api/src/routes/workbench.ts
@@ -1,0 +1,290 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { FastifyInstance } from 'fastify';
+import fs from 'node:fs';
+import path from 'node:path';
+
+let _officialRoot = '';
+let _localDevRoot = '';
+
+export function setWorkbenchRoots(officialRoot: string, localDevRoot: string): void {
+  _officialRoot = officialRoot;
+  _localDevRoot = localDevRoot;
+}
+
+export type PackKind = 'official' | 'local-dev';
+
+export interface WorkbenchPackSummary {
+  kind: PackKind;
+  slug: string;
+  pack_id: string | null;
+  name: string | null;
+  editable: boolean;
+}
+
+export interface FileNode {
+  name: string;
+  path: string;
+  kind: 'yaml' | 'markdown' | 'text' | 'dir' | 'other';
+  children?: FileNode[];
+}
+
+function rootForKind(kind: PackKind): string {
+  return kind === 'official' ? _officialRoot : _localDevRoot;
+}
+
+function readManifestBasics(packDir: string): { pack_id: string | null; name: string | null } {
+  let pack_id: string | null = null;
+  let name: string | null = null;
+  try {
+    const content = fs.readFileSync(path.join(packDir, 'manifest.yaml'), 'utf-8');
+    for (const line of content.split('\n')) {
+      if (!pack_id) {
+        const m = /^pack_id:\s*['"]?([^'"\n]+)['"]?\s*$/.exec(line);
+        if (m) pack_id = m[1].trim();
+      }
+      if (!name) {
+        const m = /^name:\s*['"]?([^'"\n]+)['"]?\s*$/.exec(line);
+        if (m) name = m[1].trim();
+      }
+      if (pack_id && name) break;
+    }
+  } catch {
+    // ignore — manifest may be missing or malformed
+  }
+  return { pack_id, name };
+}
+
+function scanRoot(kind: PackKind): WorkbenchPackSummary[] {
+  const root = rootForKind(kind);
+  if (!root) return [];
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(root);
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((e) => {
+      try {
+        return fs.statSync(path.join(root, e)).isDirectory();
+      } catch {
+        return false;
+      }
+    })
+    .map((slug) => {
+      const { pack_id, name } = readManifestBasics(path.join(root, slug));
+      return { kind, slug, pack_id, name: name ?? slug, editable: kind === 'local-dev' };
+    });
+}
+
+function buildTree(dir: string, packRoot: string): FileNode[] {
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(dir);
+  } catch {
+    return [];
+  }
+
+  const nodes: FileNode[] = [];
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry);
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(fullPath);
+    } catch {
+      continue;
+    }
+
+    const relPath = path.relative(packRoot, fullPath).replace(/\\/g, '/');
+
+    if (stat.isDirectory()) {
+      nodes.push({ name: entry, path: relPath, kind: 'dir', children: buildTree(fullPath, packRoot) });
+    } else if (stat.isFile()) {
+      const ext = path.extname(entry).toLowerCase();
+      let kind: FileNode['kind'] = 'other';
+      if (ext === '.yaml' || ext === '.yml') kind = 'yaml';
+      else if (ext === '.md') kind = 'markdown';
+      else if (ext === '.txt') kind = 'text';
+      nodes.push({ name: entry, path: relPath, kind });
+    }
+  }
+
+  return nodes.sort((a, b) => {
+    if (a.kind === 'dir' && b.kind !== 'dir') return -1;
+    if (a.kind !== 'dir' && b.kind === 'dir') return 1;
+    return a.name.localeCompare(b.name);
+  });
+}
+
+interface Reply {
+  status(code: number): void;
+}
+
+function assertValidKind(kind: string, reply: Reply): asserts kind is PackKind {
+  if (kind !== 'official' && kind !== 'local-dev') {
+    reply.status(400);
+    throw new Error(`Invalid kind "${kind}": must be "official" or "local-dev"`);
+  }
+}
+
+function getPackRoot(kind: PackKind, slug: string, reply: Reply): string {
+  const root = rootForKind(kind);
+  if (!root) {
+    reply.status(503);
+    throw new Error(`Pack root for "${kind}" is not configured`);
+  }
+  const normalRoot = path.normalize(root);
+  const packRoot = path.normalize(path.resolve(normalRoot, slug));
+  if (!packRoot.startsWith(normalRoot + path.sep) || packRoot === normalRoot) {
+    reply.status(400);
+    throw new Error('Invalid pack slug');
+  }
+  return packRoot;
+}
+
+function resolveFilePath(packRoot: string, relPath: string, reply: Reply): string {
+  const abs = path.normalize(path.resolve(packRoot, relPath));
+  if (!abs.startsWith(packRoot + path.sep) && abs !== packRoot) {
+    reply.status(400);
+    throw new Error('Path traversal not allowed');
+  }
+  return abs;
+}
+
+function copyDirRecursive(src: string, dst: string): void {
+  fs.mkdirSync(dst, { recursive: true });
+  for (const entry of fs.readdirSync(src)) {
+    const srcPath = path.join(src, entry);
+    const dstPath = path.join(dst, entry);
+    if (fs.statSync(srcPath).isDirectory()) {
+      copyDirRecursive(srcPath, dstPath);
+    } else {
+      fs.copyFileSync(srcPath, dstPath);
+    }
+  }
+}
+
+const EDITABLE_EXTENSIONS = new Set(['.yaml', '.yml', '.md', '.txt']);
+
+export async function workbenchRoutes(app: FastifyInstance): Promise<void> {
+  // GET /api/workbench/packs — list all packs from official and local-dev roots
+  app.get('/api/workbench/packs', async (): Promise<WorkbenchPackSummary[]> => {
+    return [...scanRoot('official'), ...scanRoot('local-dev')];
+  });
+
+  // GET /api/workbench/packs/:kind/:slug/files — file tree for a pack
+  app.get<{ Params: { kind: string; slug: string } }>(
+    '/api/workbench/packs/:kind/:slug/files',
+    async (req, reply): Promise<{ tree: FileNode[] }> => {
+      const { kind, slug } = req.params;
+      assertValidKind(kind, reply);
+      const packRoot = getPackRoot(kind, slug, reply);
+      if (!fs.existsSync(packRoot)) {
+        reply.status(404);
+        throw new Error(`Pack "${slug}" not found`);
+      }
+      return { tree: buildTree(packRoot, packRoot) };
+    },
+  );
+
+  // GET /api/workbench/packs/:kind/:slug/file?path=... — read a file
+  app.get<{
+    Params: { kind: string; slug: string };
+    Querystring: { path?: string };
+  }>(
+    '/api/workbench/packs/:kind/:slug/file',
+    async (req, reply): Promise<{ content: string; editable: boolean }> => {
+      const { kind, slug } = req.params;
+      assertValidKind(kind, reply);
+      const relPath = req.query.path;
+      if (!relPath) {
+        reply.status(400);
+        throw new Error('Missing required query parameter: path');
+      }
+      const packRoot = getPackRoot(kind, slug, reply);
+      const absPath = resolveFilePath(packRoot, relPath, reply);
+      if (!fs.existsSync(absPath)) {
+        reply.status(404);
+        throw new Error(`File not found: ${relPath}`);
+      }
+      const content = fs.readFileSync(absPath, 'utf-8');
+      return { content, editable: kind === 'local-dev' };
+    },
+  );
+
+  // PUT /api/workbench/packs/:kind/:slug/file?path=... — write a file (local-dev only)
+  app.put<{
+    Params: { kind: string; slug: string };
+    Querystring: { path?: string };
+    Body: { content: unknown };
+  }>(
+    '/api/workbench/packs/:kind/:slug/file',
+    async (req, reply): Promise<{ ok: boolean }> => {
+      const { kind, slug } = req.params;
+      assertValidKind(kind, reply);
+      if (kind !== 'local-dev') {
+        reply.status(403);
+        throw new Error('Official packs are read-only. Copy to local-dev first.');
+      }
+      const relPath = req.query.path;
+      if (!relPath) {
+        reply.status(400);
+        throw new Error('Missing required query parameter: path');
+      }
+      const { content } = req.body;
+      if (typeof content !== 'string') {
+        reply.status(400);
+        throw new Error('Body must include a "content" string field');
+      }
+      const packRoot = getPackRoot(kind, slug, reply);
+      const absPath = resolveFilePath(packRoot, relPath, reply);
+      const ext = path.extname(absPath).toLowerCase();
+      if (!EDITABLE_EXTENSIONS.has(ext)) {
+        reply.status(400);
+        throw new Error(`File type "${ext}" is not editable via the workbench`);
+      }
+      fs.mkdirSync(path.dirname(absPath), { recursive: true });
+      fs.writeFileSync(absPath, content, 'utf-8');
+      return { ok: true };
+    },
+  );
+
+  // POST /api/workbench/packs/:kind/:slug/copy-to-local — copy pack to local-dev
+  app.post<{ Params: { kind: string; slug: string } }>(
+    '/api/workbench/packs/:kind/:slug/copy-to-local',
+    async (req, reply): Promise<WorkbenchPackSummary> => {
+      const { kind, slug } = req.params;
+      assertValidKind(kind, reply);
+      if (kind === 'local-dev') {
+        reply.status(400);
+        throw new Error('Pack is already in local-dev');
+      }
+      const srcRoot = getPackRoot(kind, slug, reply);
+      if (!fs.existsSync(srcRoot)) {
+        reply.status(404);
+        throw new Error(`Pack "${slug}" not found`);
+      }
+      if (!_localDevRoot) {
+        reply.status(503);
+        throw new Error('Local-dev root is not configured');
+      }
+      fs.mkdirSync(_localDevRoot, { recursive: true });
+      let destSlug = slug;
+      let destPath = path.join(_localDevRoot, destSlug);
+      if (fs.existsSync(destPath)) {
+        destSlug = `${slug}-copy`;
+        destPath = path.join(_localDevRoot, destSlug);
+      }
+      if (fs.existsSync(destPath)) {
+        // Avoid collisions with a numeric suffix
+        let n = 2;
+        while (fs.existsSync(path.join(_localDevRoot, `${slug}-copy-${n}`))) n++;
+        destSlug = `${slug}-copy-${n}`;
+        destPath = path.join(_localDevRoot, destSlug);
+      }
+      copyDirRecursive(srcRoot, destPath);
+      const { pack_id, name } = readManifestBasics(destPath);
+      return { kind: 'local-dev', slug: destSlug, pack_id, name: name ?? destSlug, editable: true };
+    },
+  );
+}

--- a/apps/web/src/__tests__/CreatorWorkbench.test.tsx
+++ b/apps/web/src/__tests__/CreatorWorkbench.test.tsx
@@ -273,7 +273,7 @@ describe('CreatorWorkbench', () => {
     const newPack: WorkbenchPack = { kind: 'local-dev', slug: 'job-interview-copy', pack_id: 'local.job_interview_copy', name: 'Job Interview', editable: true }
     const copySpy = vi.fn().mockReturnValue(okJson(newPack))
 
-    stubFetch((url, opts) => {
+    stubFetch((url) => {
       if (url.includes('/copy-to-local')) return copySpy()
       if (url.includes('/files')) return okJson({ tree: MOCK_TREE })
       if (url.includes('/file?')) return okJson({ content: MANIFEST_CONTENT, editable: false })

--- a/apps/web/src/__tests__/CreatorWorkbench.test.tsx
+++ b/apps/web/src/__tests__/CreatorWorkbench.test.tsx
@@ -290,5 +290,10 @@ describe('CreatorWorkbench', () => {
     await waitFor(() => {
       expect(copySpy).toHaveBeenCalledOnce()
     })
+
+    // After copy, the file editor should be cleared (no file selected)
+    await waitFor(() => {
+      expect(screen.queryByTestId('file-editor')).not.toBeInTheDocument()
+    })
   })
 })

--- a/apps/web/src/__tests__/CreatorWorkbench.test.tsx
+++ b/apps/web/src/__tests__/CreatorWorkbench.test.tsx
@@ -296,4 +296,34 @@ describe('CreatorWorkbench', () => {
       expect(screen.queryByTestId('file-editor')).not.toBeInTheDocument()
     })
   })
+
+  it('clears dirty state immediately when switching to a different file', async () => {
+    const localContent = 'name: My Pack\n'
+    // jsdom doesn't implement window.confirm; stub it to return true (user confirms discard)
+    vi.stubGlobal('confirm', vi.fn().mockReturnValue(true))
+
+    stubFetch((url) => {
+      if (url.includes('/files')) return okJson({ tree: MOCK_TREE })
+      if (url.includes('/file?')) return okJson({ content: localContent, editable: true })
+      return okJson([OFFICIAL_PACK, LOCAL_PACK])
+    })
+
+    renderWorkbench()
+    fireEvent.click(await screen.findByRole('button', { name: /my pack/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /open manifest\.yaml/i }))
+    await waitFor(() => expect(screen.getByTestId('file-editor')).toBeInTheDocument())
+
+    // Make the editor dirty
+    fireEvent.change(screen.getByTestId('file-editor'), { target: { value: 'name: Changed\n' } })
+    expect(screen.getByTestId('dirty-indicator')).toBeInTheDocument()
+
+    // Switch to another file — dirty state must clear immediately (not wait for load to finish)
+    fireEvent.click(await screen.findByRole('button', { name: /open README\.md/i }))
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('dirty-indicator')).not.toBeInTheDocument()
+    })
+
+    vi.unstubAllGlobals()
+  })
 })

--- a/apps/web/src/__tests__/CreatorWorkbench.test.tsx
+++ b/apps/web/src/__tests__/CreatorWorkbench.test.tsx
@@ -297,6 +297,85 @@ describe('CreatorWorkbench', () => {
     })
   })
 
+  it('shows a valid badge when the pack validates cleanly', async () => {
+    stubFetch((url) => {
+      if (url.includes('/validate')) return okJson({ valid: true, errors: [], warnings: [] })
+      if (url.includes('/files')) return okJson({ tree: MOCK_TREE })
+      return okJson([OFFICIAL_PACK, LOCAL_PACK])
+    })
+
+    renderWorkbench()
+    fireEvent.click(await screen.findByRole('button', { name: /my pack/i }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('validation-panel')).toHaveTextContent(/valid/i)
+    })
+  })
+
+  it('lists validation errors when the pack is invalid', async () => {
+    stubFetch((url) => {
+      if (url.includes('/validate')) {
+        return okJson({
+          valid: false,
+          errors: [
+            { severity: 'error', rule_id: 'SCHEMA_VIOLATION', file: 'manifest.yaml', pointer: '/author', message: "'author' is a required property", suggested_fix: 'Add author' },
+          ],
+          warnings: [],
+        })
+      }
+      if (url.includes('/files')) return okJson({ tree: MOCK_TREE })
+      return okJson([OFFICIAL_PACK, LOCAL_PACK])
+    })
+
+    renderWorkbench()
+    fireEvent.click(await screen.findByRole('button', { name: /my pack/i }))
+
+    await waitFor(() => {
+      const panel = screen.getByTestId('validation-panel')
+      expect(panel).toHaveTextContent(/1 validation error/i)
+      expect(panel).toHaveTextContent(/required property/i)
+    })
+  })
+
+  it('refreshes validation from the save response', async () => {
+    const localContent = 'name: My Pack\n'
+    stubFetch((url, opts) => {
+      if (url.includes('/file?') && opts?.method === 'PUT') {
+        return okJson({
+          valid: false,
+          ok: true,
+          validation: {
+            valid: false,
+            errors: [
+              { severity: 'error', rule_id: 'INVALID_MANIFEST_YAML', file: 'manifest.yaml', pointer: '', message: 'manifest.yaml must be a YAML mapping', suggested_fix: 'Fix YAML' },
+            ],
+            warnings: [],
+          },
+        })
+      }
+      if (url.includes('/file?')) return okJson({ content: localContent, editable: true })
+      if (url.includes('/validate')) return okJson({ valid: true, errors: [], warnings: [] })
+      if (url.includes('/files')) return okJson({ tree: MOCK_TREE })
+      return okJson([OFFICIAL_PACK, LOCAL_PACK])
+    })
+
+    renderWorkbench()
+    fireEvent.click(await screen.findByRole('button', { name: /my pack/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /open manifest\.yaml/i }))
+    await waitFor(() => expect(screen.getByTestId('file-editor')).toBeInTheDocument())
+
+    // Pack initially validates clean.
+    await waitFor(() => expect(screen.getByTestId('validation-panel')).toHaveTextContent(/valid/i))
+
+    fireEvent.change(screen.getByTestId('file-editor'), { target: { value: 'broken: [' } })
+    fireEvent.click(screen.getByTestId('save-button'))
+
+    // After save, the validation panel reflects the newly-returned errors.
+    await waitFor(() => {
+      expect(screen.getByTestId('validation-panel')).toHaveTextContent(/must be a YAML mapping/i)
+    })
+  })
+
   it('clears dirty state immediately when switching to a different file', async () => {
     const localContent = 'name: My Pack\n'
     // jsdom doesn't implement window.confirm; stub it to return true (user confirms discard)

--- a/apps/web/src/__tests__/CreatorWorkbench.test.tsx
+++ b/apps/web/src/__tests__/CreatorWorkbench.test.tsx
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import CreatorWorkbench from '../screens/CreatorWorkbench'
+import type { WorkbenchPack, FileNode } from '../api/client'
+
+const OFFICIAL_PACK: WorkbenchPack = {
+  kind: 'official',
+  slug: 'job-interview',
+  pack_id: 'official.job_interview',
+  name: 'Job Interview',
+  editable: false,
+}
+
+const LOCAL_PACK: WorkbenchPack = {
+  kind: 'local-dev',
+  slug: 'my-pack',
+  pack_id: 'local.my_pack',
+  name: 'My Pack',
+  editable: true,
+}
+
+const MOCK_TREE: FileNode[] = [
+  { name: 'manifest.yaml', path: 'manifest.yaml', kind: 'yaml' },
+  { name: 'README.md', path: 'README.md', kind: 'markdown' },
+  {
+    name: 'scenarios',
+    path: 'scenarios',
+    kind: 'dir',
+    children: [{ name: 'basic.yaml', path: 'scenarios/basic.yaml', kind: 'yaml' }],
+  },
+  { name: 'logo.png', path: 'logo.png', kind: 'other' },
+]
+
+const MANIFEST_CONTENT = 'schema_version: "0.1"\npack_id: official.job_interview\nname: Job Interview\n'
+
+type FetchResponse = { ok: boolean; status?: number; json?: () => Promise<unknown>; text?: () => Promise<string> }
+
+function stubFetch(handler: (url: string, opts?: RequestInit) => FetchResponse) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((url: string, opts?: RequestInit) => Promise.resolve(handler(url, opts))),
+  )
+}
+
+function okJson(data: unknown): FetchResponse {
+  return { ok: true, json: () => Promise.resolve(data) }
+}
+
+function renderWorkbench() {
+  return render(
+    <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <CreatorWorkbench />
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  // Default: list-packs returns both packs; everything else is pending
+  stubFetch((url) => {
+    if (url.includes('/api/workbench/packs') && !url.includes('/files') && !url.includes('/file') && !url.includes('/copy-to-local')) {
+      return okJson([OFFICIAL_PACK, LOCAL_PACK])
+    }
+    return { ok: false, status: 404, text: () => Promise.resolve('Not found') }
+  })
+})
+
+describe('CreatorWorkbench', () => {
+  it('renders the heading', () => {
+    renderWorkbench()
+    expect(screen.getByRole('heading', { name: /creator workbench/i })).toBeInTheDocument()
+  })
+
+  it('shows pack list after loading', async () => {
+    renderWorkbench()
+    expect(await screen.findByText('Job Interview')).toBeInTheDocument()
+    expect(await screen.findByText('My Pack')).toBeInTheDocument()
+  })
+
+  it('shows official label for official packs', async () => {
+    renderWorkbench()
+    await screen.findByText('Job Interview')
+    expect(screen.getByText('official')).toBeInTheDocument()
+  })
+
+  it('shows file tree when a pack is selected', async () => {
+    stubFetch((url) => {
+      if (url.includes('/api/workbench/packs') && url.includes('/files')) {
+        return okJson({ tree: MOCK_TREE })
+      }
+      if (url.includes('/api/workbench/packs') && !url.includes('/')) {
+        return okJson([OFFICIAL_PACK, LOCAL_PACK])
+      }
+      return okJson([OFFICIAL_PACK, LOCAL_PACK])
+    })
+
+    renderWorkbench()
+    const packBtn = await screen.findByRole('button', { name: /job interview/i })
+    fireEvent.click(packBtn)
+
+    await waitFor(() => {
+      expect(screen.getByRole('tree')).toBeInTheDocument()
+    })
+  })
+
+  it('shows file content when a YAML file is selected', async () => {
+    stubFetch((url) => {
+      if (url.includes('/files')) return okJson({ tree: MOCK_TREE })
+      if (url.includes('/file?')) return okJson({ content: MANIFEST_CONTENT, editable: false })
+      return okJson([OFFICIAL_PACK, LOCAL_PACK])
+    })
+
+    renderWorkbench()
+    fireEvent.click(await screen.findByRole('button', { name: /job interview/i }))
+
+    const fileBtn = await screen.findByRole('button', { name: /open manifest\.yaml/i })
+    fireEvent.click(fileBtn)
+
+    await waitFor(() => {
+      const editor = screen.getByTestId('file-editor') as HTMLTextAreaElement
+      expect(editor.value).toContain('pack_id')
+    })
+  })
+
+  it('shows read-only badge for official pack file', async () => {
+    stubFetch((url) => {
+      if (url.includes('/files')) return okJson({ tree: MOCK_TREE })
+      if (url.includes('/file?')) return okJson({ content: MANIFEST_CONTENT, editable: false })
+      return okJson([OFFICIAL_PACK, LOCAL_PACK])
+    })
+
+    renderWorkbench()
+    fireEvent.click(await screen.findByRole('button', { name: /job interview/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /open manifest\.yaml/i }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('read-only-badge')).toBeInTheDocument()
+    })
+  })
+
+  it('shows create-local-copy button for read-only files', async () => {
+    stubFetch((url) => {
+      if (url.includes('/files')) return okJson({ tree: MOCK_TREE })
+      if (url.includes('/file?')) return okJson({ content: MANIFEST_CONTENT, editable: false })
+      return okJson([OFFICIAL_PACK, LOCAL_PACK])
+    })
+
+    renderWorkbench()
+    fireEvent.click(await screen.findByRole('button', { name: /job interview/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /open manifest\.yaml/i }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('copy-to-local-button')).toBeInTheDocument()
+    })
+  })
+
+  it('shows no save button for read-only official pack', async () => {
+    stubFetch((url) => {
+      if (url.includes('/files')) return okJson({ tree: MOCK_TREE })
+      if (url.includes('/file?')) return okJson({ content: MANIFEST_CONTENT, editable: false })
+      return okJson([OFFICIAL_PACK, LOCAL_PACK])
+    })
+
+    renderWorkbench()
+    fireEvent.click(await screen.findByRole('button', { name: /job interview/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /open manifest\.yaml/i }))
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('save-button')).not.toBeInTheDocument()
+    })
+  })
+
+  it('shows editable textarea and save button for local-dev pack', async () => {
+    const localContent = 'name: My Pack\n'
+    stubFetch((url) => {
+      if (url.includes('/files')) return okJson({ tree: MOCK_TREE })
+      if (url.includes('/file?')) return okJson({ content: localContent, editable: true })
+      return okJson([OFFICIAL_PACK, LOCAL_PACK])
+    })
+
+    renderWorkbench()
+    fireEvent.click(await screen.findByRole('button', { name: /my pack/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /open manifest\.yaml/i }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('save-button')).toBeInTheDocument()
+      expect(screen.queryByTestId('read-only-badge')).not.toBeInTheDocument()
+    })
+  })
+
+  it('shows dirty indicator after editing content', async () => {
+    const localContent = 'name: My Pack\n'
+    stubFetch((url) => {
+      if (url.includes('/files')) return okJson({ tree: MOCK_TREE })
+      if (url.includes('/file?')) return okJson({ content: localContent, editable: true })
+      return okJson([OFFICIAL_PACK, LOCAL_PACK])
+    })
+
+    renderWorkbench()
+    fireEvent.click(await screen.findByRole('button', { name: /my pack/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /open manifest\.yaml/i }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('file-editor')).toBeInTheDocument()
+    })
+
+    fireEvent.change(screen.getByTestId('file-editor'), {
+      target: { value: 'name: Changed\n' },
+    })
+
+    expect(screen.getByTestId('dirty-indicator')).toBeInTheDocument()
+  })
+
+  it('clears dirty state after saving', async () => {
+    const localContent = 'name: My Pack\n'
+    const putSpy = vi.fn().mockResolvedValue({ ok: true })
+    stubFetch((url, opts) => {
+      if (url.includes('/files')) return okJson({ tree: MOCK_TREE })
+      if (url.includes('/file?') && (!opts || opts.method !== 'PUT')) {
+        return okJson({ content: localContent, editable: true })
+      }
+      if (url.includes('/file?') && opts?.method === 'PUT') {
+        putSpy()
+        return okJson({ ok: true })
+      }
+      return okJson([OFFICIAL_PACK, LOCAL_PACK])
+    })
+
+    renderWorkbench()
+    fireEvent.click(await screen.findByRole('button', { name: /my pack/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /open manifest\.yaml/i }))
+    await waitFor(() => expect(screen.getByTestId('file-editor')).toBeInTheDocument())
+
+    fireEvent.change(screen.getByTestId('file-editor'), {
+      target: { value: 'name: Changed\n' },
+    })
+    expect(screen.getByTestId('dirty-indicator')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('save-button'))
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('dirty-indicator')).not.toBeInTheDocument()
+    })
+    expect(putSpy).toHaveBeenCalledOnce()
+  })
+
+  it('shows unsupported label for non-text files in tree', async () => {
+    stubFetch((url) => {
+      if (url.includes('/files')) return okJson({ tree: MOCK_TREE })
+      return okJson([OFFICIAL_PACK, LOCAL_PACK])
+    })
+
+    renderWorkbench()
+    fireEvent.click(await screen.findByRole('button', { name: /job interview/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('unsupported')).toBeInTheDocument()
+    })
+  })
+
+  it('shows pack error when API fails', async () => {
+    stubFetch(() => ({ ok: false, status: 500, text: () => Promise.resolve('Server error') }))
+
+    renderWorkbench()
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+    })
+  })
+
+  it('copy-to-local button triggers copy and switches to new pack', async () => {
+    const newPack: WorkbenchPack = { kind: 'local-dev', slug: 'job-interview-copy', pack_id: 'local.job_interview_copy', name: 'Job Interview', editable: true }
+    const copySpy = vi.fn().mockReturnValue(okJson(newPack))
+
+    stubFetch((url, opts) => {
+      if (url.includes('/copy-to-local')) return copySpy()
+      if (url.includes('/files')) return okJson({ tree: MOCK_TREE })
+      if (url.includes('/file?')) return okJson({ content: MANIFEST_CONTENT, editable: false })
+      return okJson([OFFICIAL_PACK, LOCAL_PACK])
+    })
+
+    renderWorkbench()
+    fireEvent.click(await screen.findByRole('button', { name: /job interview/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /open manifest\.yaml/i }))
+
+    const copyBtn = await screen.findByTestId('copy-to-local-button')
+    fireEvent.click(copyBtn)
+
+    await waitFor(() => {
+      expect(copySpy).toHaveBeenCalledOnce()
+    })
+  })
+})

--- a/apps/web/src/api/client.test.ts
+++ b/apps/web/src/api/client.test.ts
@@ -71,6 +71,30 @@ describe('api.createSession error handling', () => {
     expect(thrownMessage).not.toContain('"statusCode"');
   });
 
+  it('extracts the message from a convsim-core nested error object', async () => {
+    mockFetch(404, { error: { code: 'PACK_NOT_FOUND', message: 'Pack "ghost" not found' } });
+
+    let thrownMessage = '';
+    try {
+      await api.createSession({
+        scenario_id: 'behavioral_interview',
+        difficulty: 'normal',
+        player_role_name: 'Alice',
+        language: 'en',
+        input_mode: 'text-only',
+        tts_enabled: false,
+        show_state_meters: false,
+        save_transcript: true,
+        seed: null,
+      });
+    } catch (e) {
+      thrownMessage = e instanceof Error ? e.message : String(e);
+    }
+
+    expect(thrownMessage).toBe('PACK_NOT_FOUND: Pack "ghost" not found');
+    expect(thrownMessage).not.toContain('{');
+  });
+
   it('falls back to raw text when response is not JSON', async () => {
     mockFetch(500, 'Internal server error (plain text)');
 

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -177,4 +177,27 @@ export const api = {
     }
     return { close: () => ws.close() }
   },
+
+  workbench: {
+    listPacks(): Promise<WorkbenchPack[]> {
+      return get<WorkbenchPack[]>('/workbench/packs')
+    },
+    listFiles(kind: PackKind, slug: string): Promise<{ tree: FileNode[] }> {
+      return get<{ tree: FileNode[] }>(`/workbench/packs/${kind}/${slug}/files`)
+    },
+    readFile(kind: PackKind, slug: string, filePath: string): Promise<{ content: string; editable: boolean }> {
+      return get<{ content: string; editable: boolean }>(
+        `/workbench/packs/${kind}/${slug}/file?path=${encodeURIComponent(filePath)}`,
+      )
+    },
+    writeFile(kind: PackKind, slug: string, filePath: string, content: string): Promise<{ ok: boolean }> {
+      return put<{ ok: boolean }>(
+        `/workbench/packs/${kind}/${slug}/file?path=${encodeURIComponent(filePath)}`,
+        { content },
+      )
+    },
+    copyToLocal(kind: PackKind, slug: string): Promise<WorkbenchPack> {
+      return post<WorkbenchPack>(`/workbench/packs/${kind}/${slug}/copy-to-local`)
+    },
+  },
 }

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -40,8 +40,24 @@ async function parseErrorMessage(res: Response): Promise<string> {
   const text = await res.text()
   let message = text || `${res.status} ${res.statusText}`
   try {
-    const json = JSON.parse(text) as { message?: string; code?: string }
-    if (json.message) message = json.code ? `${json.code}: ${json.message}` : json.message
+    // convsim-core (Python) returns { error: { code, message } }; the interim
+    // convsim-api (TypeScript) returns { code?, message } at the top level.
+    // Accept either shape so error text is clean regardless of active backend.
+    const json = JSON.parse(text) as {
+      message?: string
+      code?: string
+      error?: { message?: string; code?: string } | string
+    }
+    // Prefer the top-level message (convsim-api shape, where `error` is a short
+    // status string), and fall back to a nested error object (convsim-core shape:
+    // { error: { code, message } }).
+    let msg = json.message
+    let code = json.code
+    if (!msg && json.error && typeof json.error === 'object') {
+      msg = json.error.message
+      code = json.error.code
+    }
+    if (msg) message = code ? `${code}: ${msg}` : msg
   } catch {
     // text is not JSON; use as-is
   }

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -61,6 +61,16 @@ async function post<T>(path: string, body?: unknown): Promise<T> {
   return res.json() as Promise<T>
 }
 
+async function put<T>(path: string, body: unknown): Promise<T> {
+  const res = await fetch(`${BASE}${path}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) throw new Error(await parseErrorMessage(res))
+  return res.json() as Promise<T>
+}
+
 async function del(path: string): Promise<void> {
   const res = await fetch(`${BASE}${path}`, { method: 'DELETE' })
   if (!res.ok) throw new Error(await parseErrorMessage(res))
@@ -88,6 +98,23 @@ export const apiClient = {
     }
     return postForm<SttUploadResponse>('/stt/upload', form)
   },
+}
+
+export type PackKind = 'official' | 'local-dev'
+
+export interface WorkbenchPack {
+  kind: PackKind
+  slug: string
+  pack_id: string | null
+  name: string | null
+  editable: boolean
+}
+
+export interface FileNode {
+  name: string
+  path: string
+  kind: 'yaml' | 'markdown' | 'text' | 'dir' | 'other'
+  children?: FileNode[]
 }
 
 export interface WsConnection {
@@ -119,6 +146,29 @@ export const api = {
   exportSession(sessionId: string): Promise<unknown> {
     return get<unknown>(`/sessions/${sessionId}/export`)
   },
+  workbench: {
+    listPacks(): Promise<WorkbenchPack[]> {
+      return get<WorkbenchPack[]>('/workbench/packs')
+    },
+    listFiles(kind: PackKind, slug: string): Promise<{ tree: FileNode[] }> {
+      return get<{ tree: FileNode[] }>(`/workbench/packs/${kind}/${slug}/files`)
+    },
+    readFile(kind: PackKind, slug: string, filePath: string): Promise<{ content: string; editable: boolean }> {
+      return get<{ content: string; editable: boolean }>(
+        `/workbench/packs/${kind}/${slug}/file?path=${encodeURIComponent(filePath)}`,
+      )
+    },
+    writeFile(kind: PackKind, slug: string, filePath: string, content: string): Promise<{ ok: boolean }> {
+      return put<{ ok: boolean }>(
+        `/workbench/packs/${kind}/${slug}/file?path=${encodeURIComponent(filePath)}`,
+        { content },
+      )
+    },
+    copyToLocal(kind: PackKind, slug: string): Promise<WorkbenchPack> {
+      return post<WorkbenchPack>(`/workbench/packs/${kind}/${slug}/copy-to-local`)
+    },
+  },
+
   connectSession(
     sessionId: string,
     onEvent: (event: WsEvent) => void,

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -173,6 +173,28 @@ export interface FileNode {
   children?: FileNode[]
 }
 
+export interface WorkbenchValidationIssue {
+  severity: 'error' | 'warning'
+  rule_id: string
+  file: string
+  pointer: string
+  message: string
+  suggested_fix: string
+}
+
+export interface WorkbenchValidation {
+  valid: boolean
+  errors: WorkbenchValidationIssue[]
+  warnings: WorkbenchValidationIssue[]
+}
+
+export interface WriteFileResult {
+  ok: boolean
+  // Present when the backend re-validates the pack after a save (convsim-core).
+  // The interim convsim-api backend has no validator and omits this field.
+  validation?: WorkbenchValidation | null
+}
+
 export interface WsConnection {
   close(): void;
 }
@@ -257,11 +279,14 @@ export const api = {
         `/workbench/packs/${kind}/${slug}/file?path=${encodeURIComponent(filePath)}`,
       )
     },
-    writeFile(kind: PackKind, slug: string, filePath: string, content: string): Promise<{ ok: boolean }> {
-      return put<{ ok: boolean }>(
+    writeFile(kind: PackKind, slug: string, filePath: string, content: string): Promise<WriteFileResult> {
+      return put<WriteFileResult>(
         `/workbench/packs/${kind}/${slug}/file?path=${encodeURIComponent(filePath)}`,
         { content },
       )
+    },
+    validate(kind: PackKind, slug: string): Promise<WorkbenchValidation> {
+      return get<WorkbenchValidation>(`/workbench/packs/${kind}/${slug}/validate`)
     },
     copyToLocal(kind: PackKind, slug: string): Promise<WorkbenchPack> {
       return post<WorkbenchPack>(`/workbench/packs/${kind}/${slug}/copy-to-local`)

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,14 +1,21 @@
 // SPDX-License-Identifier: Apache-2.0
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import { BrowserRouter } from 'react-router-dom'
+import { createBrowserRouter, RouterProvider } from 'react-router-dom'
 import App from './App'
 import './index.css'
 
+// Data router (createBrowserRouter) is required for useBlocker to work (e.g. the
+// dirty-state navigation guard in CreatorWorkbench). BrowserRouter does not
+// provide the blocking infrastructure. The catch-all route delegates all path
+// matching to the <Routes> tree inside App.
+const router = createBrowserRouter(
+  [{ path: '*', element: <App /> }],
+  { future: { v7_startTransition: true, v7_relativeSplatPath: true } },
+)
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
-      <App />
-    </BrowserRouter>
+    <RouterProvider router={router} />
   </React.StrictMode>,
 )

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -11,7 +11,7 @@ import './index.css'
 // matching to the <Routes> tree inside App.
 const router = createBrowserRouter(
   [{ path: '*', element: <App /> }],
-  { future: { v7_relativeSplatPath: true } },
+  { future: { v7_startTransition: true, v7_relativeSplatPath: true } },
 )
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -11,7 +11,7 @@ import './index.css'
 // matching to the <Routes> tree inside App.
 const router = createBrowserRouter(
   [{ path: '*', element: <App /> }],
-  { future: { v7_startTransition: true, v7_relativeSplatPath: true } },
+  { future: { v7_relativeSplatPath: true } },
 )
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/apps/web/src/screens/CreatorWorkbench.tsx
+++ b/apps/web/src/screens/CreatorWorkbench.tsx
@@ -43,13 +43,6 @@ const BTN_PRIMARY: CSSProperties = {
   color: '#a5b4fc',
 }
 
-const BTN_DANGER: CSSProperties = {
-  ...BTN,
-  background: 'rgba(239,68,68,0.1)',
-  border: '1px solid rgba(239,68,68,0.3)',
-  color: '#f87171',
-}
-
 const BTN_DISABLED: CSSProperties = {
   opacity: 0.45,
   cursor: 'not-allowed',

--- a/apps/web/src/screens/CreatorWorkbench.tsx
+++ b/apps/web/src/screens/CreatorWorkbench.tsx
@@ -3,9 +3,9 @@ import { useState, useEffect, useCallback, type CSSProperties } from 'react'
 import { useBlocker } from 'react-router-dom'
 import { api, type WorkbenchPack, type FileNode } from '../api/client'
 
-// useBlocker requires a data router (createBrowserRouter / createMemoryRouter).
-// Under MemoryRouter (tests, Storybook) it throws before registering any hooks,
-// so wrapping in try-catch is safe and consistent across renders.
+// useBlocker requires a data router. Production uses createBrowserRouter (see main.tsx)
+// which provides this. Tests and Storybook use MemoryRouter which does not, so the
+// hook throws there — the try-catch degrades gracefully to a no-op blocker.
 function useSafeBlocker(when: boolean) {
   try {
     // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/apps/web/src/screens/CreatorWorkbench.tsx
+++ b/apps/web/src/screens/CreatorWorkbench.tsx
@@ -446,7 +446,10 @@ export default function CreatorWorkbench() {
     if (!selectedPack) return
     if (isDirty && !window.confirm('You have unsaved changes. Discard them?')) return
     setSelectedFile(filePath)
+    setEditorContent('')
+    setSavedContent('')
     setSaveError(null)
+    setCopyError(null)
     setFileError(null)
     setFileLoading(true)
     try {

--- a/apps/web/src/screens/CreatorWorkbench.tsx
+++ b/apps/web/src/screens/CreatorWorkbench.tsx
@@ -1,7 +1,20 @@
 // SPDX-License-Identifier: Apache-2.0
 import { useState, useEffect, useCallback, type CSSProperties } from 'react'
 import { useBlocker } from 'react-router-dom'
-import { api, type WorkbenchPack, type FileNode } from '../api/client'
+import { api, type WorkbenchPack, type FileNode, type WorkbenchValidation } from '../api/client'
+
+// A validation response is only usable if it carries the expected error/warning
+// arrays. Backends without a validator (or unexpected shapes) are treated as
+// "no validation available" rather than crashing the screen.
+function isValidation(v: unknown): v is WorkbenchValidation {
+  return (
+    typeof v === 'object' &&
+    v !== null &&
+    typeof (v as WorkbenchValidation).valid === 'boolean' &&
+    Array.isArray((v as WorkbenchValidation).errors) &&
+    Array.isArray((v as WorkbenchValidation).warnings)
+  )
+}
 
 // useBlocker requires a data router. Production uses createBrowserRouter (see main.tsx)
 // which provides this. Tests and Storybook use MemoryRouter which does not, so the
@@ -362,6 +375,74 @@ function FileEditor({
 }
 
 // ---------------------------------------------------------------------------
+// ValidationPanel — pack-level validation status, refreshed after each save
+// ---------------------------------------------------------------------------
+
+interface ValidationPanelProps {
+  validation: WorkbenchValidation | null
+  loading: boolean
+}
+
+function ValidationPanel({ validation, loading }: ValidationPanelProps) {
+  if (loading) {
+    return (
+      <p data-testid="validation-panel" style={{ fontSize: '0.8rem', color: '#71717a', margin: '0 0 1rem' }}>
+        Validating pack…
+      </p>
+    )
+  }
+  if (!validation) return null
+
+  const errorCount = validation.errors.length
+  const warningCount = validation.warnings.length
+
+  if (validation.valid && warningCount === 0) {
+    return (
+      <p
+        data-testid="validation-panel"
+        role="status"
+        style={{ fontSize: '0.8rem', color: '#4ade80', margin: '0 0 1rem' }}
+      >
+        ✓ Pack is valid
+      </p>
+    )
+  }
+
+  const issues = [...validation.errors, ...validation.warnings]
+  return (
+    <div
+      data-testid="validation-panel"
+      role="status"
+      style={{
+        fontSize: '0.8rem',
+        margin: '0 0 1rem',
+        padding: '0.5rem 0.75rem',
+        borderRadius: '4px',
+        border: '1px solid rgba(251,191,36,0.25)',
+        background: 'rgba(251,191,36,0.06)',
+      }}
+    >
+      <div style={{ color: errorCount > 0 ? '#f87171' : '#fbbf24', fontWeight: 600, marginBottom: issues.length ? '0.4rem' : 0 }}>
+        {errorCount > 0
+          ? `${errorCount} validation error${errorCount === 1 ? '' : 's'}`
+          : `${warningCount} validation warning${warningCount === 1 ? '' : 's'}`}
+        {errorCount > 0 && warningCount > 0 && `, ${warningCount} warning${warningCount === 1 ? '' : 's'}`}
+      </div>
+      <ul style={{ margin: 0, paddingLeft: '1.1rem', color: '#a1a1aa' }}>
+        {issues.slice(0, 8).map((issue, i) => (
+          <li key={`${issue.rule_id}-${issue.file}-${issue.pointer}-${i}`} style={{ color: issue.severity === 'error' ? '#fca5a5' : '#fcd34d' }}>
+            <code style={{ color: '#a1a1aa' }}>{issue.file}</code>: {issue.message}
+          </li>
+        ))}
+        {issues.length > 8 && (
+          <li style={{ color: '#71717a' }}>…and {issues.length - 8} more</li>
+        )}
+      </ul>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
 // CreatorWorkbench (main screen)
 // ---------------------------------------------------------------------------
 
@@ -382,6 +463,8 @@ export default function CreatorWorkbench() {
   const [saveError, setSaveError] = useState<string | null>(null)
   const [copying, setCopying] = useState(false)
   const [copyError, setCopyError] = useState<string | null>(null)
+  const [validation, setValidation] = useState<WorkbenchValidation | null>(null)
+  const [validationLoading, setValidationLoading] = useState(false)
 
   const isDirty = selectedFile !== null && editorContent !== savedContent
 
@@ -430,6 +513,20 @@ export default function CreatorWorkbench() {
     }
   }, [])
 
+  // Refresh the pack's validation state. Best-effort: the interim convsim-api
+  // backend has no validator, so a failure just clears the panel silently.
+  const refreshValidation = useCallback(async (pack: WorkbenchPack) => {
+    setValidationLoading(true)
+    try {
+      const result = await api.workbench.validate(pack.kind, pack.slug)
+      setValidation(isValidation(result) ? result : null)
+    } catch {
+      setValidation(null)
+    } finally {
+      setValidationLoading(false)
+    }
+  }, [])
+
   async function handleSelectPack(pack: WorkbenchPack) {
     if (isDirty && !window.confirm('You have unsaved changes. Discard them?')) return
     setSelectedPack(pack)
@@ -438,7 +535,8 @@ export default function CreatorWorkbench() {
     setSavedContent('')
     setSaveError(null)
     setCopyError(null)
-    await loadFileTree(pack)
+    setValidation(null)
+    await Promise.all([loadFileTree(pack), refreshValidation(pack)])
   }
 
   async function handleSelectFile(filePath: string) {
@@ -468,8 +566,15 @@ export default function CreatorWorkbench() {
     setSaving(true)
     setSaveError(null)
     try {
-      await api.workbench.writeFile(selectedPack.kind, selectedPack.slug, selectedFile, editorContent)
+      const result = await api.workbench.writeFile(selectedPack.kind, selectedPack.slug, selectedFile, editorContent)
       setSavedContent(editorContent)
+      // The save re-validates the pack. Prefer the validation the write returned;
+      // fall back to a dedicated refresh if the backend omitted it.
+      if (isValidation(result.validation)) {
+        setValidation(result.validation)
+      } else {
+        await refreshValidation(selectedPack)
+      }
     } catch (e: unknown) {
       setSaveError(e instanceof Error ? e.message : 'Failed to save file')
     } finally {
@@ -489,7 +594,8 @@ export default function CreatorWorkbench() {
       setSelectedFile(null)
       setEditorContent('')
       setSavedContent('')
-      await loadFileTree(newPack)
+      setValidation(null)
+      await Promise.all([loadFileTree(newPack), refreshValidation(newPack)])
     } catch (e: unknown) {
       setCopyError(e instanceof Error ? e.message : 'Failed to copy pack to local-dev')
     } finally {
@@ -509,6 +615,8 @@ export default function CreatorWorkbench() {
           Could not load packs: {packsError}
         </p>
       )}
+
+      {selectedPack && <ValidationPanel validation={validation} loading={validationLoading} />}
 
       <div style={{ display: 'flex', gap: '1rem', height: 'calc(100vh - 220px)', minHeight: '400px' }}>
         {/* Left panel: pack selector + file tree */}

--- a/apps/web/src/screens/CreatorWorkbench.tsx
+++ b/apps/web/src/screens/CreatorWorkbench.tsx
@@ -8,7 +8,6 @@ import { api, type WorkbenchPack, type FileNode } from '../api/client'
 // hook throws there — the try-catch degrades gracefully to a no-op blocker.
 function useSafeBlocker(when: boolean) {
   try {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
     return useBlocker(when)
   } catch {
     return { state: 'unblocked' as const, proceed: undefined, reset: undefined }

--- a/apps/web/src/screens/CreatorWorkbench.tsx
+++ b/apps/web/src/screens/CreatorWorkbench.tsx
@@ -1,10 +1,625 @@
 // SPDX-License-Identifier: Apache-2.0
-export default function CreatorWorkbench() {
+import { useState, useEffect, useCallback, type CSSProperties } from 'react'
+import { useBlocker } from 'react-router-dom'
+import { api, type WorkbenchPack, type FileNode } from '../api/client'
+
+// useBlocker requires a data router (createBrowserRouter / createMemoryRouter).
+// Under MemoryRouter (tests, Storybook) it throws before registering any hooks,
+// so wrapping in try-catch is safe and consistent across renders.
+function useSafeBlocker(when: boolean) {
+  try {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    return useBlocker(when)
+  } catch {
+    return { state: 'unblocked' as const, proceed: undefined, reset: undefined }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const PANEL_STYLE: CSSProperties = {
+  background: 'rgba(255,255,255,0.03)',
+  border: '1px solid rgba(255,255,255,0.08)',
+  borderRadius: '6px',
+  overflow: 'auto',
+}
+
+const BTN: CSSProperties = {
+  padding: '0.35rem 0.8rem',
+  borderRadius: '4px',
+  border: '1px solid rgba(255,255,255,0.15)',
+  cursor: 'pointer',
+  background: 'transparent',
+  color: '#e8e8ea',
+  fontSize: '0.8rem',
+}
+
+const BTN_PRIMARY: CSSProperties = {
+  ...BTN,
+  background: 'rgba(99,102,241,0.2)',
+  border: '1px solid rgba(99,102,241,0.5)',
+  color: '#a5b4fc',
+}
+
+const BTN_DANGER: CSSProperties = {
+  ...BTN,
+  background: 'rgba(239,68,68,0.1)',
+  border: '1px solid rgba(239,68,68,0.3)',
+  color: '#f87171',
+}
+
+const BTN_DISABLED: CSSProperties = {
+  opacity: 0.45,
+  cursor: 'not-allowed',
+}
+
+// ---------------------------------------------------------------------------
+// PackList
+// ---------------------------------------------------------------------------
+
+interface PackListProps {
+  packs: WorkbenchPack[]
+  selected: WorkbenchPack | null
+  onSelect: (pack: WorkbenchPack) => void
+}
+
+function PackList({ packs, selected, onSelect }: PackListProps) {
+  const official = packs.filter((p) => p.kind === 'official')
+  const localDev = packs.filter((p) => p.kind === 'local-dev')
+
+  function group(label: string, items: WorkbenchPack[]) {
+    if (items.length === 0) return null
+    return (
+      <div style={{ marginBottom: '0.75rem' }}>
+        <div style={{ fontSize: '0.7rem', fontWeight: 600, color: '#71717a', textTransform: 'uppercase', letterSpacing: '0.06em', padding: '0.25rem 0.75rem' }}>
+          {label}
+        </div>
+        {items.map((p) => {
+          const isSelected = selected?.kind === p.kind && selected.slug === p.slug
+          return (
+            <button
+              key={`${p.kind}/${p.slug}`}
+              onClick={() => onSelect(p)}
+              style={{
+                display: 'block',
+                width: '100%',
+                textAlign: 'left',
+                padding: '0.4rem 0.75rem',
+                border: 'none',
+                borderRadius: '4px',
+                cursor: 'pointer',
+                background: isSelected ? 'rgba(99,102,241,0.15)' : 'transparent',
+                color: isSelected ? '#a5b4fc' : '#d4d4d8',
+                fontSize: '0.85rem',
+                fontWeight: isSelected ? 600 : 400,
+              }}
+              aria-pressed={isSelected}
+            >
+              <span>{p.name ?? p.slug}</span>
+              {!p.editable && (
+                <span style={{ fontSize: '0.7rem', color: '#52525b', marginLeft: '0.4rem' }}>
+                  official
+                </span>
+              )}
+            </button>
+          )
+        })}
+      </div>
+    )
+  }
+
+  if (packs.length === 0) {
+    return (
+      <p style={{ fontSize: '0.85rem', color: '#52525b', padding: '0.5rem 0.75rem' }}>
+        No packs found.
+      </p>
+    )
+  }
+
   return (
     <div>
-      <h1>Creator Workbench</h1>
-      <p>Edit scenario packs, validate YAML, and quick-test with text.</p>
-      <p><em>Pack explorer, YAML editor, validator, and test chat will appear here.</em></p>
+      {group('Official', official)}
+      {group('Local Dev', localDev)}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// FileTree
+// ---------------------------------------------------------------------------
+
+const FILE_ICONS: Record<string, string> = {
+  yaml: '📄',
+  markdown: '📝',
+  text: '📃',
+  dir: '📁',
+  other: '📎',
+}
+
+interface FileTreeProps {
+  nodes: FileNode[]
+  selected: string | null
+  onSelect: (path: string, kind: FileNode['kind']) => void
+  depth?: number
+}
+
+function FileTree({ nodes, selected, onSelect, depth = 0 }: FileTreeProps) {
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set())
+
+  function toggleDir(path: string) {
+    setCollapsed((prev) => {
+      const next = new Set(prev)
+      if (next.has(path)) next.delete(path)
+      else next.add(path)
+      return next
+    })
+  }
+
+  return (
+    <ul
+      role={depth === 0 ? 'tree' : 'group'}
+      aria-label={depth === 0 ? 'Pack files' : undefined}
+      style={{ listStyle: 'none', padding: 0, margin: 0 }}
+    >
+      {nodes.map((node) => {
+        const isDir = node.kind === 'dir'
+        const isSelected = selected === node.path
+        const isCollapsed = collapsed.has(node.path)
+        const isEditable = node.kind === 'yaml' || node.kind === 'markdown' || node.kind === 'text'
+        const icon = FILE_ICONS[node.kind] ?? '📎'
+
+        return (
+          <li
+            key={node.path}
+            role="treeitem"
+            aria-selected={isSelected}
+            aria-expanded={isDir ? !isCollapsed : undefined}
+            style={{ paddingLeft: `${depth * 0.875}rem` }}
+          >
+            <button
+              onClick={() => {
+                if (isDir) {
+                  toggleDir(node.path)
+                } else if (isEditable) {
+                  onSelect(node.path, node.kind)
+                }
+              }}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '0.35rem',
+                width: '100%',
+                textAlign: 'left',
+                padding: '0.25rem 0.5rem',
+                border: 'none',
+                borderRadius: '3px',
+                cursor: isDir || isEditable ? 'pointer' : 'default',
+                background: isSelected ? 'rgba(99,102,241,0.15)' : 'transparent',
+                color: isSelected ? '#a5b4fc' : isEditable ? '#d4d4d8' : '#52525b',
+                fontSize: '0.8rem',
+                fontFamily: 'inherit',
+              }}
+              aria-label={`${isDir ? (isCollapsed ? 'Expand' : 'Collapse') : 'Open'} ${node.name}`}
+            >
+              <span>{isDir ? (isCollapsed ? '▶' : '▼') : icon}</span>
+              <span>{node.name}</span>
+              {node.kind === 'other' && (
+                <span style={{ fontSize: '0.7rem', color: '#3f3f46', marginLeft: 'auto' }}>
+                  unsupported
+                </span>
+              )}
+            </button>
+            {isDir && !isCollapsed && node.children && node.children.length > 0 && (
+              <FileTree
+                nodes={node.children}
+                selected={selected}
+                onSelect={onSelect}
+                depth={depth + 1}
+              />
+            )}
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// FileEditor
+// ---------------------------------------------------------------------------
+
+interface FileEditorProps {
+  filePath: string
+  content: string
+  editable: boolean
+  isDirty: boolean
+  saving: boolean
+  saveError: string | null
+  copying: boolean
+  copyError: string | null
+  onChange: (v: string) => void
+  onSave: () => void
+  onCopyToLocal?: () => void
+}
+
+function FileEditor({
+  filePath,
+  content,
+  editable,
+  isDirty,
+  saving,
+  saveError,
+  copying,
+  copyError,
+  onChange,
+  onSave,
+  onCopyToLocal,
+}: FileEditorProps) {
+  const ext = filePath.split('.').pop()?.toLowerCase() ?? ''
+  const isMarkdown = ext === 'md'
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      {/* Toolbar */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '0.5rem',
+          padding: '0.5rem 0.75rem',
+          borderBottom: '1px solid rgba(255,255,255,0.08)',
+          background: 'rgba(0,0,0,0.15)',
+          flexShrink: 0,
+        }}
+      >
+        <code style={{ fontSize: '0.8rem', color: '#a1a1aa', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          {filePath}
+        </code>
+
+        {!editable && (
+          <span
+            data-testid="read-only-badge"
+            style={{
+              fontSize: '0.7rem',
+              color: '#fbbf24',
+              background: 'rgba(251,191,36,0.1)',
+              border: '1px solid rgba(251,191,36,0.25)',
+              borderRadius: '3px',
+              padding: '0.1rem 0.4rem',
+            }}
+          >
+            Read-only
+          </span>
+        )}
+
+        {isDirty && (
+          <span
+            data-testid="dirty-indicator"
+            style={{ fontSize: '0.75rem', color: '#fb923c' }}
+          >
+            Unsaved changes
+          </span>
+        )}
+
+        {editable && (
+          <button
+            onClick={onSave}
+            disabled={saving || !isDirty}
+            data-testid="save-button"
+            style={{
+              ...BTN_PRIMARY,
+              ...(saving || !isDirty ? BTN_DISABLED : {}),
+            }}
+            aria-label={saving ? 'Saving…' : 'Save file'}
+          >
+            {saving ? 'Saving…' : 'Save'}
+          </button>
+        )}
+
+        {!editable && onCopyToLocal && (
+          <button
+            onClick={onCopyToLocal}
+            disabled={copying}
+            data-testid="copy-to-local-button"
+            style={{ ...BTN, ...(copying ? BTN_DISABLED : {}) }}
+            aria-label={copying ? 'Copying…' : 'Create local copy to edit'}
+          >
+            {copying ? 'Copying…' : 'Create local copy to edit'}
+          </button>
+        )}
+      </div>
+
+      {saveError && (
+        <p role="alert" style={{ margin: '0.5rem 0.75rem', fontSize: '0.8rem', color: '#f87171' }}>
+          Save failed: {saveError}
+        </p>
+      )}
+
+      {copyError && (
+        <p role="alert" style={{ margin: '0.5rem 0.75rem', fontSize: '0.8rem', color: '#f87171' }}>
+          Copy failed: {copyError}
+        </p>
+      )}
+
+      {/* Editor */}
+      <textarea
+        data-testid="file-editor"
+        aria-label={`${isMarkdown ? 'Markdown' : 'YAML'} editor: ${filePath}`}
+        readOnly={!editable}
+        value={content}
+        onChange={(e) => onChange(e.target.value)}
+        spellCheck={false}
+        style={{
+          flex: 1,
+          padding: '0.75rem',
+          background: editable ? 'rgba(0,0,0,0.3)' : 'rgba(0,0,0,0.15)',
+          color: editable ? '#e8e8ea' : '#71717a',
+          border: 'none',
+          outline: 'none',
+          fontFamily: 'monospace',
+          fontSize: '0.85rem',
+          lineHeight: 1.6,
+          resize: 'none',
+          cursor: editable ? 'text' : 'default',
+        }}
+      />
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// CreatorWorkbench (main screen)
+// ---------------------------------------------------------------------------
+
+export default function CreatorWorkbench() {
+  const [packs, setPacks] = useState<WorkbenchPack[]>([])
+  const [packsError, setPacksError] = useState<string | null>(null)
+  const [selectedPack, setSelectedPack] = useState<WorkbenchPack | null>(null)
+  const [fileTree, setFileTree] = useState<FileNode[]>([])
+  const [treeLoading, setTreeLoading] = useState(false)
+  const [treeError, setTreeError] = useState<string | null>(null)
+  const [selectedFile, setSelectedFile] = useState<string | null>(null)
+  const [editorContent, setEditorContent] = useState('')
+  const [savedContent, setSavedContent] = useState('')
+  const [editorEditable, setEditorEditable] = useState(false)
+  const [fileLoading, setFileLoading] = useState(false)
+  const [fileError, setFileError] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const [copying, setCopying] = useState(false)
+  const [copyError, setCopyError] = useState<string | null>(null)
+
+  const isDirty = selectedFile !== null && editorContent !== savedContent
+
+  // Block in-app navigation when there are unsaved edits
+  const blocker = useSafeBlocker(isDirty)
+  useEffect(() => {
+    if (blocker.state === 'blocked') {
+      if (window.confirm('You have unsaved changes. Leave this page?')) {
+        blocker.proceed?.()
+      } else {
+        blocker.reset?.()
+      }
+    }
+  }, [blocker])
+
+  // Warn on browser/tab close
+  useEffect(() => {
+    const handler = (e: BeforeUnloadEvent) => {
+      if (isDirty) {
+        e.preventDefault()
+        e.returnValue = ''
+      }
+    }
+    window.addEventListener('beforeunload', handler)
+    return () => window.removeEventListener('beforeunload', handler)
+  }, [isDirty])
+
+  // Load pack list on mount
+  useEffect(() => {
+    api.workbench.listPacks()
+      .then((ps) => { setPacks(ps); setPacksError(null) })
+      .catch((e: unknown) => setPacksError(e instanceof Error ? e.message : 'Failed to load packs'))
+  }, [])
+
+  const loadFileTree = useCallback(async (pack: WorkbenchPack) => {
+    setTreeLoading(true)
+    setTreeError(null)
+    setFileTree([])
+    try {
+      const { tree } = await api.workbench.listFiles(pack.kind, pack.slug)
+      setFileTree(tree)
+    } catch (e: unknown) {
+      setTreeError(e instanceof Error ? e.message : 'Failed to load file tree')
+    } finally {
+      setTreeLoading(false)
+    }
+  }, [])
+
+  async function handleSelectPack(pack: WorkbenchPack) {
+    if (isDirty && !window.confirm('You have unsaved changes. Discard them?')) return
+    setSelectedPack(pack)
+    setSelectedFile(null)
+    setEditorContent('')
+    setSavedContent('')
+    setSaveError(null)
+    setCopyError(null)
+    await loadFileTree(pack)
+  }
+
+  async function handleSelectFile(filePath: string) {
+    if (!selectedPack) return
+    if (isDirty && !window.confirm('You have unsaved changes. Discard them?')) return
+    setSelectedFile(filePath)
+    setSaveError(null)
+    setFileError(null)
+    setFileLoading(true)
+    try {
+      const { content, editable } = await api.workbench.readFile(selectedPack.kind, selectedPack.slug, filePath)
+      setEditorContent(content)
+      setSavedContent(content)
+      setEditorEditable(editable)
+    } catch (e: unknown) {
+      setFileError(e instanceof Error ? e.message : 'Failed to load file')
+    } finally {
+      setFileLoading(false)
+    }
+  }
+
+  async function handleSave() {
+    if (!selectedPack || !selectedFile) return
+    setSaving(true)
+    setSaveError(null)
+    try {
+      await api.workbench.writeFile(selectedPack.kind, selectedPack.slug, selectedFile, editorContent)
+      setSavedContent(editorContent)
+    } catch (e: unknown) {
+      setSaveError(e instanceof Error ? e.message : 'Failed to save file')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleCopyToLocal() {
+    if (!selectedPack) return
+    setCopying(true)
+    setCopyError(null)
+    try {
+      const newPack = await api.workbench.copyToLocal(selectedPack.kind, selectedPack.slug)
+      setPacks((prev) => [...prev.filter((p) => !(p.kind === newPack.kind && p.slug === newPack.slug)), newPack])
+      // Switch to the new local-dev copy
+      setSelectedPack(newPack)
+      setSelectedFile(null)
+      setEditorContent('')
+      setSavedContent('')
+      await loadFileTree(newPack)
+    } catch (e: unknown) {
+      setCopyError(e instanceof Error ? e.message : 'Failed to copy pack to local-dev')
+    } finally {
+      setCopying(false)
+    }
+  }
+
+  return (
+    <div>
+      <h1 style={{ marginBottom: '0.25rem' }}>Creator Workbench</h1>
+      <p style={{ color: '#71717a', fontSize: '0.875rem', marginBottom: '1.5rem' }}>
+        Inspect and edit scenario packs. Official packs are read-only — create a local copy to modify them.
+      </p>
+
+      {packsError && (
+        <p role="alert" style={{ fontSize: '0.875rem', color: '#f87171', marginBottom: '1rem' }}>
+          Could not load packs: {packsError}
+        </p>
+      )}
+
+      <div style={{ display: 'flex', gap: '1rem', height: 'calc(100vh - 220px)', minHeight: '400px' }}>
+        {/* Left panel: pack selector + file tree */}
+        <div
+          style={{
+            width: '220px',
+            flexShrink: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '0.75rem',
+          }}
+        >
+          {/* Pack selector */}
+          <div
+            data-testid="pack-selector"
+            style={{ ...PANEL_STYLE, padding: '0.5rem 0', flexShrink: 0, maxHeight: '45%', overflow: 'auto' }}
+          >
+            <div style={{ fontSize: '0.7rem', fontWeight: 600, color: '#71717a', textTransform: 'uppercase', letterSpacing: '0.06em', padding: '0.25rem 0.75rem 0.5rem' }}>
+              Packs
+            </div>
+            <PackList packs={packs} selected={selectedPack} onSelect={handleSelectPack} />
+          </div>
+
+          {/* File tree */}
+          <div
+            data-testid="file-tree"
+            style={{ ...PANEL_STYLE, padding: '0.5rem 0.25rem', flex: 1, overflow: 'auto' }}
+          >
+            {!selectedPack && (
+              <p style={{ fontSize: '0.8rem', color: '#52525b', padding: '0.5rem' }}>
+                Select a pack above.
+              </p>
+            )}
+            {selectedPack && treeLoading && (
+              <p style={{ fontSize: '0.8rem', color: '#71717a', padding: '0.5rem' }}>Loading…</p>
+            )}
+            {selectedPack && treeError && (
+              <p role="alert" style={{ fontSize: '0.8rem', color: '#f87171', padding: '0.5rem' }}>
+                {treeError}
+              </p>
+            )}
+            {selectedPack && !treeLoading && !treeError && fileTree.length === 0 && (
+              <p style={{ fontSize: '0.8rem', color: '#52525b', padding: '0.5rem' }}>
+                Empty pack directory.
+              </p>
+            )}
+            {selectedPack && !treeLoading && fileTree.length > 0 && (
+              <FileTree
+                nodes={fileTree}
+                selected={selectedFile}
+                onSelect={handleSelectFile}
+              />
+            )}
+          </div>
+        </div>
+
+        {/* Right panel: editor */}
+        <div style={{ flex: 1, ...PANEL_STYLE, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+          {!selectedFile && !fileLoading && (
+            <div
+              style={{
+                flex: 1,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                color: '#52525b',
+                fontSize: '0.875rem',
+              }}
+            >
+              {selectedPack
+                ? 'Select a YAML or Markdown file from the tree.'
+                : 'Select a pack to get started.'}
+            </div>
+          )}
+
+          {fileLoading && (
+            <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#71717a', fontSize: '0.875rem' }}>
+              Loading file…
+            </div>
+          )}
+
+          {fileError && !fileLoading && (
+            <div style={{ flex: 1, padding: '1rem' }}>
+              <p role="alert" style={{ fontSize: '0.875rem', color: '#f87171' }}>
+                {fileError}
+              </p>
+            </div>
+          )}
+
+          {selectedFile && !fileLoading && !fileError && (
+            <FileEditor
+              filePath={selectedFile}
+              content={editorContent}
+              editable={editorEditable}
+              isDirty={isDirty}
+              saving={saving}
+              saveError={saveError}
+              copying={copying}
+              copyError={copyError}
+              onChange={setEditorContent}
+              onSave={handleSave}
+              onCopyToLocal={!editorEditable ? handleCopyToLocal : undefined}
+            />
+          )}
+        </div>
+      </div>
     </div>
   )
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,9 +1,21 @@
 // SPDX-License-Identifier: Apache-2.0
+import { resolve } from 'path'
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      // @convsim/scenario-schema ships source-only (no dist build step).
+      // Point Vite/Vitest directly at the TypeScript source so tests work
+      // without requiring a build pass first.
+      '@convsim/scenario-schema': resolve(
+        __dirname,
+        '../../packages/scenario-schema/src/index.ts',
+      ),
+    },
+  },
   server: {
     host: '127.0.0.1',
     port: 7354,

--- a/services/convsim-core/convsim_core/app.py
+++ b/services/convsim-core/convsim_core/app.py
@@ -12,7 +12,7 @@ from convsim_core.errors import (
     request_validation_error_handler,
 )
 from convsim_core.logging_setup import configure_logging
-from convsim_core.routers import diag as diag_router, health, models as models_router, packs as packs_router, scenarios as scenarios_router, sessions as sessions_router, settings as settings_router, sidecar as sidecar_router, stt as stt_router
+from convsim_core.routers import diag as diag_router, health, models as models_router, packs as packs_router, scenarios as scenarios_router, sessions as sessions_router, settings as settings_router, sidecar as sidecar_router, stt as stt_router, workbench as workbench_router
 from convsim_core.runtime import build_runtime
 from convsim_core.runtime.sidecar import LlamaCppSidecar
 from convsim_core.storage.database import Database
@@ -55,5 +55,6 @@ def create_app(config: ServiceConfig | None = None) -> FastAPI:
     app.include_router(packs_router.router)
     app.include_router(scenarios_router.router)
     app.include_router(sessions_router.router)
+    app.include_router(workbench_router.router)
 
     return app

--- a/services/convsim-core/convsim_core/app.py
+++ b/services/convsim-core/convsim_core/app.py
@@ -12,7 +12,7 @@ from convsim_core.errors import (
     request_validation_error_handler,
 )
 from convsim_core.logging_setup import configure_logging
-from convsim_core.routers import diag as diag_router, health, models as models_router, packs as packs_router, scenarios as scenarios_router, sessions as sessions_router, settings as settings_router, sidecar as sidecar_router, stt as stt_router, vad as vad_router
+from convsim_core.routers import diag as diag_router, health, models as models_router, packs as packs_router, scenarios as scenarios_router, sessions as sessions_router, settings as settings_router, sidecar as sidecar_router, stt as stt_router, vad as vad_router, workbench as workbench_router
 from convsim_core.runtime import build_runtime
 from convsim_core.runtime.sidecar import LlamaCppSidecar
 from convsim_core.storage.database import Database

--- a/services/convsim-core/convsim_core/config.py
+++ b/services/convsim-core/convsim_core/config.py
@@ -11,6 +11,10 @@ _DEFAULT_DATA_DIR = str(Path.home() / ".convsim" / "data")
 _DEFAULT_LOG_DIR = str(Path.home() / ".convsim" / "logs")
 _DEFAULT_DB_DIR = str(Path.home() / ".convsim" / "db")
 _DEFAULT_PACKS_DIR = str(Path.home() / ".convsim" / "packs")
+# Read-only bundled official packs live in the repo's packs/official directory.
+# Resolve it relative to this file so the default works regardless of the
+# process CWD (config.py -> convsim_core -> convsim-core -> services -> repo root).
+_DEFAULT_OFFICIAL_PACKS_DIR = str(Path(__file__).resolve().parents[3] / "packs" / "official")
 
 
 class ServiceConfig(BaseSettings):
@@ -34,10 +38,15 @@ class ServiceConfig(BaseSettings):
     log_dir: str = _DEFAULT_LOG_DIR
     db_dir: str = _DEFAULT_DB_DIR
     packs_dir: str = _DEFAULT_PACKS_DIR
+    # Read-only official packs served (browse-only) by the Creator Workbench.
+    # Defaults to the repo's bundled packs/official directory.
+    official_packs_dir: str = _DEFAULT_OFFICIAL_PACKS_DIR
     # Set CONVSIM_LOCAL_DEV_PACKS_DIR to a directory that contains in-progress
     # pack folders.  The /api/packs/import/folder endpoint only accepts source
     # paths that fall within packs_dir or this directory; leaving it unset
-    # restricts folder import to paths already inside packs_dir.
+    # restricts folder import to paths already inside packs_dir.  The Creator
+    # Workbench also uses it as the editable local-dev pack root, falling back
+    # to <packs_dir>/local-dev when unset.
     local_dev_packs_dir: Optional[str] = None
     lan_access_enabled: bool = False
     runtime_id: str = "fake"

--- a/services/convsim-core/convsim_core/routers/workbench.py
+++ b/services/convsim-core/convsim_core/routers/workbench.py
@@ -20,6 +20,8 @@ from pydantic import BaseModel
 
 from convsim_core.config import ServiceConfig
 from convsim_core.errors import ConvsimError
+from convsim_core.packs.models import ValidationResult
+from convsim_core.packs.validator import validate_pack_cached
 
 router = APIRouter(prefix="/api/workbench", tags=["workbench"])
 
@@ -61,6 +63,9 @@ class WriteFileBody(BaseModel):
 
 class WriteFileResponse(BaseModel):
     ok: bool
+    # Validation is re-run against the whole pack after a successful save so the
+    # editor can surface schema/policy problems introduced by the edit.
+    validation: Optional[ValidationResult] = None
 
 
 def _official_root(config: ServiceConfig) -> Path:
@@ -271,7 +276,30 @@ async def write_file(
     except OSError:
         tmp_path.unlink(missing_ok=True)
         raise
-    return WriteFileResponse(ok=True)
+    # Re-run validation so the save "refreshes" the pack's validation state.
+    # validate_pack_cached keys on file mtimes, so the just-written change forces
+    # a fresh pass. Never let a validation failure mask a successful write.
+    validation: Optional[ValidationResult] = None
+    try:
+        validation = validate_pack_cached(pack_root)
+    except Exception:  # noqa: BLE001 — validation is best-effort feedback
+        validation = None
+    return WriteFileResponse(ok=True, validation=validation)
+
+
+@router.get("/packs/{kind}/{slug}/validate", response_model=ValidationResult)
+async def validate_pack(request: Request, kind: str, slug: str) -> ValidationResult:
+    """Validate a pack directory and return schema/policy findings.
+
+    Used by the workbench to show a pack's validation state when it is opened
+    and to refresh it after a save.
+    """
+    config = _config(request)
+    valid_kind = _assert_valid_kind(kind)
+    pack_root = _pack_root(config, valid_kind, slug)
+    if not pack_root.exists():
+        raise ConvsimError("PACK_NOT_FOUND", f'Pack "{slug}" not found', status_code=404)
+    return validate_pack_cached(pack_root)
 
 
 @router.post("/packs/{kind}/{slug}/copy-to-local", response_model=WorkbenchPackSummary)

--- a/services/convsim-core/convsim_core/routers/workbench.py
+++ b/services/convsim-core/convsim_core/routers/workbench.py
@@ -1,0 +1,311 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Creator Workbench endpoints: browse and edit scenario pack files.
+
+Official packs (the repo's bundled ``packs/official``) are browse-only; the
+local-dev root is editable.  Write endpoints enforce local-dev-only access,
+path-traversal rejection, and an editable-extension whitelist so the
+unauthenticated local endpoint cannot be used to write arbitrary files.
+"""
+from __future__ import annotations
+
+import os
+import re
+import secrets
+import shutil
+from pathlib import Path
+from typing import Literal, Optional
+
+from fastapi import APIRouter, Query, Request
+from pydantic import BaseModel
+
+from convsim_core.config import ServiceConfig
+from convsim_core.errors import ConvsimError
+
+router = APIRouter(prefix="/api/workbench", tags=["workbench"])
+
+PackKind = Literal["official", "local-dev"]
+
+_EDITABLE_EXTENSIONS = {".yaml", ".yml", ".md", ".txt"}
+
+_PACK_ID_RE = re.compile(r"^pack_id:\s*['\"]?([^'\"\n]+)['\"]?\s*$")
+_NAME_RE = re.compile(r"^name:\s*['\"]?([^'\"\n]+)['\"]?\s*$")
+
+
+class WorkbenchPackSummary(BaseModel):
+    kind: PackKind
+    slug: str
+    pack_id: Optional[str] = None
+    name: Optional[str] = None
+    editable: bool
+
+
+class FileNode(BaseModel):
+    name: str
+    path: str
+    kind: Literal["yaml", "markdown", "text", "dir", "other"]
+    children: Optional[list["FileNode"]] = None
+
+
+class FileTreeResponse(BaseModel):
+    tree: list[FileNode]
+
+
+class FileContentResponse(BaseModel):
+    content: str
+    editable: bool
+
+
+class WriteFileBody(BaseModel):
+    content: str
+
+
+class WriteFileResponse(BaseModel):
+    ok: bool
+
+
+def _official_root(config: ServiceConfig) -> Path:
+    return Path(config.official_packs_dir)
+
+
+def _local_dev_root(config: ServiceConfig) -> Path:
+    if config.local_dev_packs_dir:
+        return Path(config.local_dev_packs_dir)
+    return Path(config.packs_dir) / "local-dev"
+
+
+def _root_for_kind(config: ServiceConfig, kind: PackKind) -> Path:
+    return _official_root(config) if kind == "official" else _local_dev_root(config)
+
+
+def _assert_valid_kind(kind: str) -> PackKind:
+    if kind not in ("official", "local-dev"):
+        raise ConvsimError(
+            "INVALID_KIND",
+            f'Invalid kind "{kind}": must be "official" or "local-dev"',
+            status_code=400,
+        )
+    return kind  # type: ignore[return-value]
+
+
+def _is_strictly_within(path: Path, base: Path) -> bool:
+    """True if ``path`` is a descendant of ``base`` (and not ``base`` itself)."""
+    if path == base:
+        return False
+    try:
+        path.relative_to(base)
+        return True
+    except ValueError:
+        return False
+
+
+def _pack_root(config: ServiceConfig, kind: PackKind, slug: str) -> Path:
+    root = _root_for_kind(config, kind).resolve()
+    pack_root = (root / slug).resolve()
+    if not _is_strictly_within(pack_root, root):
+        raise ConvsimError("INVALID_SLUG", "Invalid pack slug", status_code=400)
+    return pack_root
+
+
+def _resolve_file_path(pack_root: Path, rel_path: str) -> Path:
+    abs_path = (pack_root / rel_path).resolve()
+    if not _is_strictly_within(abs_path, pack_root):
+        raise ConvsimError("PATH_TRAVERSAL", "Path traversal not allowed", status_code=400)
+    return abs_path
+
+
+def _read_manifest_basics(pack_dir: Path) -> tuple[Optional[str], Optional[str]]:
+    pack_id: Optional[str] = None
+    name: Optional[str] = None
+    try:
+        content = (pack_dir / "manifest.yaml").read_text(encoding="utf-8")
+    except OSError:
+        return None, None
+    for line in content.splitlines():
+        if pack_id is None:
+            m = _PACK_ID_RE.match(line)
+            if m:
+                pack_id = m.group(1).strip()
+        if name is None:
+            m = _NAME_RE.match(line)
+            if m:
+                name = m.group(1).strip()
+        if pack_id is not None and name is not None:
+            break
+    return pack_id, name
+
+
+def _scan_root(config: ServiceConfig, kind: PackKind) -> list[WorkbenchPackSummary]:
+    root = _root_for_kind(config, kind)
+    if not root.is_dir():
+        return []
+    summaries: list[WorkbenchPackSummary] = []
+    for entry in sorted(root.iterdir(), key=lambda p: p.name):
+        if not entry.is_dir():
+            continue
+        pack_id, name = _read_manifest_basics(entry)
+        summaries.append(
+            WorkbenchPackSummary(
+                kind=kind,
+                slug=entry.name,
+                pack_id=pack_id,
+                name=name or entry.name,
+                editable=(kind == "local-dev"),
+            )
+        )
+    return summaries
+
+
+def _file_kind(path: Path) -> str:
+    ext = path.suffix.lower()
+    if ext in (".yaml", ".yml"):
+        return "yaml"
+    if ext == ".md":
+        return "markdown"
+    if ext == ".txt":
+        return "text"
+    return "other"
+
+
+def _build_tree(directory: Path, pack_root: Path) -> list[FileNode]:
+    try:
+        entries = list(directory.iterdir())
+    except OSError:
+        return []
+
+    nodes: list[FileNode] = []
+    for entry in entries:
+        rel_path = entry.relative_to(pack_root).as_posix()
+        if entry.is_dir():
+            nodes.append(
+                FileNode(
+                    name=entry.name,
+                    path=rel_path,
+                    kind="dir",
+                    children=_build_tree(entry, pack_root),
+                )
+            )
+        elif entry.is_file():
+            nodes.append(FileNode(name=entry.name, path=rel_path, kind=_file_kind(entry)))  # type: ignore[arg-type]
+
+    nodes.sort(key=lambda n: (n.kind != "dir", n.name.lower()))
+    return nodes
+
+
+def _config(request: Request) -> ServiceConfig:
+    return request.app.state.service_config
+
+
+@router.get("/packs", response_model=list[WorkbenchPackSummary])
+async def list_packs(request: Request) -> list[WorkbenchPackSummary]:
+    """List official and local-dev packs by scanning their root directories."""
+    config = _config(request)
+    return [*_scan_root(config, "official"), *_scan_root(config, "local-dev")]
+
+
+@router.get("/packs/{kind}/{slug}/files", response_model=FileTreeResponse)
+async def list_files(request: Request, kind: str, slug: str) -> FileTreeResponse:
+    """Return a recursive file tree for a pack."""
+    config = _config(request)
+    valid_kind = _assert_valid_kind(kind)
+    pack_root = _pack_root(config, valid_kind, slug)
+    if not pack_root.exists():
+        raise ConvsimError("PACK_NOT_FOUND", f'Pack "{slug}" not found', status_code=404)
+    return FileTreeResponse(tree=_build_tree(pack_root, pack_root))
+
+
+@router.get("/packs/{kind}/{slug}/file", response_model=FileContentResponse)
+async def read_file(
+    request: Request,
+    kind: str,
+    slug: str,
+    path: str = Query(default=""),
+) -> FileContentResponse:
+    """Read a single file within a pack."""
+    config = _config(request)
+    valid_kind = _assert_valid_kind(kind)
+    if not path:
+        raise ConvsimError("MISSING_PATH", "Missing required query parameter: path", status_code=400)
+    pack_root = _pack_root(config, valid_kind, slug)
+    abs_path = _resolve_file_path(pack_root, path)
+    if not abs_path.exists():
+        raise ConvsimError("FILE_NOT_FOUND", f"File not found: {path}", status_code=404)
+    if not abs_path.is_file():
+        raise ConvsimError("NOT_A_FILE", f"Path is not a file: {path}", status_code=400)
+    content = abs_path.read_text(encoding="utf-8")
+    return FileContentResponse(content=content, editable=(valid_kind == "local-dev"))
+
+
+@router.put("/packs/{kind}/{slug}/file", response_model=WriteFileResponse)
+async def write_file(
+    request: Request,
+    kind: str,
+    slug: str,
+    body: WriteFileBody,
+    path: str = Query(default=""),
+) -> WriteFileResponse:
+    """Write a single file within a local-dev pack (official packs are read-only)."""
+    config = _config(request)
+    valid_kind = _assert_valid_kind(kind)
+    if valid_kind != "local-dev":
+        raise ConvsimError(
+            "READ_ONLY_PACK",
+            "Official packs are read-only. Copy to local-dev first.",
+            status_code=403,
+        )
+    if not path:
+        raise ConvsimError("MISSING_PATH", "Missing required query parameter: path", status_code=400)
+    pack_root = _pack_root(config, valid_kind, slug)
+    abs_path = _resolve_file_path(pack_root, path)
+    if abs_path.suffix.lower() not in _EDITABLE_EXTENSIONS:
+        raise ConvsimError(
+            "NOT_EDITABLE",
+            f'File type "{abs_path.suffix}" is not editable via the workbench',
+            status_code=400,
+        )
+    abs_path.parent.mkdir(parents=True, exist_ok=True)
+    # Write atomically so a failed write cannot corrupt an existing file.
+    tmp_path = abs_path.with_name(f"{abs_path.name}.tmp.{secrets.token_hex(4)}")
+    try:
+        tmp_path.write_text(body.content, encoding="utf-8")
+        os.replace(tmp_path, abs_path)
+    except OSError:
+        tmp_path.unlink(missing_ok=True)
+        raise
+    return WriteFileResponse(ok=True)
+
+
+@router.post("/packs/{kind}/{slug}/copy-to-local", response_model=WorkbenchPackSummary)
+async def copy_to_local(request: Request, kind: str, slug: str) -> WorkbenchPackSummary:
+    """Copy an official pack into the local-dev root, avoiding slug collisions."""
+    config = _config(request)
+    valid_kind = _assert_valid_kind(kind)
+    if valid_kind == "local-dev":
+        raise ConvsimError("ALREADY_LOCAL", "Pack is already in local-dev", status_code=400)
+    src_root = _pack_root(config, valid_kind, slug)
+    if not src_root.exists():
+        raise ConvsimError("PACK_NOT_FOUND", f'Pack "{slug}" not found', status_code=404)
+
+    local_root = _local_dev_root(config)
+    local_root.mkdir(parents=True, exist_ok=True)
+
+    dest_slug = slug
+    dest_path = local_root / dest_slug
+    if dest_path.exists():
+        dest_slug = f"{slug}-copy"
+        dest_path = local_root / dest_slug
+    if dest_path.exists():
+        n = 2
+        while (local_root / f"{slug}-copy-{n}").exists():
+            n += 1
+        dest_slug = f"{slug}-copy-{n}"
+        dest_path = local_root / dest_slug
+
+    shutil.copytree(src_root, dest_path)
+    pack_id, name = _read_manifest_basics(dest_path)
+    return WorkbenchPackSummary(
+        kind="local-dev",
+        slug=dest_slug,
+        pack_id=pack_id,
+        name=name or dest_slug,
+        editable=True,
+    )

--- a/services/convsim-core/tests/test_workbench_api.py
+++ b/services/convsim-core/tests/test_workbench_api.py
@@ -275,3 +275,47 @@ def test_copy_avoids_slug_collision(client):
         "/api/workbench/packs/official/sample-pack/copy-to-local"
     ).json()["slug"]
     assert slug1 != slug2
+
+
+# ---------------------------------------------------------------------------
+# GET /api/workbench/packs/{kind}/{slug}/validate + save-triggered refresh
+# ---------------------------------------------------------------------------
+
+def test_validate_pack_returns_result(client):
+    resp = client.get("/api/workbench/packs/local-dev/my-pack/validate")
+    assert resp.status_code == 200
+    body = resp.json()
+    # A well-formed ValidationResult is returned regardless of validity.
+    assert isinstance(body["valid"], bool)
+    assert isinstance(body["errors"], list)
+    assert isinstance(body["warnings"], list)
+    # The minimal fixture pack is missing required manifest fields, proving the
+    # validator actually ran rather than short-circuiting.
+    assert body["valid"] is False
+    assert len(body["errors"]) > 0
+
+
+def test_validate_invalid_kind_returns_400(client):
+    resp = client.get("/api/workbench/packs/community/my-pack/validate")
+    assert resp.status_code == 400
+
+
+def test_validate_unknown_pack_returns_404(client):
+    resp = client.get("/api/workbench/packs/local-dev/does-not-exist/validate")
+    assert resp.status_code == 404
+
+
+def test_write_refreshes_validation(client):
+    # Writing a syntactically-broken manifest surfaces errors in the save
+    # response's validation payload — the save "triggers validation refresh".
+    resp = client.put(
+        "/api/workbench/packs/local-dev/my-pack/file",
+        params={"path": "manifest.yaml"},
+        json={"content": "schema_version: [unterminated\n"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["validation"] is not None
+    assert body["validation"]["valid"] is False
+    assert len(body["validation"]["errors"]) > 0

--- a/services/convsim-core/tests/test_workbench_api.py
+++ b/services/convsim-core/tests/test_workbench_api.py
@@ -1,0 +1,277 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Integration tests for Creator Workbench API endpoints."""
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from convsim_core.app import create_app
+from convsim_core.config import ServiceConfig
+
+
+def _make_pack(root: Path, slug: str, name: str, pack_id: str) -> Path:
+    pack_dir = root / slug
+    (pack_dir / "scenarios").mkdir(parents=True, exist_ok=True)
+    (pack_dir / "npcs").mkdir(parents=True, exist_ok=True)
+    (pack_dir / "manifest.yaml").write_text(
+        f'schema_version: "0.1"\npack_id: {pack_id}\nname: {name}\nversion: 0.1.0\n',
+        encoding="utf-8",
+    )
+    (pack_dir / "README.md").write_text(f"# {name}\n\nA test pack.\n", encoding="utf-8")
+    (pack_dir / "scenarios" / "basic.yaml").write_text(
+        'schema_version: "0.1"\nscenario_id: basic\ntitle: Basic Scenario\n',
+        encoding="utf-8",
+    )
+    return pack_dir
+
+
+@pytest.fixture()
+def roots(tmp_path):
+    official = tmp_path / "official"
+    local_dev = tmp_path / "local-dev"
+    official.mkdir()
+    local_dev.mkdir()
+    _make_pack(official, "sample-pack", "Sample Pack", "official.sample_pack")
+    _make_pack(local_dev, "my-pack", "My Pack", "local.my_pack")
+    return official, local_dev
+
+
+@pytest.fixture()
+def client(tmp_path, roots, monkeypatch):
+    official, local_dev = roots
+    monkeypatch.setenv("CONVSIM_WHISPER_CPP_BINARY_PATH", str(tmp_path / "no-whisper-cli"))
+    config = ServiceConfig(
+        host="127.0.0.1",
+        port=7355,
+        data_dir=str(tmp_path / "data"),
+        log_dir=str(tmp_path / "logs"),
+        db_dir=str(tmp_path / "db"),
+        packs_dir=str(tmp_path / "packs"),
+        official_packs_dir=str(official),
+        local_dev_packs_dir=str(local_dev),
+    )
+    app = create_app(config)
+    with TestClient(app) as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# GET /api/workbench/packs
+# ---------------------------------------------------------------------------
+
+def test_list_packs(client):
+    resp = client.get("/api/workbench/packs")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert isinstance(body, list)
+
+    official = next(p for p in body if p["kind"] == "official")
+    assert official["slug"] == "sample-pack"
+    assert official["editable"] is False
+
+    local = next(p for p in body if p["kind"] == "local-dev")
+    assert local["slug"] == "my-pack"
+    assert local["editable"] is True
+
+
+def test_list_packs_returns_manifest_basics(client):
+    body = client.get("/api/workbench/packs").json()
+    official = next(p for p in body if p["kind"] == "official")
+    assert official["pack_id"] == "official.sample_pack"
+    assert official["name"] == "Sample Pack"
+
+
+# ---------------------------------------------------------------------------
+# GET /api/workbench/packs/{kind}/{slug}/files
+# ---------------------------------------------------------------------------
+
+def test_file_tree(client):
+    resp = client.get("/api/workbench/packs/official/sample-pack/files")
+    assert resp.status_code == 200
+    tree = resp.json()["tree"]
+
+    manifest = next(n for n in tree if n["name"] == "manifest.yaml")
+    assert manifest["kind"] == "yaml"
+
+    readme = next(n for n in tree if n["name"] == "README.md")
+    assert readme["kind"] == "markdown"
+
+    scenarios = next(n for n in tree if n["name"] == "scenarios")
+    assert scenarios["kind"] == "dir"
+    # Directories sort first and contain nested files.
+    assert tree[0]["kind"] == "dir"
+    assert any(child["name"] == "basic.yaml" for child in scenarios["children"])
+
+
+def test_file_tree_unknown_pack_returns_404(client):
+    resp = client.get("/api/workbench/packs/official/does-not-exist/files")
+    assert resp.status_code == 404
+
+
+def test_file_tree_invalid_kind_returns_400(client):
+    resp = client.get("/api/workbench/packs/community/sample-pack/files")
+    assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# GET /api/workbench/packs/{kind}/{slug}/file
+# ---------------------------------------------------------------------------
+
+def test_read_official_file(client):
+    resp = client.get(
+        "/api/workbench/packs/official/sample-pack/file", params={"path": "README.md"}
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "Sample Pack" in body["content"]
+    assert body["editable"] is False
+
+
+def test_read_local_dev_file_is_editable(client):
+    resp = client.get(
+        "/api/workbench/packs/local-dev/my-pack/file", params={"path": "manifest.yaml"}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["editable"] is True
+
+
+def test_read_file_missing_path_returns_400(client):
+    resp = client.get("/api/workbench/packs/official/sample-pack/file")
+    assert resp.status_code == 400
+
+
+def test_read_file_directory_returns_400(client):
+    resp = client.get(
+        "/api/workbench/packs/official/sample-pack/file", params={"path": "scenarios"}
+    )
+    assert resp.status_code == 400
+
+
+def test_read_file_path_traversal_returns_400(client):
+    resp = client.get(
+        "/api/workbench/packs/official/sample-pack/file",
+        params={"path": "../../etc/passwd"},
+    )
+    assert resp.status_code == 400
+
+
+def test_read_file_dot_returns_400(client):
+    resp = client.get(
+        "/api/workbench/packs/official/sample-pack/file", params={"path": "."}
+    )
+    assert resp.status_code == 400
+
+
+def test_read_file_missing_returns_404(client):
+    resp = client.get(
+        "/api/workbench/packs/official/sample-pack/file", params={"path": "ghost.yaml"}
+    )
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/workbench/packs/{kind}/{slug}/file
+# ---------------------------------------------------------------------------
+
+def test_write_local_dev_file(client):
+    new_content = 'schema_version: "0.1"\nname: Updated\n'
+    resp = client.put(
+        "/api/workbench/packs/local-dev/my-pack/file",
+        params={"path": "manifest.yaml"},
+        json={"content": new_content},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+
+    read_back = client.get(
+        "/api/workbench/packs/local-dev/my-pack/file", params={"path": "manifest.yaml"}
+    )
+    assert read_back.json()["content"] == new_content
+
+
+def test_write_official_file_returns_403(client):
+    resp = client.put(
+        "/api/workbench/packs/official/sample-pack/file",
+        params={"path": "manifest.yaml"},
+        json={"content": "evil"},
+    )
+    assert resp.status_code == 403
+
+
+def test_write_non_editable_type_returns_400(client):
+    resp = client.put(
+        "/api/workbench/packs/local-dev/my-pack/file",
+        params={"path": "image.png"},
+        json={"content": "binary"},
+    )
+    assert resp.status_code == 400
+
+
+def test_write_path_traversal_returns_400(client):
+    resp = client.put(
+        "/api/workbench/packs/local-dev/my-pack/file",
+        params={"path": "../../etc/cron.d/evil"},
+        json={"content": "evil"},
+    )
+    assert resp.status_code == 400
+
+
+def test_write_missing_path_returns_400(client):
+    resp = client.put(
+        "/api/workbench/packs/local-dev/my-pack/file",
+        json={"content": "hello"},
+    )
+    assert resp.status_code == 400
+
+
+def test_write_dot_returns_400(client):
+    resp = client.put(
+        "/api/workbench/packs/local-dev/my-pack/file",
+        params={"path": "."},
+        json={"content": "hello"},
+    )
+    assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# POST /api/workbench/packs/{kind}/{slug}/copy-to-local
+# ---------------------------------------------------------------------------
+
+def test_copy_to_local(client):
+    resp = client.post("/api/workbench/packs/official/sample-pack/copy-to-local")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["kind"] == "local-dev"
+    assert "sample-pack" in body["slug"]
+    assert body["editable"] is True
+
+    packs = client.get("/api/workbench/packs").json()
+    assert any(p["slug"] == body["slug"] for p in packs)
+
+    # The copied file is now writable.
+    write = client.put(
+        f"/api/workbench/packs/local-dev/{body['slug']}/file",
+        params={"path": "README.md"},
+        json={"content": "# edited\n"},
+    )
+    assert write.status_code == 200
+
+
+def test_copy_local_dev_returns_400(client):
+    resp = client.post("/api/workbench/packs/local-dev/my-pack/copy-to-local")
+    assert resp.status_code == 400
+
+
+def test_copy_unknown_pack_returns_404(client):
+    resp = client.post("/api/workbench/packs/official/does-not-exist/copy-to-local")
+    assert resp.status_code == 404
+
+
+def test_copy_avoids_slug_collision(client):
+    slug1 = client.post(
+        "/api/workbench/packs/official/sample-pack/copy-to-local"
+    ).json()["slug"]
+    slug2 = client.post(
+        "/api/workbench/packs/official/sample-pack/copy-to-local"
+    ).json()["slug"]
+    assert slug1 != slug2


### PR DESCRIPTION
## Summary

This PR fully implements the Creator Workbench to allow scenario authors to browse, edit, and manage conversation packs both in the web UI and the running backend (convsim-core). The feature spans two new TypeScript backends (apps/api and apps/web), a new Python backend (convsim-core), and 40+ integration and component tests.

### Architecture

**Backend (apps/api):** New `workbench.ts` router with configurable pack roots (`PACKS_OFFICIAL_ROOT`, `PACKS_LOCAL_DEV_ROOT` environment variables, defaulting to `packs/official/` and `~/.convsim/packs/local-dev/`), injected at startup in `index.ts`.

**Backend (convsim-core):** Port of the workbench router to FastAPI (`routers/workbench.py`), with the same HTTP contract. Official-pack directory configured via `CONVSIM_OFFICIAL_PACKS_DIR` (defaults to the repo's `packs/official/` resolved CWD-independently); local-dev root reuses the existing `local_dev_packs_dir` config with fallback to `<packs_dir>/local-dev`.

**Frontend:** Full `CreatorWorkbench.tsx` screen with pack selector, recursive file tree, dual-mode editor, dirty tracking, and end-to-end save + validation.

### API Endpoints

Both backends implement the same HTTP contract:

- `GET /api/workbench/packs` — list all official and local-dev packs with metadata
- `GET /api/workbench/packs/:kind/:slug/files` — recursive file tree (directories first, with node kinds: yaml, markdown, text, dir, other; unsupported files visibly labeled)
- `GET /api/workbench/packs/:kind/:slug/file?path=...` — read a file
- `PUT /api/workbench/packs/:kind/:slug/file?path=...` — write a file (local-dev only; 403 for official packs)
- `POST /api/workbench/packs/:kind/:slug/copy-to-local` — copy official pack to local-dev with slug-collision avoidance
- `GET /api/workbench/packs/:kind/:slug/validate` — fetch pack validation result (convsim-core only)

**Security:** Official packs are read-only (403 on write); path traversal is rejected; writes are whitelisted to editable extensions (`.yaml`, `.yml`, `.md`, `.txt`); writes are atomic (temp file + `os.replace`) so a failed write cannot corrupt a file.

### Frontend Features

- **Pack selector sidebar** grouped by kind (official, local-dev, etc.)
- **Recursive file tree** with directory collapse/expand, unsupported-file labels
- **Dual-mode textarea editor:** read-only for official packs with a "Read-only" badge and "Create local copy to edit" button; editable for local-dev packs
- **Dirty-state tracking** with an "Unsaved changes" indicator and save button
- **Validation panel** showing pack validation state (valid/errors/warnings) refreshed on pack select, after save, and after copy-to-local
- **In-app navigation blocking** via `useSafeBlocker` (gracefully falls back when not in a data router, e.g., in tests)
- `beforeunload` warning on browser close with unsaved changes

### API Client

- Added `put()` helper, `WorkbenchPack`/`FileNode` types, and `ValidationResult` type
- Added `api.workbench` namespace with `listPacks`, `listFiles`, `readFile`, `writeFile`, `copyToLocal`, and `validate` methods
- Gracefully handles missing validation shapes (interim backends without validators)

### Bug Fixes

- **Pre-existing test failure:** `App.test.tsx` was broken because `@convsim/scenario-schema` (a source-only package) was not aliased in the web app's Vite config. Added the alias matching the pattern already used in `packages/ui/vitest.config.ts`; this fixed 10 previously-broken App tests.

### Tests

- **Backend (apps/api):** 18 integration tests covering all endpoints, security boundaries, and copy-collision logic
- **Backend (convsim-core):** 26 integration tests covering listing, tree, read/write, security boundaries, copy-collision behavior, and validation refresh
- **Frontend:** 18 component tests covering pack display, file tree expansion, YAML/Markdown editor, dirty indicator, save flow, read-only enforcement, copy-to-local trigger, unsupported file labels, validation display, and error states

**Test results:**
- `pnpm --filter @convsim/api test` — 152 tests pass (includes 18 new workbench tests)
- `pnpm --filter @convsim/web test` — 167 tests pass (includes 18 new workbench tests + 10 previously-broken App tests now fixed)
- `pnpm --filter convsim-core test` — includes 26 new workbench tests

Closes #65