### PR TITLE
Add official scenario pack quality bar, authoring guide, and validation docs

### DIFF
--- a/docs/official-pack-quality-bar.md
+++ b/docs/official-pack-quality-bar.md
@@ -14,9 +14,11 @@ as their content definition of done.
 code, shell commands, or scripts of any kind.**
 
 The pack schema enforces this: a `manifest.yaml` that declares a `scripts`
-field fails validation immediately. The validator also scans all pack files
-for template injection patterns and rejects any file that appears to embed
-executable directives.
+field fails validation immediately. Before any YAML is parsed, the loader also
+refuses to load a pack that contains an executable or script file — matched by
+extension (`.sh`, `.py`, `.js`, `.exe`, …), by executable magic-byte signature
+(so a binary renamed to a data extension is still caught), or a symlink (which
+could escape the pack root).
 
 This rule is non-negotiable in MVP. Treat every pack file as a document, not
 a program.

--- a/docs/official-pack-quality-bar.md
+++ b/docs/official-pack-quality-bar.md
@@ -473,8 +473,9 @@ response_style:
   teaching.
 - Include a rubric dimension for language accuracy/complexity alongside
   content dimensions (e.g. communication effectiveness).
-- Set `supported_languages` to the language being practiced (not `en` unless
-  the scenario is in English).
+- Set `supported_languages` in `manifest.yaml` to the language being practiced
+  (not `en` unless the scenario is in English). This field lives on the pack
+  manifest, not on individual scenario files.
 - Vocabulary difficulty and grammar complexity should vary across difficulty
   levels.
 

--- a/docs/official-pack-quality-bar.md
+++ b/docs/official-pack-quality-bar.md
@@ -599,7 +599,8 @@ Items marked **[manual]** require human review.
 
 ### Rubric
 
-- [ ] At least 2 rubric dimensions **[validator]** (minItems: 1 in schema, manual bar is ≥ 2)
+- [ ] At least 1 rubric dimension **[validator]** (schema enforces `minItems: 1`)
+- [ ] At least 2 rubric dimensions (official quality bar) **[manual]**
 - [ ] All three scoring anchors (low/medium/high) present **[validator]**
 - [ ] Anchors describe observable behaviours, not abstract qualities **[manual]**
 - [ ] Dimension names are ≤ 3 words **[manual]**

--- a/docs/official-pack-quality-bar.md
+++ b/docs/official-pack-quality-bar.md
@@ -1,0 +1,686 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+# Official scenario pack quality bar
+
+This document defines what makes an official Conversation Simulator pack
+polished, safe, replayable, and reviewable. New contributors should read it
+before starting content work. Official pack issues can reference this document
+as their content definition of done.
+
+---
+
+## Packs are data, not code (MVP rule)
+
+**Packs contain only declarative YAML and JSON files. They do not execute
+code, shell commands, or scripts of any kind.**
+
+The pack schema enforces this: a `manifest.yaml` that declares a `scripts`
+field fails validation immediately. The validator also scans all pack files
+for template injection patterns and rejects any file that appears to embed
+executable directives.
+
+This rule is non-negotiable in MVP. Treat every pack file as a document, not
+a program.
+
+---
+
+## Required file structure
+
+Every official pack must contain at minimum:
+
+```
+my-pack/
+├── manifest.yaml            # Required. Pack identity, rating, and safety ref.
+├── scenarios/
+│   └── <scenario>.yaml      # At least one scenario listed in entry_scenarios.
+├── npcs/
+│   └── <npc>.yaml           # At least one NPC, referenced by each scenario.
+├── rubrics/
+│   └── <rubric>.yaml        # At least one rubric, referenced by each scenario.
+├── safety/
+│   └── <policy>.yaml        # Safety policy referenced from manifest.yaml.
+└── tests/
+    └── smoke_<scenario>.yaml # At least one smoke test per entry scenario.
+```
+
+Optional (include when relevant):
+
+```
+├── scenes/
+│   └── <scene>.yaml         # Scene context files referenced by scenarios.
+└── assets/
+    └── portraits/           # NPC portrait images (optional, no external URLs).
+```
+
+All files must have an SPDX license header comment on the first line:
+
+```yaml
+# SPDX-License-Identifier: CC-BY-4.0
+```
+
+---
+
+## Licensing
+
+Official packs must be licensed under **CC-BY-4.0**. The `license` field in
+`manifest.yaml` must be exactly `"CC-BY-4.0"`. Community-submitted packs
+released under other open licenses may be accepted case by case; contact the
+maintainers before choosing a different license.
+
+Pack content — NPC names, writing, and scenario text — must be original. Do
+not adapt copyrighted characters, scripts, or training material without a
+compatible license.
+
+---
+
+## Content rating
+
+Official packs are rated **G**, **PG**, or **PG-13**. No NSFW content is
+permitted at any rating. The `content_rating` field in `manifest.yaml` must
+reflect the highest rating of any scenario in the pack.
+
+| Rating | Permitted content |
+|--------|-------------------|
+| `G`    | All audiences. No profanity, no adult themes, no conflict beyond mild social friction. |
+| `PG`   | Mild professional tension, conflict, and rejection. No sexual content, no graphic violence. Suitable for workplace training. |
+| `PG-13`| Relationship dynamics, rejection handling, and emotional difficulty. No sexual content, no minors, no coercion. See [Dating-confidence: PG-13 boundaries](#dating-confidence-pg-13-boundaries). |
+
+Validator rule: `content_rating` must be one of `["G", "PG", "PG-13"]`.  
+Manual check: every scenario in the pack stays within its declared rating.
+
+---
+
+## Safety requirements
+
+Safety rules are enforced by the runtime and cannot be weakened by a pack.
+The following requirements apply to every official pack.
+
+### Required safety policy file
+
+`manifest.yaml` must reference a safety policy YAML file:
+
+```yaml
+safety:
+  policy: safety/my_policy.yaml
+```
+
+The policy file is validated against `schemas/safety.schema.json` at load
+time. An invalid or missing policy file fails validation.
+
+### Non-overridable global rules
+
+These two rules are hardcoded in the runtime. A pack cannot disable or weaken
+them regardless of what `content_categories` says:
+
+1. **`minors_romantic_or_sexual` → `stop`** — Any romantic or sexual content
+   involving minors ends the session immediately. Always.
+2. **`self_harm_crisis` → `stop_with_resource_message`** — Suicidal ideation
+   or self-harm crisis language ends the session and shows the player real
+   crisis resources. Always.
+
+Additionally, `criminal_instruction` is always present as at least `refuse`
+even if the pack omits it. A pack may make it stricter by setting `stop`.
+
+### Minimum required categories for official packs
+
+Every official pack safety policy must declare at minimum:
+
+```yaml
+content_categories:
+  nsfw_sexual_content: stop
+  criminal_instruction: refuse   # or stop — stricter is always fine
+  self_harm_crisis: stop_with_resource_message
+  minors_romantic_or_sexual: stop
+```
+
+Additional categories are recommended based on the scenario context:
+- Interview/professional packs: add `harassment_extreme: redirect`
+- Relationship/social packs: add `medical_or_therapy_claim: redirect`
+- Any pack: add `real_person_impersonation: stop` if there is any risk that
+  the NPC name could be mistaken for a real person
+
+### Redirect messages
+
+The `redirect_message` field is what the NPC says when a `redirect` action
+fires. Write it in the NPC's voice so it does not break immersion:
+
+```yaml
+# Good — in the NPC's voice
+redirect_message: >-
+  That's outside the scope of what I can discuss here. If you'd like to
+  continue, let's refocus on your experience.
+
+# Bad — generic and robotic
+redirect_message: "This content is not permitted."
+```
+
+---
+
+## NPC design guidelines
+
+### Fictional only
+
+Every NPC must set `fictional: true`. Real-person impersonation is not
+permitted. This is enforced by the schema — the field is `const: true` and
+validation fails if it is absent or false.
+
+Do not use names of real public figures, real executives, real celebrities, or
+real historical figures. Fictional NPCs in clearly fictional companies are
+fine.
+
+### Adult only
+
+`age_band: adult` is the only permitted value in MVP. Do not write NPCs who
+are implied to be minors. This applies to the character's written age, their
+stated role, and their described appearance.
+
+### Public persona
+
+The `public_persona` section is what the player and the runtime see as the
+NPC's surface presentation. Make it specific and concrete:
+
+```yaml
+public_persona:
+  occupation: >-
+    Engineering Manager at Meridian Systems, a mid-sized B2B software company.
+    Dana leads a team of eight engineers and has been with the company for
+    four years.
+  speaking_style: >-
+    Direct and warm. Uses clear, professional language without jargon. Asks
+    follow-up questions to surface the specifics behind vague statements.
+  demeanor: >-
+    Calm, attentive, and quietly encouraging. Becomes noticeably more reserved
+    when answers are vague or run significantly over time.
+```
+
+A weak public persona ("professional manager") produces flat, interchangeable
+NPCs. Aim for a character with a specific background and a recognizable voice.
+
+### Private persona and hidden agendas
+
+The `private_persona` section is system-prompt context the player never sees.
+Use it to give the NPC an interior life that shapes their visible reactions:
+
+```yaml
+private_persona:
+  hidden_agenda:
+    - "Identify whether the candidate gives specific examples or defaults to vague generalizations"
+    - "Assess how the candidate handles mistakes — looking for ownership and evidence of growth"
+  biases_to_simulate:
+    - "Slight skepticism toward overly polished, rehearsed-sounding answers"
+    - "Increased warmth toward candidates who ask thoughtful questions"
+```
+
+Hidden agendas create the asymmetry that makes conversation practice
+meaningful: the player has to discover what the NPC actually cares about.
+Write each agenda item as a specific, observable criterion, not a vague
+attitude.
+
+### NPC boundaries
+
+The `private_persona.boundaries` list enumerates hard rules the NPC must
+never violate, regardless of player input. Every NPC must include at minimum:
+
+```yaml
+boundaries:
+  - "Never generate sexual, violent, or graphically disturbing content"
+  - "Never impersonate a real person, named public figure, or real company executive"
+```
+
+Add scenario-specific boundaries as needed. For interview NPCs:
+
+```yaml
+  - "Never ask illegal interview questions about age, marital status, family plans, religion, national origin, sexual orientation, or disability"
+  - "Never make promises about hiring outcomes"
+```
+
+### NPC voice consistency
+
+The NPC's speaking style must remain consistent across the session. The
+opening line is the clearest test of this: if the opening does not sound like
+the persona described in `public_persona`, fix the persona or the opening.
+
+---
+
+## Scenario design guidelines
+
+### Titles and summaries
+
+- `title`: Short and specific. Names the situation the player is walking into.
+  "The Behavioral Interview" is better than "Interview Practice".
+- `summary`: Two or three sentences that give the player enough context to
+  orient themselves before speaking. Mention the NPC by name, their role, and
+  what is at stake.
+
+### Player role brief
+
+`player_role.brief` is shown to the player at the start. It should answer:
+what is my character, and what do I need to accomplish? Keep it to two or
+three sentences. Do not give away the hidden goals.
+
+### Goals: visible and hidden
+
+`goals.player_visible` tells the player what success looks like from their
+perspective. `goals.hidden` is system-prompt context that reveals what the
+NPC is actually evaluating. The gap between the two is where the scenario's
+learning value lives.
+
+```yaml
+goals:
+  player_visible:
+    - "Impress Dana with specific, concrete examples from your past work"
+    - "Demonstrate self-awareness about your strengths and areas for growth"
+  hidden:
+    - "Dana is testing whether you use vague platitudes or real examples"
+    - "Dana wants to see how you handle ambiguity and own your mistakes"
+```
+
+Write hidden goals as observable NPC evaluation criteria, not as abstract
+virtues.
+
+### State variables
+
+Use state variables to drive NPC behavior and ending conditions. Design them
+to reflect what the NPC is tracking internally:
+
+- Visible variables should correspond to something the player can reasonably
+  infer from conversational feedback (e.g. `impression`, `rapport`).
+- Hidden variables should reflect NPC internal state the player has to
+  discover (e.g. `rambling_count`, `specificity_score`).
+
+**Variable design guidelines:**
+
+| Field | Recommendation |
+|-------|----------------|
+| `min` / `max` | Use 0–100 unless the variable has a meaningful natural range |
+| `default` | Set a neutral starting value, not 0 unless the variable is a counter |
+| `visibility` | `visible` if the player can plausibly monitor it; `hidden` otherwise |
+| `max_delta_per_turn` | Match how quickly the NPC would realistically change their view. Impression rarely shifts more than 15 points per turn. |
+
+### Events
+
+Events let the NPC respond to state changes with specific instructions.
+Write event `npc_instruction` in prose that tells the NPC exactly what to do
+and optionally provides a suggested phrase:
+
+```yaml
+npc_instruction: >-
+  The candidate has been giving lengthy, unfocused answers. Gently but firmly
+  redirect: "That's helpful context — let me zoom in. Can you walk me through
+  one specific situation? What exactly did you do, and what was the result?"
+```
+
+Provide suggested phrasing when the NPC's response needs to match a specific
+tone or pacing. Without phrasing guidance, the NPC will interpolate, which
+can produce inconsistent results.
+
+### Endings
+
+Every official scenario must define at minimum a `success` and `failure`
+ending condition in `ending_conditions`. A scenario that only times out is
+not teaching the player what they did wrong.
+
+Ending conditions should be grounded in visible or hidden variables the NPC
+is plausibly tracking:
+
+```yaml
+ending_conditions:
+  success:
+    type: variable_above
+    variable: impression
+    threshold: 70
+  failure:
+    type: variable_below
+    variable: impression
+    threshold: 15
+```
+
+### Replay variation
+
+Set `replay_seed` when you want deterministic replay for testing or demo
+purposes. Omit it in production scenarios unless the scenario explicitly calls
+for a fixed sequence — varied LLM sampling produces the natural replay
+variation that makes the scenario worth practicing more than once.
+
+Difficulty levels (easy/normal/hard) should produce meaningfully different
+challenges, not just cosmetic variation:
+
+- `easy`: Lower expectations, more patience from the NPC.
+- `normal`: Realistic professional standards.
+- `hard`: Stricter evaluation, less patience, more probing follow-ups.
+
+---
+
+## Rubric design guidelines
+
+The rubric is the primary mechanism for communicating what good looks like.
+Poor rubric writing is the single most common quality bar failure in scenario
+submissions.
+
+### Minimum rubric requirements
+
+- At least **2 dimensions** per rubric.
+- Every dimension must have `low`, `medium`, and `high` scoring anchors.
+- Scoring anchors must be **specific and observable**, not aspirational.
+
+### Writing useful scoring anchors
+
+Each scoring anchor should describe a concrete, observable behaviour the
+LLM evaluator can detect in the conversation transcript:
+
+```yaml
+# Good — specific and observable
+scoring:
+  low: "Answer is mostly abstract ('I always try to communicate clearly') with no concrete situation described."
+  medium: "A real situation is mentioned but lacks specific personal actions or a clear, observable result."
+  high: "Answer names a specific situation, details the concrete actions the player personally took, and states a clear and measurable result."
+
+# Bad — vague and aspirational
+scoring:
+  low: "Poor answer."
+  medium: "Okay answer."
+  high: "Excellent answer."
+```
+
+### Debrief evidence
+
+The rubric directly determines the quality of the debrief the player receives
+after the session. The debrief surfaces turning points, strengths, and
+improvements from the transcript. Rubric dimensions that are specific produce
+debriefs that name the exact moments where the player succeeded or failed.
+
+**Checklist for debrief-quality rubrics:**
+
+- [ ] Each dimension targets a behaviour the player can directly influence.
+- [ ] `high` anchor describes what excellent looks like in concrete terms.
+- [ ] `low` anchor names the failure mode, not just "bad".
+- [ ] Dimension names are short and self-explanatory (≤ 3 words).
+- [ ] Weights add up meaningfully (the evaluator uses them proportionally).
+
+### Recommended dimension count
+
+| Scenario type | Recommended dimensions |
+|---------------|------------------------|
+| Simple social / G-rated | 2–3 |
+| Professional interview | 3–5 |
+| Negotiation | 3–4 |
+| Language practice | 2–4 |
+| Difficult conversation | 3–5 |
+
+---
+
+## Response style guidelines
+
+Set `response_style` in the scenario to guide how the NPC responds:
+
+```yaml
+response_style:
+  max_words: 80        # Soft target; prevents rambling
+  verbosity: moderate  # terse | moderate | verbose
+  formality: professional  # casual | professional | formal
+```
+
+**General guidance:**
+
+- Keep `max_words` at or below **100** for professional contexts. Conversational
+  NPCs who ramble train the player to tune them out.
+- Use `terse` verbosity for time-pressured scenarios (job interviews, quick
+  negotiations). Use `verbose` only for scenarios where the NPC genuinely
+  needs to explain complex material (e.g. a technical mentor).
+- Match `formality` to the scenario's social register. A café conversation
+  should be `casual`; a salary negotiation should be `professional`.
+
+---
+
+## Content-specific guidance
+
+### Interview packs
+
+- The NPC should be a named professional with a specific company context, not
+  a generic "interviewer".
+- Use the STAR method (Situation, Task, Action, Result) as the implicit
+  evaluation framework for specificity rubric dimensions.
+- Hidden agendas should reflect real-world interview patterns: evaluating
+  ownership of mistakes, cultural fit signals, handling ambiguity.
+- Include an event that fires when the candidate rambles, redirecting them to
+  a concrete example.
+- Do not include illegal interview questions (age, religion, national origin,
+  disability, family plans, marital status, sexual orientation). Add these to
+  NPC boundaries.
+- Success threshold: impression above 65–75 is typical for a "strong positive"
+  result. Tune to feel achievable on the second or third attempt.
+
+### Negotiation packs
+
+- Establish a clear BATNA (best alternative to negotiated agreement) as a
+  hidden variable or hidden agenda item for the NPC. This gives the NPC a
+  principled walk-away point.
+- Include both a visible variable the player can track (e.g. `deal_progress`)
+  and a hidden variable the NPC uses internally (e.g. `npc_flexibility`).
+- Write events that shift the NPC's stance when leverage changes hands.
+- A good negotiation scenario ends at least three different ways: agreement,
+  walk-away, and time-out with no deal.
+- Difficulty should affect how much flexibility the NPC has, not just their
+  patience.
+
+### Language practice packs
+
+- Target a specific proficiency level (A2, B1, B2, C1). State this clearly in
+  `summary` and `player_role.brief`.
+- The NPC should adapt naturally to the player's language level — correct
+  errors by modelling correct usage in their response, not by explicitly
+  teaching.
+- Include a rubric dimension for language accuracy/complexity alongside
+  content dimensions (e.g. communication effectiveness).
+- Set `supported_languages` to the language being practiced (not `en` unless
+  the scenario is in English).
+- Vocabulary difficulty and grammar complexity should vary across difficulty
+  levels.
+
+### Difficult conversations packs
+
+- Frame the scenario around a specific real-world situation the player is
+  likely to encounter: giving critical feedback, handling a conflict with a
+  colleague, discussing a performance issue.
+- The NPC should have a credible emotional state that the player's approach
+  can shift — for better or worse.
+- Include visible variables for emotional tone (e.g. `receptiveness`,
+  `defensiveness`) so the player can track their impact.
+- Write hidden agendas that reflect the NPC's underlying concern, not just
+  their surface position. A defensive colleague may secretly be anxious about
+  job security.
+- Safety policy should include `harassment_extreme: redirect` and
+  `medical_or_therapy_claim: redirect`. These scenarios edge toward emotional
+  territory; redirect messaging should feel empathetic, not robotic.
+- Do not write scenarios that require the player to provide clinical therapy
+  or medical advice. The scenario should simulate a human conversation, not a
+  professional consultation.
+
+---
+
+## Dating-confidence: PG-13 boundaries
+
+Scenarios targeting social confidence or dating contexts may be rated PG-13.
+The following rules are non-negotiable:
+
+**Always in-bounds:**
+- Practising asking someone out in a polite, respectful way
+- Handling rejection gracefully without hostility
+- Building conversation skills in social settings
+- Expressing interest clearly and reading social cues
+
+**Always out-of-bounds (regardless of rating):**
+- Any sexual or explicit romantic content
+- NPCs who are implied to be minors
+- Coercive or manipulative pursuit after rejection
+- Content designed to simulate harassment or stalking
+- Scenarios that reward persistent pressure after a clear "no"
+
+**Required safety categories for PG-13 dating scenarios:**
+
+```yaml
+content_categories:
+  nsfw_sexual_content: stop
+  minors_romantic_or_sexual: stop
+  harassment_extreme: stop
+  self_harm_crisis: stop_with_resource_message
+  criminal_instruction: refuse
+```
+
+The NPC's `boundaries` must explicitly prohibit romantic escalation beyond
+the stated PG-13 context and must enforce a firm and final "no" if the player
+continues to pursue after rejection.
+
+---
+
+## Contribution checklist
+
+Use this checklist when authoring or reviewing an official pack submission.
+Items marked **[validator]** are automatically enforced by `convsim validate-pack`.
+Items marked **[manual]** require human review.
+
+### Structure and files
+
+- [ ] Pack directory is named with kebab-case (e.g. `job-interview-basic`) **[manual]**
+- [ ] `manifest.yaml` present and valid against schema **[validator]**
+- [ ] At least one scenario in `entry_scenarios` **[validator]**
+- [ ] All `entry_scenarios` paths resolve to existing files **[validator]**
+- [ ] All NPC refs resolve to existing files **[validator]**
+- [ ] All rubric refs resolve to existing files **[validator]**
+- [ ] Safety policy path resolves to existing file **[validator]**
+- [ ] SPDX header on every YAML file **[manual]**
+
+### Licensing and identity
+
+- [ ] `license: CC-BY-4.0` **[manual]**
+- [ ] `pack_id` uses `official.` prefix and reverse-domain format **[manual]**
+- [ ] `author: Outright Mental` for first-party packs **[manual]**
+- [ ] No copyrighted content (characters, scripts, proprietary training material) **[manual]**
+
+### Content rating
+
+- [ ] `content_rating` set correctly for the pack's most mature scenario **[manual]**
+- [ ] No NSFW content in any file **[manual]**
+- [ ] PG-13 checklist reviewed if applicable **[manual]**
+
+### Safety
+
+- [ ] Safety policy valid against schema **[validator]**
+- [ ] `nsfw_sexual_content: stop` declared **[manual]**
+- [ ] `criminal_instruction: refuse` or `stop` declared **[manual]**
+- [ ] `self_harm_crisis: stop_with_resource_message` declared **[manual]**
+- [ ] `minors_romantic_or_sexual: stop` declared **[manual]**
+- [ ] `redirect_message` written in the NPC's voice **[manual]**
+
+### NPCs
+
+- [ ] All NPCs have `fictional: true` **[validator]**
+- [ ] All NPCs have `age_band: adult` **[validator]**
+- [ ] NPC name is not an identifiable real person **[manual]**
+- [ ] `public_persona` contains specific occupation, speaking style, and demeanor **[manual]**
+- [ ] `private_persona.hidden_agenda` contains ≥ 2 observable evaluation criteria **[manual]**
+- [ ] `private_persona.boundaries` covers at minimum: no sexual content, no real-person impersonation **[manual]**
+- [ ] Opening line is consistent with the NPC's declared speaking style **[manual]**
+
+### Scenarios
+
+- [ ] `title` is specific and names the situation **[manual]**
+- [ ] `summary` (≤ 500 chars) clearly describes what the player is walking into **[validator]**
+- [ ] `player_role.brief` answers: who am I, what must I do **[manual]**
+- [ ] `goals.player_visible` gives the player at least one concrete target **[manual]**
+- [ ] `goals.hidden` reveals the NPC's evaluation criteria (not shown to player) **[manual]**
+- [ ] State variables have meaningful names and appropriate defaults **[manual]**
+- [ ] At least one event is defined **[manual]**
+- [ ] `ending_conditions.success` and `ending_conditions.failure` are both defined **[manual]**
+- [ ] Ending thresholds are achievable with reasonable performance **[manual]**
+- [ ] `response_style.max_words` set to ≤ 100 for professional contexts **[manual]**
+
+### Rubric
+
+- [ ] At least 2 rubric dimensions **[validator]** (minItems: 1 in schema, manual bar is ≥ 2)
+- [ ] All three scoring anchors (low/medium/high) present **[validator]**
+- [ ] Anchors describe observable behaviours, not abstract qualities **[manual]**
+- [ ] Dimension names are ≤ 3 words **[manual]**
+- [ ] Weights declared and meaningful (not all equal) **[manual]**
+
+### Tests
+
+- [ ] At least one smoke test per entry scenario **[manual]**
+- [ ] Smoke test verifies opening line is non-empty **[manual]**
+- [ ] Smoke test verifies `npc.fictional` is true **[manual]**
+- [ ] Smoke test verifies at least one safety category is active **[manual]**
+- [ ] Smoke test includes at least one realistic player input and checks
+      that the session continues without a safety stop **[manual]**
+- [ ] All tests pass: `convsim test-pack <pack-dir>` **[validator / CI]**
+
+---
+
+## Submission review rubric
+
+Use this rubric when reviewing a pull request that adds or modifies an
+official pack.
+
+| Dimension | Low | Medium | High |
+|-----------|-----|--------|------|
+| **NPC believability** | Generic archetype with no distinguishing traits. Reads like a stock character. | Specific occupation and style but the persona is inconsistently applied across the scenario. | Distinctive, consistent voice. Public and private persona are coherent. Opening line sounds exactly like this character. |
+| **Scenario tension** | No meaningful stakes. The NPC has no preferences and accepts everything equally. | Some variation in NPC response but the player cannot tell what the NPC values. | Clear gap between what the player sees and what the NPC is evaluating. The player has to work to uncover the winning approach. |
+| **Rubric specificity** | Scoring anchors describe abstract qualities ("good", "bad"). An evaluator could not reliably distinguish low from high. | Anchors reference some observable behaviours but leave significant ambiguity. | Anchors name specific behaviours and quote the kind of language that earns each score. A different reviewer would score the same transcript the same way. |
+| **Debrief evidence** | Rubric dimensions are too vague to generate useful debrief feedback. Players cannot identify what they did wrong. | Debrief feedback is technically correct but too generic to motivate a specific change. | Debrief identifies the exact moment(s) where the player's approach diverged from the high anchor, with a replay suggestion targeting that moment. |
+| **Safety completeness** | Safety policy is missing required categories or uses inappropriate actions. | All required categories present but redirect message is generic or breaks NPC voice. | All required categories present; redirect message is in the NPC's voice and contextually appropriate to the scenario. |
+| **Test coverage** | No smoke tests, or tests with no assertions. | Smoke tests load the scenario but do not check any meaningful behaviour. | At least one smoke test per entry scenario with structural assertions and a realistic player input that verifies session continuation. |
+| **Polish** | Multiple spelling, grammar, or formatting errors. File structure missing required files. | Minor issues that do not affect functionality. | Zero errors. All files present, all headers present, scenario reads at the level of the `job-interview-basic` reference pack. |
+
+Submissions must score **medium or higher on every dimension** to be merged.
+Submissions scoring **high on all dimensions** are fast-tracked.
+
+---
+
+## Testing requirements
+
+Every official pack requires at minimum one smoke test per entry scenario.
+Smoke tests are YAML files in the pack's `tests/` directory, validated against
+`schemas/pack-test.schema.json`, and run by `convsim test-pack`.
+
+A minimal smoke test must assert:
+1. The scenario's opening line is non-empty.
+2. The NPC is marked fictional.
+3. At least one safety category is active.
+4. A realistic player input advances the session without a safety stop.
+
+Run all tests locally before opening a pull request:
+
+```sh
+convsim validate-pack packs/official/my-pack
+convsim test-pack packs/official/my-pack
+```
+
+Both commands must exit with code `0`. A pack that fails either command will
+not be merged.
+
+See [`docs/pack-validation.md`](pack-validation.md) for a full description of
+what each command checks and how to interpret common errors.
+
+---
+
+## Reviewing an existing pack against this quality bar
+
+The `job-interview-basic` pack is the current reference implementation. To
+audit a new pack, compare it against that pack across each section of this
+document.
+
+Key gaps to look for in submissions:
+
+1. **Flat NPCs** — `public_persona` contains one-line placeholders. The NPC
+   has no discernible personality in the opening line.
+2. **Vague rubric** — scoring anchors use words like "good", "poor", or
+   "adequate" with no concrete description of observable behaviour.
+3. **Missing endings** — only `timeout` is implicitly defined; `success` and
+   `failure` are absent.
+4. **Safety policy copy-paste** — the redirect message is the same generic
+   sentence in every pack rather than being written in the NPC's voice.
+5. **No hidden agendas** — `private_persona.hidden_agenda` is empty or
+   identical to the player-visible goals.
+6. **Trivial tests** — smoke tests contain no player turns, no assertions on
+   session state, and no safety checks.
+
+Use the [submission review rubric](#submission-review-rubric) to score each
+dimension and document the findings in the pull request review.

--- a/docs/pack-validation.md
+++ b/docs/pack-validation.md
@@ -72,15 +72,20 @@ the schema field that failed.
 
 **Safety policy validation**
 
-- The safety policy file must parse as valid YAML and pass schema validation.
-- The `content_rating_cap` field must match the `content_rating` declared in
-  `manifest.yaml` or be stricter.
+- The safety policy file must parse as valid YAML and pass schema validation
+  against `schemas/safety.schema.json` — this includes the required
+  `content_rating_cap` field and the allowed action for each declared category.
 
-**Injection scan**
+> Keeping `content_rating_cap` consistent with the manifest's `content_rating`
+> is a **manual** review item; the validator does not currently compare the two.
 
-Pack files are scanned for template injection patterns. Any file that appears
-to embed executable directives is rejected with error code
-`INJECTION_PATTERN_DETECTED`. Packs are data, not code.
+**Executable-content scan**
+
+Before any YAML is parsed, the loader scans the pack directory and rejects it
+if it finds an executable or script file — matched by extension (`.sh`, `.py`,
+`.js`, `.exe`, …), by executable magic-byte signature (a disguised binary given
+a data extension), or a symlink (which could escape the pack root). Violations
+fail with `FORBIDDEN_FILE` or `FORBIDDEN_BINARY`. Packs are data, not code.
 
 **No-scripts enforcement**
 
@@ -138,7 +143,7 @@ For each turn, the test runner checks:
 |-----------------|----------------|
 | `state_delta_contains` | Listed state variables changed value during the turn |
 | `session_control` | `continue_session` or `end_session` |
-| `safety_status` | `ok`, `redirect`, `refuse`, or `stop` |
+| `safety_status` | `ok`, `redirect`, or `stop` |
 | `npc_emotion_not` | NPC emotional state does not include the listed value |
 
 #### Static assertions
@@ -150,7 +155,7 @@ and `check` expressions:
 |-------|---------|
 | `non_empty_string` | `check: non_empty_string` |
 | `equals <value>` | `check: "equals true"` |
-| `min_length_<n>` | `check: min_length_1` |
+| `min_length_1` | `check: min_length_1` |
 | `contains <value>` | `check: "contains scenarios/my_scenario.yaml"` |
 | Compound (`AND`) | `check: "type=variable_above AND variable=impression"` |
 
@@ -186,91 +191,75 @@ done
 
 ## Common validation errors and how to fix them
 
-### MANIFEST_NOT_FOUND
+Each failure is reported with a stable error `code` (also surfaced in `--json`
+mode) followed by a human-readable message. The codes below are the ones the
+loader actually emits.
+
+### MISSING_FILE
 
 ```
-✗ Pack validation failed: MANIFEST_NOT_FOUND
-  manifest.yaml not found at: my-pack/manifest.yaml
+✗ Pack validation failed: MISSING_FILE
+  File not found: my-pack/manifest.yaml
 ```
 
-The pack directory does not contain a `manifest.yaml`. Check the path you
-passed to `validate-pack` and ensure the file exists.
+A required file is missing. This covers a missing `manifest.yaml`, a
+`safety.policy` / `npc.ref` / `rubric.ref` / `scene.ref` that resolves to a
+non-existent file, and an `entry_scenarios` path that does not match a
+discovered scenario. Check the path you passed to `validate-pack` and confirm
+every referenced file exists at the resolved relative path.
 
-### SCHEMA_INVALID
-
-```
-✗ Pack validation failed: SCHEMA_INVALID
-  File: my-pack/manifest.yaml
-  Validation error at /content_rating: must be one of ["G", "PG", "PG-13"]
-```
-
-A file failed JSON Schema validation. The error message includes the file
-path and the failing field. Check the value against the allowed options in the
-corresponding schema file.
-
-### NPC_NOT_FICTIONAL
+### SCHEMA_VALIDATION
 
 ```
-✗ Pack validation failed: NPC_NOT_FICTIONAL
-  File: my-pack/npcs/my_npc.yaml
-  NPC must have fictional: true
+✗ Pack validation failed: SCHEMA_VALIDATION
+  Schema validation failed for my-pack/manifest.yaml: /content_rating: must be equal to one of the allowed values
 ```
 
-Every NPC must set `fictional: true`. Real-person impersonation is not
-permitted. Add or correct the `fictional` field.
+A file failed JSON Schema validation. The message names the file path and the
+failing field (JSON pointer). Common cases include an out-of-range
+`content_rating`, a missing required field, and an NPC with `fictional: false`
+or a missing `fictional` field (the schema requires `fictional: true`). Check
+the value against the corresponding schema in `schemas/`.
 
-### MISSING_SAFETY_POLICY
-
-```
-✗ Pack validation failed: MISSING_SAFETY_POLICY
-  File: my-pack/safety/my_policy.yaml not found
-  Referenced from: manifest.yaml → safety.policy
-```
-
-The safety policy file referenced in `manifest.yaml` does not exist. Create
-the file or correct the path.
-
-### UNRESOLVED_REF
+### INVALID_YAML
 
 ```
-✗ Pack validation failed: UNRESOLVED_REF
-  File: my-pack/scenarios/my_scenario.yaml
-  npc.ref resolves to a file that does not exist: my-pack/npcs/missing_npc.yaml
+✗ Pack validation failed: INVALID_YAML
+  YAML parse error in my-pack/npcs/my_npc.yaml: bad indentation of a mapping entry
 ```
 
-A `ref` field in a scenario points to a file that does not exist. Check the
-relative path and create or rename the file.
+A file is not well-formed YAML, or its top level is not a mapping. Fix the
+syntax reported in the message.
 
-### INJECTION_PATTERN_DETECTED
-
-```
-✗ Pack validation failed: INJECTION_PATTERN_DETECTED
-  File: my-pack/npcs/my_npc.yaml
-  Executable directive pattern detected in field: public_persona.speaking_style
-```
-
-A pack file contains a pattern that looks like template injection or an
-embedded executable directive. Packs are data, not code. Remove any
-`{{...}}`, `{% %}`, or similar template syntax from the file.
-
-### CONTENT_RATING_MISMATCH
+### FORBIDDEN_FILE / FORBIDDEN_BINARY
 
 ```
-✗ Pack validation failed: CONTENT_RATING_MISMATCH
-  manifest.yaml declares content_rating: G but safety policy declares content_rating_cap: PG
+✗ Pack validation failed: FORBIDDEN_FILE
+  Executable or script file not allowed in pack: 'scripts/setup.py'. MVP packs are data, not code.
 ```
 
-The `content_rating_cap` in the safety policy must match or be stricter than
-the `content_rating` in `manifest.yaml`. Update one of the values to be
-consistent.
+The pack contains a script/executable file (by extension), a file whose bytes
+match an executable format (`FORBIDDEN_BINARY`), or a symlink. Packs are data,
+not code — remove the offending file and inline any needed content as data.
 
-### TEST_FIXTURE_FAILED
+### DUPLICATE_ID
 
 ```
-✗ Test failed: smoke_my_scenario
-  Turn 1 assertion failed: session_control expected continue_session, got end_session
+✗ Pack validation failed: DUPLICATE_ID
+  Duplicate scenario_id "behavioral_interview" found in pack "official.my_pack"
+```
+
+Two scenarios share a `scenario_id`, or two NPCs share an `npc_id`. IDs must
+be unique within a pack. Rename one of them.
+
+### Test fixture failure (`convsim test-pack`)
+
+```
+✗ 1 failed, 0 passed
+  smoke_my_scenario: Turn 1: session_control expected "continue_session", got "end_session"
 ```
 
 A smoke test turn assertion failed. Check the fixture's `player_input` for
 that turn — it may be triggering an unexpected session end (safety stop or
 ending condition). Adjust the input or check the scenario's ending thresholds.
+`test-pack` exits `1` when any fixture fails and `0` when all pass.

--- a/docs/pack-validation.md
+++ b/docs/pack-validation.md
@@ -1,16 +1,276 @@
 <!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Pack validation
 
-> **Status:** Placeholder. Will be completed in Milestone 2 (scenario pack system).
+This document describes what `convsim validate-pack` and `convsim test-pack`
+check, how to run them in CI, and how to fix common errors.
 
-This document will cover:
+For the scenario authoring guide, see
+[`docs/scenario-authoring.md`](scenario-authoring.md).  
+For the official quality bar and contribution checklist, see
+[`docs/official-pack-quality-bar.md`](official-pack-quality-bar.md).
 
-- What `convsim validate-pack` checks
-- JSON Schema validation for pack files
-- NPC consistency checks
-- Safety policy validation
-- Running the validator in CI
-- Common validation errors and how to fix them
+---
 
-For the schema definitions, see [schemas/README.md](../schemas/README.md).
-For the scenario authoring guide, see [scenario-authoring.md](scenario-authoring.md).
+## What convsim validate-pack checks
+
+Run schema validation and structural checks with:
+
+```sh
+convsim validate-pack <pack-dir>
+```
+
+Exit codes:
+
+| Code | Meaning |
+|------|---------|
+| `0`  | Pack is valid. |
+| `1`  | Pack is invalid. Error details are printed to stderr. |
+| `3`  | Unexpected system error (out of memory, OS error, etc.). |
+
+Use `--json` to get machine-readable output:
+
+```sh
+convsim validate-pack my-pack/ --json
+```
+
+### Checks performed
+
+**Schema validation**
+
+Every file is validated against its corresponding JSON Schema:
+
+| File type | Schema |
+|-----------|--------|
+| `manifest.yaml` | `schemas/pack.schema.json` |
+| `scenarios/*.yaml` | `schemas/scenario.schema.json` |
+| `npcs/*.yaml` | `schemas/npc.schema.json` |
+| `rubrics/*.yaml` | `schemas/rubric.schema.json` |
+| `safety/*.yaml` | `schemas/safety.schema.json` |
+| `scenes/*.yaml` | `schemas/scene.schema.json` |
+| `tests/*.yaml` | `schemas/pack-test.schema.json` |
+
+A file that fails its schema check produces an error with the file path and
+the schema field that failed.
+
+**Cross-file reference resolution**
+
+- All paths in `manifest.yaml → entry_scenarios` must resolve to existing
+  scenario files.
+- All `npc.ref` paths in scenario files must resolve to existing NPC files.
+- All `rubric.ref` paths in scenario files must resolve to existing rubric
+  files.
+- All `scene.ref` paths in scenario files must resolve to existing scene
+  files (if set).
+- The `safety.policy` path in `manifest.yaml` must resolve to an existing
+  file.
+
+**NPC consistency checks**
+
+- Every NPC must have `fictional: true`. Any NPC without this field, or with
+  `fictional: false`, fails validation.
+- Every NPC must have `age_band: adult`. The schema enforces this via `enum`.
+
+**Safety policy validation**
+
+- The safety policy file must parse as valid YAML and pass schema validation.
+- The `content_rating_cap` field must match the `content_rating` declared in
+  `manifest.yaml` or be stricter.
+
+**Injection scan**
+
+Pack files are scanned for template injection patterns. Any file that appears
+to embed executable directives is rejected with error code
+`INJECTION_PATTERN_DETECTED`. Packs are data, not code.
+
+**No-scripts enforcement**
+
+`manifest.yaml` must not declare a `scripts` field. The schema enforces this
+with a `not: { required: ["scripts"] }` constraint.
+
+---
+
+## JSON Schema validation for pack files
+
+The full schema suite is in `schemas/`. Schema files use JSON Schema draft
+2020-12 and are versioned via `$id` URIs:
+
+```
+https://schemas.convsim.dev/v0.1/pack.schema.json
+https://schemas.convsim.dev/v0.1/scenario.schema.json
+https://schemas.convsim.dev/v0.1/npc.schema.json
+https://schemas.convsim.dev/v0.1/rubric.schema.json
+https://schemas.convsim.dev/v0.1/safety.schema.json
+https://schemas.convsim.dev/v0.1/scene.schema.json
+https://schemas.convsim.dev/v0.1/pack-test.schema.json
+```
+
+For worked examples, see `schemas/examples/`.
+
+Schema versioning policy: see [`schemas/VERSIONING.md`](../schemas/VERSIONING.md).
+
+---
+
+## What convsim test-pack checks
+
+Run the pack's smoke tests with:
+
+```sh
+convsim test-pack <pack-dir>
+```
+
+This runs every `tests/*.yaml` fixture file against the fake runtime and
+checks that assertions pass. The fake runtime uses a deterministic
+pseudo-random sequence seeded from each fixture's `seed` field.
+
+### Fixture structure
+
+Fixture files contain:
+
+- **`turns`** — a sequence of player inputs and expected outcomes for each turn.
+- **`static_assertions`** — structural checks against resolved pack fields
+  (opening lines, NPC properties, safety categories, etc.).
+
+#### Turn-level checks
+
+For each turn, the test runner checks:
+
+| Assertion field | What it checks |
+|-----------------|----------------|
+| `state_delta_contains` | Listed state variables changed value during the turn |
+| `session_control` | `continue_session` or `end_session` |
+| `safety_status` | `ok`, `redirect`, `refuse`, or `stop` |
+| `npc_emotion_not` | NPC emotional state does not include the listed value |
+
+#### Static assertions
+
+Static assertions use `path` (dot notation with optional `[id=...]` filters)
+and `check` expressions:
+
+| Check | Example |
+|-------|---------|
+| `non_empty_string` | `check: non_empty_string` |
+| `equals <value>` | `check: "equals true"` |
+| `min_length_<n>` | `check: min_length_1` |
+| `contains <value>` | `check: "contains scenarios/my_scenario.yaml"` |
+| Compound (`AND`) | `check: "type=variable_above AND variable=impression"` |
+
+---
+
+## Running the validator in CI
+
+The CI pipeline runs both validation commands on every pull request:
+
+```sh
+convsim validate-pack packs/official/my-pack/
+convsim test-pack packs/official/my-pack/
+```
+
+Both commands must exit with code `0` for the PR to pass the pack quality
+gate.
+
+To reproduce the CI check locally before pushing:
+
+```sh
+# Validate all official packs
+for pack in packs/official/*/; do
+  convsim validate-pack "$pack"
+done
+
+# Test all official packs
+for pack in packs/official/*/; do
+  convsim test-pack "$pack"
+done
+```
+
+---
+
+## Common validation errors and how to fix them
+
+### MANIFEST_NOT_FOUND
+
+```
+✗ Pack validation failed: MANIFEST_NOT_FOUND
+  manifest.yaml not found at: my-pack/manifest.yaml
+```
+
+The pack directory does not contain a `manifest.yaml`. Check the path you
+passed to `validate-pack` and ensure the file exists.
+
+### SCHEMA_INVALID
+
+```
+✗ Pack validation failed: SCHEMA_INVALID
+  File: my-pack/manifest.yaml
+  Validation error at /content_rating: must be one of ["G", "PG", "PG-13"]
+```
+
+A file failed JSON Schema validation. The error message includes the file
+path and the failing field. Check the value against the allowed options in the
+corresponding schema file.
+
+### NPC_NOT_FICTIONAL
+
+```
+✗ Pack validation failed: NPC_NOT_FICTIONAL
+  File: my-pack/npcs/my_npc.yaml
+  NPC must have fictional: true
+```
+
+Every NPC must set `fictional: true`. Real-person impersonation is not
+permitted. Add or correct the `fictional` field.
+
+### MISSING_SAFETY_POLICY
+
+```
+✗ Pack validation failed: MISSING_SAFETY_POLICY
+  File: my-pack/safety/my_policy.yaml not found
+  Referenced from: manifest.yaml → safety.policy
+```
+
+The safety policy file referenced in `manifest.yaml` does not exist. Create
+the file or correct the path.
+
+### UNRESOLVED_REF
+
+```
+✗ Pack validation failed: UNRESOLVED_REF
+  File: my-pack/scenarios/my_scenario.yaml
+  npc.ref resolves to a file that does not exist: my-pack/npcs/missing_npc.yaml
+```
+
+A `ref` field in a scenario points to a file that does not exist. Check the
+relative path and create or rename the file.
+
+### INJECTION_PATTERN_DETECTED
+
+```
+✗ Pack validation failed: INJECTION_PATTERN_DETECTED
+  File: my-pack/npcs/my_npc.yaml
+  Executable directive pattern detected in field: public_persona.speaking_style
+```
+
+A pack file contains a pattern that looks like template injection or an
+embedded executable directive. Packs are data, not code. Remove any
+`{{...}}`, `{% %}`, or similar template syntax from the file.
+
+### CONTENT_RATING_MISMATCH
+
+```
+✗ Pack validation failed: CONTENT_RATING_MISMATCH
+  manifest.yaml declares content_rating: G but safety policy declares content_rating_cap: PG
+```
+
+The `content_rating_cap` in the safety policy must match or be stricter than
+the `content_rating` in `manifest.yaml`. Update one of the values to be
+consistent.
+
+### TEST_FIXTURE_FAILED
+
+```
+✗ Test failed: smoke_my_scenario
+  Turn 1 assertion failed: session_control expected continue_session, got end_session
+```
+
+A smoke test turn assertion failed. Check the fixture's `player_input` for
+that turn — it may be triggering an unexpected session end (safety stop or
+ending condition). Adjust the input or check the scenario's ending thresholds.

--- a/docs/pack-validation.md
+++ b/docs/pack-validation.md
@@ -124,8 +124,11 @@ convsim test-pack <pack-dir>
 ```
 
 This runs every `tests/*.yaml` fixture file against the fake runtime and
-checks that assertions pass. The fake runtime uses a deterministic
-pseudo-random sequence seeded from each fixture's `seed` field.
+checks that assertions pass. The fake runtime is fully deterministic: it
+invokes no model and produces the same structural output every run. A fixture
+may declare an optional `seed` field for forward compatibility, but the current
+fake runtime does not consume it — it is reserved for reproducible results once
+a real runtime is wired in.
 
 ### Fixture structure
 
@@ -144,7 +147,7 @@ For each turn, the test runner checks:
 | `state_delta_contains` | Listed variable names appear in the turn's `state_delta` output |
 | `session_control` | Turn's `session_control` equals the expected `continue_session` or `end_session` |
 | `safety_status` | Turn's `safety_status` equals the expected `ok`, `redirect`, or `stop` |
-| `npc_emotion_not` | Turn's `npc_emotion` does not equal the listed value |
+| `npc_emotion_not` | Reserved. Accepted in fixtures but not evaluated by the fake runtime (emotion is always `null`), so it trivially passes today. Will assert that the turn's `npc_emotion` does not equal the listed value once a real runtime is wired in. |
 
 > **Fake-runtime limitation.** `test-pack` runs against a deterministic fake
 > runtime that requires no model weights. It populates `state_delta` with every
@@ -153,9 +156,10 @@ For each turn, the test runner checks:
 > `safety_status=ok`, and `npc_emotion=null`. In practice this means CI smoke
 > tests verify structure — that a variable is declared and the session proceeds
 > without an unexpected end — rather than dynamic behaviour. A turn assertion
-> expecting `end_session`, `safety_status: redirect`/`stop`, or a specific
-> emotion cannot pass under the fake runtime; those assertions are reserved for
-> when a real runtime is wired in. Assert `session_control: continue_session`
+> expecting `end_session` or `safety_status: redirect`/`stop` cannot pass under
+> the fake runtime, and `npc_emotion_not` is accepted but not evaluated (it
+> trivially passes); those assertions are reserved for when a real runtime is
+> wired in. Assert `session_control: continue_session`
 > and `safety_status: ok` in smoke tests.
 
 #### Static assertions
@@ -263,6 +267,28 @@ not code — remove the offending file and inline any needed content as data.
 
 Two scenarios share a `scenario_id`, or two NPCs share an `npc_id`. IDs must
 be unique within a pack. Rename one of them.
+
+### UNSUPPORTED_VERSION
+
+```
+✗ Pack validation failed: UNSUPPORTED_VERSION
+  Unsupported schema_version "0.2" in my-pack/manifest.yaml. Expected "0.1".
+```
+
+A file declares a `schema_version` the loader does not support. MVP supports
+`"0.1"` only. Set every file's `schema_version` to `"0.1"`.
+
+### PATH_TRAVERSAL
+
+```
+✗ Pack validation failed: PATH_TRAVERSAL
+  Ref "../../etc/passwd" escapes the pack root "my-pack"
+```
+
+A `ref` (or other referenced path) resolves outside the pack directory, or
+contains a null byte. References must stay within the pack root — a ref that
+escapes it fails with `PATH_TRAVERSAL` rather than `MISSING_FILE`. Keep all
+paths relative to the pack and pointing at files inside it.
 
 ### Test fixture failure (`convsim test-pack`)
 

--- a/docs/pack-validation.md
+++ b/docs/pack-validation.md
@@ -141,10 +141,22 @@ For each turn, the test runner checks:
 
 | Assertion field | What it checks |
 |-----------------|----------------|
-| `state_delta_contains` | Listed state variables changed value during the turn |
-| `session_control` | `continue_session` or `end_session` |
-| `safety_status` | `ok`, `redirect`, or `stop` |
-| `npc_emotion_not` | NPC emotional state does not include the listed value |
+| `state_delta_contains` | Listed variable names appear in the turn's `state_delta` output |
+| `session_control` | Turn's `session_control` equals the expected `continue_session` or `end_session` |
+| `safety_status` | Turn's `safety_status` equals the expected `ok`, `redirect`, or `stop` |
+| `npc_emotion_not` | Turn's `npc_emotion` does not equal the listed value |
+
+> **Fake-runtime limitation.** `test-pack` runs against a deterministic fake
+> runtime that requires no model weights. It populates `state_delta` with every
+> declared state variable at its **default** value (it does not simulate value
+> changes), and always returns `session_control=continue_session`,
+> `safety_status=ok`, and `npc_emotion=null`. In practice this means CI smoke
+> tests verify structure — that a variable is declared and the session proceeds
+> without an unexpected end — rather than dynamic behaviour. A turn assertion
+> expecting `end_session`, `safety_status: redirect`/`stop`, or a specific
+> emotion cannot pass under the fake runtime; those assertions are reserved for
+> when a real runtime is wired in. Assert `session_control: continue_session`
+> and `safety_status: ok` in smoke tests.
 
 #### Static assertions
 

--- a/docs/scenario-authoring.md
+++ b/docs/scenario-authoring.md
@@ -1,19 +1,424 @@
 <!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Scenario authoring
 
-> **Status:** Placeholder. Will be completed in Milestone 2 (scenario pack system).
+This guide explains how to build a scenario pack from scratch. For the
+official quality bar — what makes a pack ready for merge — see
+[`docs/official-pack-quality-bar.md`](official-pack-quality-bar.md).
 
-This document will cover:
+---
 
-- Scenario pack folder structure
-- Writing a `manifest.yaml`
-- Defining NPCs: personality, tone, goals, and hidden state
-- Writing scenario YAML files (setup, turns, success/failure conditions)
-- Writing rubric files
-- Writing safety policy files
-- Validating a pack with `convsim validate-pack`
-- Testing a pack interactively
-- Publishing a pack
+## Pack folder structure
 
-For the planned JSON Schema definitions, see [schemas/README.md](../schemas/README.md).
-For the official example packs, see [packs/official/](../packs/official/).
+A scenario pack is a directory of YAML and JSON files. No code, no scripts.
+
+```
+my-pack/
+├── manifest.yaml            # Pack identity, rating, and safety reference.
+├── scenarios/
+│   └── my_scenario.yaml     # One file per scenario.
+├── npcs/
+│   └── my_npc.yaml          # One file per NPC.
+├── rubrics/
+│   └── my_rubric.yaml       # One file per rubric.
+├── safety/
+│   └── my_policy.yaml       # Safety policy file.
+└── tests/
+    └── smoke_my_scenario.yaml
+```
+
+Optional directories:
+
+```
+├── scenes/
+│   └── my_scene.yaml        # Scene/setting context.
+└── assets/
+    └── portraits/           # NPC portrait images.
+```
+
+All YAML files must start with an SPDX license header:
+
+```yaml
+# SPDX-License-Identifier: CC-BY-4.0
+```
+
+---
+
+## Writing a manifest.yaml
+
+`manifest.yaml` is the entry point for the pack. It declares identity,
+rating, and references the safety policy.
+
+```yaml
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+pack_id: official.my_pack          # Reverse-domain, lowercase, underscores
+name: My Pack                      # Human-readable name (≤ 100 chars)
+version: 0.1.0                     # Semantic version
+description: >-
+  One to three sentences describing what the player practises in this pack
+  and what skills they will build. Shown in the scenario browser.
+author: Outright Mental
+license: CC-BY-4.0
+content_rating: PG                 # G | PG | PG-13 — use the highest in the pack
+tags:
+  - interview
+  - professional
+supported_languages:
+  - en
+entry_scenarios:
+  - scenarios/my_scenario.yaml     # Relative path; must exist
+assets:
+  allow_external_urls: false       # Must be false for offline-first packs
+safety:
+  policy: safety/my_policy.yaml   # Relative path; must exist
+```
+
+Validate it immediately after creation:
+
+```sh
+convsim validate-pack my-pack/
+```
+
+---
+
+## Defining NPCs
+
+NPC files live in `npcs/`. The schema is `schemas/npc.schema.json`.
+
+```yaml
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+npc_id: hiring_manager
+display_name: Dana Reyes
+archetype: professional_interviewer
+fictional: true        # Required. Must be true.
+age_band: adult        # Required. Only adult is allowed in MVP.
+portrait: assets/portraits/dana_reyes.png    # Optional
+voice:
+  engine: none         # kokoro | sherpa-onnx | none
+```
+
+### Public persona
+
+The public persona shapes how the NPC appears to the player and how the
+runtime constructs prompts. Be specific:
+
+```yaml
+public_persona:
+  occupation: >-
+    Engineering Manager at Meridian Systems, a mid-sized B2B software company.
+    Dana leads a team of eight engineers.
+  speaking_style: >-
+    Direct and warm. Asks follow-up questions to surface specifics. Paraphrases
+    to show active listening.
+  demeanor: >-
+    Calm and attentive. Becomes more reserved when answers are vague or run
+    significantly over time without landing on a clear point.
+```
+
+### Private persona
+
+The private persona is system-prompt context the player never sees. It gives
+the NPC an interior life that produces natural, consistent reactions:
+
+```yaml
+private_persona:
+  hidden_agenda:
+    - "Identify whether the candidate gives specific, concrete examples or defaults to vague generalizations"
+    - "Assess how the candidate handles situations where they made a mistake — looking for ownership and growth"
+  biases_to_simulate:
+    - "Slight skepticism toward overly polished, rehearsed-sounding answers"
+    - "Increased warmth toward candidates who ask thoughtful questions"
+  boundaries:
+    - "Never ask illegal interview questions about age, marital status, family plans, religion, national origin, sexual orientation, or disability"
+    - "Never generate sexual, violent, or graphically disturbing content"
+    - "Never impersonate a real person or named public figure"
+```
+
+---
+
+## Writing scenario YAML files
+
+Scenario files live in `scenarios/`. The schema is `schemas/scenario.schema.json`.
+
+```yaml
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+scenario_id: my_scenario           # Unique within the pack, lowercase_underscores
+title: The Behavioral Interview
+summary: >-
+  You are interviewing for a Software Engineer role at Meridian Systems.
+  Dana Reyes, the Engineering Manager, will ask behavioral questions.
+  Specific, structured answers earn a stronger impression.
+
+player_role:
+  label: Job Candidate
+  brief: >-
+    You are applying for a mid-level Software Engineer position. You have
+    relevant experience but need to convince Dana you can handle ambiguous
+    problems and grow from mistakes. This is your final-round interview.
+
+npc:
+  ref: ../npcs/hiring_manager.yaml
+
+scene:
+  ref: ../scenes/conference_room.yaml   # Optional
+
+rubric:
+  ref: ../rubrics/interview_rubric.yaml
+
+duration:
+  max_turns: 20
+  soft_time_limit_minutes: 15
+
+opening:
+  npc_says: >-
+    Good morning! Thanks for making the time. I'm Dana Reyes, Engineering
+    Manager at Meridian Systems. Tell me about a time when you had to work
+    through a difficult technical problem under real pressure.
+
+goals:
+  player_visible:
+    - "Impress Dana with specific, concrete examples from your past work"
+    - "Demonstrate self-awareness about your strengths and areas for growth"
+  hidden:
+    - "Dana is testing whether you use vague platitudes or real examples with measurable outcomes"
+    - "Dana wants to see how you handle ambiguity and own your mistakes"
+```
+
+### State variables
+
+State variables track the NPC's internal state across turns:
+
+```yaml
+state:
+  variables:
+    impression:
+      min: 0
+      max: 100
+      default: 50
+      visibility: visible          # Player can see this variable
+      max_delta_per_turn: 15
+    rambling_count:
+      min: 0
+      max: 10
+      default: 0
+      visibility: hidden           # Player cannot see this
+      max_delta_per_turn: 2
+```
+
+### Events
+
+Events fire NPC instructions when conditions are met:
+
+```yaml
+events:
+  - id: rambling_redirect
+    when:
+      type: variable_above
+      variable: rambling_count
+      threshold: 2
+    npc_instruction: >-
+      The candidate has been giving lengthy, unfocused answers. Redirect:
+      "That's helpful context — let me zoom in. Can you walk me through
+      one specific situation? What exactly did you do and what was the result?"
+    repeat: true    # Fires every turn the condition holds; false = fires once
+```
+
+Event trigger types:
+
+| Type | Fields | Description |
+|------|--------|-------------|
+| `variable_above` | `variable`, `threshold` | Fires when variable > threshold |
+| `variable_below` | `variable`, `threshold` | Fires when variable < threshold |
+| `max_turns` | `value` | Fires when turn count reaches value |
+| `flag` | `flag_id` | Fires when a named flag is set |
+
+### Ending conditions
+
+Define explicit success and failure conditions. Do not rely on timeout alone:
+
+```yaml
+ending_conditions:
+  success:
+    type: variable_above
+    variable: impression
+    threshold: 70
+  failure:
+    type: variable_below
+    variable: impression
+    threshold: 15
+```
+
+### Response style
+
+Control NPC verbosity and register:
+
+```yaml
+response_style:
+  max_words: 80          # Soft target; keep ≤ 100 for professional contexts
+  verbosity: moderate    # terse | moderate | verbose
+  formality: professional  # casual | professional | formal
+```
+
+### Difficulty
+
+Define how difficulty levels change NPC behaviour:
+
+```yaml
+difficulty:
+  default: normal
+  options:
+    easy:
+      npc_patience_modifier: 20
+      challenge_frequency: low
+    normal:
+      npc_patience_modifier: 0
+      challenge_frequency: medium
+    hard:
+      npc_patience_modifier: -20
+      challenge_frequency: high
+```
+
+---
+
+## Writing rubric files
+
+Rubric files live in `rubrics/`. The schema is `schemas/rubric.schema.json`.
+
+```yaml
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+rubric_id: interview_rubric
+title: Behavioral Interview Rubric
+dimensions:
+  - id: specificity
+    name: Specificity
+    description: >-
+      Whether the player uses concrete examples rather than vague generalizations.
+      Does the answer name a specific situation, describe concrete actions, and
+      report an observable result?
+    scoring:
+      low: "Answer is mostly abstract ('I always try to communicate clearly') with no concrete situation described."
+      medium: "A real situation is mentioned but lacks specific actions or a clear, observable result."
+      high: "Answer names a specific situation, details the concrete actions the player personally took, and states a clear measurable result."
+    weight: 0.30
+```
+
+Scoring anchors must describe **observable behaviours**, not abstract qualities.
+Each anchor should describe what an evaluator would actually see in the
+transcript. Aim for two to four dimensions per rubric.
+
+---
+
+## Writing safety policy files
+
+Safety policy files live in `safety/`. The schema is `schemas/safety.schema.json`.
+
+```yaml
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+policy_id: interview_safety
+content_categories:
+  nsfw_sexual_content: stop
+  criminal_instruction: refuse
+  harassment_extreme: redirect
+  self_harm_crisis: stop_with_resource_message
+  minors_romantic_or_sexual: stop
+  real_person_impersonation: refuse
+redirect_message: >-
+  That's outside the scope of what I can discuss here. If you'd like to
+  continue, let's refocus on your professional experience.
+allow_profanity: false
+content_rating_cap: PG
+```
+
+Write `redirect_message` in the NPC's voice so it does not break immersion.
+
+See [`docs/safety-policy.md`](safety-policy.md) for a full description of
+each category, action, and the non-overridable global rules.
+
+---
+
+## Validating a pack
+
+Run schema validation and structural checks:
+
+```sh
+convsim validate-pack my-pack/
+```
+
+This checks:
+- All required files are present
+- All files are valid against their schemas
+- All cross-file references resolve (NPC refs, rubric refs, safety policy)
+- No injection patterns or executable fields
+
+A valid pack exits with code `0`. Errors are reported with the failing file
+path and schema field.
+
+See [`docs/pack-validation.md`](pack-validation.md) for a full description of
+checks and how to fix common errors.
+
+---
+
+## Testing a pack
+
+Run the pack's smoke tests:
+
+```sh
+convsim test-pack my-pack/
+```
+
+This executes all fixture files in `tests/` against a deterministic fake
+runtime and checks that assertions pass.
+
+A minimal smoke test for each entry scenario:
+
+```yaml
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+fixture_id: smoke_my_scenario
+scenario_id: my_scenario
+description: >-
+  Verifies my_scenario loads cleanly and a strong first response advances
+  the session without triggering a safety stop.
+seed: 42
+input_mode: text
+difficulty: normal
+turns:
+  - turn: 1
+    player_input: "Hello, I'm excited to be here. I have a great example ready."
+    expect:
+      state_delta_contains:
+        - impression
+      session_control: continue_session
+      safety_status: ok
+static_assertions:
+  - description: Scenario opening line is non-empty
+    path: opening.npc_says
+    check: non_empty_string
+  - description: NPC is marked fictional
+    path: npc.fictional
+    check: "equals true"
+  - description: Safety policy stops nsfw_sexual_content
+    path: safety.content_categories.nsfw_sexual_content
+    check: "equals stop"
+```
+
+---
+
+## Publishing a pack
+
+For official packs, open a pull request against `main`. The CI pipeline runs
+`convsim validate-pack` and `convsim test-pack` on every PR. Both must pass.
+
+Before opening a PR:
+
+1. Run `convsim validate-pack my-pack/` locally — exit code must be `0`.
+2. Run `convsim test-pack my-pack/` locally — exit code must be `0`.
+3. Review against the contribution checklist in
+   [`docs/official-pack-quality-bar.md`](official-pack-quality-bar.md).
+
+Community packs that are not intended for the official repository can be
+distributed as directories or zip archives and loaded with `convsim import-pack`.

--- a/docs/scenario-authoring.md
+++ b/docs/scenario-authoring.md
@@ -352,7 +352,8 @@ This checks:
 - All required files are present
 - All files are valid against their schemas
 - All cross-file references resolve (NPC refs, rubric refs, safety policy)
-- No injection patterns or executable fields
+- No executable or script files, disguised binaries, or symlinks; no `scripts`
+  field in the manifest (packs are data, not code)
 
 A valid pack exits with code `0`. Errors are reported with the failing file
 path and schema field.


### PR DESCRIPTION
## Summary

This PR establishes the official scenario pack quality bar and provides comprehensive documentation for pack authoring and validation. Three key documents define what makes an official pack production-ready and guide contributors through the full lifecycle from design to CI merge.

### What changed

- **`docs/official-pack-quality-bar.md`** (new, 686 lines) — Defines what makes an official pack polished, safe, replayable, and reviewable. Covers:
  - File structure requirements and SPDX licensing
  - Content rating (G/PG/PG-13) and NSFW boundary enforcement
  - Non-negotiable safety rules (minors protection, self-harm handling, content scan enforcement)
  - NPC design: fictional-only, adult-only, specific public/private personas, hidden agendas, and boundaries
  - Scenario design: state variables, events, ending conditions, replay variation, and difficulty scaling
  - Rubric guidelines emphasizing specific, observable scoring anchors and debrief-quality checks
  - Content-specific guidance for interview, negotiation, language-practice, and difficult-conversation packs
  - PG-13 dating-confidence boundaries (strict in-bounds/out-of-bounds rules)
  - Contribution checklist with `[validator]` (automatically enforced) and `[manual]` (human review) labels
  - 7-dimension submission review rubric for PR reviewers
  - Testing requirements and reference audit procedure

- **`docs/scenario-authoring.md`** (437 additions) — Replaces placeholder with a complete pack-creation guide covering folder structure, manifest declaration, NPC files (public/private personas, hidden agendas, boundaries), scenario YAML (state variables, events, ending conditions, response style, difficulty levels), rubric files, safety policies, validation commands, testing fixtures, and publishing workflow.

- **`docs/pack-validation.md`** (280 additions) — Replaces placeholder with a full validation reference. Covers what `convsim validate-pack` checks (schema validation, cross-file references, NPC consistency, safety policy, executable scan, no-scripts enforcement), JSON Schema versioning, what `convsim test-pack` checks (fixture structure, turn assertions, static assertions), fake-runtime limitations, CI integration examples, and a catalog of common validation errors with fixes.

### Why this matters

**Acceptance criteria from #33 are met:**
1. New contributors can read `official-pack-quality-bar.md` and understand what acceptable packs require.
2. Every contribution checklist item is labeled as `[validator]` (automatically enforced by CLI) or `[manual]` (human review required) — this mapping is accurate against the loader source (`packages/pack-loader/src/validator.ts`, `services/convsim-core/convsim_core/packs/validator.py`).
3. Both authoring and quality-bar documents explicitly state that packs are data, not code, in MVP — the loader enforces this by scanning for executables, scripts, symlinks, and rejecting manifests with a `scripts` field.
4. Safety boundaries (non-overridable global rules, minimum required categories) are stated in their own section as non-negotiable.
5. Rubric guidance and debrief-quality checklist emphasize specific, observable scoring anchors with examples of good vs. bad.
6. Official pack issues can reference `official-pack-quality-bar.md` as their authoritative content definition of done.

### Refinements after initial commit

Subsequent commits fixed factual inaccuracies found auditing the docs against the real CLI/loader source:
- **Commit 8d8ee5a**: Corrected `test-pack` turn-assertion descriptions to match actual runner behavior (key-presence checks, not value-change detection; fake runtime is fully deterministic, not pseudo-random).
- **Commit 71ea1ba**: Clarified fake-runtime limitations; added note that `npc_emotion_not` is currently not evaluated (emotion is always null).
- **Commit 046ef24**: Added missing error codes `UNSUPPORTED_VERSION` and `PATH_TRAVERSAL` to common-errors catalog. Fixed language-practice guidance to clarify that `supported_languages` lives on `manifest.yaml`, not on scenario files.
- **Commit 567819b**: Split rubric-dimension checklist into separate `[validator]` (≥1, schema-enforced) and `[manual]` (≥2, quality-bar convention) items to accurately map the validator rules as required by #33.

## Test plan

All three documents reviewed for accuracy:
- ✓ Cross-checked against schemas in `schemas/`
- ✓ Validated against the existing reference pack `packs/official/job-interview-basic/`
- ✓ Verified CLI commands against real interfaces in `packages/convsim-cli/`
- ✓ Contribution checklist items audited against validator source to confirm `[validator]` labels are accurate
- ✓ Example schema fields and command options verified against schema definitions
- ✓ Safety policy section aligned with hardcoded runtime rules and non-overridable categories

Closes #33