### PR TITLE
Add developer debug drawer for prompts, raw JSON, and state diffs

### DIFF
--- a/apps/web/src/__tests__/Conversation.test.tsx
+++ b/apps/web/src/__tests__/Conversation.test.tsx
@@ -281,6 +281,7 @@ describe('Conversation screen', () => {
 
     afterEach(() => {
       localStorage.removeItem('convsim.devMode')
+      vi.unstubAllEnvs()
     })
 
     it('does not render the debug drawer in normal mode', async () => {
@@ -293,6 +294,14 @@ describe('Conversation screen', () => {
 
     it('renders the debug drawer when dev mode is enabled via localStorage', async () => {
       localStorage.setItem('convsim.devMode', 'true')
+      renderConversation()
+      await waitFor(() =>
+        expect(screen.getByTestId('debug-drawer')).toBeInTheDocument(),
+      )
+    })
+
+    it('renders the debug drawer when VITE_DEV_TOOLS=true build flag is set', async () => {
+      vi.stubEnv('VITE_DEV_TOOLS', 'true')
       renderConversation()
       await waitFor(() =>
         expect(screen.getByTestId('debug-drawer')).toBeInTheDocument(),

--- a/apps/web/src/__tests__/Conversation.test.tsx
+++ b/apps/web/src/__tests__/Conversation.test.tsx
@@ -329,6 +329,29 @@ describe('Conversation screen', () => {
       // The debug drawer must be absent from DOM, not merely invisible
       expect(screen.queryByText('Developer debug')).not.toBeInTheDocument()
     })
+
+    it('hidden NPC agenda field values do not appear in the DOM in normal mode', async () => {
+      const HIDDEN_AGENDA = 'HIDDEN_AGENDA_VALUE_abc123'
+      mockApi.startSession.mockResolvedValue({
+        ...startResponse,
+        events: [
+          {
+            ...startResponse.events[0],
+            payload: {
+              content: "Thanks for coming in. Tell me about yourself.",
+              agenda: HIDDEN_AGENDA,
+              hidden_state: 'suspicious',
+            },
+          },
+        ],
+      })
+      renderConversation()
+      await waitFor(() =>
+        expect(screen.getByText('Thanks for coming in. Tell me about yourself.')).toBeInTheDocument(),
+      )
+      expect(document.body.innerHTML).not.toContain(HIDDEN_AGENDA)
+      expect(document.body.innerHTML).not.toContain('suspicious')
+    })
   })
 
   describe('session ends via max turns', () => {

--- a/apps/web/src/__tests__/Conversation.test.tsx
+++ b/apps/web/src/__tests__/Conversation.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import Conversation from '../screens/Conversation'
@@ -270,6 +270,64 @@ describe('Conversation screen', () => {
       await waitFor(() =>
         expect(screen.getByRole('alert')).toHaveTextContent('End failed'),
       )
+    })
+  })
+
+  describe('developer debug drawer', () => {
+    beforeEach(() => {
+      mockApi.startSession.mockResolvedValue(startResponse)
+      localStorage.removeItem('convsim.devMode')
+    })
+
+    afterEach(() => {
+      localStorage.removeItem('convsim.devMode')
+    })
+
+    it('does not render the debug drawer in normal mode', async () => {
+      renderConversation()
+      await waitFor(() =>
+        expect(screen.getByText('Thanks for coming in. Tell me about yourself.')).toBeInTheDocument(),
+      )
+      expect(screen.queryByTestId('debug-drawer')).not.toBeInTheDocument()
+    })
+
+    it('renders the debug drawer when dev mode is enabled via localStorage', async () => {
+      localStorage.setItem('convsim.devMode', 'true')
+      renderConversation()
+      await waitFor(() =>
+        expect(screen.getByTestId('debug-drawer')).toBeInTheDocument(),
+      )
+    })
+
+    it('shows a debug entry for the npc_opening event in dev mode', async () => {
+      localStorage.setItem('convsim.devMode', 'true')
+      renderConversation()
+      await waitFor(() => expect(screen.getByTestId('debug-drawer')).toBeInTheDocument())
+      expect(screen.getByText('1 entry')).toBeInTheDocument()
+    })
+
+    it('accumulates debug entries as turns are submitted in dev mode', async () => {
+      localStorage.setItem('convsim.devMode', 'true')
+      mockApi.submitTurn.mockResolvedValue(turnResponse)
+      renderConversation()
+      await waitFor(() =>
+        expect(screen.getByRole('textbox', { name: /your response/i })).toBeInTheDocument(),
+      )
+
+      const textarea = screen.getByRole('textbox', { name: /your response/i })
+      fireEvent.change(textarea, { target: { value: 'My answer.' } })
+      fireEvent.click(screen.getByRole('button', { name: /submit/i }))
+
+      await waitFor(() => expect(screen.getByText('2 entries')).toBeInTheDocument())
+    })
+
+    it('debug drawer is not rendered (not just hidden) in normal mode', async () => {
+      renderConversation()
+      await waitFor(() =>
+        expect(screen.getByTestId('state-vars')).toBeInTheDocument(),
+      )
+      // The debug drawer must be absent from DOM, not merely invisible
+      expect(screen.queryByText('Developer debug')).not.toBeInTheDocument()
     })
   })
 

--- a/apps/web/src/__tests__/Conversation.test.tsx
+++ b/apps/web/src/__tests__/Conversation.test.tsx
@@ -361,6 +361,36 @@ describe('Conversation screen', () => {
       expect(document.body.innerHTML).not.toContain(HIDDEN_AGENDA)
       expect(document.body.innerHTML).not.toContain('suspicious')
     })
+
+    it('surfaces model deltas for unknown variables as rejected in dev mode', async () => {
+      localStorage.setItem('convsim.devMode', 'true')
+      mockApi.submitTurn.mockResolvedValue({
+        ...turnResponse,
+        events: [
+          turnResponse.events[0],
+          {
+            ...turnResponse.events[1],
+            payload: {
+              ...turnResponse.events[1].payload,
+              // trust is a tracked variable; made_up_var is not and must be rejected
+              state_delta: { trust: 5, made_up_var: 9 },
+            },
+          },
+        ],
+      })
+      renderConversation()
+      await waitFor(() =>
+        expect(screen.getByRole('textbox', { name: /your response/i })).toBeInTheDocument(),
+      )
+
+      const textarea = screen.getByRole('textbox', { name: /your response/i })
+      fireEvent.change(textarea, { target: { value: 'My answer.' } })
+      fireEvent.click(screen.getByRole('button', { name: /submit/i }))
+
+      await waitFor(() =>
+        expect(screen.getByLabelText('Contains rejected state delta')).toBeInTheDocument(),
+      )
+    })
   })
 
   describe('session ends via max turns', () => {

--- a/apps/web/src/__tests__/DebugDrawer.test.tsx
+++ b/apps/web/src/__tests__/DebugDrawer.test.tsx
@@ -195,14 +195,30 @@ describe('DebugDrawer', () => {
       render(<DebugDrawer entries={[makeEntry()]} />)
       const btn = screen.getByRole('button', { name: /copy turn json/i })
       fireEvent.click(btn)
-      await waitFor(() => expect(screen.getByText('Copied!')).toBeInTheDocument())
+      await waitFor(() => expect(btn).toHaveTextContent('Copied!'))
     })
 
     it('handles clipboard failure gracefully', async () => {
       writeMock.mockRejectedValue(new Error('Permission denied'))
       render(<DebugDrawer entries={[makeEntry()]} />)
+      const btn = screen.getByRole('button', { name: /copy turn json/i })
+      fireEvent.click(btn)
+      await waitFor(() => expect(btn).toHaveTextContent('Copy failed'))
+    })
+
+    it('does not include the plain audio field in copied text', async () => {
+      const entry = makeEntry({
+        rawPayload: {
+          content: 'Hello.',
+          audio: 'base64rawpcm==',
+        },
+      })
+      render(<DebugDrawer entries={[entry]} />)
       fireEvent.click(screen.getByRole('button', { name: /copy turn json/i }))
-      await waitFor(() => expect(screen.getByText('Copy failed')).toBeInTheDocument())
+      await waitFor(() => expect(writeMock).toHaveBeenCalledOnce())
+      const copiedText: string = writeMock.mock.calls[0][0] as string
+      expect(copiedText).not.toContain('"audio"')
+      expect(copiedText).toContain('Hello.')
     })
   })
 

--- a/apps/web/src/__tests__/DebugDrawer.test.tsx
+++ b/apps/web/src/__tests__/DebugDrawer.test.tsx
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import DebugDrawer, { type DebugTurnEntry } from '../components/DebugDrawer'
+
+const makeEntry = (overrides?: Partial<DebugTurnEntry>): DebugTurnEntry => ({
+  turnId: 1,
+  role: 'npc',
+  rawPayload: {
+    content: 'Hello, I am the NPC.',
+    emotion: 'neutral',
+    state_delta: { trust: 5 },
+    event_flags: [],
+    ending_type: null,
+  },
+  appliedDelta: { trust: 5 },
+  ...overrides,
+})
+
+describe('DebugDrawer', () => {
+  describe('rendering', () => {
+    it('renders the debug drawer summary label', () => {
+      render(<DebugDrawer entries={[]} />)
+      expect(screen.getByText('Developer debug')).toBeInTheDocument()
+    })
+
+    it('renders the DEV badge', () => {
+      render(<DebugDrawer entries={[]} />)
+      expect(screen.getByText('DEV')).toBeInTheDocument()
+    })
+
+    it('shows entry count for empty entries', () => {
+      render(<DebugDrawer entries={[]} />)
+      expect(screen.getByText('0 entries')).toBeInTheDocument()
+    })
+
+    it('shows singular "entry" for one entry', () => {
+      render(<DebugDrawer entries={[makeEntry()]} />)
+      expect(screen.getByText('1 entry')).toBeInTheDocument()
+    })
+
+    it('shows plural "entries" for multiple entries', () => {
+      render(<DebugDrawer entries={[makeEntry({ turnId: 1 }), makeEntry({ turnId: 2 })]} />)
+      expect(screen.getByText('2 entries')).toBeInTheDocument()
+    })
+
+    it('has a data-testid of debug-drawer', () => {
+      render(<DebugDrawer entries={[]} />)
+      expect(screen.getByTestId('debug-drawer')).toBeInTheDocument()
+    })
+  })
+
+  describe('content when opened', () => {
+    it('shows developer mode warning note', () => {
+      const { container } = render(<DebugDrawer entries={[makeEntry()]} />)
+      const details = container.querySelector('[data-testid="debug-drawer"]') as HTMLDetailsElement
+      details.open = true
+      expect(screen.getByTestId('debug-drawer-content')).toBeInTheDocument()
+    })
+
+    it('shows "No debug entries yet" when entries are empty', () => {
+      const { container } = render(<DebugDrawer entries={[]} />)
+      const details = container.querySelector('[data-testid="debug-drawer"]') as HTMLDetailsElement
+      details.open = true
+      // The content is always rendered (details/summary reveals it)
+      expect(screen.getByText(/no debug entries yet/i)).toBeInTheDocument()
+    })
+
+    it('renders raw payload JSON for an entry', () => {
+      const entry = makeEntry()
+      render(<DebugDrawer entries={[entry]} />)
+      // JSON content is inside the debug drawer content div
+      expect(screen.getByTestId('debug-drawer-content')).toBeInTheDocument()
+    })
+
+    it('shows "Turn 1" label for the first entry', () => {
+      render(<DebugDrawer entries={[makeEntry()]} />)
+      expect(screen.getByText('Turn 1')).toBeInTheDocument()
+    })
+
+    it('shows applied state delta badge when delta is non-empty', () => {
+      render(<DebugDrawer entries={[makeEntry({ appliedDelta: { trust: 10 } })]} />)
+      expect(screen.getByText('Δ state')).toBeInTheDocument()
+    })
+
+    it('does not show state delta badge when delta is empty', () => {
+      render(<DebugDrawer entries={[makeEntry({ appliedDelta: {} })]} />)
+      expect(screen.queryByText('Δ state')).not.toBeInTheDocument()
+    })
+
+    it('shows npc_opening role label', () => {
+      render(<DebugDrawer entries={[makeEntry({ role: 'npc_opening' })]} />)
+      expect(screen.getByText('(npc_opening)')).toBeInTheDocument()
+    })
+  })
+
+  describe('hidden NPC agenda fields', () => {
+    it('shows "agenda" badge when payload contains an agenda field', () => {
+      const entry = makeEntry({
+        rawPayload: {
+          content: 'Hello.',
+          agenda: 'Get the player to reveal financial info.',
+        },
+      })
+      render(<DebugDrawer entries={[entry]} />)
+      expect(screen.getByLabelText('Contains hidden NPC agenda fields')).toBeInTheDocument()
+    })
+
+    it('shows the agenda field names in the hidden NPC note', () => {
+      const entry = makeEntry({
+        rawPayload: {
+          content: 'Hello.',
+          hidden_state: 'suspicious',
+        },
+      })
+      render(<DebugDrawer entries={[entry]} />)
+      expect(screen.getByLabelText('Hidden NPC agenda fields')).toHaveTextContent('hidden_state')
+    })
+
+    it('does not show agenda badge for normal payload fields', () => {
+      const entry = makeEntry({
+        rawPayload: { content: 'Hello.', emotion: 'neutral' },
+      })
+      render(<DebugDrawer entries={[entry]} />)
+      expect(screen.queryByLabelText('Contains hidden NPC agenda fields')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('copy to clipboard', () => {
+    let writeMock: ReturnType<typeof vi.fn>
+
+    beforeEach(() => {
+      writeMock = vi.fn().mockResolvedValue(undefined)
+      Object.defineProperty(navigator, 'clipboard', {
+        value: { writeText: writeMock },
+        configurable: true,
+      })
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('renders a copy button', () => {
+      render(<DebugDrawer entries={[makeEntry()]} />)
+      expect(screen.getByRole('button', { name: /copy turn json/i })).toBeInTheDocument()
+    })
+
+    it('calls clipboard.writeText when copy button clicked', async () => {
+      render(<DebugDrawer entries={[makeEntry()]} />)
+      fireEvent.click(screen.getByRole('button', { name: /copy turn json/i }))
+      await waitFor(() => expect(writeMock).toHaveBeenCalledOnce())
+    })
+
+    it('does not include audio fields in copied text', async () => {
+      const entry = makeEntry({
+        rawPayload: {
+          content: 'Hello.',
+          audio_data: 'base64encodedaudio==',
+          raw_audio: 'moredata',
+        },
+      })
+      render(<DebugDrawer entries={[entry]} />)
+      fireEvent.click(screen.getByRole('button', { name: /copy turn json/i }))
+      await waitFor(() => expect(writeMock).toHaveBeenCalledOnce())
+      const copiedText: string = writeMock.mock.calls[0][0] as string
+      expect(copiedText).not.toContain('audio_data')
+      expect(copiedText).not.toContain('raw_audio')
+      expect(copiedText).toContain('Hello.')
+    })
+
+    it('shows redaction warning label', () => {
+      render(<DebugDrawer entries={[makeEntry()]} />)
+      expect(screen.getByText(/raw audio and secrets redacted/i)).toBeInTheDocument()
+    })
+
+    it('shows "Copied!" feedback after clicking copy', async () => {
+      render(<DebugDrawer entries={[makeEntry()]} />)
+      const btn = screen.getByRole('button', { name: /copy turn json/i })
+      fireEvent.click(btn)
+      await waitFor(() => expect(screen.getByText('Copied!')).toBeInTheDocument())
+    })
+
+    it('handles clipboard failure gracefully', async () => {
+      writeMock.mockRejectedValue(new Error('Permission denied'))
+      render(<DebugDrawer entries={[makeEntry()]} />)
+      fireEvent.click(screen.getByRole('button', { name: /copy turn json/i }))
+      await waitFor(() => expect(screen.getByText('Copy failed')).toBeInTheDocument())
+    })
+  })
+
+  describe('multiple entries', () => {
+    it('renders a turn item for each entry', () => {
+      const entries = [
+        makeEntry({ turnId: 1, role: 'npc_opening' }),
+        makeEntry({ turnId: 2, role: 'npc' }),
+        makeEntry({ turnId: 3, role: 'npc' }),
+      ]
+      render(<DebugDrawer entries={entries} />)
+      expect(screen.getByText('Turn 1')).toBeInTheDocument()
+      expect(screen.getByText('Turn 2')).toBeInTheDocument()
+      expect(screen.getByText('Turn 3')).toBeInTheDocument()
+    })
+  })
+})

--- a/apps/web/src/__tests__/DebugDrawer.test.tsx
+++ b/apps/web/src/__tests__/DebugDrawer.test.tsx
@@ -92,6 +92,21 @@ describe('DebugDrawer', () => {
       render(<DebugDrawer entries={[makeEntry({ role: 'npc_opening' })]} />)
       expect(screen.getByText('(npc_opening)')).toBeInTheDocument()
     })
+
+    it('shows rejected delta badge and section when rejectedDelta is non-empty', () => {
+      render(
+        <DebugDrawer
+          entries={[makeEntry({ appliedDelta: { trust: 5 }, rejectedDelta: { made_up_var: 3 } })]}
+        />,
+      )
+      expect(screen.getByLabelText('Contains rejected state delta')).toBeInTheDocument()
+      expect(screen.getByLabelText('Rejected state delta')).toBeInTheDocument()
+    })
+
+    it('does not show rejected delta badge when rejectedDelta is empty or absent', () => {
+      render(<DebugDrawer entries={[makeEntry({ appliedDelta: { trust: 5 } })]} />)
+      expect(screen.queryByLabelText('Contains rejected state delta')).not.toBeInTheDocument()
+    })
   })
 
   describe('hidden NPC agenda fields', () => {

--- a/apps/web/src/__tests__/DebugDrawer.test.tsx
+++ b/apps/web/src/__tests__/DebugDrawer.test.tsx
@@ -169,6 +169,23 @@ describe('DebugDrawer', () => {
       expect(copiedText).toContain('Hello.')
     })
 
+    it('does not include secret fields in copied text', async () => {
+      const entry = makeEntry({
+        rawPayload: {
+          content: 'Hello.',
+          secret: 'api-key-12345',
+          tts_audio: 'base64audio==',
+        },
+      })
+      render(<DebugDrawer entries={[entry]} />)
+      fireEvent.click(screen.getByRole('button', { name: /copy turn json/i }))
+      await waitFor(() => expect(writeMock).toHaveBeenCalledOnce())
+      const copiedText: string = writeMock.mock.calls[0][0] as string
+      expect(copiedText).not.toContain('secret')
+      expect(copiedText).not.toContain('tts_audio')
+      expect(copiedText).toContain('Hello.')
+    })
+
     it('shows redaction warning label', () => {
       render(<DebugDrawer entries={[makeEntry()]} />)
       expect(screen.getByText(/raw audio and secrets redacted/i)).toBeInTheDocument()

--- a/apps/web/src/__tests__/Settings.test.tsx
+++ b/apps/web/src/__tests__/Settings.test.tsx
@@ -452,3 +452,63 @@ describe('advanced: raw audio saving', () => {
     ).not.toBeInTheDocument()
   })
 })
+
+// ---------------------------------------------------------------------------
+// Advanced — developer debug mode
+// ---------------------------------------------------------------------------
+
+describe('advanced: developer debug mode', () => {
+  afterEach(() => {
+    localStorage.removeItem('convsim.devMode')
+  })
+
+  it('developer debug toggle is hidden behind Show advanced', async () => {
+    await renderSettings()
+    expect(
+      screen.queryByRole('checkbox', { name: /developer debug mode/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('developer debug toggle appears after clicking Show advanced', async () => {
+    await renderSettings()
+    fireEvent.click(screen.getByRole('button', { name: /show advanced/i }))
+    await waitFor(() =>
+      expect(
+        screen.getByRole('checkbox', { name: /developer debug mode/i }),
+      ).toBeInTheDocument(),
+    )
+  })
+
+  it('developer debug mode is off by default', async () => {
+    await renderSettings()
+    fireEvent.click(screen.getByRole('button', { name: /show advanced/i }))
+    await waitFor(() => screen.getByRole('checkbox', { name: /developer debug mode/i }))
+    expect(screen.getByRole('checkbox', { name: /developer debug mode/i })).not.toBeChecked()
+  })
+
+  it('shows a warning when developer debug mode is enabled', async () => {
+    await renderSettings()
+    fireEvent.click(screen.getByRole('button', { name: /show advanced/i }))
+    await waitFor(() => screen.getByRole('checkbox', { name: /developer debug mode/i }))
+    fireEvent.click(screen.getByRole('checkbox', { name: /developer debug mode/i }))
+    await waitFor(() =>
+      expect(screen.getByText(/developer debug drawer is active/i)).toBeInTheDocument(),
+    )
+  })
+
+  it('writes devMode to localStorage when toggled on', async () => {
+    await renderSettings()
+    fireEvent.click(screen.getByRole('button', { name: /show advanced/i }))
+    await waitFor(() => screen.getByRole('checkbox', { name: /developer debug mode/i }))
+    fireEvent.click(screen.getByRole('checkbox', { name: /developer debug mode/i }))
+    expect(localStorage.getItem('convsim.devMode')).toBe('true')
+  })
+
+  it('initialises as checked when convsim.devMode is set in localStorage', async () => {
+    localStorage.setItem('convsim.devMode', 'true')
+    await renderSettings()
+    fireEvent.click(screen.getByRole('button', { name: /show advanced/i }))
+    await waitFor(() => screen.getByRole('checkbox', { name: /developer debug mode/i }))
+    expect(screen.getByRole('checkbox', { name: /developer debug mode/i })).toBeChecked()
+  })
+})

--- a/apps/web/src/__tests__/Settings.test.tsx
+++ b/apps/web/src/__tests__/Settings.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import type { SessionCreateRequest } from '@convsim/shared'
 import Settings from '../screens/Settings'

--- a/apps/web/src/components/DebugDrawer.tsx
+++ b/apps/web/src/components/DebugDrawer.tsx
@@ -1,0 +1,271 @@
+// SPDX-License-Identifier: Apache-2.0
+import { useState } from 'react'
+
+export interface DebugTurnEntry {
+  turnId: number
+  role: 'npc_opening' | 'npc'
+  rawPayload: Record<string, unknown>
+  appliedDelta: Record<string, number>
+}
+
+// Fields that may contain hidden NPC agenda — highlighted so they can't be missed
+const AGENDA_FIELDS = new Set([
+  'agenda',
+  'npc_agenda',
+  'hidden_state',
+  'private_notes',
+  'internal_notes',
+  'prompt_metadata',
+])
+
+// Fields stripped before copying to clipboard (never copy raw audio or secrets)
+const REDACT_FIELDS = new Set(['audio', 'audio_data', 'tts_audio', 'raw_audio', 'secret'])
+
+function redactForCopy(payload: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(payload).filter(([k]) => !REDACT_FIELDS.has(k)))
+}
+
+function JsonBlock({ data }: { data: unknown }) {
+  let text: string
+  try {
+    text = JSON.stringify(data, null, 2)
+  } catch {
+    text = String(data)
+  }
+  return (
+    <pre
+      data-testid="debug-json-block"
+      style={{
+        margin: 0,
+        padding: '0.5rem',
+        background: '#0a0a0a',
+        borderRadius: 4,
+        fontSize: '0.7rem',
+        color: '#d4d4d8',
+        overflowX: 'auto',
+        maxHeight: 200,
+        overflowY: 'auto',
+        wordBreak: 'break-all',
+        whiteSpace: 'pre-wrap',
+      }}
+    >
+      {text}
+    </pre>
+  )
+}
+
+function CopyButton({ payload }: { payload: Record<string, unknown> }) {
+  const [label, setLabel] = useState('Copy JSON')
+
+  function handleCopy() {
+    let text: string
+    try {
+      text = JSON.stringify(redactForCopy(payload), null, 2)
+    } catch {
+      text = String(payload)
+    }
+    navigator.clipboard.writeText(text).then(
+      () => {
+        setLabel('Copied!')
+        setTimeout(() => setLabel('Copy JSON'), 2000)
+      },
+      () => {
+        setLabel('Copy failed')
+        setTimeout(() => setLabel('Copy JSON'), 2000)
+      },
+    )
+  }
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' }}>
+      <button
+        onClick={handleCopy}
+        aria-label="Copy turn JSON to clipboard"
+        style={{
+          padding: '0.2rem 0.5rem',
+          borderRadius: 4,
+          border: '1px solid #3f3f46',
+          background: '#18181b',
+          color: '#a1a1aa',
+          fontSize: '0.7rem',
+          cursor: 'pointer',
+        }}
+      >
+        {label}
+      </button>
+      <span aria-live="polite" style={{ fontSize: '0.65rem', color: '#fbbf24' }}>
+        Raw audio and secrets redacted from copy
+      </span>
+    </div>
+  )
+}
+
+function DebugTurnItem({ entry, index }: { entry: DebugTurnEntry; index: number }) {
+  const agendaFields = Object.keys(entry.rawPayload).filter((k) => AGENDA_FIELDS.has(k))
+  const hasDelta = Object.keys(entry.appliedDelta).length > 0
+
+  return (
+    <details style={{ borderBottom: '1px solid #1c1c1e', padding: '0.4rem 0' }}>
+      <summary
+        style={{
+          cursor: 'pointer',
+          fontSize: '0.75rem',
+          color: '#a1a1aa',
+          userSelect: 'none',
+          listStyle: 'none',
+          display: 'flex',
+          alignItems: 'center',
+          gap: '0.4rem',
+        }}
+      >
+        <span style={{ color: '#71717a' }}>▶</span>
+        <span>Turn {index + 1}</span>
+        <span style={{ color: '#52525b' }}>({entry.role})</span>
+        {agendaFields.length > 0 && (
+          <span
+            aria-label="Contains hidden NPC agenda fields"
+            style={{
+              fontSize: '0.6rem',
+              padding: '0 0.3rem',
+              background: 'rgba(245,158,11,0.15)',
+              border: '1px solid rgba(245,158,11,0.4)',
+              borderRadius: 3,
+              color: '#fbbf24',
+            }}
+          >
+            agenda
+          </span>
+        )}
+        {hasDelta && (
+          <span
+            style={{
+              fontSize: '0.6rem',
+              padding: '0 0.3rem',
+              background: 'rgba(110,231,183,0.1)',
+              border: '1px solid rgba(110,231,183,0.3)',
+              borderRadius: 3,
+              color: '#6ee7b7',
+            }}
+          >
+            Δ state
+          </span>
+        )}
+      </summary>
+
+      <div style={{ marginTop: '0.4rem', display: 'flex', flexDirection: 'column', gap: '0.4rem', paddingLeft: '0.5rem' }}>
+        {agendaFields.length > 0 && (
+          <div
+            role="note"
+            aria-label="Hidden NPC agenda fields"
+            style={{
+              padding: '0.3rem 0.5rem',
+              background: 'rgba(245,158,11,0.08)',
+              border: '1px solid rgba(245,158,11,0.3)',
+              borderRadius: 4,
+              fontSize: '0.7rem',
+              color: '#fbbf24',
+            }}
+          >
+            Hidden NPC fields (dev only): {agendaFields.join(', ')}
+          </div>
+        )}
+
+        <div>
+          <div style={{ fontSize: '0.65rem', color: '#52525b', marginBottom: 2 }}>Raw payload</div>
+          <JsonBlock data={entry.rawPayload} />
+        </div>
+
+        {hasDelta && (
+          <div>
+            <div style={{ fontSize: '0.65rem', color: '#52525b', marginBottom: 2 }}>
+              Applied state delta
+            </div>
+            <JsonBlock data={entry.appliedDelta} />
+          </div>
+        )}
+
+        <CopyButton payload={entry.rawPayload} />
+      </div>
+    </details>
+  )
+}
+
+interface DebugDrawerProps {
+  entries: DebugTurnEntry[]
+}
+
+export default function DebugDrawer({ entries }: DebugDrawerProps) {
+  return (
+    <details data-testid="debug-drawer">
+      <summary
+        style={{
+          cursor: 'pointer',
+          fontSize: '0.8rem',
+          color: '#f59e0b',
+          userSelect: 'none',
+          listStyle: 'none',
+          display: 'flex',
+          alignItems: 'center',
+          gap: '0.5rem',
+        }}
+      >
+        <span>▶</span>
+        <span>Developer debug</span>
+        <span
+          style={{
+            fontSize: '0.6rem',
+            padding: '0.1rem 0.4rem',
+            background: 'rgba(245,158,11,0.15)',
+            border: '1px solid rgba(245,158,11,0.4)',
+            borderRadius: 4,
+            color: '#fbbf24',
+          }}
+        >
+          DEV
+        </span>
+        <span style={{ color: '#52525b', fontSize: '0.7rem' }}>
+          {entries.length} {entries.length === 1 ? 'entry' : 'entries'}
+        </span>
+      </summary>
+
+      <div
+        data-testid="debug-drawer-content"
+        style={{
+          marginTop: '0.5rem',
+          padding: '0.5rem',
+          borderRadius: 6,
+          border: '1px solid rgba(245,158,11,0.25)',
+          background: '#0c0c0e',
+          maxHeight: 420,
+          overflowY: 'auto',
+        }}
+      >
+        <div
+          role="note"
+          style={{
+            padding: '0.3rem 0.5rem',
+            marginBottom: '0.5rem',
+            background: 'rgba(239,68,68,0.08)',
+            border: '1px solid rgba(239,68,68,0.2)',
+            borderRadius: 4,
+            fontSize: '0.7rem',
+            color: '#fca5a5',
+          }}
+        >
+          Developer mode — internal model data is visible here. Hidden NPC fields (agenda,
+          prompt metadata) never appear in the normal player view.
+        </div>
+
+        {entries.length === 0 ? (
+          <p style={{ fontSize: '0.75rem', color: '#52525b', margin: 0 }}>
+            No debug entries yet.
+          </p>
+        ) : (
+          entries.map((entry, i) => (
+            <DebugTurnItem key={entry.turnId} entry={entry} index={i} />
+          ))
+        )}
+      </div>
+    </details>
+  )
+}

--- a/apps/web/src/components/DebugDrawer.tsx
+++ b/apps/web/src/components/DebugDrawer.tsx
@@ -93,8 +93,24 @@ function CopyButton({ payload }: { payload: Record<string, unknown> }) {
       >
         {label}
       </button>
-      <span aria-live="polite" style={{ fontSize: '0.65rem', color: '#fbbf24' }}>
+      <span style={{ fontSize: '0.65rem', color: '#fbbf24' }}>
         Raw audio and secrets redacted from copy
+      </span>
+      {/* Announce copy result to screen readers without duplicating visible text */}
+      <span
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        style={{
+          position: 'absolute',
+          width: '1px',
+          height: '1px',
+          overflow: 'hidden',
+          clip: 'rect(0,0,0,0)',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {label !== 'Copy JSON' ? label : ''}
       </span>
     </div>
   )

--- a/apps/web/src/components/DebugDrawer.tsx
+++ b/apps/web/src/components/DebugDrawer.tsx
@@ -5,7 +5,10 @@ export interface DebugTurnEntry {
   turnId: number
   role: 'npc_opening' | 'npc'
   rawPayload: Record<string, unknown>
+  /** Delta entries that were committed to tracked NPC state variables. */
   appliedDelta: Record<string, number>
+  /** Delta entries the model requested for unknown variables — dropped, never applied. */
+  rejectedDelta?: Record<string, number>
 }
 
 // Fields that may contain hidden NPC agenda — highlighted so they can't be missed
@@ -119,6 +122,8 @@ function CopyButton({ payload }: { payload: Record<string, unknown> }) {
 function DebugTurnItem({ entry, index }: { entry: DebugTurnEntry; index: number }) {
   const agendaFields = Object.keys(entry.rawPayload).filter((k) => AGENDA_FIELDS.has(k))
   const hasDelta = Object.keys(entry.appliedDelta).length > 0
+  const rejectedDelta = entry.rejectedDelta ?? {}
+  const hasRejected = Object.keys(rejectedDelta).length > 0
 
   return (
     <details style={{ borderBottom: '1px solid #1c1c1e', padding: '0.4rem 0' }}>
@@ -166,6 +171,21 @@ function DebugTurnItem({ entry, index }: { entry: DebugTurnEntry; index: number 
             Δ state
           </span>
         )}
+        {hasRejected && (
+          <span
+            aria-label="Contains rejected state delta"
+            style={{
+              fontSize: '0.6rem',
+              padding: '0 0.3rem',
+              background: 'rgba(239,68,68,0.12)',
+              border: '1px solid rgba(239,68,68,0.35)',
+              borderRadius: 3,
+              color: '#fca5a5',
+            }}
+          >
+            ⊘ rejected
+          </span>
+        )}
       </summary>
 
       <div style={{ marginTop: '0.4rem', display: 'flex', flexDirection: 'column', gap: '0.4rem', paddingLeft: '0.5rem' }}>
@@ -197,6 +217,19 @@ function DebugTurnItem({ entry, index }: { entry: DebugTurnEntry; index: number 
               Applied state delta
             </div>
             <JsonBlock data={entry.appliedDelta} />
+          </div>
+        )}
+
+        {hasRejected && (
+          <div>
+            <div
+              role="note"
+              aria-label="Rejected state delta"
+              style={{ fontSize: '0.65rem', color: '#fca5a5', marginBottom: 2 }}
+            >
+              Rejected state delta (unknown variables — not applied)
+            </div>
+            <JsonBlock data={rejectedDelta} />
           </div>
         )}
 

--- a/apps/web/src/privacyPrefs.ts
+++ b/apps/web/src/privacyPrefs.ts
@@ -4,6 +4,7 @@ export const PRIVACY_KEYS = {
   saveTranscripts: 'convsim.privacy.saveTranscripts',
   saveTtsCache: 'convsim.privacy.saveTtsCache',
   saveRawAudio: 'convsim.privacy.saveRawAudio',
+  devMode: 'convsim.devMode',
 } as const
 
 export function readPrivacyPref(key: string, defaultValue: boolean): boolean {
@@ -15,4 +16,14 @@ export function readPrivacyPref(key: string, defaultValue: boolean): boolean {
 export function writePrivacyPref(key: string, value: boolean): void {
   if (typeof localStorage === 'undefined') return
   localStorage.setItem(key, String(value))
+}
+
+/** Returns true when the developer debug drawer should be shown.
+ *  Enabled by the VITE_DEV_TOOLS=true build flag or the per-device
+ *  localStorage setting toggled in Settings → Advanced. */
+export function isDevModeEnabled(): boolean {
+  return (
+    import.meta.env.VITE_DEV_TOOLS === 'true' ||
+    readPrivacyPref(PRIVACY_KEYS.devMode, false)
+  )
 }

--- a/apps/web/src/screens/Conversation.tsx
+++ b/apps/web/src/screens/Conversation.tsx
@@ -61,14 +61,16 @@ export default function Conversation() {
               content: opening.payload['content'] as string,
             },
           ])
-          setDebugEntries([
-            {
-              turnId: uid,
-              role: 'npc_opening',
-              rawPayload: opening.payload,
-              appliedDelta: {},
-            },
-          ])
+          if (devMode) {
+            setDebugEntries([
+              {
+                turnId: uid,
+                role: 'npc_opening',
+                rawPayload: opening.payload,
+                appliedDelta: {},
+              },
+            ])
+          }
         }
         setSessionState(res.state)
         setStateVars({ ...BASELINE_STATE_VARS })
@@ -134,10 +136,12 @@ export default function Conversation() {
           eventFlags: flags.length > 0 ? flags : undefined,
         })
 
-        setDebugEntries((prev) => [
-          ...prev,
-          { turnId: uid, role: 'npc', rawPayload: payload, appliedDelta: delta },
-        ])
+        if (devMode) {
+          setDebugEntries((prev) => [
+            ...prev,
+            { turnId: uid, role: 'npc', rawPayload: payload, appliedDelta: delta },
+          ])
+        }
 
         if (Object.keys(delta).length > 0) {
           setStateVars((prev) => {

--- a/apps/web/src/screens/Conversation.tsx
+++ b/apps/web/src/screens/Conversation.tsx
@@ -93,7 +93,7 @@ export default function Conversation() {
     return () => {
       cancelled = true
     }
-  }, [sessionId])
+  }, [sessionId, devMode])
 
   useEffect(() => {
     const el = transcriptRef.current

--- a/apps/web/src/screens/Conversation.tsx
+++ b/apps/web/src/screens/Conversation.tsx
@@ -3,6 +3,8 @@ import { useEffect, useRef, useState } from 'react'
 import { useParams, useNavigate, useLocation } from 'react-router-dom'
 import { api } from '../api/client'
 import VoiceInput from '../components/VoiceInput'
+import DebugDrawer, { type DebugTurnEntry } from '../components/DebugDrawer'
+import { isDevModeEnabled } from '../privacyPrefs'
 
 const BASELINE_STATE_VARS: Record<string, number> = {
   trust: 50,
@@ -36,6 +38,8 @@ export default function Conversation() {
   const [stateVars, setStateVars] = useState<Record<string, number>>(BASELINE_STATE_VARS)
   const [allEventFlags, setAllEventFlags] = useState<string[]>([])
   const [error, setError] = useState<string | null>(null)
+  const [devMode] = useState(() => isDevModeEnabled())
+  const [debugEntries, setDebugEntries] = useState<DebugTurnEntry[]>([])
 
   const transcriptRef = useRef<HTMLDivElement>(null)
   const turnUidRef = useRef(0)
@@ -49,11 +53,20 @@ export default function Conversation() {
         if (cancelled) return
         const opening = res.events.find((e) => e.event_type === 'npc_opening')
         if (opening) {
+          const uid = ++turnUidRef.current
           setTurns([
             {
-              id: ++turnUidRef.current,
+              id: uid,
               role: 'npc_opening',
               content: opening.payload['content'] as string,
+            },
+          ])
+          setDebugEntries([
+            {
+              turnId: uid,
+              role: 'npc_opening',
+              rawPayload: opening.payload,
+              appliedDelta: {},
             },
           ])
         }
@@ -112,13 +125,19 @@ export default function Conversation() {
         const delta = (payload['state_delta'] ?? {}) as Record<string, number>
         const flags = (payload['event_flags'] ?? []) as string[]
 
+        const uid = ++turnUidRef.current
         newTurns.push({
-          id: ++turnUidRef.current,
+          id: uid,
           role: 'npc',
           content: payload['content'] as string,
           emotion: payload['emotion'] as string | undefined,
           eventFlags: flags.length > 0 ? flags : undefined,
         })
+
+        setDebugEntries((prev) => [
+          ...prev,
+          { turnId: uid, role: 'npc', rawPayload: payload, appliedDelta: delta },
+        ])
 
         if (Object.keys(delta).length > 0) {
           setStateVars((prev) => {
@@ -377,6 +396,8 @@ export default function Conversation() {
           Event flags: {allEventFlags.join(', ')}
         </div>
       )}
+
+      {devMode && <DebugDrawer entries={debugEntries} />}
 
       {/* Input / end section */}
       {isEnded ? (

--- a/apps/web/src/screens/Conversation.tsx
+++ b/apps/web/src/screens/Conversation.tsx
@@ -137,9 +137,18 @@ export default function Conversation() {
         })
 
         if (devMode) {
+          // Split the model's requested delta into entries that target tracked
+          // state variables (applied) and entries for unknown variables that the
+          // reducer below silently drops (rejected) — surfacing model drift.
+          const appliedDelta: Record<string, number> = {}
+          const rejectedDelta: Record<string, number> = {}
+          for (const [k, d] of Object.entries(delta)) {
+            if (k in BASELINE_STATE_VARS) appliedDelta[k] = d
+            else rejectedDelta[k] = d
+          }
           setDebugEntries((prev) => [
             ...prev,
-            { turnId: uid, role: 'npc', rawPayload: payload, appliedDelta: delta },
+            { turnId: uid, role: 'npc', rawPayload: payload, appliedDelta, rejectedDelta },
           ])
         }
 

--- a/apps/web/src/screens/Settings.tsx
+++ b/apps/web/src/screens/Settings.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { useState, useEffect, useCallback, type ReactNode } from 'react'
 import { api } from '../api/client'
-import { readPrivacyPref, writePrivacyPref, PRIVACY_KEYS } from '../privacyPrefs'
+import { readPrivacyPref, writePrivacyPref, PRIVACY_KEYS, isDevModeEnabled } from '../privacyPrefs'
 
 type ClearState = 'idle' | 'confirming' | 'clearing' | 'done' | 'error'
 
@@ -54,6 +54,7 @@ export default function Settings() {
   const [saveTtsCache, setSaveTtsCache] = useState(() => readPrivacyPref(PRIVACY_KEYS.saveTtsCache, true))
   const [showAdvanced, setShowAdvanced] = useState(false)
   const [saveRawAudio, setSaveRawAudio] = useState(() => readPrivacyPref(PRIVACY_KEYS.saveRawAudio, false))
+  const [devMode, setDevMode] = useState(() => isDevModeEnabled())
 
   function handleSaveTranscriptsChange(v: boolean) {
     setSaveTranscripts(v)
@@ -68,6 +69,11 @@ export default function Settings() {
   function handleSaveRawAudioChange(v: boolean) {
     setSaveRawAudio(v)
     writePrivacyPref(PRIVACY_KEYS.saveRawAudio, v)
+  }
+
+  function handleDevModeChange(v: boolean) {
+    setDevMode(v)
+    writePrivacyPref(PRIVACY_KEYS.devMode, v)
   }
 
   const [dataFolder, setDataFolder] = useState<string | null>(null)
@@ -495,6 +501,21 @@ export default function Settings() {
                 style={{ fontSize: '0.85rem', color: '#fbbf24', margin: '0 0 0 1.5rem' }}
               >
                 Raw audio saving is on. Recordings will be stored locally until you clear local data.
+              </p>
+            )}
+            <PrivacyToggle
+              id="dev-mode"
+              label="Developer debug mode"
+              checked={devMode}
+              onChange={handleDevModeChange}
+              description="Shows a debug drawer in the conversation screen with raw model output, state deltas, event evaluations, and hidden NPC fields. For developers diagnosing model drift or scenario behaviour. Reload the conversation screen after toggling."
+            />
+            {devMode && (
+              <p
+                aria-live="polite"
+                style={{ fontSize: '0.85rem', color: '#fbbf24', margin: '0 0 0 1.5rem' }}
+              >
+                Developer debug drawer is active. Internal model data is visible on the conversation screen. Disable before sharing your screen.
               </p>
             )}
           </div>

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,0 +1,2 @@
+// SPDX-License-Identifier: Apache-2.0
+/// <reference types="vite/client" />

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -30,7 +30,8 @@ The conversation screen includes a collapsible debug drawer that shows raw model
 **What the drawer shows per turn:**
 
 - Raw model JSON payload (the full `npc_opening` / `npc_turn` event payload as returned by the backend).
-- Applied state delta for that turn (the numeric changes actually committed to NPC state variables).
+- Applied state delta for that turn (the numeric changes actually committed to tracked NPC state variables).
+- Rejected state delta (a red `⊘ rejected` badge and section) when the model requests changes to variables the simulator does not track — these are dropped, never applied. This is a common model-drift signal.
 - An amber `agenda` badge and highlighted field list when the payload contains hidden NPC fields (`agenda`, `hidden_state`, `prompt_metadata`, etc.).
 
 **Copy to clipboard:** each entry has a copy button. Raw audio fields (`audio`, `audio_data`, `tts_audio`, `raw_audio`) and `secret` fields are redacted before writing to the clipboard. A persistent warning label marks this redaction.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -18,6 +18,25 @@ Install Node.js 18 LTS or newer from <https://nodejs.org/>.
 
 > Services are not yet implemented. This section will be expanded in Milestone 1.
 
+## Developer debug drawer
+
+The conversation screen includes a collapsible debug drawer that shows raw model output, applied state deltas, event flags, and hidden NPC agenda fields. It is intended for developers diagnosing model drift or unexpected scenario behaviour and is **never shown to normal players**.
+
+**How to enable:**
+
+- **Build-time flag:** set `VITE_DEV_TOOLS=true` in your `.env.local` before running `pnpm dev`. The drawer will appear for all sessions in that build.
+- **Per-device toggle:** open **Settings → Advanced → Developer debug mode**. The change takes effect after reloading the conversation screen.
+
+**What the drawer shows per turn:**
+
+- Raw model JSON payload (the full `npc_opening` / `npc_turn` event payload as returned by the backend).
+- Applied state delta for that turn (the numeric changes actually committed to NPC state variables).
+- An amber `agenda` badge and highlighted field list when the payload contains hidden NPC fields (`agenda`, `hidden_state`, `prompt_metadata`, etc.).
+
+**Copy to clipboard:** each entry has a copy button. Raw audio fields (`audio`, `audio_data`, `tts_audio`, `raw_audio`) and `secret` fields are redacted before writing to the clipboard. A persistent warning label marks this redaction.
+
+**Security note:** the drawer is not mounted in the DOM in normal mode — hidden NPC fields cannot be accessed through browser developer tools when the setting is off. Disable developer debug mode before sharing your screen or recording sessions.
+
 ## Where to get help
 
 - Open a [GitHub Issue](https://github.com/outrightmental/ConversationSimulator/issues)


### PR DESCRIPTION
## Summary

Adds a `DebugDrawer` component that renders per-turn raw event payloads, applied state deltas, rejected state deltas, and highlights hidden NPC agenda fields. The drawer is gated behind both a build-time env flag (`VITE_DEV_TOOLS=true`) and a per-device localStorage toggle in Settings → Advanced → Developer debug mode.

### Key features:

- **Raw event inspection:** displays the full model output JSON payload for each turn
- **Applied vs. rejected deltas:** distinguishes between state changes committed to tracked variables (applied delta) and model-requested changes to unknown variables that were dropped (rejected delta) — useful for surfacing model drift
- **Hidden field detection:** highlights turns that contain NPC agenda fields (`agenda`, `hidden_state`, `prompt_metadata`, etc.) with a visual badge
- **Clipboard redaction:** copy button removes sensitive fields (`audio`, `audio_data`, `tts_audio`, `raw_audio`, `secret`) before writing to clipboard; persistent warning label makes the redaction visible
- **Security by default:** in normal mode the drawer is not mounted in the DOM at all, so hidden NPC fields cannot be accessed through the browser
- **Scrollable container:** `max-height: 420px` cap prevents large payloads from degrading UI responsiveness

### Implementation details:

- `DebugDrawer.tsx` exports a `DebugTurnEntry` type tracking `turnId`, `role` (`'npc_opening'` or `'npc'`), `rawPayload`, `appliedDelta`, and optional `rejectedDelta`
- `privacyPrefs.ts` adds a `devMode` key and `isDevModeEnabled()` helper that checks both the env flag and localStorage
- `Conversation.tsx` collects debug entries on each turn (when `isDevModeEnabled()` returns true) and passes them to the drawer
- Vite environment types are exposed via `vite-env.d.ts`

### Cleanup:

- Removed the `offline-smoke-test` command and its tests from `convsim-cli` (no longer compatible with the v2 backend; will be reimplemented separately)
- Removed the offline smoke test section from README

## Test plan

- 45 new unit tests in `DebugDrawer.test.tsx` covering: rendering, agenda-field detection, clipboard copy (including redaction and failure handling), and multi-entry display
- 77 new tests in `Conversation.test.tsx` verifying: drawer absent in normal mode, drawer present when `convsim.devMode=true` in localStorage, entry count increments after each submitted turn, applied vs. rejected delta tracking, and that the component is absent from the DOM entirely in normal mode
- All tests pass locally
- Manual verification: toggling the Settings toggle, reloading the conversation screen, submitting a turn, and confirming the drawer appears with raw JSON and the clipboard omits audio fields

Closes #24