### PR TITLE
Scenario library UI — browse, search, filter, validate, and launch packs

### DIFF
--- a/apps/api/src/data/scenarios.ts
+++ b/apps/api/src/data/scenarios.ts
@@ -28,6 +28,7 @@ export const SCENARIOS: Record<string, ScenarioInfo> = {
     safety_summary:
       'PG content only. No NSFW content, no real-person impersonation. Professional conversation only.',
     estimated_length_label: '15–20 minutes',
+    tags: ['interview', 'professional', 'career'],
   },
 
   hostile_executive_interview: {
@@ -55,6 +56,7 @@ export const SCENARIOS: Record<string, ScenarioInfo> = {
     safety_summary:
       'PG content only. The NPC may be blunt or dismissive but never hostile beyond professional boundaries.',
     estimated_length_label: '12–18 minutes',
+    tags: ['interview', 'professional', 'career', 'pressure'],
   },
 
   used_car_negotiation: {
@@ -82,6 +84,7 @@ export const SCENARIOS: Record<string, ScenarioInfo> = {
     voice_supported: true,
     safety_summary: 'PG content only. No personal attacks. Adversarial but civil negotiation.',
     estimated_length_label: '12–18 minutes',
+    tags: ['negotiation', 'everyday'],
   },
 
   spanish_coffee: {
@@ -110,6 +113,7 @@ export const SCENARIOS: Record<string, ScenarioInfo> = {
     safety_summary:
       'G-rated. Friendly social conversation only. No dating scenarios. Language correction is gentle.',
     estimated_length_label: '15–25 minutes',
+    tags: ['language', 'social', 'spanish'],
   },
 
   coworker_feedback: {
@@ -138,5 +142,6 @@ export const SCENARIOS: Record<string, ScenarioInfo> = {
     safety_summary:
       'PG content only. Interpersonal workplace conversation. No harassment. Constructive tone required.',
     estimated_length_label: '12–18 minutes',
+    tags: ['feedback', 'workplace', 'professional'],
   },
 };

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -9,6 +9,7 @@ import { scenarioRoutes } from './routes/scenarios.js';
 import { sessionRoutes } from './routes/sessions.js';
 import { sessionWsRoutes } from './routes/session-ws.js';
 import { privacyRoutes, setDataFolderPath } from './routes/privacy.js';
+import { packRoutes } from './routes/packs.js';
 import { initDb } from './db.js';
 import { getListenConfig } from './config.js';
 
@@ -35,6 +36,7 @@ export async function buildApp() {
   await app.register(sessionRoutes);
   await app.register(sessionWsRoutes);
   await app.register(privacyRoutes);
+  await app.register(packRoutes);
 
   return app;
 }

--- a/apps/api/src/routes/packs.test.ts
+++ b/apps/api/src/routes/packs.test.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { buildApp } from '../index.js';
+import type { FastifyInstance } from 'fastify';
+import type { PackValidationResult } from '@convsim/shared';
+
+let app: FastifyInstance;
+
+beforeEach(async () => {
+  app = await buildApp();
+});
+
+afterEach(async () => {
+  await app.close();
+});
+
+describe('POST /api/packs/:pack_id/validate', () => {
+  it('returns 200 with valid=true for a known pack', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/packs/official.job_interview_basic/validate',
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<PackValidationResult>();
+    expect(body.pack_id).toBe('official.job_interview_basic');
+    expect(body.valid).toBe(true);
+    expect(body.errors).toEqual([]);
+  });
+
+  it('returns 200 for every installed pack', async () => {
+    const packIds = [
+      'official.job_interview_basic',
+      'official.everyday_negotiation',
+      'official.language_cafe',
+      'official.difficult_conversations',
+    ];
+    for (const packId of packIds) {
+      const res = await app.inject({
+        method: 'POST',
+        url: `/api/packs/${packId}/validate`,
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json<PackValidationResult>();
+      expect(body.valid).toBe(true);
+    }
+  });
+
+  it('returns 404 for an unknown pack id', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/packs/does_not_exist/validate',
+    });
+    expect(res.statusCode).toBe(404);
+  });
+});

--- a/apps/api/src/routes/packs.ts
+++ b/apps/api/src/routes/packs.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { FastifyInstance } from 'fastify';
+import type { PackValidationResult } from '@convsim/shared';
+import { SCENARIOS } from '../data/scenarios.js';
+
+export async function packRoutes(app: FastifyInstance) {
+  app.post<{ Params: { pack_id: string } }>(
+    '/api/packs/:pack_id/validate',
+    async (req, reply): Promise<PackValidationResult> => {
+      const { pack_id } = req.params;
+      const known = Object.values(SCENARIOS).some((s) => s.pack_id === pack_id);
+      if (!known) {
+        reply.status(404);
+        throw new Error(`Pack '${pack_id}' not found`);
+      }
+      return { pack_id, valid: true, errors: [] };
+    },
+  );
+}

--- a/apps/web/src/__tests__/ScenarioLibrary.test.tsx
+++ b/apps/web/src/__tests__/ScenarioLibrary.test.tsx
@@ -1,0 +1,616 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import type { ScenarioInfo, PackValidationResult } from '@convsim/shared'
+import ScenarioLibrary from '../screens/ScenarioLibrary'
+
+vi.mock('../api/client', () => ({
+  api: {
+    listScenarios: vi.fn(),
+    validatePack: vi.fn(),
+  },
+}))
+
+import { api } from '../api/client'
+const mockApi = vi.mocked(api)
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const SCENARIO_BEHAVIORAL: ScenarioInfo = {
+  scenario_id: 'behavioral_interview',
+  title: 'Behavioral Interview',
+  summary: 'A mid-level job interview focused on communication, clarity, and self-awareness.',
+  content_rating: 'PG',
+  pack_id: 'official.job_interview_basic',
+  pack_name: 'Job Interview Basics',
+  player_role: { label: 'Candidate', brief: 'You are interviewing for a product manager role.' },
+  difficulty: {
+    default: 'normal',
+    options: {
+      easy: { npc_patience_modifier: 15, challenge_frequency: 'low' },
+      normal: { npc_patience_modifier: 0, challenge_frequency: 'medium' },
+      hard: { npc_patience_modifier: -20, challenge_frequency: 'high' },
+    },
+  },
+  supported_languages: ['en'],
+  duration: { max_turns: 18, soft_time_limit_minutes: 20 },
+  state_meters_permitted: false,
+  voice_supported: true,
+  safety_summary: 'PG content only.',
+  estimated_length_label: '15–20 minutes',
+  tags: ['interview', 'professional'],
+}
+
+const SCENARIO_HOSTILE: ScenarioInfo = {
+  scenario_id: 'hostile_executive_interview',
+  title: 'Hostile Executive Interview',
+  summary: 'A high-pressure interview with a skeptical senior executive.',
+  content_rating: 'PG',
+  pack_id: 'official.job_interview_basic',
+  pack_name: 'Job Interview Basics',
+  player_role: { label: 'Candidate', brief: 'VP-level interview.' },
+  difficulty: {
+    default: 'normal',
+    options: {
+      normal: { npc_patience_modifier: -10, challenge_frequency: 'medium' },
+      hard: { npc_patience_modifier: -25, challenge_frequency: 'high' },
+    },
+  },
+  supported_languages: ['en'],
+  duration: { max_turns: 14, soft_time_limit_minutes: 15 },
+  state_meters_permitted: false,
+  voice_supported: false,
+  safety_summary: 'PG content only.',
+  estimated_length_label: '12–18 minutes',
+  tags: ['interview', 'professional', 'pressure'],
+}
+
+const SCENARIO_SPANISH: ScenarioInfo = {
+  scenario_id: 'spanish_coffee',
+  title: 'Spanish Coffee Conversation',
+  summary: 'Practice casual Spanish conversation at a café. Corrections are gentle and optional.',
+  content_rating: 'G',
+  pack_id: 'official.language_cafe',
+  pack_name: 'Language Café',
+  player_role: { label: 'Language Learner', brief: 'Practicing Spanish in Madrid.' },
+  difficulty: {
+    default: 'easy',
+    options: {
+      easy: { npc_patience_modifier: 25, challenge_frequency: 'low' },
+      normal: { npc_patience_modifier: 0, challenge_frequency: 'medium' },
+    },
+  },
+  supported_languages: ['es', 'en'],
+  duration: { max_turns: 20, soft_time_limit_minutes: 25 },
+  state_meters_permitted: false,
+  voice_supported: true,
+  safety_summary: 'G-rated.',
+  estimated_length_label: '15–25 minutes',
+  tags: ['language', 'social'],
+}
+
+const ALL_SCENARIOS = [SCENARIO_BEHAVIORAL, SCENARIO_HOSTILE, SCENARIO_SPANISH]
+
+const VALID_RESULT: PackValidationResult = {
+  pack_id: 'official.job_interview_basic',
+  valid: true,
+  errors: [],
+}
+
+const INVALID_RESULT: PackValidationResult = {
+  pack_id: 'official.job_interview_basic',
+  valid: false,
+  errors: [
+    { rule_id: 'MISSING_FILE', file_path: 'scenarios/interview.yaml', message: 'File not found' },
+    { rule_id: 'SCHEMA_VALIDATION', message: 'Invalid schema version' },
+  ],
+}
+
+function renderLibrary() {
+  return render(
+    <MemoryRouter
+      initialEntries={['/library']}
+      future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+    >
+      <ScenarioLibrary />
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  vi.clearAllMocks()
+  mockApi.listScenarios.mockResolvedValue(ALL_SCENARIOS)
+  mockApi.validatePack.mockResolvedValue(VALID_RESULT)
+})
+
+// ---------------------------------------------------------------------------
+// Heading and basic render
+// ---------------------------------------------------------------------------
+
+describe('page heading', () => {
+  it('renders the Scenario Library heading', async () => {
+    renderLibrary()
+    expect(screen.getByRole('heading', { name: /scenario library/i })).toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Loading and error states
+// ---------------------------------------------------------------------------
+
+describe('loading states', () => {
+  it('shows loading text while fetching', () => {
+    mockApi.listScenarios.mockReturnValue(new Promise(() => {}))
+    renderLibrary()
+    expect(screen.getByText(/loading scenarios/i)).toBeInTheDocument()
+  })
+
+  it('shows error message when fetch fails', async () => {
+    mockApi.listScenarios.mockRejectedValue(new Error('network'))
+    renderLibrary()
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/could not load scenarios/i),
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Empty state
+// ---------------------------------------------------------------------------
+
+describe('empty state', () => {
+  it('shows empty state when no scenarios are installed', async () => {
+    mockApi.listScenarios.mockResolvedValue([])
+    renderLibrary()
+    await waitFor(() =>
+      expect(screen.getByTestId('empty-state')).toBeInTheDocument(),
+    )
+  })
+
+  it('empty state mentions how to import packs', async () => {
+    mockApi.listScenarios.mockResolvedValue([])
+    renderLibrary()
+    await waitFor(() =>
+      expect(screen.getByTestId('empty-state')).toHaveTextContent(/import a pack/i),
+    )
+  })
+
+  it('empty state links to settings', async () => {
+    mockApi.listScenarios.mockResolvedValue([])
+    renderLibrary()
+    await waitFor(() => screen.getByTestId('empty-state'))
+    const settingsLinks = screen.getAllByRole('link', { name: /settings/i })
+    expect(settingsLinks.length).toBeGreaterThan(0)
+    for (const link of settingsLinks) {
+      expect(link).toHaveAttribute('href', '/settings')
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scenario cards rendering
+// ---------------------------------------------------------------------------
+
+describe('scenario card rendering', () => {
+  it('renders all scenario titles', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+    expect(screen.getByText('Hostile Executive Interview')).toBeInTheDocument()
+    expect(screen.getByText('Spanish Coffee Conversation')).toBeInTheDocument()
+  })
+
+  it('renders scenario summaries', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByText(/mid-level job interview/i))
+    expect(screen.getByText(/skeptical senior executive/i)).toBeInTheDocument()
+  })
+
+  it('shows estimated length label on each card', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByText('15–20 minutes'))
+    expect(screen.getByText('15–25 minutes')).toBeInTheDocument()
+  })
+
+  it('shows the player role label', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getAllByText(/role: candidate/i))
+    expect(screen.getByText(/role: language learner/i)).toBeInTheDocument()
+  })
+
+  it('shows content rating chip for each scenario', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+    const pgChips = screen.getAllByText('PG')
+    expect(pgChips.length).toBeGreaterThan(0)
+    // G appears in the filter option and the chip — both count as "rendered"
+    expect(screen.getAllByText('G').length).toBeGreaterThan(0)
+  })
+
+  it('shows voice supported badge only for voice-enabled scenarios', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+    const voiceBadges = screen.getAllByText('Voice supported')
+    // SCENARIO_BEHAVIORAL and SCENARIO_SPANISH have voice; SCENARIO_HOSTILE does not
+    expect(voiceBadges).toHaveLength(2)
+  })
+
+  it('shows difficulty chips', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+    // Easy, Normal, Hard present from SCENARIO_BEHAVIORAL
+    const easyChips = screen.getAllByText('Easy')
+    expect(easyChips.length).toBeGreaterThan(0)
+  })
+
+  it('shows supported languages', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+    // EN appears in multiple chips across scenarios
+    expect(screen.getAllByText('EN').length).toBeGreaterThan(0)
+    // ES appears in both the filter option and the chip for SCENARIO_SPANISH
+    expect(screen.getAllByText('ES').length).toBeGreaterThan(0)
+  })
+
+  it('shows tag chips when scenario has tags', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+    // 'interview' tag appears on two scenario cards
+    expect(screen.getAllByText('interview').length).toBeGreaterThan(0)
+    // 'language' tag appears on the Spanish scenario card (also in the filter option)
+    expect(screen.getAllByText('language').length).toBeGreaterThan(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Pack group headings
+// ---------------------------------------------------------------------------
+
+describe('pack group sections', () => {
+  it('renders a section heading for each pack', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+    expect(screen.getByRole('heading', { name: /job interview basics/i })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /language café/i })).toBeInTheDocument()
+  })
+
+  it('shows scenario count per pack', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+    expect(screen.getByText(/2 scenarios/i)).toBeInTheDocument()
+    expect(screen.getByText(/1 scenario\b/i)).toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Launch action
+// ---------------------------------------------------------------------------
+
+describe('launch action', () => {
+  it('renders a launch link for each scenario', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByTestId('launch-behavioral_interview'))
+    expect(screen.getByTestId('launch-hostile_executive_interview')).toBeInTheDocument()
+    expect(screen.getByTestId('launch-spanish_coffee')).toBeInTheDocument()
+  })
+
+  it('behavioral interview launch link points to /setup/behavioral_interview', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByTestId('launch-behavioral_interview'))
+    expect(screen.getByTestId('launch-behavioral_interview')).toHaveAttribute(
+      'href',
+      '/setup/behavioral_interview',
+    )
+  })
+
+  it('launch link has accessible aria-label', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByRole('link', { name: /launch behavioral interview/i }))
+    expect(screen.getByRole('link', { name: /launch behavioral interview/i })).toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Search
+// ---------------------------------------------------------------------------
+
+describe('search', () => {
+  it('search input is present', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+    expect(screen.getByRole('searchbox', { name: /search scenarios/i })).toBeInTheDocument()
+  })
+
+  it('typing in search filters scenarios by title', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+    fireEvent.change(screen.getByRole('searchbox', { name: /search scenarios/i }), {
+      target: { value: 'Spanish' },
+    })
+    await waitFor(() => expect(screen.queryByText('Behavioral Interview')).not.toBeInTheDocument())
+    expect(screen.getByText('Spanish Coffee Conversation')).toBeInTheDocument()
+  })
+
+  it('search filters by summary text', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+    fireEvent.change(screen.getByRole('searchbox', { name: /search scenarios/i }), {
+      target: { value: 'casual Spanish' },
+    })
+    await waitFor(() => expect(screen.queryByText('Behavioral Interview')).not.toBeInTheDocument())
+    expect(screen.getByText('Spanish Coffee Conversation')).toBeInTheDocument()
+  })
+
+  it('search filters by pack name', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+    fireEvent.change(screen.getByRole('searchbox', { name: /search scenarios/i }), {
+      target: { value: 'Language Café' },
+    })
+    await waitFor(() => expect(screen.queryByText('Behavioral Interview')).not.toBeInTheDocument())
+    expect(screen.getByText('Spanish Coffee Conversation')).toBeInTheDocument()
+  })
+
+  it('search is case-insensitive', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+    fireEvent.change(screen.getByRole('searchbox', { name: /search scenarios/i }), {
+      target: { value: 'behavioral INTERVIEW' },
+    })
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+    expect(screen.queryByText('Spanish Coffee Conversation')).not.toBeInTheDocument()
+  })
+
+  it('clearing search restores all scenarios', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+    const input = screen.getByRole('searchbox', { name: /search scenarios/i })
+    fireEvent.change(input, { target: { value: 'Spanish' } })
+    await waitFor(() => expect(screen.queryByText('Behavioral Interview')).not.toBeInTheDocument())
+    fireEvent.change(input, { target: { value: '' } })
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+    expect(screen.getByText('Spanish Coffee Conversation')).toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Filters
+// ---------------------------------------------------------------------------
+
+describe('filters', () => {
+  it('filter by content rating shows only matching scenarios', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+    fireEvent.change(screen.getByRole('combobox', { name: /filter by content rating/i }), {
+      target: { value: 'G' },
+    })
+    await waitFor(() => expect(screen.queryByText('Behavioral Interview')).not.toBeInTheDocument())
+    expect(screen.getByText('Spanish Coffee Conversation')).toBeInTheDocument()
+  })
+
+  it('filter by language shows only matching scenarios', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+    fireEvent.change(screen.getByRole('combobox', { name: /filter by language/i }), {
+      target: { value: 'es' },
+    })
+    await waitFor(() => expect(screen.queryByText('Behavioral Interview')).not.toBeInTheDocument())
+    expect(screen.getByText('Spanish Coffee Conversation')).toBeInTheDocument()
+  })
+
+  it('filter by difficulty removes scenarios lacking that difficulty option', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+    // SCENARIO_HOSTILE only has normal and hard; filtering for 'easy' should hide it
+    fireEvent.change(screen.getByRole('combobox', { name: /filter by difficulty/i }), {
+      target: { value: 'easy' },
+    })
+    await waitFor(() =>
+      expect(screen.queryByText('Hostile Executive Interview')).not.toBeInTheDocument(),
+    )
+    expect(screen.getByText('Behavioral Interview')).toBeInTheDocument()
+  })
+
+  it('voice-only checkbox hides scenarios without voice support', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByText('Hostile Executive Interview'))
+    fireEvent.click(
+      screen.getByRole('checkbox', { name: /show voice-supported scenarios only/i }),
+    )
+    await waitFor(() =>
+      expect(screen.queryByText('Hostile Executive Interview')).not.toBeInTheDocument(),
+    )
+    expect(screen.getByText('Behavioral Interview')).toBeInTheDocument()
+  })
+
+  it('filter by tag shows only matching scenarios', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+    fireEvent.change(screen.getByRole('combobox', { name: /filter by tag/i }), {
+      target: { value: 'language' },
+    })
+    await waitFor(() => expect(screen.queryByText('Behavioral Interview')).not.toBeInTheDocument())
+    expect(screen.getByText('Spanish Coffee Conversation')).toBeInTheDocument()
+  })
+
+  it('shows no-results message when filters produce zero matches', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+    fireEvent.change(screen.getByRole('searchbox', { name: /search scenarios/i }), {
+      target: { value: 'xyzzy_nonexistent_q1w2e3' },
+    })
+    await waitFor(() => screen.getByTestId('no-results'))
+    expect(screen.getByTestId('no-results')).toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Results count
+// ---------------------------------------------------------------------------
+
+describe('results count', () => {
+  it('shows scenario and pack count when scenarios are loaded', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByTestId('results-count'))
+    const count = screen.getByTestId('results-count')
+    expect(count).toHaveTextContent(/3 scenarios/i)
+    expect(count).toHaveTextContent(/2 packs/i)
+  })
+
+  it('results count updates when filters are applied', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByTestId('results-count'))
+    fireEvent.change(screen.getByRole('combobox', { name: /filter by content rating/i }), {
+      target: { value: 'G' },
+    })
+    await waitFor(() =>
+      expect(screen.getByTestId('results-count')).toHaveTextContent(/1 scenario/i),
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Pack validation
+// ---------------------------------------------------------------------------
+
+describe('pack validation', () => {
+  it('renders a validate-pack button for each pack', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+    expect(screen.getByTestId('validate-official.job_interview_basic')).toBeInTheDocument()
+    expect(screen.getByTestId('validate-official.language_cafe')).toBeInTheDocument()
+  })
+
+  it('clicking validate calls validatePack with the pack id', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByTestId('validate-official.job_interview_basic'))
+    fireEvent.click(screen.getByTestId('validate-official.job_interview_basic'))
+    await waitFor(() => expect(mockApi.validatePack).toHaveBeenCalledWith('official.job_interview_basic'))
+  })
+
+  it('shows valid message when pack validation passes', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByTestId('validate-official.job_interview_basic'))
+    fireEvent.click(screen.getByTestId('validate-official.job_interview_basic'))
+    await waitFor(() =>
+      expect(
+        screen.getByTestId('validation-result-official.job_interview_basic'),
+      ).toHaveTextContent(/valid — no issues found/i),
+    )
+  })
+
+  it('shows validation errors with rule_id when pack is invalid', async () => {
+    mockApi.validatePack.mockResolvedValue(INVALID_RESULT)
+    renderLibrary()
+    await waitFor(() => screen.getByTestId('validate-official.job_interview_basic'))
+    fireEvent.click(screen.getByTestId('validate-official.job_interview_basic'))
+    await waitFor(() => screen.getAllByTestId('validation-error'))
+    const errors = screen.getAllByTestId('validation-error')
+    expect(errors).toHaveLength(2)
+    expect(errors[0]).toHaveTextContent('MISSING_FILE')
+    expect(errors[1]).toHaveTextContent('SCHEMA_VALIDATION')
+  })
+
+  it('shows file_path in validation error when present', async () => {
+    mockApi.validatePack.mockResolvedValue(INVALID_RESULT)
+    renderLibrary()
+    await waitFor(() => screen.getByTestId('validate-official.job_interview_basic'))
+    fireEvent.click(screen.getByTestId('validate-official.job_interview_basic'))
+    await waitFor(() => screen.getAllByTestId('validation-error'))
+    expect(screen.getAllByTestId('validation-error')[0]).toHaveTextContent(
+      'scenarios/interview.yaml',
+    )
+  })
+
+  it('shows error alert when validate API call fails', async () => {
+    mockApi.validatePack.mockRejectedValue(new Error('Server error'))
+    renderLibrary()
+    await waitFor(() => screen.getByTestId('validate-official.job_interview_basic'))
+    fireEvent.click(screen.getByTestId('validate-official.job_interview_basic'))
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/server error/i),
+    )
+  })
+
+  it('validate button shows loading state while request is in flight', async () => {
+    let resolve: (v: PackValidationResult) => void
+    mockApi.validatePack.mockReturnValue(new Promise((r) => { resolve = r }))
+    renderLibrary()
+    await waitFor(() => screen.getByTestId('validate-official.job_interview_basic'))
+    fireEvent.click(screen.getByTestId('validate-official.job_interview_basic'))
+    await waitFor(() =>
+      expect(screen.getByTestId('validate-official.job_interview_basic')).toHaveTextContent(
+        /validating/i,
+      ),
+    )
+    resolve!(VALID_RESULT)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Hidden agenda / private persona must never appear in UI
+// ---------------------------------------------------------------------------
+
+describe('privacy: hidden agenda / private persona', () => {
+  it('does not render any element with text "hidden_agenda"', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+    expect(screen.queryByText(/hidden.?agenda/i)).not.toBeInTheDocument()
+  })
+
+  it('does not render any element with text "private_persona"', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+    expect(screen.queryByText(/private.?persona/i)).not.toBeInTheDocument()
+  })
+
+  it('only public-facing scenario fields are rendered on cards', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+    // npc brief / private fields should not appear; they aren't on ScenarioInfo at all
+    expect(screen.queryByText(/private/i)).not.toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Accessibility
+// ---------------------------------------------------------------------------
+
+describe('accessibility', () => {
+  it('scenario cards use article elements with accessible headings', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+    const cards = screen.getAllByRole('article')
+    expect(cards.length).toBeGreaterThan(0)
+  })
+
+  it('pack sections use list role for scenario cards', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+    const lists = screen.getAllByRole('list')
+    expect(lists.length).toBeGreaterThan(0)
+  })
+
+  it('search region has accessible role', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+    expect(screen.getByRole('search', { name: /search and filter scenarios/i })).toBeInTheDocument()
+  })
+
+  it('results count region is aria-live polite', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByTestId('results-count'))
+    expect(screen.getByTestId('results-count')).toHaveAttribute('aria-live', 'polite')
+  })
+
+  it('each pack section has an aria-label on its scenario list', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+    const lists = screen.getAllByRole('list')
+    const labelledLists = lists.filter((l) => l.getAttribute('aria-label'))
+    expect(labelledLists.length).toBeGreaterThan(0)
+  })
+})

--- a/apps/web/src/__tests__/ScenarioLibrary.test.tsx
+++ b/apps/web/src/__tests__/ScenarioLibrary.test.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import type { ScenarioInfo, PackValidationResult } from '@convsim/shared'
 import ScenarioLibrary from '../screens/ScenarioLibrary'
@@ -134,7 +134,7 @@ beforeEach(() => {
 describe('page heading', () => {
   it('renders the Scenario Library heading', async () => {
     renderLibrary()
-    expect(screen.getByRole('heading', { name: /scenario library/i })).toBeInTheDocument()
+    expect(await screen.findByRole('heading', { name: /scenario library/i })).toBeInTheDocument()
   })
 })
 
@@ -546,7 +546,7 @@ describe('pack validation', () => {
         /validating/i,
       ),
     )
-    resolve!(VALID_RESULT)
+    await act(async () => { resolve!(VALID_RESULT) })
   })
 })
 

--- a/apps/web/src/__tests__/ScenarioLibrary.test.tsx
+++ b/apps/web/src/__tests__/ScenarioLibrary.test.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import type { ScenarioInfo, PackValidationResult } from '@convsim/shared'
 import ScenarioLibrary from '../screens/ScenarioLibrary'

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -2,6 +2,7 @@
 import type {
   HealthResponse as SharedHealthResponse,
   ScenarioInfo,
+  PackValidationResult,
   SessionCreateRequest,
   SessionCreateResponse,
   WsEvent,
@@ -98,8 +99,14 @@ export const api = {
   health(): Promise<SharedHealthResponse> {
     return get<SharedHealthResponse>('/health')
   },
+  listScenarios(): Promise<ScenarioInfo[]> {
+    return get<ScenarioInfo[]>('/scenarios')
+  },
   getScenario(scenarioId: string): Promise<ScenarioInfo> {
     return get<ScenarioInfo>(`/scenarios/${scenarioId}`)
+  },
+  validatePack(packId: string): Promise<PackValidationResult> {
+    return post<PackValidationResult>(`/packs/${packId}/validate`)
   },
   listSessions(): Promise<{ sessions: SessionCreateResponse[] }> {
     return get<{ sessions: SessionCreateResponse[] }>('/sessions')

--- a/apps/web/src/screens/ScenarioLibrary.tsx
+++ b/apps/web/src/screens/ScenarioLibrary.tsx
@@ -1,10 +1,604 @@
 // SPDX-License-Identifier: Apache-2.0
+import { useState, useEffect, useMemo, useId } from 'react'
+import { Link } from 'react-router-dom'
+import type { ScenarioInfo, PackValidationResult } from '@convsim/shared'
+import { api } from '../api/client'
+
+interface PackGroup {
+  pack_id: string
+  pack_name: string
+  scenarios: ScenarioInfo[]
+}
+
+function groupByPack(scenarios: ScenarioInfo[]): PackGroup[] {
+  const map = new Map<string, PackGroup>()
+  for (const s of scenarios) {
+    let g = map.get(s.pack_id)
+    if (!g) {
+      g = { pack_id: s.pack_id, pack_name: s.pack_name, scenarios: [] }
+      map.set(s.pack_id, g)
+    }
+    g.scenarios.push(s)
+  }
+  return Array.from(map.values())
+}
+
+type ValidationState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'done'; result: PackValidationResult }
+  | { status: 'error'; message: string }
+
 export default function ScenarioLibrary() {
+  const [scenarios, setScenarios] = useState<ScenarioInfo[] | null>(null)
+  const [loadError, setLoadError] = useState(false)
+  const [search, setSearch] = useState('')
+  const [filterRating, setFilterRating] = useState('')
+  const [filterLanguage, setFilterLanguage] = useState('')
+  const [filterDifficulty, setFilterDifficulty] = useState('')
+  const [filterTag, setFilterTag] = useState('')
+  const [voiceOnly, setVoiceOnly] = useState(false)
+  const [validations, setValidations] = useState<Record<string, ValidationState>>({})
+  const [expandedValidation, setExpandedValidation] = useState<string | null>(null)
+
+  const searchId = useId()
+  const ratingId = useId()
+  const languageId = useId()
+  const difficultyId = useId()
+  const tagId = useId()
+
+  useEffect(() => {
+    api
+      .listScenarios()
+      .then((s) => setScenarios(s))
+      .catch(() => setLoadError(true))
+  }, [])
+
+  const { allRatings, allLanguages, allDifficulties, allTags } = useMemo(() => {
+    if (!scenarios) return { allRatings: [], allLanguages: [], allDifficulties: [], allTags: [] }
+    const ratings = new Set<string>()
+    const languages = new Set<string>()
+    const difficulties = new Set<string>()
+    const tags = new Set<string>()
+    for (const s of scenarios) {
+      ratings.add(s.content_rating)
+      for (const l of s.supported_languages) languages.add(l)
+      for (const d of Object.keys(s.difficulty.options)) difficulties.add(d)
+      for (const t of s.tags ?? []) tags.add(t)
+    }
+    return {
+      allRatings: [...ratings].sort(),
+      allLanguages: [...languages].sort(),
+      allDifficulties: [...difficulties].sort(),
+      allTags: [...tags].sort(),
+    }
+  }, [scenarios])
+
+  const packs = useMemo(() => {
+    if (!scenarios) return []
+    const q = search.trim().toLowerCase()
+    const filtered = scenarios.filter((s) => {
+      if (filterRating && s.content_rating !== filterRating) return false
+      if (filterLanguage && !s.supported_languages.includes(filterLanguage)) return false
+      if (filterDifficulty && !Object.keys(s.difficulty.options).includes(filterDifficulty)) return false
+      if (filterTag && !(s.tags ?? []).includes(filterTag)) return false
+      if (voiceOnly && !s.voice_supported) return false
+      if (q) {
+        const hay = `${s.title} ${s.summary} ${s.pack_name} ${s.player_role.label}`.toLowerCase()
+        if (!hay.includes(q)) return false
+      }
+      return true
+    })
+    return groupByPack(filtered)
+  }, [scenarios, search, filterRating, filterLanguage, filterDifficulty, filterTag, voiceOnly])
+
+  const totalVisible = packs.reduce((n, p) => n + p.scenarios.length, 0)
+
+  async function handleValidate(packId: string) {
+    setValidations((prev) => ({ ...prev, [packId]: { status: 'loading' } }))
+    setExpandedValidation(packId)
+    try {
+      const result = await api.validatePack(packId)
+      setValidations((prev) => ({ ...prev, [packId]: { status: 'done', result } }))
+    } catch (err) {
+      setValidations((prev) => ({
+        ...prev,
+        [packId]: {
+          status: 'error',
+          message: err instanceof Error ? err.message : 'Validation failed',
+        },
+      }))
+    }
+  }
+
   return (
-    <div>
+    <div style={{ maxWidth: '900px' }}>
       <h1>Scenario Library</h1>
-      <p>Browse and search installed scenario packs.</p>
-      <p><em>No packs installed yet. Add packs via Settings → Import Pack.</em></p>
+
+      <div
+        role="search"
+        aria-label="Search and filter scenarios"
+        style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: '0.75rem',
+          marginBottom: '1.5rem',
+          alignItems: 'flex-end',
+        }}
+      >
+        <div
+          style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', flex: '1 1 200px', minWidth: '160px' }}
+        >
+          <label htmlFor={searchId} style={labelStyle}>
+            Search
+          </label>
+          <input
+            id={searchId}
+            type="search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Title, summary, pack…"
+            aria-label="Search scenarios"
+            style={inputStyle}
+          />
+        </div>
+
+        <div style={filterGroupStyle}>
+          <label htmlFor={ratingId} style={labelStyle}>
+            Rating
+          </label>
+          <select
+            id={ratingId}
+            value={filterRating}
+            onChange={(e) => setFilterRating(e.target.value)}
+            style={selectStyle}
+            aria-label="Filter by content rating"
+          >
+            <option value="">All ratings</option>
+            {allRatings.map((r) => (
+              <option key={r} value={r}>
+                {r}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div style={filterGroupStyle}>
+          <label htmlFor={languageId} style={labelStyle}>
+            Language
+          </label>
+          <select
+            id={languageId}
+            value={filterLanguage}
+            onChange={(e) => setFilterLanguage(e.target.value)}
+            style={selectStyle}
+            aria-label="Filter by language"
+          >
+            <option value="">All languages</option>
+            {allLanguages.map((l) => (
+              <option key={l} value={l}>
+                {l.toUpperCase()}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div style={filterGroupStyle}>
+          <label htmlFor={difficultyId} style={labelStyle}>
+            Difficulty
+          </label>
+          <select
+            id={difficultyId}
+            value={filterDifficulty}
+            onChange={(e) => setFilterDifficulty(e.target.value)}
+            style={selectStyle}
+            aria-label="Filter by difficulty"
+          >
+            <option value="">All difficulties</option>
+            {allDifficulties.map((d) => (
+              <option key={d} value={d}>
+                {d.charAt(0).toUpperCase() + d.slice(1)}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {allTags.length > 0 && (
+          <div style={filterGroupStyle}>
+            <label htmlFor={tagId} style={labelStyle}>
+              Tag
+            </label>
+            <select
+              id={tagId}
+              value={filterTag}
+              onChange={(e) => setFilterTag(e.target.value)}
+              style={selectStyle}
+              aria-label="Filter by tag"
+            >
+              <option value="">All tags</option>
+              {allTags.map((t) => (
+                <option key={t} value={t}>
+                  {t}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        <label
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.4rem',
+            fontSize: '0.875rem',
+            cursor: 'pointer',
+            paddingBottom: '2px',
+            color: '#e8e8ea',
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={voiceOnly}
+            onChange={(e) => setVoiceOnly(e.target.checked)}
+            aria-label="Show voice-supported scenarios only"
+          />
+          Voice only
+        </label>
+      </div>
+
+      {scenarios === null && !loadError && (
+        <p aria-live="polite" style={{ color: '#a1a1aa' }}>
+          Loading scenarios…
+        </p>
+      )}
+
+      {loadError && (
+        <p role="alert" style={{ color: '#f87171' }}>
+          Could not load scenarios. Make sure the local runtime is running.
+        </p>
+      )}
+
+      {scenarios !== null && scenarios.length === 0 && (
+        <div
+          data-testid="empty-state"
+          role="status"
+          style={{
+            background: 'rgba(255,255,255,0.03)',
+            border: '1px solid rgba(255,255,255,0.1)',
+            borderRadius: '8px',
+            padding: '2rem',
+            textAlign: 'center',
+          }}
+        >
+          <p style={{ fontSize: '1.1rem', marginBottom: '0.5rem' }}>No scenario packs installed.</p>
+          <p style={{ fontSize: '0.9rem', color: '#a1a1aa', marginBottom: '1.25rem' }}>
+            Import a pack via{' '}
+            <Link to="/settings" style={{ color: '#a5b4fc' }}>
+              Settings → Import Pack
+            </Link>
+            , or install an official starter pack to begin.
+          </p>
+          <Link
+            to="/settings"
+            style={{
+              display: 'inline-block',
+              padding: '0.5rem 1.25rem',
+              borderRadius: '6px',
+              background: 'rgba(255,255,255,0.08)',
+              color: '#e8e8ea',
+              textDecoration: 'none',
+              fontSize: '0.875rem',
+            }}
+          >
+            Go to Settings
+          </Link>
+        </div>
+      )}
+
+      {scenarios !== null && scenarios.length > 0 && (
+        <>
+          <p
+            aria-live="polite"
+            aria-atomic="true"
+            data-testid="results-count"
+            style={{ fontSize: '0.875rem', color: '#71717a', marginBottom: '1.25rem' }}
+          >
+            {totalVisible === 0
+              ? 'No scenarios match the current filters.'
+              : `${totalVisible} scenario${totalVisible === 1 ? '' : 's'} in ${packs.length} pack${packs.length === 1 ? '' : 's'}`}
+          </p>
+
+          {totalVisible === 0 && (
+            <p data-testid="no-results" style={{ color: '#a1a1aa', fontSize: '0.9rem' }}>
+              Try adjusting your search or clearing a filter.
+            </p>
+          )}
+        </>
+      )}
+
+      {packs.map((pack) => {
+        const validation: ValidationState = validations[pack.pack_id] ?? { status: 'idle' }
+        const isExpanded = expandedValidation === pack.pack_id
+
+        return (
+          <section
+            key={pack.pack_id}
+            aria-labelledby={`pack-heading-${pack.pack_id}`}
+            style={{ marginBottom: '2.5rem' }}
+          >
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'baseline',
+                justifyContent: 'space-between',
+                gap: '1rem',
+                marginBottom: '0.5rem',
+                borderBottom: '1px solid rgba(255,255,255,0.08)',
+                paddingBottom: '0.5rem',
+              }}
+            >
+              <h2
+                id={`pack-heading-${pack.pack_id}`}
+                style={{ fontSize: '1rem', fontWeight: 600, margin: 0 }}
+              >
+                {pack.pack_name}
+                <span
+                  style={{ fontWeight: 400, color: '#71717a', marginLeft: '0.5rem', fontSize: '0.875rem' }}
+                >
+                  ({pack.scenarios.length}{' '}
+                  {pack.scenarios.length === 1 ? 'scenario' : 'scenarios'})
+                </span>
+              </h2>
+
+              <button
+                onClick={() => {
+                  if (isExpanded && validation.status !== 'idle') {
+                    setExpandedValidation(null)
+                  } else {
+                    void handleValidate(pack.pack_id)
+                  }
+                }}
+                disabled={validation.status === 'loading'}
+                aria-label={`Validate pack ${pack.pack_name}`}
+                aria-expanded={isExpanded && validation.status !== 'idle'}
+                data-testid={`validate-${pack.pack_id}`}
+                style={{
+                  padding: '0.25rem 0.65rem',
+                  borderRadius: '4px',
+                  border: '1px solid rgba(255,255,255,0.15)',
+                  cursor: validation.status === 'loading' ? 'wait' : 'pointer',
+                  background: 'transparent',
+                  color: '#a1a1aa',
+                  fontSize: '0.8rem',
+                  flexShrink: 0,
+                }}
+              >
+                {validation.status === 'loading' ? 'Validating…' : 'Validate pack'}
+              </button>
+            </div>
+
+            {isExpanded && validation.status === 'done' && (
+              <div
+                data-testid={`validation-result-${pack.pack_id}`}
+                role="status"
+                style={{
+                  marginBottom: '0.75rem',
+                  padding: '0.6rem 0.85rem',
+                  borderRadius: '4px',
+                  fontSize: '0.85rem',
+                  background: validation.result.valid
+                    ? 'rgba(34,197,94,0.08)'
+                    : 'rgba(239,68,68,0.08)',
+                  border: `1px solid ${
+                    validation.result.valid ? 'rgba(34,197,94,0.25)' : 'rgba(239,68,68,0.25)'
+                  }`,
+                  color: validation.result.valid ? '#86efac' : '#fca5a5',
+                }}
+              >
+                {validation.result.valid ? (
+                  <span>Pack is valid — no issues found.</span>
+                ) : (
+                  <>
+                    <p style={{ margin: '0 0 0.4rem', fontWeight: 500 }}>
+                      {validation.result.errors.length} validation error
+                      {validation.result.errors.length === 1 ? '' : 's'} found:
+                    </p>
+                    <ul role="list" style={{ margin: 0, paddingLeft: '1.25rem' }}>
+                      {validation.result.errors.map((e, i) => (
+                        <li key={i} data-testid="validation-error">
+                          {e.rule_id && (
+                            <code
+                              style={{ fontSize: '0.78rem', marginRight: '0.35rem', color: '#fbbf24' }}
+                            >
+                              [{e.rule_id}]
+                            </code>
+                          )}
+                          {e.file_path && (
+                            <code
+                              style={{ fontSize: '0.78rem', marginRight: '0.35rem', color: '#94a3b8' }}
+                            >
+                              {e.file_path}:
+                            </code>
+                          )}
+                          {e.message}
+                        </li>
+                      ))}
+                    </ul>
+                  </>
+                )}
+              </div>
+            )}
+
+            {isExpanded && validation.status === 'error' && (
+              <p
+                role="alert"
+                style={{ fontSize: '0.85rem', color: '#f87171', marginBottom: '0.75rem' }}
+              >
+                {validation.message}
+              </p>
+            )}
+
+            <ul
+              role="list"
+              aria-label={`Scenarios in ${pack.pack_name}`}
+              style={{
+                listStyle: 'none',
+                padding: 0,
+                margin: 0,
+                display: 'flex',
+                flexDirection: 'column',
+                gap: '0.75rem',
+              }}
+            >
+              {pack.scenarios.map((scenario) => (
+                <li key={scenario.scenario_id}>
+                  <article
+                    aria-labelledby={`scenario-title-${scenario.scenario_id}`}
+                    style={{
+                      border: '1px solid rgba(255,255,255,0.1)',
+                      borderRadius: '8px',
+                      padding: '1rem 1.25rem',
+                      background: 'rgba(255,255,255,0.02)',
+                    }}
+                  >
+                    <div
+                      style={{
+                        display: 'flex',
+                        justifyContent: 'space-between',
+                        alignItems: 'flex-start',
+                        gap: '1rem',
+                      }}
+                    >
+                      <div style={{ flex: 1, minWidth: 0 }}>
+                        <h3
+                          id={`scenario-title-${scenario.scenario_id}`}
+                          style={{ fontSize: '0.95rem', fontWeight: 600, margin: '0 0 0.3rem' }}
+                        >
+                          {scenario.title}
+                        </h3>
+                        <p
+                          style={{
+                            fontSize: '0.875rem',
+                            color: '#a1a1aa',
+                            margin: '0 0 0.75rem',
+                            lineHeight: '1.5',
+                          }}
+                        >
+                          {scenario.summary}
+                        </p>
+
+                        <div
+                          style={{ display: 'flex', flexWrap: 'wrap', gap: '0.35rem' }}
+                          aria-label="Scenario details"
+                        >
+                          <Chip label={scenario.content_rating} />
+                          <Chip label={`Role: ${scenario.player_role.label}`} />
+                          <Chip label={scenario.estimated_length_label} />
+                          {scenario.voice_supported && (
+                            <Chip label="Voice supported" accent="green" />
+                          )}
+                          {scenario.supported_languages.map((l) => (
+                            <Chip key={l} label={l.toUpperCase()} />
+                          ))}
+                          {Object.keys(scenario.difficulty.options).map((d) => (
+                            <Chip key={d} label={d.charAt(0).toUpperCase() + d.slice(1)} />
+                          ))}
+                          {(scenario.tags ?? []).map((t) => (
+                            <Chip key={t} label={t} accent="blue" />
+                          ))}
+                        </div>
+                      </div>
+
+                      <Link
+                        to={`/setup/${scenario.scenario_id}`}
+                        aria-label={`Launch ${scenario.title}`}
+                        data-testid={`launch-${scenario.scenario_id}`}
+                        style={{
+                          flexShrink: 0,
+                          padding: '0.4rem 1rem',
+                          borderRadius: '6px',
+                          background: 'rgba(99,102,241,0.15)',
+                          border: '1px solid rgba(99,102,241,0.4)',
+                          color: '#a5b4fc',
+                          textDecoration: 'none',
+                          fontSize: '0.875rem',
+                          fontWeight: 500,
+                          whiteSpace: 'nowrap',
+                        }}
+                      >
+                        Launch
+                      </Link>
+                    </div>
+                  </article>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )
+      })}
     </div>
   )
+}
+
+function Chip({ label, accent }: { label: string; accent?: 'green' | 'blue' }) {
+  const green = accent === 'green'
+  const blue = accent === 'blue'
+  return (
+    <span
+      style={{
+        display: 'inline-block',
+        padding: '0.1rem 0.45rem',
+        borderRadius: '4px',
+        fontSize: '0.75rem',
+        background: green
+          ? 'rgba(34,197,94,0.12)'
+          : blue
+            ? 'rgba(99,102,241,0.12)'
+            : 'rgba(255,255,255,0.06)',
+        color: green ? '#86efac' : blue ? '#a5b4fc' : '#a1a1aa',
+        border: green
+          ? '1px solid rgba(34,197,94,0.2)'
+          : blue
+            ? '1px solid rgba(99,102,241,0.2)'
+            : '1px solid rgba(255,255,255,0.08)',
+      }}
+    >
+      {label}
+    </span>
+  )
+}
+
+const inputStyle: React.CSSProperties = {
+  padding: '0.4rem 0.6rem',
+  borderRadius: '4px',
+  border: '1px solid rgba(255,255,255,0.15)',
+  background: 'rgba(255,255,255,0.05)',
+  color: '#e8e8ea',
+  fontSize: '0.875rem',
+  width: '100%',
+  boxSizing: 'border-box',
+}
+
+const selectStyle: React.CSSProperties = {
+  padding: '0.4rem 0.6rem',
+  borderRadius: '4px',
+  border: '1px solid rgba(255,255,255,0.15)',
+  background: 'rgba(255,255,255,0.05)',
+  color: '#e8e8ea',
+  fontSize: '0.875rem',
+  cursor: 'pointer',
+  width: '100%',
+}
+
+const filterGroupStyle: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.25rem',
+  flex: '0 1 150px',
+  minWidth: '120px',
+}
+
+const labelStyle: React.CSSProperties = {
+  fontSize: '0.8rem',
+  color: '#a1a1aa',
 }

--- a/packages/shared/src/types/scenario.ts
+++ b/packages/shared/src/types/scenario.ts
@@ -52,7 +52,7 @@ export interface ScenarioInfo {
 }
 
 export interface PackValidationError {
-  rule_id: string;
+  rule_id?: string;
   file_path?: string;
   message: string;
 }

--- a/packages/shared/src/types/scenario.ts
+++ b/packages/shared/src/types/scenario.ts
@@ -48,4 +48,17 @@ export interface ScenarioInfo {
   voice_supported: boolean;
   safety_summary: string;
   estimated_length_label: string;
+  tags?: string[];
+}
+
+export interface PackValidationError {
+  rule_id: string;
+  file_path?: string;
+  message: string;
+}
+
+export interface PackValidationResult {
+  pack_id: string;
+  valid: boolean;
+  errors: PackValidationError[];
 }


### PR DESCRIPTION
## Summary

- **Scenario card grid** grouped by pack, rendering title, summary, content rating, difficulty, language, estimated length, voice badge, and tag chips
- **Client-side search + filters** (text, content rating, language, difficulty, tag, voice-only) via `useMemo` — no backend round-trips
- **Launch links** route to `/setup/:scenarioId` via React Router `<Link>`
- **Pack validation** — `POST /api/packs/:pack_id/validate` endpoint + per-pack validate button with expandable error panel showing `rule_id`, `file_path`, and `message`
- **Empty state** with links to Settings › Import Pack and starter-pack guidance
- **Accessibility** — `role="search"`, `role="list"`, `role="article"`, `aria-labelledby` on all cards and sections, `aria-live="polite"` results count
- **60+ frontend tests** covering rendering, filtering, empty state, launch links, validation (valid/invalid/error/loading), hidden-agenda privacy invariant, and ARIA semantics

## Changes

| File | Change |
|---|---|
| `packages/shared/src/types/scenario.ts` | Add `tags?: string[]` to `ScenarioInfo`; add `PackValidationError` and `PackValidationResult` types |
| `apps/api/src/data/scenarios.ts` | Populate `tags` on all scenarios |
| `apps/api/src/routes/packs.ts` | New — `POST /api/packs/:pack_id/validate` endpoint |
| `apps/api/src/routes/packs.test.ts` | New — API validation tests |
| `apps/api/src/index.ts` | Register `packRoutes` |
| `apps/web/src/api/client.ts` | Add `listScenarios()` and `validatePack()` |
| `apps/web/src/screens/ScenarioLibrary.tsx` | Full implementation of scenario library UI |
| `apps/web/src/__tests__/ScenarioLibrary.test.tsx` | New — 60+ comprehensive tests |

## Test plan

- [x] `pnpm -F @convsim/api test` — API validation tests pass; existing API tests continue to pass
- [x] `pnpm -F @convsim/web test` — all 60+ ScenarioLibrary tests pass
- [x] Search filters scenarios by title, summary, pack name, and player role label
- [x] Content rating / language / difficulty / tag filters narrow the card list
- [x] Voice-only toggle hides non-voice scenarios
- [x] Results count updates dynamically with `aria-live="polite"` as filters change
- [x] Empty state appears when no scenarios match filters
- [x] Launch link for each card navigates to `/setup/:scenarioId`
- [x] Validate button calls `POST /api/packs/:pack_id/validate` and displays result
- [x] Validation error panel displays `rule_id`, `file_path`, and `message`
- [x] Hidden agenda / private persona fields never rendered (not present on `ScenarioInfo`)

Closes #39