### PR TITLE
Build polished text conversation screen with NPC panel, scene card, streaming, and event banners

### DIFF
--- a/apps/web/src/__tests__/Conversation.test.tsx
+++ b/apps/web/src/__tests__/Conversation.test.tsx
@@ -345,6 +345,41 @@ describe('Conversation screen', () => {
       )
     })
 
+    it('rolls back the optimistic player turn when submitTurn fails', async () => {
+      mockApi.submitTurn.mockRejectedValue(new Error('Turn failed'))
+      renderConversation()
+      await waitFor(() =>
+        expect(screen.getByRole('textbox', { name: /your response/i })).toBeInTheDocument(),
+      )
+
+      fireEvent.change(screen.getByRole('textbox', { name: /your response/i }), {
+        target: { value: 'This will fail.' },
+      })
+      fireEvent.click(screen.getByRole('button', { name: /submit/i }))
+
+      await waitFor(() =>
+        expect(screen.getByRole('alert')).toHaveTextContent('Turn failed'),
+      )
+      // The failed message must not linger in the transcript.
+      expect(screen.queryByText('This will fail.')).not.toBeInTheDocument()
+
+      // A successful retry should be labelled Turn 2 (opening was Turn 1),
+      // with no gap or duplicate from the rolled-back attempt.
+      mockApi.submitTurn.mockResolvedValue(turnResponse)
+      fireEvent.change(screen.getByRole('textbox', { name: /your response/i }), {
+        target: { value: 'Retry message.' },
+      })
+      fireEvent.click(screen.getByRole('button', { name: /submit/i }))
+
+      await waitFor(() =>
+        expect(screen.getByText('Retry message.')).toBeInTheDocument(),
+      )
+      // Opening=Turn 1, retry player=Turn 2, NPC=Turn 3. The absence of a
+      // Turn 4 confirms the failed attempt did not consume a turn number.
+      expect(screen.getByText('Turn 2')).toBeInTheDocument()
+      expect(screen.queryByText('Turn 4')).not.toBeInTheDocument()
+    })
+
     it('shows turn number markers in the transcript', async () => {
       mockApi.submitTurn.mockResolvedValue(turnResponse)
       renderConversation()

--- a/apps/web/src/__tests__/Conversation.test.tsx
+++ b/apps/web/src/__tests__/Conversation.test.tsx
@@ -648,6 +648,42 @@ describe('Conversation screen', () => {
       // Final NPC content from REST should be present
       expect(screen.getByText('Hello there. I am a simulated NPC.')).toBeInTheDocument()
     })
+
+    it('clears streaming text when the turn fails', async () => {
+      let wsCallback: ((event: WsEvent) => void) | null = null
+      mockApi.connectSession.mockImplementation((_id, cb) => {
+        wsCallback = cb
+        return { close: vi.fn() }
+      })
+      mockApi.startSession.mockResolvedValue(startResponse)
+      mockApi.submitTurn.mockRejectedValue(new Error('Turn failed'))
+      renderConversation()
+      await waitFor(() =>
+        expect(screen.getByRole('textbox', { name: /your response/i })).toBeInTheDocument(),
+      )
+
+      fireEvent.change(screen.getByRole('textbox', { name: /your response/i }), {
+        target: { value: 'Tell me more.' },
+      })
+      fireEvent.click(screen.getByRole('button', { name: /submit/i }))
+
+      // Partial tokens stream in before the REST call rejects.
+      act(() => {
+        wsCallback?.({
+          type: 'npc.token',
+          seq: 1,
+          session_id: SESSION_ID,
+          ts: '2026-07-01T00:01:00Z',
+          payload: { text: 'Partial…' },
+        })
+      })
+
+      await waitFor(() =>
+        expect(screen.getByRole('alert')).toHaveTextContent('Turn failed'),
+      )
+      // No phantom streaming bubble should linger next to the error.
+      expect(screen.queryByTestId('streaming-turn')).not.toBeInTheDocument()
+    })
   })
 
   describe('debug drawer', () => {

--- a/apps/web/src/__tests__/Conversation.test.tsx
+++ b/apps/web/src/__tests__/Conversation.test.tsx
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import Conversation from '../screens/Conversation'
 import type {
   SessionStartResponse,
   TurnResponse,
   SessionEndResponse,
+  ScenarioInfo,
+  WsEvent,
 } from '@convsim/shared'
 
 vi.mock('../api/client', () => ({
@@ -16,6 +18,7 @@ vi.mock('../api/client', () => ({
     endSession: vi.fn(),
     generateDebrief: vi.fn(),
     connectSession: vi.fn(),
+    getScenario: vi.fn(),
   },
 }))
 
@@ -23,6 +26,7 @@ import { api } from '../api/client'
 const mockApi = vi.mocked(api)
 
 const SESSION_ID = 'sess-demo0001'
+const SCENARIO_ID = 'scenario-job-interview'
 
 const startResponse: SessionStartResponse = {
   session_id: SESSION_ID,
@@ -72,9 +76,32 @@ const endResponse: SessionEndResponse = {
   ending_type: 'player_exit',
 }
 
-function renderConversation() {
+const mockScenario: ScenarioInfo = {
+  scenario_id: SCENARIO_ID,
+  title: 'Software Engineer Interview',
+  summary: 'Practice a technical job interview with a realistic hiring manager.',
+  content_rating: 'G',
+  pack_id: 'job-interview-basic',
+  pack_name: 'Job Interview Basics',
+  player_role: { label: 'Job Candidate', brief: 'You are applying for a software engineering role.' },
+  difficulty: { default: 'normal', options: { easy: { npc_patience_modifier: 0.5, challenge_frequency: 'low' }, normal: { npc_patience_modifier: 0, challenge_frequency: 'medium' } } },
+  supported_languages: ['en'],
+  duration: { max_turns: 20, soft_time_limit_minutes: 15 },
+  state_meters_permitted: true,
+  voice_supported: false,
+  safety_summary: 'This scenario contains professional workplace language only.',
+  estimated_length_label: '10–15 min',
+}
+
+function renderConversation(routeState?: Record<string, unknown>) {
   return render(
-    <MemoryRouter initialEntries={[`/conversation/${SESSION_ID}`]}>
+    <MemoryRouter
+      initialEntries={[
+        routeState
+          ? { pathname: `/conversation/${SESSION_ID}`, state: routeState }
+          : `/conversation/${SESSION_ID}`,
+      ]}
+    >
       <Routes>
         <Route path="/conversation/:sessionId" element={<Conversation />} />
         <Route path="/debrief/:sessionId" element={<div>Debrief page</div>} />
@@ -86,6 +113,9 @@ function renderConversation() {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  // Default: connectSession returns a no-op connection; getScenario returns null
+  mockApi.connectSession.mockReturnValue({ close: vi.fn() })
+  mockApi.getScenario.mockResolvedValue(null as unknown as ScenarioInfo)
 })
 
 describe('Conversation screen', () => {
@@ -141,6 +171,83 @@ describe('Conversation screen', () => {
         expect(screen.getByRole('alert')).toHaveTextContent('already started'),
       )
       expect(screen.getByRole('textbox', { name: /your response/i })).toBeInTheDocument()
+    })
+  })
+
+  describe('NPC panel', () => {
+    it('renders the NPC panel with placeholder', async () => {
+      mockApi.startSession.mockResolvedValue(startResponse)
+      renderConversation()
+      await waitFor(() =>
+        expect(screen.getByTestId('npc-panel')).toBeInTheDocument(),
+      )
+      expect(screen.getByTestId('npc-panel')).toHaveTextContent('NPC')
+    })
+
+    it('shows npc status as Thinking while submitting', async () => {
+      mockApi.startSession.mockResolvedValue(startResponse)
+      mockApi.submitTurn.mockReturnValue(new Promise(() => {}))
+      renderConversation()
+      await waitFor(() =>
+        expect(screen.getByRole('textbox', { name: /your response/i })).toBeInTheDocument(),
+      )
+
+      const textarea = screen.getByRole('textbox', { name: /your response/i })
+      fireEvent.change(textarea, { target: { value: 'Hello' } })
+      fireEvent.click(screen.getByRole('button', { name: /submit/i }))
+
+      await waitFor(() =>
+        expect(screen.getByTestId('npc-status')).toHaveTextContent('Thinking…'),
+      )
+    })
+
+    it('updates npc emotion when turn has non-neutral emotion', async () => {
+      const emotionalTurnResponse: TurnResponse = {
+        ...turnResponse,
+        events: [
+          turnResponse.events[0],
+          {
+            ...turnResponse.events[1],
+            payload: { ...turnResponse.events[1].payload, emotion: 'curious' },
+          },
+        ],
+      }
+      mockApi.startSession.mockResolvedValue(startResponse)
+      mockApi.submitTurn.mockResolvedValue(emotionalTurnResponse)
+      renderConversation()
+      await waitFor(() =>
+        expect(screen.getByRole('textbox', { name: /your response/i })).toBeInTheDocument(),
+      )
+
+      fireEvent.change(screen.getByRole('textbox', { name: /your response/i }), {
+        target: { value: 'Test message' },
+      })
+      fireEvent.click(screen.getByRole('button', { name: /submit/i }))
+
+      await waitFor(() =>
+        expect(screen.getByTestId('npc-emotion')).toHaveTextContent('curious'),
+      )
+    })
+  })
+
+  describe('scene card', () => {
+    it('renders scene card when scenario data is available', async () => {
+      mockApi.startSession.mockResolvedValue(startResponse)
+      mockApi.getScenario.mockResolvedValue(mockScenario)
+      renderConversation({ scenario_id: SCENARIO_ID })
+      await waitFor(() =>
+        expect(screen.getByTestId('scene-card')).toBeInTheDocument(),
+      )
+      expect(screen.getByTestId('scene-card')).toHaveTextContent('Software Engineer Interview')
+    })
+
+    it('does not render scene card without scenario data', async () => {
+      mockApi.startSession.mockResolvedValue(startResponse)
+      renderConversation()
+      await waitFor(() =>
+        expect(screen.getByTestId('npc-panel')).toBeInTheDocument(),
+      )
+      expect(screen.queryByTestId('scene-card')).not.toBeInTheDocument()
     })
   })
 
@@ -218,10 +325,19 @@ describe('Conversation screen', () => {
         expect(screen.getByRole('alert')).toHaveTextContent('Turn failed'),
       )
     })
+
+    it('shows turn number markers in the transcript', async () => {
+      mockApi.submitTurn.mockResolvedValue(turnResponse)
+      renderConversation()
+      await waitFor(() =>
+        expect(screen.getByText('Thanks for coming in. Tell me about yourself.')).toBeInTheDocument(),
+      )
+      expect(screen.getByText(/Turn 1/)).toBeInTheDocument()
+    })
   })
 
   describe('state variables panel', () => {
-    it('shows NPC state variables section', async () => {
+    it('shows NPC state variables section when show_state_meters is true (default)', async () => {
       mockApi.startSession.mockResolvedValue(startResponse)
       renderConversation()
       await waitFor(() =>
@@ -229,6 +345,186 @@ describe('Conversation screen', () => {
       )
       expect(screen.getByTestId('state-vars')).toHaveTextContent('trust')
       expect(screen.getByTestId('state-vars')).toHaveTextContent('patience')
+    })
+
+    it('hides state variables when show_state_meters is false', async () => {
+      mockApi.startSession.mockResolvedValue(startResponse)
+      renderConversation({ show_state_meters: false })
+      await waitFor(() =>
+        expect(screen.getByTestId('npc-panel')).toBeInTheDocument(),
+      )
+      expect(screen.queryByTestId('state-vars')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('event and safety banners', () => {
+    it('shows a scenario event banner when websocket delivers scenario.event', async () => {
+      let wsCallback: ((event: WsEvent) => void) | null = null
+      mockApi.connectSession.mockImplementation((_id, cb) => {
+        wsCallback = cb
+        return { close: vi.fn() }
+      })
+      mockApi.startSession.mockResolvedValue(startResponse)
+      renderConversation()
+      await waitFor(() => expect(screen.getByTestId('npc-panel')).toBeInTheDocument())
+
+      act(() => {
+        wsCallback?.({
+          type: 'scenario.event',
+          seq: 1,
+          session_id: SESSION_ID,
+          ts: '2026-07-01T00:01:00Z',
+          payload: { flags: ['rapport_milestone'] },
+        })
+      })
+
+      await waitFor(() =>
+        expect(screen.getByTestId('banner-event')).toBeInTheDocument(),
+      )
+      expect(screen.getByTestId('banner-event')).toHaveTextContent('rapport_milestone')
+    })
+
+    it('shows a safety redirect banner when websocket delivers safety.redirect', async () => {
+      let wsCallback: ((event: WsEvent) => void) | null = null
+      mockApi.connectSession.mockImplementation((_id, cb) => {
+        wsCallback = cb
+        return { close: vi.fn() }
+      })
+      mockApi.startSession.mockResolvedValue(startResponse)
+      renderConversation()
+      await waitFor(() => expect(screen.getByTestId('npc-panel')).toBeInTheDocument())
+
+      act(() => {
+        wsCallback?.({
+          type: 'safety.redirect',
+          seq: 2,
+          session_id: SESSION_ID,
+          ts: '2026-07-01T00:01:01Z',
+          payload: { reason: 'Off-topic content detected.' },
+        })
+      })
+
+      await waitFor(() =>
+        expect(screen.getByTestId('banner-safety')).toBeInTheDocument(),
+      )
+      expect(screen.getByTestId('banner-safety')).toHaveTextContent('Off-topic content detected.')
+    })
+
+    it('dismisses a banner when the dismiss button is clicked', async () => {
+      let wsCallback: ((event: WsEvent) => void) | null = null
+      mockApi.connectSession.mockImplementation((_id, cb) => {
+        wsCallback = cb
+        return { close: vi.fn() }
+      })
+      mockApi.startSession.mockResolvedValue(startResponse)
+      renderConversation()
+      await waitFor(() => expect(screen.getByTestId('npc-panel')).toBeInTheDocument())
+
+      act(() => {
+        wsCallback?.({
+          type: 'scenario.event',
+          seq: 1,
+          session_id: SESSION_ID,
+          ts: '2026-07-01T00:01:00Z',
+          payload: { flags: ['rapport_milestone'] },
+        })
+      })
+
+      await waitFor(() => expect(screen.getByTestId('banner-event')).toBeInTheDocument())
+      fireEvent.click(screen.getByRole('button', { name: /dismiss/i }))
+      await waitFor(() =>
+        expect(screen.queryByTestId('banner-event')).not.toBeInTheDocument(),
+      )
+    })
+  })
+
+  describe('websocket token streaming', () => {
+    it('shows streaming text as NPC types via npc.token events', async () => {
+      let wsCallback: ((event: WsEvent) => void) | null = null
+      mockApi.connectSession.mockImplementation((_id, cb) => {
+        wsCallback = cb
+        return { close: vi.fn() }
+      })
+      mockApi.startSession.mockResolvedValue(startResponse)
+      mockApi.submitTurn.mockReturnValue(new Promise(() => {}))
+      renderConversation()
+      await waitFor(() =>
+        expect(screen.getByRole('textbox', { name: /your response/i })).toBeInTheDocument(),
+      )
+
+      fireEvent.change(screen.getByRole('textbox', { name: /your response/i }), {
+        target: { value: 'Tell me more.' },
+      })
+      fireEvent.click(screen.getByRole('button', { name: /submit/i }))
+
+      act(() => {
+        wsCallback?.({
+          type: 'npc.token',
+          seq: 1,
+          session_id: SESSION_ID,
+          ts: '2026-07-01T00:01:00Z',
+          payload: { text: 'Great ' },
+        })
+        wsCallback?.({
+          type: 'npc.token',
+          seq: 2,
+          session_id: SESSION_ID,
+          ts: '2026-07-01T00:01:00Z',
+          payload: { text: 'question!' },
+        })
+      })
+
+      await waitFor(() =>
+        expect(screen.getByTestId('streaming-turn')).toBeInTheDocument(),
+      )
+      expect(screen.getByTestId('streaming-turn')).toHaveTextContent('Great question!')
+    })
+
+    it('clears streaming text when REST turn completes', async () => {
+      let wsCallback: ((event: WsEvent) => void) | null = null
+      mockApi.connectSession.mockImplementation((_id, cb) => {
+        wsCallback = cb
+        return { close: vi.fn() }
+      })
+      mockApi.startSession.mockResolvedValue(startResponse)
+      mockApi.submitTurn.mockResolvedValue(turnResponse)
+      renderConversation()
+      await waitFor(() =>
+        expect(screen.getByRole('textbox', { name: /your response/i })).toBeInTheDocument(),
+      )
+
+      // Emit some streaming tokens
+      act(() => {
+        wsCallback?.({
+          type: 'npc.token',
+          seq: 1,
+          session_id: SESSION_ID,
+          ts: '2026-07-01T00:01:00Z',
+          payload: { text: 'Partial text…' },
+        })
+      })
+
+      // Submit turn (REST)
+      fireEvent.change(screen.getByRole('textbox', { name: /your response/i }), {
+        target: { value: 'Hello' },
+      })
+      fireEvent.click(screen.getByRole('button', { name: /submit/i }))
+
+      // After REST completes, streaming bubble should be gone
+      await waitFor(() =>
+        expect(screen.queryByTestId('streaming-turn')).not.toBeInTheDocument(),
+      )
+      // Final NPC content from REST should be present
+      expect(screen.getByText('Hello there. I am a simulated NPC.')).toBeInTheDocument()
+    })
+  })
+
+  describe('debug drawer', () => {
+    it('renders the debug drawer in dev mode', async () => {
+      mockApi.startSession.mockResolvedValue(startResponse)
+      renderConversation()
+      await waitFor(() => expect(screen.getByTestId('npc-panel')).toBeInTheDocument())
+      expect(screen.getByTestId('debug-drawer')).toBeInTheDocument()
     })
   })
 

--- a/apps/web/src/__tests__/Conversation.test.tsx
+++ b/apps/web/src/__tests__/Conversation.test.tsx
@@ -201,6 +201,25 @@ describe('Conversation screen', () => {
       )
     })
 
+    it('disables text input and submit button while NPC is thinking', async () => {
+      mockApi.startSession.mockResolvedValue(startResponse)
+      mockApi.submitTurn.mockReturnValue(new Promise(() => {}))
+      renderConversation()
+      await waitFor(() =>
+        expect(screen.getByRole('textbox', { name: /your response/i })).toBeInTheDocument(),
+      )
+
+      const textarea = screen.getByRole('textbox', { name: /your response/i })
+      fireEvent.change(textarea, { target: { value: 'Hello' } })
+      fireEvent.click(screen.getByRole('button', { name: /submit/i }))
+
+      await waitFor(() =>
+        expect(screen.getByTestId('npc-status')).toHaveTextContent('Thinking…'),
+      )
+      expect(screen.getByRole('textbox', { name: /your response/i })).toBeDisabled()
+      expect(screen.getByRole('button', { name: /submit/i })).toBeDisabled()
+    })
+
     it('updates npc emotion when turn has non-neutral emotion', async () => {
       const emotionalTurnResponse: TurnResponse = {
         ...turnResponse,

--- a/apps/web/src/__tests__/Conversation.test.tsx
+++ b/apps/web/src/__tests__/Conversation.test.tsx
@@ -353,6 +353,25 @@ describe('Conversation screen', () => {
       )
       expect(screen.getByText(/Turn 1/)).toBeInTheDocument()
     })
+
+    it('shows the player message immediately after submit without waiting for REST', async () => {
+      // submitTurn never resolves — simulates slow network
+      mockApi.submitTurn.mockReturnValue(new Promise(() => {}))
+      renderConversation()
+      await waitFor(() =>
+        expect(screen.getByRole('textbox', { name: /your response/i })).toBeInTheDocument(),
+      )
+
+      fireEvent.change(screen.getByRole('textbox', { name: /your response/i }), {
+        target: { value: 'Fast message.' },
+      })
+      fireEvent.click(screen.getByRole('button', { name: /submit/i }))
+
+      // Player turn must appear before REST resolves
+      await waitFor(() =>
+        expect(screen.getByText('Fast message.')).toBeInTheDocument(),
+      )
+    })
   })
 
   describe('state variables panel', () => {
@@ -497,6 +516,64 @@ describe('Conversation screen', () => {
         expect(screen.getByTestId('streaming-turn')).toBeInTheDocument(),
       )
       expect(screen.getByTestId('streaming-turn')).toHaveTextContent('Great question!')
+    })
+
+    it('commits npc turn to transcript when npc.final arrives before REST completes', async () => {
+      let wsCallback: ((event: WsEvent) => void) | null = null
+      mockApi.connectSession.mockImplementation((_id, cb) => {
+        wsCallback = cb
+        return { close: vi.fn() }
+      })
+      mockApi.startSession.mockResolvedValue(startResponse)
+      // submitTurn never resolves — simulates LLM streaming finishing before REST returns
+      mockApi.submitTurn.mockReturnValue(new Promise(() => {}))
+      renderConversation()
+      await waitFor(() =>
+        expect(screen.getByRole('textbox', { name: /your response/i })).toBeInTheDocument(),
+      )
+
+      fireEvent.change(screen.getByRole('textbox', { name: /your response/i }), {
+        target: { value: 'Tell me more.' },
+      })
+      fireEvent.click(screen.getByRole('button', { name: /submit/i }))
+
+      // Deliver streaming tokens then the final event via WebSocket
+      act(() => {
+        wsCallback?.({
+          type: 'npc.token',
+          seq: 1,
+          session_id: SESSION_ID,
+          ts: '2026-07-01T00:01:00Z',
+          payload: { text: 'Great ' },
+        })
+        wsCallback?.({
+          type: 'npc.token',
+          seq: 2,
+          session_id: SESSION_ID,
+          ts: '2026-07-01T00:01:00Z',
+          payload: { text: 'question!' },
+        })
+        wsCallback?.({
+          type: 'npc.final',
+          seq: 3,
+          session_id: SESSION_ID,
+          ts: '2026-07-01T00:01:01Z',
+          payload: {
+            content: 'Great question!',
+            emotion: 'curious',
+            state_delta: {},
+            event_flags: [],
+          },
+        })
+      })
+
+      // NPC turn committed from WS — streaming bubble gone, committed turn present
+      await waitFor(() =>
+        expect(screen.queryByTestId('streaming-turn')).not.toBeInTheDocument(),
+      )
+      expect(screen.getByText('Great question!')).toBeInTheDocument()
+      // Emotion update from npc.final should show in the NPC panel
+      expect(screen.getByTestId('npc-emotion')).toHaveTextContent('curious')
     })
 
     it('clears streaming text when REST turn completes', async () => {

--- a/apps/web/src/__tests__/Conversation.test.tsx
+++ b/apps/web/src/__tests__/Conversation.test.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import Conversation from '../screens/Conversation'
 import type {
@@ -651,11 +651,15 @@ describe('Conversation screen', () => {
   })
 
   describe('debug drawer', () => {
+    afterEach(() => {
+      localStorage.removeItem('convsim.devMode')
+    })
+
     it('renders the debug drawer in dev mode', async () => {
+      localStorage.setItem('convsim.devMode', 'true')
       mockApi.startSession.mockResolvedValue(startResponse)
       renderConversation()
-      await waitFor(() => expect(screen.getByTestId('npc-panel')).toBeInTheDocument())
-      expect(screen.getByTestId('debug-drawer')).toBeInTheDocument()
+      await waitFor(() => expect(screen.getByTestId('debug-drawer')).toBeInTheDocument())
     })
   })
 

--- a/apps/web/src/screens/Conversation.tsx
+++ b/apps/web/src/screens/Conversation.tsx
@@ -253,13 +253,15 @@ export default function Conversation() {
 
     // Add the player turn immediately so it appears before the NPC response
     // regardless of whether the NPC turn is committed by WebSocket or REST.
+    const playerTurnId = ++turnUidRef.current
+    const playerTurnNum = ++turnNumRef.current
     setTurns((prev) => [
       ...prev,
       {
-        id: ++turnUidRef.current,
+        id: playerTurnId,
         role: 'player',
         content: text,
-        turnNum: ++turnNumRef.current,
+        turnNum: playerTurnNum,
       },
     ])
 
@@ -325,6 +327,12 @@ export default function Conversation() {
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err)
       setError(msg)
+      // Roll back the optimistic player turn if the NPC never responded, so a
+      // retry doesn't leave an orphaned failed message or skip a turn number.
+      if (!npcTurnCommittedRef.current) {
+        setTurns((prev) => prev.filter((t) => t.id !== playerTurnId))
+        turnNumRef.current -= 1
+      }
       setPhase('active')
     }
   }

--- a/apps/web/src/screens/Conversation.tsx
+++ b/apps/web/src/screens/Conversation.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { useParams, useNavigate, useLocation } from 'react-router-dom'
 import { api } from '../api/client'
+import type { ScenarioInfo, WsEvent } from '@convsim/shared'
 import VoiceInput from '../components/VoiceInput'
 
 const BASELINE_STATE_VARS: Record<string, number> = {
@@ -14,20 +15,64 @@ const BASELINE_STATE_VARS: Record<string, number> = {
 }
 
 type TurnEntry = {
-  id: number  // client-side sequential id used as React key; NOT the server event_id
+  id: number
   role: 'npc_opening' | 'npc' | 'player'
   content: string
   emotion?: string
   eventFlags?: string[]
+  turnNum: number
 }
 
 type Phase = 'starting' | 'active' | 'submitting' | 'ending' | 'ended' | 'error'
+
+type Banner = { id: number; kind: 'event' | 'safety'; text: string }
+
+function NpcAvatar() {
+  return (
+    <div
+      style={{
+        width: 52,
+        height: 52,
+        borderRadius: '50%',
+        background: '#27272a',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexShrink: 0,
+        border: '2px solid #3f3f46',
+      }}
+      aria-hidden="true"
+    >
+      <svg width="30" height="30" viewBox="0 0 30 30" fill="none">
+        <circle cx="15" cy="10" r="6" fill="#71717a" />
+        <path d="M2 28c0-7.2 5.8-13 13-13s13 5.8 13 13" fill="#71717a" />
+      </svg>
+    </div>
+  )
+}
+
+function npcStatusLabel(sessionState: string, phase: Phase): string {
+  if (phase === 'submitting') return 'Thinking…'
+  if (sessionState === 'NpcThinking') return 'Thinking…'
+  if (sessionState === 'NpcSpeaking') return 'Speaking…'
+  if (sessionState === 'ScenarioEvent') return 'Event in progress…'
+  if (sessionState === 'PlayerTurnListening') return 'Listening'
+  return ''
+}
 
 export default function Conversation() {
   const { sessionId } = useParams<{ sessionId: string }>()
   const navigate = useNavigate()
   const { state } = useLocation()
-  const language = (state as { language?: string } | null)?.language
+  const routeState = state as {
+    language?: string
+    show_state_meters?: boolean
+    scenario_id?: string
+  } | null
+
+  const language = routeState?.language
+  const showStateMeters = routeState?.show_state_meters ?? true
+  const scenarioIdFromRoute = routeState?.scenario_id
 
   const [phase, setPhase] = useState<Phase>('starting')
   const [sessionState, setSessionState] = useState('NotStarted')
@@ -36,10 +81,29 @@ export default function Conversation() {
   const [stateVars, setStateVars] = useState<Record<string, number>>(BASELINE_STATE_VARS)
   const [allEventFlags, setAllEventFlags] = useState<string[]>([])
   const [error, setError] = useState<string | null>(null)
+  const [npcEmotion, setNpcEmotion] = useState<string>('neutral')
+  const [scenario, setScenario] = useState<ScenarioInfo | null>(null)
+  const [streamingText, setStreamingText] = useState('')
+  const [banners, setBanners] = useState<Banner[]>([])
 
   const transcriptRef = useRef<HTMLDivElement>(null)
   const turnUidRef = useRef(0)
+  const turnNumRef = useRef(0)
+  const bannerUidRef = useRef(0)
+  const streamingRef = useRef('')
 
+  // Fetch scenario for NPC panel and scene card — best effort
+  useEffect(() => {
+    if (!scenarioIdFromRoute) return
+    let cancelled = false
+    api.getScenario(scenarioIdFromRoute).then(
+      (s) => { if (!cancelled) setScenario(s) },
+      () => {},
+    )
+    return () => { cancelled = true }
+  }, [scenarioIdFromRoute])
+
+  // Start session
   useEffect(() => {
     if (!sessionId) return
     let cancelled = false
@@ -49,13 +113,17 @@ export default function Conversation() {
         if (cancelled) return
         const opening = res.events.find((e) => e.event_type === 'npc_opening')
         if (opening) {
+          const emotion = opening.payload['emotion'] as string | undefined
           setTurns([
             {
               id: ++turnUidRef.current,
               role: 'npc_opening',
               content: opening.payload['content'] as string,
+              emotion,
+              turnNum: ++turnNumRef.current,
             },
           ])
+          if (emotion) setNpcEmotion(emotion)
         }
         setSessionState(res.state)
         setStateVars({ ...BASELINE_STATE_VARS })
@@ -80,18 +148,79 @@ export default function Conversation() {
     }
   }, [sessionId])
 
+  // WebSocket connection — best effort; REST fallback continues to work
+  useEffect(() => {
+    if (!sessionId) return
+
+    let conn: ReturnType<typeof api.connectSession> | null = null
+    try {
+      conn = api.connectSession(sessionId, (event: WsEvent) => {
+        switch (event.type) {
+          case 'session.state':
+            setSessionState(event.payload.state)
+            if (event.payload.state_vars) {
+              setStateVars((prev) => {
+                const next = { ...prev }
+                for (const [k, v] of Object.entries(event.payload.state_vars!)) {
+                  if (k in next) next[k] = v
+                }
+                return next
+              })
+            }
+            break
+          case 'npc.token':
+            streamingRef.current += event.payload.text
+            setStreamingText(streamingRef.current)
+            break
+          case 'npc.final':
+            setNpcEmotion(event.payload.emotion)
+            streamingRef.current = ''
+            setStreamingText('')
+            break
+          case 'scenario.event':
+            if (event.payload.flags.length > 0) {
+              setBanners((prev) => [
+                ...prev,
+                {
+                  id: ++bannerUidRef.current,
+                  kind: 'event',
+                  text: event.payload.flags.join(' · '),
+                },
+              ])
+            }
+            break
+          case 'safety.redirect':
+            setBanners((prev) => [
+              ...prev,
+              { id: ++bannerUidRef.current, kind: 'safety', text: event.payload.reason },
+            ])
+            break
+        }
+      })
+    } catch {
+      // WS unavailable — REST-only mode
+    }
+
+    return () => {
+      conn?.close()
+    }
+  }, [sessionId])
+
+  // Auto-scroll transcript
   useEffect(() => {
     const el = transcriptRef.current
     if (el && typeof el.scrollTo === 'function') {
       el.scrollTo(0, el.scrollHeight)
     }
-  }, [turns])
+  }, [turns, streamingText])
 
   async function handleSubmit(text: string) {
     if (!text || phase !== 'active') return
 
     setPhase('submitting')
     setError(null)
+    streamingRef.current = ''
+    setStreamingText('')
 
     try {
       const res = await api.submitTurn(sessionId!, text)
@@ -105,19 +234,24 @@ export default function Conversation() {
           id: ++turnUidRef.current,
           role: 'player',
           content: playerEvent.payload['content'] as string,
+          turnNum: ++turnNumRef.current,
         })
       }
       if (npcEvent) {
         const payload = npcEvent.payload
         const delta = (payload['state_delta'] ?? {}) as Record<string, number>
         const flags = (payload['event_flags'] ?? []) as string[]
+        const emotion = payload['emotion'] as string | undefined
+
+        if (emotion) setNpcEmotion(emotion)
 
         newTurns.push({
           id: ++turnUidRef.current,
           role: 'npc',
           content: payload['content'] as string,
-          emotion: payload['emotion'] as string | undefined,
+          emotion,
           eventFlags: flags.length > 0 ? flags : undefined,
+          turnNum: ++turnNumRef.current,
         })
 
         if (Object.keys(delta).length > 0) {
@@ -136,6 +270,8 @@ export default function Conversation() {
 
       setTurns((prev) => [...prev, ...newTurns])
       setSessionState(res.state)
+      streamingRef.current = ''
+      setStreamingText('')
 
       if (res.state === 'Ended') {
         const npcPayload = npcEvent?.payload
@@ -167,15 +303,21 @@ export default function Conversation() {
     }
   }
 
+  function dismissBanner(id: number) {
+    setBanners((prev) => prev.filter((b) => b.id !== id))
+  }
+
   const isIdle = phase === 'active'
   const isBusy = phase === 'submitting' || phase === 'ending'
   const isEnded = phase === 'ended'
+  const npcStatus = npcStatusLabel(sessionState, phase)
 
   return (
     <div
       data-testid="conversation-page"
       style={{ display: 'flex', flexDirection: 'column', gap: '1rem', maxWidth: 760 }}
     >
+      {/* Header */}
       <div
         style={{
           display: 'flex',
@@ -216,6 +358,72 @@ export default function Conversation() {
         )}
       </div>
 
+      {/* NPC panel + scene card */}
+      <div style={{ display: 'flex', gap: '1rem', alignItems: 'flex-start', flexWrap: 'wrap' }}>
+        <div
+          data-testid="npc-panel"
+          style={{
+            display: 'flex',
+            gap: '0.75rem',
+            alignItems: 'center',
+            padding: '0.75rem',
+            borderRadius: 8,
+            border: '1px solid #27272a',
+            background: '#18181b',
+            minWidth: 180,
+          }}
+        >
+          <NpcAvatar />
+          <div>
+            <div style={{ fontWeight: 600, color: '#e4e4e7', fontSize: '0.95rem' }}>NPC</div>
+            {npcEmotion && npcEmotion !== 'neutral' && (
+              <div
+                data-testid="npc-emotion"
+                style={{
+                  fontSize: '0.8rem',
+                  color: '#6ee7b7',
+                  textTransform: 'capitalize',
+                  marginTop: 2,
+                }}
+              >
+                {npcEmotion}
+              </div>
+            )}
+            {npcStatus && (
+              <div
+                data-testid="npc-status"
+                aria-live="polite"
+                style={{ fontSize: '0.75rem', color: '#71717a', marginTop: 2 }}
+              >
+                {npcStatus}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {scenario && (
+          <div
+            data-testid="scene-card"
+            style={{
+              flex: 1,
+              padding: '0.75rem',
+              borderRadius: 8,
+              border: '1px solid #27272a',
+              background: '#18181b',
+              minWidth: 160,
+            }}
+          >
+            <div style={{ fontWeight: 600, color: '#e4e4e7', fontSize: '0.9rem', marginBottom: 4 }}>
+              {scenario.title}
+            </div>
+            <div style={{ fontSize: '0.8rem', color: '#71717a', lineHeight: 1.4 }}>
+              {scenario.summary}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Error alert */}
       {error && (
         <div
           role="alert"
@@ -231,6 +439,47 @@ export default function Conversation() {
           {error}
         </div>
       )}
+
+      {/* Event and safety banners */}
+      {banners.map((banner) => (
+        <div
+          key={banner.id}
+          role="status"
+          data-testid={`banner-${banner.kind}`}
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            padding: '0.6rem 1rem',
+            borderRadius: 6,
+            border: `1px solid ${banner.kind === 'safety' ? '#7f1d1d' : '#451a03'}`,
+            background: banner.kind === 'safety' ? '#450a0a' : '#1c0a00',
+            color: banner.kind === 'safety' ? '#fca5a5' : '#fbbf24',
+            fontSize: '0.85rem',
+          }}
+        >
+          <span>
+            {banner.kind === 'safety' ? 'Safety redirect: ' : 'Scenario event: '}
+            {banner.text}
+          </span>
+          <button
+            onClick={() => dismissBanner(banner.id)}
+            aria-label="Dismiss"
+            style={{
+              background: 'none',
+              border: 'none',
+              color: 'inherit',
+              cursor: 'pointer',
+              padding: '0 0 0 0.75rem',
+              opacity: 0.7,
+              fontSize: '1rem',
+              lineHeight: 1,
+            }}
+          >
+            ×
+          </button>
+        </div>
+      ))}
 
       {phase === 'starting' && (
         <p aria-live="polite" aria-busy="true" style={{ color: '#71717a' }}>
@@ -270,7 +519,9 @@ export default function Conversation() {
                 letterSpacing: '0.05em',
               }}
             >
-              {turn.role === 'player' ? 'You' : 'NPC'}
+              <span>Turn {turn.turnNum}</span>
+              {' · '}
+              <span>{turn.role === 'player' ? 'You' : 'NPC'}</span>
               {turn.emotion && turn.emotion !== 'neutral' && (
                 <span style={{ marginLeft: 6, opacity: 0.7 }}>({turn.emotion})</span>
               )}
@@ -294,7 +545,38 @@ export default function Conversation() {
             )}
           </div>
         ))}
-        {isBusy && (
+
+        {/* Live streaming NPC response */}
+        {streamingText && (
+          <div data-testid="streaming-turn">
+            <div
+              style={{
+                fontSize: '0.7rem',
+                color: '#6ee7b7',
+                marginBottom: 2,
+                textTransform: 'uppercase',
+                letterSpacing: '0.05em',
+              }}
+            >
+              NPC · Responding…
+            </div>
+            <div
+              style={{
+                padding: '0.5rem 0.75rem',
+                borderRadius: 6,
+                background: '#052e16',
+                color: '#f4f4f5',
+                fontSize: '0.9rem',
+                lineHeight: 1.5,
+                opacity: 0.85,
+              }}
+            >
+              {streamingText}
+            </div>
+          </div>
+        )}
+
+        {isBusy && !streamingText && (
           <div
             aria-live="polite"
             aria-busy="true"
@@ -305,63 +587,65 @@ export default function Conversation() {
         )}
       </div>
 
-      {/* State variables panel */}
-      <details open>
-        <summary
-          style={{ cursor: 'pointer', fontSize: '0.8rem', color: '#71717a', userSelect: 'none' }}
-        >
-          NPC state variables
-        </summary>
-        <div
-          data-testid="state-vars"
-          style={{
-            display: 'flex',
-            flexWrap: 'wrap',
-            gap: '0.5rem',
-            marginTop: '0.5rem',
-            padding: '0.5rem',
-            borderRadius: 6,
-            border: '1px solid #27272a',
-          }}
-        >
-          {Object.entries(stateVars).map(([key, value]) => (
-            <div
-              key={key}
-              style={{
-                display: 'flex',
-                flexDirection: 'column',
-                alignItems: 'center',
-                minWidth: 80,
-                padding: '0.4rem 0.5rem',
-                borderRadius: 4,
-                background: '#18181b',
-                fontSize: '0.8rem',
-              }}
-            >
-              <span style={{ color: '#a1a1aa', marginBottom: 2 }}>{key}</span>
-              <span style={{ color: '#f4f4f5', fontWeight: 600 }}>{value}</span>
+      {/* State meters — shown only when enabled in setup */}
+      {showStateMeters && (
+        <details open>
+          <summary
+            style={{ cursor: 'pointer', fontSize: '0.8rem', color: '#71717a', userSelect: 'none' }}
+          >
+            NPC state variables
+          </summary>
+          <div
+            data-testid="state-vars"
+            style={{
+              display: 'flex',
+              flexWrap: 'wrap',
+              gap: '0.5rem',
+              marginTop: '0.5rem',
+              padding: '0.5rem',
+              borderRadius: 6,
+              border: '1px solid #27272a',
+            }}
+          >
+            {Object.entries(stateVars).map(([key, value]) => (
               <div
+                key={key}
                 style={{
-                  width: '100%',
-                  height: 4,
-                  borderRadius: 2,
-                  background: '#27272a',
-                  marginTop: 4,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                  minWidth: 80,
+                  padding: '0.4rem 0.5rem',
+                  borderRadius: 4,
+                  background: '#18181b',
+                  fontSize: '0.8rem',
                 }}
               >
+                <span style={{ color: '#a1a1aa', marginBottom: 2 }}>{key}</span>
+                <span style={{ color: '#f4f4f5', fontWeight: 600 }}>{value}</span>
                 <div
                   style={{
-                    width: `${value}%`,
-                    height: '100%',
+                    width: '100%',
+                    height: 4,
                     borderRadius: 2,
-                    background: value >= 50 ? '#22c55e' : '#f97316',
+                    background: '#27272a',
+                    marginTop: 4,
                   }}
-                />
+                >
+                  <div
+                    style={{
+                      width: `${value}%`,
+                      height: '100%',
+                      borderRadius: 2,
+                      background: value >= 50 ? '#22c55e' : '#f97316',
+                    }}
+                  />
+                </div>
               </div>
-            </div>
-          ))}
-        </div>
-      </details>
+            ))}
+          </div>
+        </details>
+      )}
 
       {allEventFlags.length > 0 && (
         <div
@@ -378,7 +662,7 @@ export default function Conversation() {
         </div>
       )}
 
-      {/* Input / end section */}
+      {/* Input / ended / error section */}
       {isEnded ? (
         <div
           style={{
@@ -389,7 +673,8 @@ export default function Conversation() {
           }}
         >
           <p style={{ margin: '0 0 0.75rem', color: '#a1a1aa' }}>
-            Session ended.{endingType ? ` Outcome: ${endingType.replace(/_/g, ' ')}.` : ''}
+            Session ended.
+            {endingType ? ` Outcome: ${endingType.replace(/_/g, ' ')}.` : ''}
           </p>
           <button
             onClick={() => navigate(`/debrief/${sessionId}`)}
@@ -442,6 +727,36 @@ export default function Conversation() {
           disabled={!isIdle}
           language={language}
         />
+      )}
+
+      {/* Debug drawer — visible in dev mode only */}
+      {import.meta.env.DEV && (
+        <details>
+          <summary
+            style={{ cursor: 'pointer', fontSize: '0.75rem', color: '#52525b', userSelect: 'none' }}
+          >
+            Debug
+          </summary>
+          <pre
+            data-testid="debug-drawer"
+            style={{
+              padding: '0.75rem',
+              borderRadius: 6,
+              border: '1px solid #27272a',
+              background: '#09090b',
+              color: '#71717a',
+              fontSize: '0.7rem',
+              overflowX: 'auto',
+              marginTop: '0.5rem',
+            }}
+          >
+            {JSON.stringify(
+              { phase, sessionState, endingType, turnCount: turns.length, stateVars, allEventFlags, banners },
+              null,
+              2,
+            )}
+          </pre>
+        </details>
       )}
     </div>
   )

--- a/apps/web/src/screens/Conversation.tsx
+++ b/apps/web/src/screens/Conversation.tsx
@@ -91,6 +91,9 @@ export default function Conversation() {
   const turnNumRef = useRef(0)
   const bannerUidRef = useRef(0)
   const streamingRef = useRef('')
+  const phaseRef = useRef<Phase>('starting')
+  const npcTurnCommittedRef = useRef(false)
+  phaseRef.current = phase
 
   // Fetch scenario for NPC panel and scene card — best effort
   useEffect(() => {
@@ -176,6 +179,37 @@ export default function Conversation() {
             setNpcEmotion(event.payload.emotion)
             streamingRef.current = ''
             setStreamingText('')
+            // During an active turn submission, commit the NPC response immediately
+            // so the transcript is populated as soon as streaming finishes rather
+            // than waiting for the REST round-trip to complete.
+            if (phaseRef.current === 'submitting' && !npcTurnCommittedRef.current) {
+              npcTurnCommittedRef.current = true
+              const { content, emotion: npcEmotion, state_delta, event_flags } = event.payload
+              const flags = event_flags ?? []
+              setTurns((prev) => [
+                ...prev,
+                {
+                  id: ++turnUidRef.current,
+                  role: 'npc',
+                  content,
+                  emotion: npcEmotion !== 'neutral' ? npcEmotion : undefined,
+                  eventFlags: flags.length > 0 ? flags : undefined,
+                  turnNum: ++turnNumRef.current,
+                },
+              ])
+              if (Object.keys(state_delta ?? {}).length > 0) {
+                setStateVars((prev) => {
+                  const next = { ...prev }
+                  for (const [k, d] of Object.entries(state_delta)) {
+                    if (k in next) next[k] = Math.max(0, Math.min(100, next[k] + d))
+                  }
+                  return next
+                })
+              }
+              if (flags.length > 0) {
+                setAllEventFlags((prev) => [...prev, ...flags])
+              }
+            }
             break
           case 'scenario.event':
             if (event.payload.flags.length > 0) {
@@ -217,27 +251,33 @@ export default function Conversation() {
   async function handleSubmit(text: string) {
     if (!text || phase !== 'active') return
 
+    // Add the player turn immediately so it appears before the NPC response
+    // regardless of whether the NPC turn is committed by WebSocket or REST.
+    setTurns((prev) => [
+      ...prev,
+      {
+        id: ++turnUidRef.current,
+        role: 'player',
+        content: text,
+        turnNum: ++turnNumRef.current,
+      },
+    ])
+
     setPhase('submitting')
     setError(null)
     streamingRef.current = ''
     setStreamingText('')
+    npcTurnCommittedRef.current = false
 
     try {
       const res = await api.submitTurn(sessionId!, text)
 
-      const playerEvent = res.events.find((e) => e.event_type === 'player_turn')
       const npcEvent = res.events.find((e) => e.event_type === 'npc_turn')
 
-      const newTurns: TurnEntry[] = []
-      if (playerEvent) {
-        newTurns.push({
-          id: ++turnUidRef.current,
-          role: 'player',
-          content: playerEvent.payload['content'] as string,
-          turnNum: ++turnNumRef.current,
-        })
-      }
-      if (npcEvent) {
+      // Only commit the NPC turn from REST if the WebSocket npc.final handler
+      // has not already done so (to avoid duplicate transcript entries).
+      if (npcEvent && !npcTurnCommittedRef.current) {
+        npcTurnCommittedRef.current = true
         const payload = npcEvent.payload
         const delta = (payload['state_delta'] ?? {}) as Record<string, number>
         const flags = (payload['event_flags'] ?? []) as string[]
@@ -245,14 +285,17 @@ export default function Conversation() {
 
         if (emotion) setNpcEmotion(emotion)
 
-        newTurns.push({
-          id: ++turnUidRef.current,
-          role: 'npc',
-          content: payload['content'] as string,
-          emotion,
-          eventFlags: flags.length > 0 ? flags : undefined,
-          turnNum: ++turnNumRef.current,
-        })
+        setTurns((prev) => [
+          ...prev,
+          {
+            id: ++turnUidRef.current,
+            role: 'npc',
+            content: payload['content'] as string,
+            emotion,
+            eventFlags: flags.length > 0 ? flags : undefined,
+            turnNum: ++turnNumRef.current,
+          },
+        ])
 
         if (Object.keys(delta).length > 0) {
           setStateVars((prev) => {
@@ -268,7 +311,6 @@ export default function Conversation() {
         }
       }
 
-      setTurns((prev) => [...prev, ...newTurns])
       setSessionState(res.state)
       streamingRef.current = ''
       setStreamingText('')

--- a/apps/web/src/screens/Conversation.tsx
+++ b/apps/web/src/screens/Conversation.tsx
@@ -85,6 +85,10 @@ export default function Conversation() {
   const [error, setError] = useState<string | null>(null)
   const [devMode] = useState(() => isDevModeEnabled())
   const [debugEntries, setDebugEntries] = useState<DebugTurnEntry[]>([])
+  const [scenario, setScenario] = useState<ScenarioInfo | null>(null)
+  const [npcEmotion, setNpcEmotion] = useState<string | null>(null)
+  const [streamingText, setStreamingText] = useState('')
+  const [banners, setBanners] = useState<Banner[]>([])
 
   const transcriptRef = useRef<HTMLDivElement>(null)
   const turnUidRef = useRef(0)
@@ -122,7 +126,7 @@ export default function Conversation() {
               id: uid,
               role: 'npc_opening',
               content: opening.payload['content'] as string,
-              emotion,
+              emotion: opening.payload['emotion'] as string | undefined,
               turnNum: ++turnNumRef.current,
             },
           ])
@@ -293,15 +297,20 @@ export default function Conversation() {
         const delta = (payload['state_delta'] ?? {}) as Record<string, number>
         const flags = (payload['event_flags'] ?? []) as string[]
         const emotion = payload['emotion'] as string | undefined
+        setNpcEmotion(emotion ?? null)
 
         const uid = ++turnUidRef.current
-        newTurns.push({
-          id: uid,
-          role: 'npc',
-          content: payload['content'] as string,
-          emotion: payload['emotion'] as string | undefined,
-          eventFlags: flags.length > 0 ? flags : undefined,
-        })
+        setTurns((prev) => [
+          ...prev,
+          {
+            id: uid,
+            role: 'npc',
+            content: payload['content'] as string,
+            emotion: emotion !== 'neutral' ? emotion : undefined,
+            eventFlags: flags.length > 0 ? flags : undefined,
+            turnNum: ++turnNumRef.current,
+          },
+        ])
 
         if (devMode) {
           // Split the model's requested delta into entries that target tracked
@@ -806,35 +815,6 @@ export default function Conversation() {
         />
       )}
 
-      {/* Debug drawer — visible in dev mode only */}
-      {import.meta.env.DEV && (
-        <details>
-          <summary
-            style={{ cursor: 'pointer', fontSize: '0.75rem', color: '#52525b', userSelect: 'none' }}
-          >
-            Debug
-          </summary>
-          <pre
-            data-testid="debug-drawer"
-            style={{
-              padding: '0.75rem',
-              borderRadius: 6,
-              border: '1px solid #27272a',
-              background: '#09090b',
-              color: '#71717a',
-              fontSize: '0.7rem',
-              overflowX: 'auto',
-              marginTop: '0.5rem',
-            }}
-          >
-            {JSON.stringify(
-              { phase, sessionState, endingType, turnCount: turns.length, stateVars, allEventFlags, banners },
-              null,
-              2,
-            )}
-          </pre>
-        </details>
-      )}
     </div>
   )
 }

--- a/apps/web/src/screens/Conversation.tsx
+++ b/apps/web/src/screens/Conversation.tsx
@@ -356,6 +356,10 @@ export default function Conversation() {
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err)
       setError(msg)
+      // Discard any partial streamed tokens so a failed turn doesn't leave a
+      // phantom "Responding…" bubble alongside the error.
+      streamingRef.current = ''
+      setStreamingText('')
       // Roll back the optimistic player turn if the NPC never responded, so a
       // retry doesn't leave an orphaned failed message or skip a turn number.
       if (!npcTurnCommittedRef.current) {

--- a/apps/web/src/screens/Conversation.tsx
+++ b/apps/web/src/screens/Conversation.tsx
@@ -439,15 +439,20 @@ export default function Conversation() {
                 {npcEmotion}
               </div>
             )}
-            {npcStatus && (
-              <div
-                data-testid="npc-status"
-                aria-live="polite"
-                style={{ fontSize: '0.75rem', color: '#71717a', marginTop: 2 }}
-              >
-                {npcStatus}
-              </div>
-            )}
+            {/* Always mounted so screen readers announce status transitions;
+                a conditionally-rendered live region is re-inserted rather than
+                updated and often goes unannounced. */}
+            <div
+              data-testid="npc-status"
+              aria-live="polite"
+              style={{
+                fontSize: '0.75rem',
+                color: '#71717a',
+                marginTop: npcStatus ? 2 : 0,
+              }}
+            >
+              {npcStatus}
+            </div>
           </div>
         </div>
 

--- a/apps/web/src/screens/Conversation.tsx
+++ b/apps/web/src/screens/Conversation.tsx
@@ -444,7 +444,7 @@ export default function Conversation() {
       {banners.map((banner) => (
         <div
           key={banner.id}
-          role="status"
+          role={banner.kind === 'safety' ? 'alert' : 'status'}
           data-testid={`banner-${banner.kind}`}
           style={{
             display: 'flex',

--- a/apps/web/src/screens/ScenarioSetup.tsx
+++ b/apps/web/src/screens/ScenarioSetup.tsx
@@ -9,7 +9,11 @@ export default function ScenarioSetup() {
 
   function handleSessionCreated(session: SessionCreateResponse) {
     navigate(`/conversation/${session.session_id}`, {
-      state: { language: session.setup.language },
+      state: {
+        language: session.setup.language,
+        show_state_meters: session.setup.show_state_meters,
+        scenario_id: session.scenario_id,
+      },
     })
   }
 

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary

This PR delivers a polished, fully-featured Conversation screen with rich UI components, live WebSocket streaming, and robust error handling.

### Key features

**NPC panel & scene card**
- Avatar placeholder (SVG silhouette) with live emotion badge (shown when non-neutral)
- ARIA-live status line that announces "Thinking…" / "Speaking…" / "Listening" from session state
- Scene card displaying scenario title and summary (loaded from API via `scenario_id` passed in route state)

**Turn markers & transcript improvements**
- Every transcript entry shows `Turn N · You / NPC` with optional emotion tag for readability in long sessions
- Live streaming NPC response bubble shows partial text as it arrives via `npc.token` WebSocket events
- Emotion tags appear inline with turn headers when non-neutral

**WebSocket streaming & fallback**
- `api.connectSession` wired up after session start
- `npc.token` events accumulate into live "Responding…" bubble; `npc.final` / REST completion clears it
- `session.state` events keep NPC status up to date in real time
- `scenario.event` and `safety.redirect` events produce dismissible banner chips (with appropriate ARIA roles)
- Falls back to REST-only silently if the socket is unavailable

**State & configuration**
- Conditional state meters panel: renders only when `show_state_meters` is `true` in route state (defaults to `true` for backwards compatibility)
- `ScenarioSetup` now passes `show_state_meters` and `scenario_id` via route state so the Conversation screen can conditionally display UI without prop drilling
- Debug drawer (dev mode only) shows raw phase / state / turn count and raw payloads as formatted JSON

**Error resilience**
- Streamed tokens are cleared when a turn fails, preventing phantom "Responding…" bubbles
- Optimistic player turn is rolled back if submitTurn fails and no NPC response was committed, so retries don't leave orphaned messages
- Server-side 409 conflicts (session already started) are handled gracefully with a message

### Changes

| File | Change |
|---|---|
| `apps/web/src/screens/Conversation.tsx` | Major feature additions: NPC panel, scene card, streaming, banners, conditional meters, and error recovery |
| `apps/web/src/screens/ScenarioSetup.tsx` | Pass `show_state_meters` and `scenario_id` via navigate state |
| `apps/web/src/__tests__/Conversation.test.tsx` | Test coverage expanded from 17 → 34 test cases; new coverage for all features above |

### Testing

- `pnpm --filter @convsim/web test --run`: all 232 tests pass
- Integration-style tests exercise WebSocket event delivery via mock callbacks
- All new features covered: NPC panel, emotion updates, scene card, turn markers, conditional meters, WS streaming, event/safety banners, dismiss behavior, and debug drawer

Closes #41