### PR TITLE
Add model manager first-run wizard for recommended install, Ollama, GGUF, and text-only demo

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -9,6 +9,7 @@ import Conversation from './screens/Conversation'
 import Debrief from './screens/Debrief'
 import CreatorWorkbench from './screens/CreatorWorkbench'
 import Settings from './screens/Settings'
+import ModelManager from './screens/ModelManager'
 
 export default function App() {
   return (
@@ -22,6 +23,7 @@ export default function App() {
           <Route path="/debrief/:sessionId" element={<Debrief />} />
           <Route path="/workbench" element={<CreatorWorkbench />} />
           <Route path="/settings" element={<Settings />} />
+          <Route path="/model-manager" element={<ModelManager />} />
         </Route>
       </Routes>
     </ErrorBoundary>

--- a/apps/web/src/__tests__/Home.test.tsx
+++ b/apps/web/src/__tests__/Home.test.tsx
@@ -150,6 +150,22 @@ describe('Home — no-model state', () => {
   })
 })
 
+describe('Home — no-model links lead to model manager', () => {
+  it('GGUF model link goes to /model-manager', async () => {
+    stubFetches(makeHealth(), makePacks(0))
+    renderHome()
+    const link = await screen.findByRole('link', { name: /install a gguf model/i })
+    expect(link).toHaveAttribute('href', '/model-manager')
+  })
+
+  it('Ollama link goes to /model-manager', async () => {
+    stubFetches(makeHealth(), makePacks(0))
+    renderHome()
+    const link = await screen.findByRole('link', { name: /connect ollama/i })
+    expect(link).toHaveAttribute('href', '/model-manager')
+  })
+})
+
 describe('Home — no-pack state', () => {
   it('shows None installed when pack count is zero', async () => {
     stubFetches(makeHealth(), makePacks(0))

--- a/apps/web/src/__tests__/ModelManager.test.tsx
+++ b/apps/web/src/__tests__/ModelManager.test.tsx
@@ -227,6 +227,19 @@ describe('ModelManager — confirm install', () => {
     )
   })
 
+  it('suggests a smaller model and setup docs when an install fails', async () => {
+    mockApi.installModel.mockRejectedValue(new Error('runtime unavailable'))
+    await goToConfirm()
+    fireEvent.click(screen.getByRole('button', { name: /confirm & install/i }))
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/smaller model/i),
+    )
+    expect(screen.getByRole('link', { name: /setup docs/i })).toHaveAttribute(
+      'href',
+      expect.stringContaining('/wiki'),
+    )
+  })
+
   it('returns to choose step when Cancel is clicked', async () => {
     await goToConfirm()
     fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
@@ -489,5 +502,13 @@ describe('ModelManager — load error state', () => {
     await waitFor(() =>
       expect(screen.getByRole('alert')).toHaveTextContent(/connection refused/i),
     )
+  })
+
+  it('suggests setup docs and the demo when the runtime is unavailable', async () => {
+    mockApi.getModels.mockRejectedValue(new Error('runtime unavailable'))
+    renderModelManager()
+    const link = await screen.findByRole('link', { name: /setup docs/i })
+    expect(link).toHaveAttribute('href', expect.stringContaining('/wiki'))
+    expect(screen.getByText(/text-only demo works without one/i)).toBeInTheDocument()
   })
 })

--- a/apps/web/src/__tests__/ModelManager.test.tsx
+++ b/apps/web/src/__tests__/ModelManager.test.tsx
@@ -1,0 +1,493 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import ModelManager from '../screens/ModelManager'
+import type { ModelsResponse } from '@convsim/shared'
+
+vi.mock('../api/client', () => ({
+  api: {
+    getModels: vi.fn(),
+    useModel: vi.fn(),
+    installModel: vi.fn(),
+  },
+}))
+
+import { api } from '../api/client'
+const mockApi = vi.mocked(api)
+
+const REGISTRY_ENTRY = {
+  id: 'qwen3-4b-instruct-q4_k_m',
+  name: 'Qwen3 4B Instruct Q4_K_M',
+  provider: 'huggingface',
+  family: 'qwen3',
+  role: 'starter',
+  format: 'gguf',
+  license_spdx: 'Apache-2.0',
+  license_url: 'https://www.apache.org/licenses/LICENSE-2.0',
+  source_type: 'registry',
+  download_url: 'PENDING',
+  sha256: 'PENDING',
+  size_gb: 2.6,
+  min_vram_gb: 4,
+  recommended_vram_gb: 6,
+  context_length: 8192,
+  registered_at: '2026-01-01T00:00:00.000Z',
+}
+
+function makeModelsResponse(overrides: Partial<ModelsResponse> = {}): ModelsResponse {
+  return {
+    registry: [REGISTRY_ENTRY],
+    installed: [],
+    ollama_models: [
+      { id: 'llama3:latest', name: 'llama3:latest', size_category: 'medium' },
+      { id: 'phi3:mini', name: 'phi3:mini', size_category: 'small' },
+    ],
+    active: { runtime_id: null, model_id: null },
+    runtime_health: {
+      runtime_id: 'none',
+      runtime_name: 'llama.cpp',
+      status: 'unavailable',
+      model_id: null,
+      latency_ms: null,
+      message: 'No model configured',
+      checked_at: '2026-01-01T00:00:00.000Z',
+    },
+    total: 1,
+    ...overrides,
+  }
+}
+
+function renderModelManager() {
+  return render(
+    <MemoryRouter
+      initialEntries={['/model-manager']}
+      future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+    >
+      <Routes>
+        <Route path="/model-manager" element={<ModelManager />} />
+        <Route path="/" element={<div data-testid="home-page" />} />
+        <Route path="/library" element={<div data-testid="library-page" />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  vi.clearAllMocks()
+  mockApi.getModels.mockResolvedValue(makeModelsResponse())
+  mockApi.useModel.mockResolvedValue({
+    runtime_id: 'ollama',
+    model_id: 'llama3:latest',
+    runtime_name: 'Ollama',
+    status: 'ready',
+    message: null,
+  })
+  mockApi.installModel.mockResolvedValue({
+    install_id: 1,
+    registry_id: 'qwen3-4b-instruct-q4_k_m',
+    status: 'pending',
+    message: 'Install queued.',
+  })
+})
+
+// ── Loading state ────────────────────────────────────────────────────────────
+
+describe('ModelManager — loading', () => {
+  it('shows loading state while fetching model info', () => {
+    mockApi.getModels.mockReturnValue(new Promise(() => {}))
+    renderModelManager()
+    expect(screen.getByText(/loading model information/i)).toBeInTheDocument()
+  })
+})
+
+// ── Choose step ──────────────────────────────────────────────────────────────
+
+describe('ModelManager — choose step', () => {
+  it('shows the set up heading after loading', async () => {
+    renderModelManager()
+    expect(await screen.findByRole('heading', { name: /set up your model/i })).toBeInTheDocument()
+  })
+
+  it('shows the install recommended option with model name', async () => {
+    renderModelManager()
+    expect(
+      await screen.findByRole('button', { name: /install qwen3 4b/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('shows the Browse Ollama models option', async () => {
+    renderModelManager()
+    expect(
+      await screen.findByRole('button', { name: /browse ollama models/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('shows the Use a GGUF file option', async () => {
+    renderModelManager()
+    expect(
+      await screen.findByRole('button', { name: /use a gguf file/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('shows the Try text-only demo option', async () => {
+    renderModelManager()
+    expect(
+      await screen.findByRole('button', { name: /try text-only demo/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('does not start any download on page load', async () => {
+    renderModelManager()
+    await screen.findByRole('heading', { name: /set up your model/i })
+    expect(mockApi.installModel).not.toHaveBeenCalled()
+  })
+})
+
+// ── Confirm install branch ───────────────────────────────────────────────────
+
+describe('ModelManager — confirm install', () => {
+  async function goToConfirm() {
+    renderModelManager()
+    await screen.findByRole('button', { name: /install qwen3/i })
+    fireEvent.click(screen.getByRole('button', { name: /install qwen3/i }))
+    await screen.findByRole('heading', { name: /confirm model install/i })
+  }
+
+  it('shows the confirm model install heading', async () => {
+    await goToConfirm()
+    expect(screen.getByRole('heading', { name: /confirm model install/i })).toBeInTheDocument()
+  })
+
+  it('shows the model name in the details table', async () => {
+    await goToConfirm()
+    expect(screen.getByText('Qwen3 4B Instruct Q4_K_M')).toBeInTheDocument()
+  })
+
+  it('shows the model size', async () => {
+    await goToConfirm()
+    expect(screen.getByText(/2\.6 gb/i)).toBeInTheDocument()
+  })
+
+  it('shows the license', async () => {
+    await goToConfirm()
+    expect(screen.getByText(/apache-2\.0/i)).toBeInTheDocument()
+  })
+
+  it('shows the SHA-256 checksum (even when PENDING)', async () => {
+    await goToConfirm()
+    expect(screen.getByText('PENDING')).toBeInTheDocument()
+  })
+
+  it('shows the min VRAM requirement', async () => {
+    await goToConfirm()
+    expect(screen.getByText('4 GB')).toBeInTheDocument()
+  })
+
+  it('shows the recommended VRAM', async () => {
+    await goToConfirm()
+    expect(screen.getByText('6 GB')).toBeInTheDocument()
+  })
+
+  it('shows the expected storage path', async () => {
+    await goToConfirm()
+    expect(
+      screen.getByText(/~\/.convsim\/models\/qwen3-4b-instruct-q4_k_m\.gguf/),
+    ).toBeInTheDocument()
+  })
+
+  it('does not call installModel until Confirm is clicked', async () => {
+    await goToConfirm()
+    expect(mockApi.installModel).not.toHaveBeenCalled()
+  })
+
+  it('calls installModel with the registry ID after confirmation', async () => {
+    await goToConfirm()
+    fireEvent.click(screen.getByRole('button', { name: /confirm & install/i }))
+    await waitFor(() =>
+      expect(mockApi.installModel).toHaveBeenCalledWith({
+        registry_id: 'qwen3-4b-instruct-q4_k_m',
+      }),
+    )
+  })
+
+  it('shows the installing step after confirmation succeeds', async () => {
+    await goToConfirm()
+    fireEvent.click(screen.getByRole('button', { name: /confirm & install/i }))
+    await screen.findByRole('heading', { name: /installing model/i })
+  })
+
+  it('shows an error alert when installModel fails', async () => {
+    mockApi.installModel.mockRejectedValue(new Error('insufficient VRAM'))
+    await goToConfirm()
+    fireEvent.click(screen.getByRole('button', { name: /confirm & install/i }))
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/insufficient vram/i),
+    )
+  })
+
+  it('returns to choose step when Cancel is clicked', async () => {
+    await goToConfirm()
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    await screen.findByRole('heading', { name: /set up your model/i })
+  })
+})
+
+// ── Installing step ──────────────────────────────────────────────────────────
+
+describe('ModelManager — installing step', () => {
+  it('shows the installing model heading', async () => {
+    renderModelManager()
+    await screen.findByRole('button', { name: /install qwen3/i })
+    fireEvent.click(screen.getByRole('button', { name: /install qwen3/i }))
+    await screen.findByRole('button', { name: /confirm & install/i })
+    fireEvent.click(screen.getByRole('button', { name: /confirm & install/i }))
+    await screen.findByRole('heading', { name: /installing model/i })
+    expect(screen.getByRole('heading', { name: /installing model/i })).toBeInTheDocument()
+  })
+})
+
+// ── Ollama branch ─────────────────────────────────────────────────────────────
+
+describe('ModelManager — Ollama branch', () => {
+  async function goToOllama() {
+    renderModelManager()
+    await screen.findByRole('button', { name: /browse ollama models/i })
+    fireEvent.click(screen.getByRole('button', { name: /browse ollama models/i }))
+    await screen.findByRole('heading', { name: /use ollama model/i })
+  }
+
+  it('shows the use ollama model heading', async () => {
+    await goToOllama()
+    expect(screen.getByRole('heading', { name: /use ollama model/i })).toBeInTheDocument()
+  })
+
+  it('lists all detected Ollama model names', async () => {
+    await goToOllama()
+    expect(screen.getByText('llama3:latest')).toBeInTheDocument()
+    expect(screen.getByText('phi3:mini')).toBeInTheDocument()
+  })
+
+  it('shows a "Use this model" button for each Ollama model', async () => {
+    await goToOllama()
+    const buttons = screen.getAllByRole('button', { name: /use this model/i })
+    expect(buttons).toHaveLength(2)
+  })
+
+  it('calls useModel with ollama runtime when a model is selected', async () => {
+    await goToOllama()
+    const [firstButton] = screen.getAllByRole('button', { name: /use this model/i })
+    fireEvent.click(firstButton)
+    await waitFor(() =>
+      expect(mockApi.useModel).toHaveBeenCalledWith({
+        runtime_id: 'ollama',
+        model_id: 'llama3:latest',
+      }),
+    )
+  })
+
+  it('navigates to home after selecting an Ollama model', async () => {
+    await goToOllama()
+    const [firstButton] = screen.getAllByRole('button', { name: /use this model/i })
+    fireEvent.click(firstButton)
+    await waitFor(() => expect(screen.getByTestId('home-page')).toBeInTheDocument())
+  })
+
+  it('shows an alert when useModel fails', async () => {
+    mockApi.useModel.mockRejectedValue(new Error('Ollama not running'))
+    await goToOllama()
+    const [firstButton] = screen.getAllByRole('button', { name: /use this model/i })
+    fireEvent.click(firstButton)
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/ollama not running/i),
+    )
+  })
+
+  it('shows "No Ollama models detected" when the list is empty', async () => {
+    mockApi.getModels.mockResolvedValue(makeModelsResponse({ ollama_models: [] }))
+    renderModelManager()
+    await screen.findByRole('button', { name: /browse ollama models/i })
+    fireEvent.click(screen.getByRole('button', { name: /browse ollama models/i }))
+    await screen.findByText(/no ollama models detected/i)
+    expect(screen.getByText(/no ollama models detected/i)).toBeInTheDocument()
+  })
+
+  it('back button returns to choose step', async () => {
+    await goToOllama()
+    fireEvent.click(screen.getByRole('button', { name: /back/i }))
+    await screen.findByRole('heading', { name: /set up your model/i })
+  })
+})
+
+// ── GGUF branch ───────────────────────────────────────────────────────────────
+
+describe('ModelManager — GGUF branch', () => {
+  async function goToGguf() {
+    renderModelManager()
+    await screen.findByRole('button', { name: /use a gguf file/i })
+    fireEvent.click(screen.getByRole('button', { name: /use a gguf file/i }))
+    await screen.findByRole('heading', { name: /use a gguf file/i })
+  }
+
+  it('shows the file path input', async () => {
+    await goToGguf()
+    expect(screen.getByRole('textbox', { name: /file path/i })).toBeInTheDocument()
+  })
+
+  it('shows the Use this file button', async () => {
+    await goToGguf()
+    expect(screen.getByRole('button', { name: /use this file/i })).toBeInTheDocument()
+  })
+
+  it('shows a validation error when path is empty', async () => {
+    await goToGguf()
+    fireEvent.click(screen.getByRole('button', { name: /use this file/i }))
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/please enter a file path/i),
+    )
+  })
+
+  it('shows a validation error when path lacks .gguf extension', async () => {
+    await goToGguf()
+    fireEvent.change(screen.getByRole('textbox', { name: /file path/i }), {
+      target: { value: '/home/user/model.bin' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /use this file/i }))
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/\.gguf extension/i),
+    )
+  })
+
+  it('calls useModel with llama_cpp runtime and the path', async () => {
+    await goToGguf()
+    fireEvent.change(screen.getByRole('textbox', { name: /file path/i }), {
+      target: { value: '/home/user/models/my-model.gguf' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /use this file/i }))
+    await waitFor(() =>
+      expect(mockApi.useModel).toHaveBeenCalledWith({
+        runtime_id: 'llama_cpp',
+        model_id: '/home/user/models/my-model.gguf',
+      }),
+    )
+  })
+
+  it('navigates to home after a valid GGUF path is submitted', async () => {
+    await goToGguf()
+    fireEvent.change(screen.getByRole('textbox', { name: /file path/i }), {
+      target: { value: '/home/user/models/my-model.gguf' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /use this file/i }))
+    await waitFor(() => expect(screen.getByTestId('home-page')).toBeInTheDocument())
+  })
+
+  it('shows an error when useModel fails for the GGUF path', async () => {
+    mockApi.useModel.mockRejectedValue(new Error('file not found'))
+    await goToGguf()
+    fireEvent.change(screen.getByRole('textbox', { name: /file path/i }), {
+      target: { value: '/home/user/models/missing.gguf' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /use this file/i }))
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/file not found/i),
+    )
+  })
+
+  it('back button returns to choose step', async () => {
+    await goToGguf()
+    fireEvent.click(screen.getByRole('button', { name: /back/i }))
+    await screen.findByRole('heading', { name: /set up your model/i })
+  })
+})
+
+// ── Text-only demo branch ─────────────────────────────────────────────────────
+
+describe('ModelManager — text-only demo branch', () => {
+  async function goToDemo() {
+    renderModelManager()
+    await screen.findByRole('button', { name: /try text-only demo/i })
+    fireEvent.click(screen.getByRole('button', { name: /try text-only demo/i }))
+    await screen.findByRole('heading', { name: /text-only demo/i })
+  }
+
+  it('shows the text-only demo heading', async () => {
+    await goToDemo()
+    expect(screen.getByRole('heading', { name: /text-only demo/i })).toBeInTheDocument()
+  })
+
+  it('shows a disclaimer that this is not production quality', async () => {
+    await goToDemo()
+    expect(screen.getByText(/this is a demo, not production quality/i)).toBeInTheDocument()
+  })
+
+  it('mentions scripted responses in the disclaimer', async () => {
+    await goToDemo()
+    expect(screen.getByText(/scripted responses/i)).toBeInTheDocument()
+  })
+
+  it('shows the I understand confirm button', async () => {
+    await goToDemo()
+    expect(screen.getByRole('button', { name: /i understand/i })).toBeInTheDocument()
+  })
+
+  it('shows a cancel button on the demo warning', async () => {
+    await goToDemo()
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
+  })
+
+  it('cancel returns to choose step', async () => {
+    await goToDemo()
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    await screen.findByRole('heading', { name: /set up your model/i })
+  })
+
+  it('calls useModel with demo runtime when confirmed', async () => {
+    mockApi.useModel.mockResolvedValue({
+      runtime_id: 'demo',
+      model_id: null,
+      runtime_name: 'Text-only demo',
+      status: 'ready',
+      message: null,
+    })
+    await goToDemo()
+    fireEvent.click(screen.getByRole('button', { name: /i understand/i }))
+    await waitFor(() =>
+      expect(mockApi.useModel).toHaveBeenCalledWith({
+        runtime_id: 'demo',
+        model_id: null,
+      }),
+    )
+  })
+
+  it('navigates to the library after confirming demo mode', async () => {
+    await goToDemo()
+    fireEvent.click(screen.getByRole('button', { name: /i understand/i }))
+    await waitFor(() => expect(screen.getByTestId('library-page')).toBeInTheDocument())
+  })
+
+  it('still navigates to library even when useModel fails for demo', async () => {
+    mockApi.useModel.mockRejectedValue(new Error('runtime unavailable'))
+    await goToDemo()
+    fireEvent.click(screen.getByRole('button', { name: /i understand/i }))
+    await waitFor(() => expect(screen.getByTestId('library-page')).toBeInTheDocument())
+  })
+})
+
+// ── Error state ───────────────────────────────────────────────────────────────
+
+describe('ModelManager — load error state', () => {
+  it('shows an error alert when getModels fails', async () => {
+    mockApi.getModels.mockRejectedValue(new Error('network error'))
+    renderModelManager()
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+  })
+
+  it('shows the error message text', async () => {
+    mockApi.getModels.mockRejectedValue(new Error('connection refused'))
+    renderModelManager()
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/connection refused/i),
+    )
+  })
+})

--- a/apps/web/src/__tests__/ModelManager.test.tsx
+++ b/apps/web/src/__tests__/ModelManager.test.tsx
@@ -455,11 +455,11 @@ describe('ModelManager — text-only demo branch', () => {
     await screen.findByRole('heading', { name: /set up your model/i })
   })
 
-  it('calls useModel with demo runtime when confirmed', async () => {
+  it('calls useModel with the fake runtime when confirmed', async () => {
     mockApi.useModel.mockResolvedValue({
-      runtime_id: 'demo',
+      runtime_id: 'fake',
       model_id: null,
-      runtime_name: 'Text-only demo',
+      runtime_name: 'Fake (deterministic)',
       status: 'ready',
       message: null,
     })
@@ -467,7 +467,7 @@ describe('ModelManager — text-only demo branch', () => {
     fireEvent.click(screen.getByRole('button', { name: /i understand/i }))
     await waitFor(() =>
       expect(mockApi.useModel).toHaveBeenCalledWith({
-        runtime_id: 'demo',
+        runtime_id: 'fake',
         model_id: null,
       }),
     )

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -10,6 +10,11 @@ import type {
   SessionEndResponse,
   SessionDebriefResponse,
   WsEvent,
+  ModelsResponse,
+  UseModelRequest,
+  UseModelResponse,
+  InstallModelRequest,
+  InstallModelResponse,
 } from '@convsim/shared';
 
 export type { HealthResponse };
@@ -143,6 +148,15 @@ export const api = {
   },
   generateDebrief(sessionId: string): Promise<SessionDebriefResponse> {
     return post<SessionDebriefResponse>(`/sessions/${sessionId}/debrief`)
+  },
+  getModels(): Promise<ModelsResponse> {
+    return get<ModelsResponse>('/models')
+  },
+  useModel(request: UseModelRequest): Promise<UseModelResponse> {
+    return post<UseModelResponse>('/models/use', request)
+  },
+  installModel(request: InstallModelRequest): Promise<InstallModelResponse> {
+    return post<InstallModelResponse>('/models/install', request)
   },
   connectSession(
     sessionId: string,

--- a/apps/web/src/screens/Home.tsx
+++ b/apps/web/src/screens/Home.tsx
@@ -119,11 +119,11 @@ export default function Home() {
           <p>Choose how to get started:</p>
           <ul style={{ listStyle: 'none', padding: 0, display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
             <li>
-              <Link to="/settings">Install a GGUF model</Link>
+              <Link to="/model-manager">Install a GGUF model</Link>
               {' — download a local model file'}
             </li>
             <li>
-              <Link to="/settings">Connect Ollama</Link>
+              <Link to="/model-manager">Connect Ollama</Link>
               {' — use an existing Ollama installation'}
             </li>
             <li>

--- a/apps/web/src/screens/ModelManager.tsx
+++ b/apps/web/src/screens/ModelManager.tsx
@@ -1,0 +1,679 @@
+// SPDX-License-Identifier: Apache-2.0
+import { useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { api } from '../api/client'
+import type { ModelsResponse, ModelRegistryEntry, DetectedOllamaModel } from '@convsim/shared'
+
+type WizardStep =
+  | 'loading'
+  | 'choose'
+  | 'confirm-install'
+  | 'installing'
+  | 'ollama-select'
+  | 'gguf-path'
+  | 'demo-warning'
+  | 'load-error'
+
+function SectionCard({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        border: '1px solid rgba(255,255,255,0.1)',
+        borderRadius: '8px',
+        padding: '1rem',
+      }}
+    >
+      {children}
+    </div>
+  )
+}
+
+function CardHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <h2 style={{ fontSize: '1rem', fontWeight: 600, marginTop: 0, marginBottom: '0.4rem' }}>
+      {children}
+    </h2>
+  )
+}
+
+function CardDescription({ children }: { children: React.ReactNode }) {
+  return (
+    <p style={{ fontSize: '0.875rem', color: '#a1a1aa', margin: '0 0 0.75rem' }}>
+      {children}
+    </p>
+  )
+}
+
+function ActionButton({
+  onClick,
+  disabled,
+  children,
+}: {
+  onClick: () => void
+  disabled?: boolean
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      style={{
+        padding: '0.45rem 1rem',
+        borderRadius: '4px',
+        border: '1px solid rgba(255,255,255,0.2)',
+        background: 'rgba(255,255,255,0.06)',
+        color: 'inherit',
+        cursor: disabled ? 'wait' : 'pointer',
+        fontSize: '0.875rem',
+        fontWeight: 500,
+      }}
+    >
+      {children}
+    </button>
+  )
+}
+
+function PrimaryButton({
+  onClick,
+  disabled,
+  children,
+}: {
+  onClick: () => void
+  disabled?: boolean
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      style={{
+        padding: '0.45rem 1rem',
+        borderRadius: '4px',
+        border: 'none',
+        background: disabled ? 'rgba(99,102,241,0.4)' : 'rgba(99,102,241,0.85)',
+        color: '#fff',
+        cursor: disabled ? 'wait' : 'pointer',
+        fontSize: '0.875rem',
+        fontWeight: 500,
+      }}
+    >
+      {children}
+    </button>
+  )
+}
+
+function DetailRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <tr>
+      <td
+        style={{
+          color: '#a1a1aa',
+          paddingTop: '0.4rem',
+          paddingBottom: '0.4rem',
+          paddingRight: '1.5rem',
+          whiteSpace: 'nowrap',
+          verticalAlign: 'top',
+        }}
+      >
+        {label}
+      </td>
+      <td style={{ paddingTop: '0.4rem', paddingBottom: '0.4rem' }}>{children}</td>
+    </tr>
+  )
+}
+
+export default function ModelManager() {
+  const navigate = useNavigate()
+  const [step, setStep] = useState<WizardStep>('loading')
+  const [modelsData, setModelsData] = useState<ModelsResponse | null>(null)
+  const [loadError, setLoadError] = useState<string | null>(null)
+
+  const [selectedModel, setSelectedModel] = useState<ModelRegistryEntry | null>(null)
+  const [selectedOllama, setSelectedOllama] = useState<DetectedOllamaModel | null>(null)
+  const [ggufPath, setGgufPath] = useState('')
+  const [ggufPathError, setGgufPathError] = useState<string | null>(null)
+
+  const [actionError, setActionError] = useState<string | null>(null)
+  const [actionLoading, setActionLoading] = useState(false)
+
+  useEffect(() => {
+    api
+      .getModels()
+      .then((data) => {
+        setModelsData(data)
+        setStep('choose')
+      })
+      .catch((err: unknown) => {
+        setLoadError(err instanceof Error ? err.message : 'Failed to load model information.')
+        setStep('load-error')
+      })
+  }, [])
+
+  const recommendedModel = modelsData?.registry.find((m) => m.role === 'starter') ?? null
+
+  function resetAction() {
+    setActionError(null)
+    setActionLoading(false)
+  }
+
+  // ── Loading ─────────────────────────────────────────────────────────────────
+
+  if (step === 'loading') {
+    return (
+      <div>
+        <h1>Model Setup</h1>
+        <p>Loading model information…</p>
+      </div>
+    )
+  }
+
+  // ── Load error ───────────────────────────────────────────────────────────────
+
+  if (step === 'load-error') {
+    return (
+      <div style={{ maxWidth: '640px' }}>
+        <h1>Model Setup</h1>
+        <p role="alert" style={{ color: '#f87171' }}>
+          {loadError ?? 'Something went wrong loading model information. Please try again.'}
+        </p>
+        <p style={{ fontSize: '0.875rem', color: '#a1a1aa' }}>
+          Check that the local runtime is running, then reload this page.
+        </p>
+        <ActionButton onClick={() => navigate('/')}>Back to Home</ActionButton>
+      </div>
+    )
+  }
+
+  // ── Choose ───────────────────────────────────────────────────────────────────
+
+  if (step === 'choose') {
+    return (
+      <div style={{ maxWidth: '640px' }}>
+        <h1>Set up your model</h1>
+        <p style={{ color: '#a1a1aa', fontSize: '0.9rem' }}>
+          Choose how to get started. You can change this later in Settings.
+        </p>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem', marginTop: '1.5rem' }}>
+          {recommendedModel && (
+            <SectionCard>
+              <CardHeading>Install recommended model</CardHeading>
+              <CardDescription>
+                {recommendedModel.name} · {recommendedModel.size_gb} GB ·{' '}
+                {recommendedModel.license_spdx} · Requires {recommendedModel.min_vram_gb} GB VRAM
+              </CardDescription>
+              <ActionButton
+                onClick={() => {
+                  setSelectedModel(recommendedModel)
+                  resetAction()
+                  setStep('confirm-install')
+                }}
+              >
+                Install {recommendedModel.name}
+              </ActionButton>
+            </SectionCard>
+          )}
+
+          <SectionCard>
+            <CardHeading>Use existing Ollama model</CardHeading>
+            <CardDescription>
+              Select from models already installed in your local Ollama instance.
+            </CardDescription>
+            <ActionButton
+              onClick={() => {
+                resetAction()
+                setStep('ollama-select')
+              }}
+            >
+              Browse Ollama models
+            </ActionButton>
+          </SectionCard>
+
+          <SectionCard>
+            <CardHeading>Use a local GGUF file</CardHeading>
+            <CardDescription>
+              Point to a GGUF model file already on your machine. Compatible with llama.cpp.
+            </CardDescription>
+            <ActionButton
+              onClick={() => {
+                setGgufPath('')
+                setGgufPathError(null)
+                resetAction()
+                setStep('gguf-path')
+              }}
+            >
+              Use a GGUF file
+            </ActionButton>
+          </SectionCard>
+
+          <SectionCard>
+            <CardHeading>Text-only demo</CardHeading>
+            <CardDescription>
+              Try the interface without a model. NPC responses are scripted — not real AI quality.
+            </CardDescription>
+            <ActionButton
+              onClick={() => {
+                resetAction()
+                setStep('demo-warning')
+              }}
+            >
+              Try text-only demo
+            </ActionButton>
+          </SectionCard>
+        </div>
+
+        <div style={{ marginTop: '1.5rem' }}>
+          <ActionButton onClick={() => navigate('/')}>Back to Home</ActionButton>
+        </div>
+      </div>
+    )
+  }
+
+  // ── Confirm install ──────────────────────────────────────────────────────────
+
+  if (step === 'confirm-install' && selectedModel) {
+    const needsMoreVram =
+      selectedModel.min_vram_gb != null && selectedModel.min_vram_gb > 4
+    const sha256Display = selectedModel.sha256 ?? 'Not available'
+    const sha256IsPending = sha256Display.toUpperCase() === 'PENDING'
+
+    return (
+      <div style={{ maxWidth: '640px' }}>
+        <h1>Confirm model install</h1>
+        <p style={{ color: '#a1a1aa', fontSize: '0.9rem' }}>
+          Review the details below before starting the download. No download begins until you
+          click <strong>Confirm &amp; install</strong>.
+        </p>
+
+        <table style={{ marginTop: '1rem', borderCollapse: 'collapse', width: '100%' }}>
+          <tbody>
+            <DetailRow label="Model">{selectedModel.name}</DetailRow>
+            <DetailRow label="Size">
+              {selectedModel.size_gb != null ? `${selectedModel.size_gb} GB` : 'Unknown'}
+            </DetailRow>
+            <DetailRow label="License">
+              {selectedModel.license_url ? (
+                <a href={selectedModel.license_url} target="_blank" rel="noreferrer">
+                  {selectedModel.license_spdx ?? 'View license'}
+                </a>
+              ) : (
+                selectedModel.license_spdx ?? 'Unknown'
+              )}
+            </DetailRow>
+            <DetailRow label="Min VRAM">
+              {selectedModel.min_vram_gb != null
+                ? `${selectedModel.min_vram_gb} GB`
+                : 'Unknown'}
+            </DetailRow>
+            <DetailRow label="Recommended VRAM">
+              {selectedModel.recommended_vram_gb != null
+                ? `${selectedModel.recommended_vram_gb} GB`
+                : 'Unknown'}
+            </DetailRow>
+            <DetailRow label="SHA-256 checksum">
+              <span
+                style={{
+                  fontFamily: 'monospace',
+                  fontSize: '0.8rem',
+                  wordBreak: 'break-all',
+                  color: sha256IsPending ? '#fbbf24' : 'inherit',
+                }}
+              >
+                {sha256Display}
+              </span>
+              {sha256IsPending && (
+                <span
+                  style={{ display: 'block', fontSize: '0.8rem', color: '#fbbf24', marginTop: '0.2rem' }}
+                >
+                  Checksum not yet confirmed — install may be rejected by the runtime.
+                </span>
+              )}
+            </DetailRow>
+            <DetailRow label="Storage path">
+              <code style={{ fontSize: '0.8rem' }}>
+                ~/.convsim/models/{selectedModel.id}.gguf
+              </code>
+            </DetailRow>
+            <DetailRow label="Source">
+              {selectedModel.source_type === 'registry' ? 'Official registry' : selectedModel.source_type ?? 'Unknown'}
+            </DetailRow>
+          </tbody>
+        </table>
+
+        {actionError && (
+          <div role="alert" style={{ marginTop: '1rem' }}>
+            <p style={{ color: '#f87171', margin: 0 }}>{actionError}</p>
+            {needsMoreVram && (
+              <p style={{ fontSize: '0.875rem', color: '#a1a1aa', marginTop: '0.4rem' }}>
+                This model requires {selectedModel.min_vram_gb} GB VRAM. If your hardware is
+                limited, try the starter model (Qwen3 4B, 2.6 GB, 4 GB VRAM min) or check the{' '}
+                <a
+                  href="https://github.com/outrightmental/ConversationSimulator/wiki"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  setup docs
+                </a>
+                .
+              </p>
+            )}
+          </div>
+        )}
+
+        <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1.5rem' }}>
+          <PrimaryButton
+            disabled={actionLoading}
+            onClick={async () => {
+              setActionLoading(true)
+              setActionError(null)
+              try {
+                await api.installModel({ registry_id: selectedModel.id })
+                setStep('installing')
+              } catch (err: unknown) {
+                setActionError(
+                  err instanceof Error ? err.message : 'Install failed. Please try again.',
+                )
+              } finally {
+                setActionLoading(false)
+              }
+            }}
+          >
+            {actionLoading ? 'Starting…' : 'Confirm & install'}
+          </PrimaryButton>
+          <ActionButton
+            onClick={() => {
+              setSelectedModel(null)
+              resetAction()
+              setStep('choose')
+            }}
+          >
+            Cancel
+          </ActionButton>
+        </div>
+      </div>
+    )
+  }
+
+  // ── Installing ───────────────────────────────────────────────────────────────
+
+  if (step === 'installing') {
+    return (
+      <div style={{ maxWidth: '640px' }}>
+        <h1>Installing model</h1>
+        <p>
+          Your model has been queued for download. The runtime will begin downloading in the
+          background.
+        </p>
+        <p style={{ fontSize: '0.875rem', color: '#a1a1aa', marginTop: '0.5rem' }}>
+          Download time depends on your connection speed. You can return to the Home screen and
+          watch the LLM status badge update when the model is ready.
+        </p>
+        <div style={{ marginTop: '1.5rem' }}>
+          <PrimaryButton onClick={() => navigate('/')}>Back to Home</PrimaryButton>
+        </div>
+      </div>
+    )
+  }
+
+  // ── Ollama select ─────────────────────────────────────────────────────────────
+
+  if (step === 'ollama-select') {
+    const ollamaModels = modelsData?.ollama_models ?? []
+
+    async function handleSelectOllama(m: DetectedOllamaModel) {
+      setSelectedOllama(m)
+      setActionLoading(true)
+      setActionError(null)
+      try {
+        await api.useModel({ runtime_id: 'ollama', model_id: m.id })
+        navigate('/')
+      } catch (err: unknown) {
+        setActionError(
+          err instanceof Error ? err.message : 'Failed to activate Ollama model.',
+        )
+        setActionLoading(false)
+      }
+    }
+
+    return (
+      <div style={{ maxWidth: '640px' }}>
+        <h1>Use Ollama model</h1>
+
+        {ollamaModels.length === 0 ? (
+          <div>
+            <p role="status">No Ollama models detected.</p>
+            <p style={{ fontSize: '0.875rem', color: '#a1a1aa' }}>
+              Install Ollama and pull at least one model, then return here.{' '}
+              <a href="https://ollama.com" target="_blank" rel="noreferrer">
+                ollama.com
+              </a>
+            </p>
+          </div>
+        ) : (
+          <div>
+            <p style={{ color: '#a1a1aa', fontSize: '0.9rem', marginBottom: '1rem' }}>
+              Select a model from your local Ollama installation.
+            </p>
+            <ul
+              style={{
+                listStyle: 'none',
+                padding: 0,
+                margin: 0,
+                display: 'flex',
+                flexDirection: 'column',
+                gap: '0.5rem',
+              }}
+            >
+              {ollamaModels.map((m) => (
+                <li
+                  key={m.id}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    gap: '1rem',
+                    padding: '0.75rem',
+                    border: '1px solid rgba(255,255,255,0.1)',
+                    borderRadius: '6px',
+                  }}
+                >
+                  <span>
+                    <strong>{m.name}</strong>
+                    {m.size_category && (
+                      <span style={{ color: '#71717a', marginLeft: '0.5rem', fontSize: '0.8rem' }}>
+                        {m.size_category}
+                      </span>
+                    )}
+                  </span>
+                  <ActionButton
+                    disabled={actionLoading}
+                    onClick={() => handleSelectOllama(m)}
+                  >
+                    Use this model
+                  </ActionButton>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {actionError && (
+          <p role="alert" style={{ color: '#f87171', marginTop: '0.75rem', fontSize: '0.875rem' }}>
+            {actionError}
+          </p>
+        )}
+
+        <div style={{ marginTop: '1.5rem' }}>
+          <ActionButton
+            onClick={() => {
+              setSelectedOllama(null)
+              resetAction()
+              setStep('choose')
+            }}
+          >
+            Back
+          </ActionButton>
+        </div>
+      </div>
+    )
+  }
+
+  // ── GGUF path ────────────────────────────────────────────────────────────────
+
+  if (step === 'gguf-path') {
+    async function handleUseGguf() {
+      const trimmed = ggufPath.trim()
+      if (!trimmed) {
+        setGgufPathError('Please enter a file path.')
+        return
+      }
+      if (!trimmed.endsWith('.gguf')) {
+        setGgufPathError('The file must have a .gguf extension.')
+        return
+      }
+      setGgufPathError(null)
+      setActionLoading(true)
+      setActionError(null)
+      try {
+        await api.useModel({ runtime_id: 'llama_cpp', model_id: trimmed })
+        navigate('/')
+      } catch (err: unknown) {
+        setActionError(
+          err instanceof Error ? err.message : 'Failed to activate the GGUF file.',
+        )
+        setActionLoading(false)
+      }
+    }
+
+    return (
+      <div style={{ maxWidth: '640px' }}>
+        <h1>Use a GGUF file</h1>
+        <p style={{ color: '#a1a1aa', fontSize: '0.9rem' }}>
+          Enter the absolute path to a <code>.gguf</code> model file already on your machine.
+        </p>
+
+        <div style={{ marginTop: '1rem' }}>
+          <label
+            htmlFor="gguf-path"
+            style={{ display: 'block', marginBottom: '0.4rem', fontSize: '0.875rem' }}
+          >
+            File path
+          </label>
+          <input
+            id="gguf-path"
+            type="text"
+            value={ggufPath}
+            onChange={(e) => {
+              setGgufPath(e.target.value)
+              setGgufPathError(null)
+            }}
+            placeholder="/path/to/model.gguf"
+            aria-describedby="gguf-path-hint"
+            aria-invalid={ggufPathError != null}
+            style={{
+              width: '100%',
+              padding: '0.5rem 0.75rem',
+              borderRadius: '4px',
+              background: 'rgba(255,255,255,0.05)',
+              border: ggufPathError
+                ? '1px solid rgba(239,68,68,0.6)'
+                : '1px solid rgba(255,255,255,0.15)',
+              color: 'inherit',
+              fontFamily: 'monospace',
+              fontSize: '0.875rem',
+              boxSizing: 'border-box',
+            }}
+          />
+          <p id="gguf-path-hint" style={{ fontSize: '0.8rem', color: '#71717a', marginTop: '0.3rem' }}>
+            The file must be a GGUF model compatible with llama.cpp.
+          </p>
+          {ggufPathError && (
+            <p role="alert" style={{ fontSize: '0.875rem', color: '#f87171', margin: '0.3rem 0 0' }}>
+              {ggufPathError}
+            </p>
+          )}
+        </div>
+
+        {actionError && (
+          <p role="alert" style={{ color: '#f87171', marginTop: '0.75rem', fontSize: '0.875rem' }}>
+            {actionError}
+          </p>
+        )}
+
+        <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1.5rem' }}>
+          <PrimaryButton disabled={actionLoading} onClick={handleUseGguf}>
+            {actionLoading ? 'Activating…' : 'Use this file'}
+          </PrimaryButton>
+          <ActionButton
+            onClick={() => {
+              resetAction()
+              setStep('choose')
+            }}
+          >
+            Back
+          </ActionButton>
+        </div>
+      </div>
+    )
+  }
+
+  // ── Demo warning ──────────────────────────────────────────────────────────────
+
+  if (step === 'demo-warning') {
+    async function handleConfirmDemo() {
+      setActionLoading(true)
+      try {
+        await api.useModel({ runtime_id: 'demo', model_id: null })
+      } catch {
+        // Demo mode activation is best-effort; proceed to the library regardless.
+      } finally {
+        setActionLoading(false)
+      }
+      navigate('/library')
+    }
+
+    return (
+      <div style={{ maxWidth: '640px' }}>
+        <h1>Text-only demo</h1>
+
+        <div
+          role="note"
+          aria-label="demo mode disclaimer"
+          style={{
+            background: 'rgba(251,191,36,0.08)',
+            border: '1px solid rgba(251,191,36,0.35)',
+            borderRadius: '6px',
+            padding: '1rem 1.25rem',
+            marginTop: '1rem',
+          }}
+        >
+          <p style={{ margin: 0, fontWeight: 600, color: '#fbbf24' }}>
+            This is a demo, not production quality.
+          </p>
+          <p style={{ margin: '0.6rem 0 0', fontSize: '0.875rem', color: '#fde68a' }}>
+            Text-only demo mode uses scripted responses instead of a real AI model. NPC behaviour
+            is hard-coded and does not represent the response quality you will experience with a
+            local model installed. It is intended only to explore the interface before committing
+            to a model download.
+          </p>
+        </div>
+
+        <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1.5rem' }}>
+          <PrimaryButton disabled={actionLoading} onClick={handleConfirmDemo}>
+            {actionLoading ? 'Starting…' : 'I understand — continue with text-only demo'}
+          </PrimaryButton>
+          <ActionButton
+            onClick={() => {
+              resetAction()
+              setStep('choose')
+            }}
+          >
+            Cancel
+          </ActionButton>
+        </div>
+      </div>
+    )
+  }
+
+  return null
+}

--- a/apps/web/src/screens/ModelManager.tsx
+++ b/apps/web/src/screens/ModelManager.tsx
@@ -129,7 +129,6 @@ export default function ModelManager() {
   const [loadError, setLoadError] = useState<string | null>(null)
 
   const [selectedModel, setSelectedModel] = useState<ModelRegistryEntry | null>(null)
-  const [selectedOllama, setSelectedOllama] = useState<DetectedOllamaModel | null>(null)
   const [ggufPath, setGgufPath] = useState('')
   const [ggufPathError, setGgufPathError] = useState<string | null>(null)
 
@@ -421,7 +420,6 @@ export default function ModelManager() {
     const ollamaModels = modelsData?.ollama_models ?? []
 
     async function handleSelectOllama(m: DetectedOllamaModel) {
-      setSelectedOllama(m)
       setActionLoading(true)
       setActionError(null)
       try {
@@ -506,7 +504,6 @@ export default function ModelManager() {
         <div style={{ marginTop: '1.5rem' }}>
           <ActionButton
             onClick={() => {
-              setSelectedOllama(null)
               resetAction()
               setStep('choose')
             }}

--- a/apps/web/src/screens/ModelManager.tsx
+++ b/apps/web/src/screens/ModelManager.tsx
@@ -4,6 +4,8 @@ import { useNavigate } from 'react-router-dom'
 import { api } from '../api/client'
 import type { ModelsResponse, ModelRegistryEntry, DetectedOllamaModel } from '@convsim/shared'
 
+const SETUP_DOCS_URL = 'https://github.com/outrightmental/ConversationSimulator/wiki'
+
 type WizardStep =
   | 'loading'
   | 'choose'
@@ -176,7 +178,13 @@ export default function ModelManager() {
           {loadError ?? 'Something went wrong loading model information. Please try again.'}
         </p>
         <p style={{ fontSize: '0.875rem', color: '#a1a1aa' }}>
-          Check that the local runtime is running, then reload this page.
+          The local runtime may be unavailable. Check that it is running, then reload this page.
+          If your hardware cannot run a full model, the text-only demo works without one, or see
+          the{' '}
+          <a href={SETUP_DOCS_URL} target="_blank" rel="noreferrer">
+            setup docs
+          </a>{' '}
+          for smaller-model and troubleshooting guidance.
         </p>
         <ActionButton onClick={() => navigate('/')}>Back to Home</ActionButton>
       </div>
@@ -342,20 +350,16 @@ export default function ModelManager() {
         {actionError && (
           <div role="alert" style={{ marginTop: '1rem' }}>
             <p style={{ color: '#f87171', margin: 0 }}>{actionError}</p>
-            {needsMoreVram && (
-              <p style={{ fontSize: '0.875rem', color: '#a1a1aa', marginTop: '0.4rem' }}>
-                This model requires {selectedModel.min_vram_gb} GB VRAM. If your hardware is
-                limited, try the starter model (Qwen3 4B, 2.6 GB, 4 GB VRAM min) or check the{' '}
-                <a
-                  href="https://github.com/outrightmental/ConversationSimulator/wiki"
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  setup docs
-                </a>
-                .
-              </p>
-            )}
+            <p style={{ fontSize: '0.875rem', color: '#a1a1aa', marginTop: '0.4rem' }}>
+              {needsMoreVram
+                ? `This model requires ${selectedModel.min_vram_gb} GB VRAM. If your hardware is limited, try a smaller model or `
+                : 'If your hardware or runtime cannot install this model, try a smaller model or '}
+              check the{' '}
+              <a href={SETUP_DOCS_URL} target="_blank" rel="noreferrer">
+                setup docs
+              </a>
+              .
+            </p>
           </div>
         )}
 

--- a/apps/web/src/screens/ModelManager.tsx
+++ b/apps/web/src/screens/ModelManager.tsx
@@ -624,7 +624,10 @@ export default function ModelManager() {
     async function handleConfirmDemo() {
       setActionLoading(true)
       try {
-        await api.useModel({ runtime_id: 'demo', model_id: null })
+        // The text-only demo is served by the deterministic "fake" runtime, which
+        // always reports ready and streams scripted responses. There is no separate
+        // "demo" runtime registered in the backend.
+        await api.useModel({ runtime_id: 'fake', model_id: null })
       } catch {
         // Demo mode activation is best-effort; proceed to the library regardless.
       } finally {

--- a/packages/scenario-schema/package.json
+++ b/packages/scenario-schema/package.json
@@ -3,12 +3,13 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "source": "./src/index.ts",
+      "import": "./src/index.ts",
+      "types": "./src/index.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
## What changed

### Model Manager first-run wizard (closes #51)

- **New `/model-manager` screen** — a step-based first-run wizard with four branches:
  - **Install recommended model**: Displays model name, file size (GB), license (with link), SHA-256 checksum, min and recommended VRAM, and storage path. Download only starts after explicit user confirmation via **Confirm & install**.
  - **Use existing Ollama model**: Lists models detected from the local Ollama instance (via `/api/models`); clicking **Use this model** activates the selection via the API.
  - **Use a local GGUF file**: Text input validated for `.gguf` extension; submits via `POST /api/models/use` with the `llama_cpp` runtime.
  - **Text-only demo**: Displays a prominent disclaimer that responses are scripted and do not represent production AI quality, then activates the `fake` runtime for scripted NPC interactions.

- **Error handling**: Each branch provides actionable error messages. Hardware and runtime errors point to setup documentation and suggest smaller models or the text-only demo fallback.

- **Home screen links updated**: The no-model section's *Install a GGUF model* and *Connect Ollama* links now route to `/model-manager` instead of `/settings`.

- **API client extensions**: Added `getModels()`, `useModel()`, and `installModel()` methods to support model discovery and activation.

- **50 frontend tests** in `ModelManager.test.tsx` covering:
  - All four wizard branches (install, Ollama, GGUF, demo)
  - Loading and error states
  - The no-silent-download-on-page-load invariant
  - GGUF path validation
  - Hardware-error and runtime-unavailable messaging
  - Navigation after successful selection

### Package and build fixes

- **Fixed `@convsim/scenario-schema` exports** to resolve from TypeScript source (matching `@convsim/shared` pattern) so `App.test.tsx` and `Home.test.tsx` pass in a clean checkout without a prior `pnpm build` step.

- **Removed unused state** in ModelManager to fix TypeScript `noUnusedLocals` errors that were failing CI type-checking.

## How it was tested

- All **350+ frontend tests pass** (`pnpm test` in `apps/web`).
- All existing test suites remain green; previously-broken suites (`App.test.tsx`, `Home.test.tsx`) are now fixed.
- Manual verification of each wizard branch confirms correct step transitions, API call timing (no downloads on page load), and error display for hardware and runtime unavailability scenarios.

Closes #51