### PR TITLE
Add safety policy, privacy, and local-first documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ On Windows (PowerShell), use `scripts\dev.ps1` instead.
 - Raw audio is never saved by default — only the transcribed text is processed.
 - TTS-synthesized audio is cached locally. Nothing is sent to external servers.
 - **Telemetry is absent from the MVP.** No usage data, analytics, or crash
-  reports are transmitted. There is no opt-in or opt-out telemetry switch.
+  reports are transmitted. A `telemetry_enabled` setting exists and defaults to
+  off, but the MVP ships no telemetry subsystem — nothing is sent regardless.
 - All services bind to `127.0.0.1` so no ports are reachable from other machines.
 
 See [`docs/privacy.md`](docs/privacy.md) for the full data-handling policy,

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ On Windows (PowerShell), use `scripts\dev.ps1` instead.
 
 - LLM inference, speech-to-text, and text-to-speech all run on local models —
   no cloud API calls during a session.
-- Transcripts are stored in a local SQLite database only when you opt in.
+- Transcripts are stored in a local SQLite database on your machine only, and
+  are never uploaded. Saving is on by default; you can turn it off in Settings.
 - Raw audio is never saved by default — only the transcribed text is processed.
 - TTS-synthesized audio is cached locally. Nothing is sent to external servers.
 - **Telemetry is absent from the MVP.** No usage data, analytics, or crash

--- a/README.md
+++ b/README.md
@@ -90,10 +90,25 @@ On Windows (PowerShell), use `scripts\dev.ps1` instead.
 ## Local-first promise
 
 > Conversation Simulator does not send your conversations, audio, prompts,
-> transcripts, or model outputs to any server. Model and pack downloads
-> happen only when you explicitly request them.
+> transcripts, or model outputs to any server during play. Model and pack
+> downloads happen only when you explicitly request them.
 
-You can verify this at any time with the built-in offline smoke test:
+**What this means in practice:**
+
+- LLM inference, speech-to-text, and text-to-speech all run on local models —
+  no cloud API calls during a session.
+- Transcripts are stored in a local SQLite database only when you opt in.
+- Raw audio is never saved by default — only the transcribed text is processed.
+- TTS-synthesized audio is cached locally. Nothing is sent to external servers.
+- **Telemetry is absent from the MVP.** No usage data, analytics, or crash
+  reports are transmitted. There is no opt-in or opt-out telemetry switch.
+- All services bind to `127.0.0.1` so no ports are reachable from other machines.
+
+See [`docs/privacy.md`](docs/privacy.md) for the full data-handling policy,
+including what is logged, how to export your data, and how to delete everything.
+
+You can verify the local-only guarantee at any time with the built-in offline
+smoke test:
 
 ```bash
 # Run against an official pack (no model download needed)

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -99,8 +99,10 @@ Log files are rotated and stored locally only. They are never transmitted.
 **Telemetry is absent from the MVP.**
 
 No usage analytics, session counts, feature-use events, or performance
-metrics are sent to any server. There are no background pings, no anonymous
-reporting, and no opt-in or opt-out telemetry switches in the MVP release.
+metrics are sent to any server. There are no background pings and no anonymous
+reporting. The settings model carries a `telemetry_enabled` flag that defaults
+to off (exposed read-only on `/health`), but the MVP ships no telemetry
+subsystem to act on it — nothing is transmitted regardless of the flag.
 
 If telemetry is ever added in a future release, it will:
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -33,20 +33,21 @@ This is enforced at the code level, not just by policy:
 
 ### Conversation transcripts
 
-**Default:** not saved.
+**Default:** saved locally (on your machine only). You can turn this off.
 
-Transcripts are stored in a local SQLite database (`~/.convsim/db/sessions.db`)
-**only when you enable transcript saving in Settings.** If transcript saving is
-off (the default), no conversation text is written to disk after the session ends.
+Transcripts are stored in a local SQLite database (`~/.convsim/db/sessions.db`).
+Saving is **on by default** so you can review, export, and search past sessions.
+You can disable it under **Settings → Transcript → Save transcripts locally**;
+when saving is off, no conversation text is written to disk after the session ends.
 
-When transcript saving is on:
+Whether saving is on or off, transcripts are never transmitted anywhere:
 
 - The database contains the session metadata, turn-by-turn exchange text, and
   structured debrief results.
 - All data stays on your machine under `~/.convsim/`.
 - Nothing in the transcript is transmitted to any server.
 
-To clear all saved transcripts: **Settings → Privacy → Clear all transcripts**,
+To clear all saved transcripts: use **Clear all local data** in **Settings**,
 or call `POST /api/privacy/clear` on the local API.
 
 ### Raw audio
@@ -70,7 +71,7 @@ re-generating the same phrase twice.
 - The TTS cache is local only. No audio is sent to external servers.
 - Cache files contain synthesized voice output for short NPC phrases.
   They do not contain your voice or any player input.
-- To clear the TTS cache: **Settings → Privacy → Clear TTS cache**.
+- To clear the TTS cache, delete the cache directory: `rm -rf ~/.convsim/tts-cache/`.
 
 ### Runtime logs
 
@@ -155,7 +156,7 @@ uploaded or synchronized.
 
 ### Delete all conversation data
 
-**Settings → Privacy → Clear all transcripts**  
+Use the **Clear all local data** button in **Settings**  
 or  
 ```
 POST /api/privacy/clear
@@ -166,8 +167,6 @@ the local SQLite database. It cannot be undone.
 
 ### Delete TTS cache
 
-**Settings → Privacy → Clear TTS cache**  
-or  
 ```
 rm -rf ~/.convsim/tts-cache/
 ```
@@ -209,42 +208,39 @@ npx convsim offline-smoke-test --json packs/official/job-interview-basic
 **Expected output (success):**
 
 ```
-convsim offline-smoke-test
-  pack:     packs/official/job-interview-basic
-  scenario: behavioral-q1
-  turns:    3
-  network:  no outbound connections detected
-  result:   PASS
+✓ Offline smoke test passed
+  Pack:     job-interview-basic
+  Scenario: behavioral-q1
+  Turns:    3
+  Debrief:  generated
+  Network:  no outbound calls detected
 ```
 
 **Expected output (failure):**
 
 ```
-convsim offline-smoke-test
-  pack:     packs/official/job-interview-basic
-  scenario: behavioral-q1
-  network:  OUTBOUND CONNECTION DETECTED
-    subsystem: tts
-    host:      api.example.com
-    port:      443
-  result:   FAIL — subsystem 'tts' made an outbound connection during play.
-             Check that the TTS runtime is configured for local synthesis only.
+✗ Offline smoke test FAILED: outbound network detected during play (1 violation)
+  Subsystem: tts
+  URL: https://api.example.com/synthesize
+  Install a local runtime or check for background telemetry.
 ```
 
 The command exits nonzero on failure, making it suitable as a CI gate.
 
-The same verification is performed programmatically in
-`services/convsim-core/tests/test_network_policy.py` on every CI run.
+The same end-to-end verification runs on every CI build in
+`packages/convsim-cli/tests/offline-smoke-test.test.ts`, and the underlying
+network-policy guard is unit-tested in
+`services/convsim-core/tests/test_network_policy.py`.
 
 ---
 
 ## Privacy preferences reference
 
-The following preferences are available in **Settings → Privacy**:
+The following preferences are available in **Settings**:
 
 | Preference | Default | Effect |
 |---|---|---|
-| Save transcripts | Off | When on, conversation text is written to the local SQLite database. |
+| Save transcripts | On | When on, conversation text is written to the local SQLite database. Turn off to keep nothing after a session ends. |
 | Save raw audio | Off | When on (dev setting only), microphone audio is written to a local temp directory. |
 | Save TTS cache | On | When off, synthesized audio clips are discarded after each session. |
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -17,12 +17,16 @@ For content safety policy, see [`safety-policy.md`](safety-policy.md).
 > transcripts, or model outputs to any server during play. Model and pack
 > downloads happen only when you explicitly request them.
 
-This is enforced at the code level, not just by policy:
+This is backed by the code, not just by policy:
 
 - All services bind to `127.0.0.1` by default. No ports are reachable from
-  other machines.
-- The `NetworkMode.PLAY` guard (`convsim_core.network_policy`) raises an error
-  if any subsystem attempts an outbound connection during a live session.
+  other machines. This is the primary runtime guarantee.
+- Play-mode network calls (LLM, TTS, STT) route through a central gate,
+  `require_network(NetworkMode.PLAY)` in `convsim_core.network_policy`. When
+  local-only mode is enabled (`LOCAL_MODE = True`) the gate raises
+  `NetworkBlockedError` on any play-mode outbound attempt. Local-only mode is
+  what the offline smoke test and CI run under, so an accidental outbound call
+  is caught before it can ship.
 - The offline smoke test (see [Verifying local-only operation](#verifying-local-only-operation))
   runs an end-to-end session with a blocked network and confirms that nothing
   reaches out.
@@ -101,8 +105,9 @@ Log files are rotated and stored locally only. They are never transmitted.
 No usage analytics, session counts, feature-use events, or performance
 metrics are sent to any server. There are no background pings and no anonymous
 reporting. The settings model carries a `telemetry_enabled` flag that defaults
-to off (exposed read-only on `/health`), but the MVP ships no telemetry
-subsystem to act on it — nothing is transmitted regardless of the flag.
+to off (surfaced read-only under the `privacy` object of the `/api/health`
+response), but the MVP ships no telemetry subsystem to act on it — nothing is
+transmitted regardless of the flag.
 
 If telemetry is ever added in a future release, it will:
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -21,15 +21,17 @@ This is backed by the code, not just by policy:
 
 - All services bind to `127.0.0.1` by default. No ports are reachable from
   other machines. This is the primary runtime guarantee.
-- Play-mode network calls (LLM, TTS, STT) route through a central gate,
-  `require_network(NetworkMode.PLAY)` in `convsim_core.network_policy`. When
-  local-only mode is enabled (`LOCAL_MODE = True`) the gate raises
-  `NetworkBlockedError` on any play-mode outbound attempt. Local-only mode is
-  what the offline smoke test and CI run under, so an accidental outbound call
-  is caught before it can ship.
+- `convsim_core.network_policy` provides a central guard,
+  `require_network(NetworkMode.PLAY)`, that outbound-capable play-mode code
+  (LLM, TTS, STT) is required to clear before opening a connection. Setting
+  `LOCAL_MODE = True` makes any play-mode attempt raise `NetworkBlockedError`.
+  This contract is enforced by the unit tests in
+  `services/convsim-core/tests/test_network_policy.py`, which run in CI.
 - The offline smoke test (see [Verifying local-only operation](#verifying-local-only-operation))
-  runs an end-to-end session with a blocked network and confirms that nothing
-  reaches out.
+  is the end-to-end check. It installs a socket-level network guard that blocks
+  any non-localhost connection during a scripted session and records a violation
+  if anything reaches out — so an accidental outbound call fails the test before
+  it can ship.
 
 ---
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,0 +1,261 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+# Privacy and data handling
+
+Conversation Simulator is designed so that **nothing leaves your computer
+during play**. This document explains exactly what data exists, where it is
+stored, and how to delete it.
+
+For network-level enforcement of this guarantee, see
+[`network-security.md`](network-security.md).  
+For content safety policy, see [`safety-policy.md`](safety-policy.md).
+
+---
+
+## The local-first promise
+
+> Conversation Simulator does not send your conversations, audio, prompts,
+> transcripts, or model outputs to any server during play. Model and pack
+> downloads happen only when you explicitly request them.
+
+This is enforced at the code level, not just by policy:
+
+- All services bind to `127.0.0.1` by default. No ports are reachable from
+  other machines.
+- The `NetworkMode.PLAY` guard (`convsim_core.network_policy`) raises an error
+  if any subsystem attempts an outbound connection during a live session.
+- The offline smoke test (see [Verifying local-only operation](#verifying-local-only-operation))
+  runs an end-to-end session with a blocked network and confirms that nothing
+  reaches out.
+
+---
+
+## What data exists and where it lives
+
+### Conversation transcripts
+
+**Default:** not saved.
+
+Transcripts are stored in a local SQLite database (`~/.convsim/db/sessions.db`)
+**only when you enable transcript saving in Settings.** If transcript saving is
+off (the default), no conversation text is written to disk after the session ends.
+
+When transcript saving is on:
+
+- The database contains the session metadata, turn-by-turn exchange text, and
+  structured debrief results.
+- All data stays on your machine under `~/.convsim/`.
+- Nothing in the transcript is transmitted to any server.
+
+To clear all saved transcripts: **Settings → Privacy → Clear all transcripts**,
+or call `POST /api/privacy/clear` on the local API.
+
+### Raw audio
+
+**Default:** never saved.
+
+The microphone stream is processed in memory by the local speech-to-text
+(Whisper) runtime. Raw audio is not written to disk at any point in the default
+configuration. Only the transcribed text is passed to the scenario engine.
+
+If you enable the `convsim.privacy.saveRawAudio` developer setting, audio
+is written to a local temporary directory for debugging purposes only. This
+setting is off by default and should not be enabled in normal use.
+
+### TTS cache
+
+Text-to-speech synthesis is computationally expensive. The app caches
+synthesized audio clips locally at `~/.convsim/tts-cache/` to avoid
+re-generating the same phrase twice.
+
+- The TTS cache is local only. No audio is sent to external servers.
+- Cache files contain synthesized voice output for short NPC phrases.
+  They do not contain your voice or any player input.
+- To clear the TTS cache: **Settings → Privacy → Clear TTS cache**.
+
+### Runtime logs
+
+Log files are written to `~/.convsim/logs/` (configurable with the
+`CONVSIM_LOG_DIR` environment variable).
+
+What **is** logged:
+
+- Safety events (matched category and action, but **not** the raw player text).
+- Session lifecycle events (start, end, ending type).
+- Service startup, shutdown, and error events.
+- Model inference timing (duration only, no prompts or outputs).
+
+What **is not** logged:
+
+- Raw player text or voice input.
+- NPC responses or model outputs.
+- The full conversation transcript.
+- Any personally identifying information.
+
+Log files are rotated and stored locally only. They are never transmitted.
+
+### Telemetry
+
+**Telemetry is absent from the MVP.**
+
+No usage analytics, session counts, feature-use events, or performance
+metrics are sent to any server. There are no background pings, no anonymous
+reporting, and no opt-in or opt-out telemetry switches in the MVP release.
+
+If telemetry is ever added in a future release, it will:
+
+- Require explicit opt-in from the user.
+- Be documented here in advance of the release.
+- Default to off.
+
+### Crash reports
+
+**No crash reports are transmitted in the MVP.**
+
+If the app crashes, error output is written to the local log at
+`~/.convsim/logs/`. Nothing is sent to Sentry, Bugsnag, or any third-party
+crash reporting service in the MVP release.
+
+To report a crash, copy the relevant portion of the local log and open a
+GitHub issue manually.
+
+### Exports
+
+You can export a single session's transcript and events to a local JSON file
+via the UI (**Session → Export**) or via the API:
+
+```
+GET /api/sessions/<session_id>/export
+```
+
+The export contains:
+
+- Session metadata (scenario ID, start time, ending type, turn count).
+- Full turn-by-turn exchange (player input as transcribed text, NPC response).
+- Structured debrief results.
+
+Exports are written to wherever you choose to save them. The app does not
+transmit exports anywhere.
+
+### Model files
+
+Model weights are stored at `~/.convsim/models/` after you download them
+through the in-app model manager. Model files are never uploaded or
+synchronized. The model manager only downloads files when you explicitly
+request a model.
+
+### Pack files
+
+Installed packs are stored at `~/.convsim/packs/` (for user-installed packs)
+or in the repository's `packs/official/` directory. Pack files are never
+uploaded or synchronized.
+
+---
+
+## Deletion
+
+### Delete all conversation data
+
+**Settings → Privacy → Clear all transcripts**  
+or  
+```
+POST /api/privacy/clear
+```
+
+This deletes all rows from the `sessions` and `session_events` tables in
+the local SQLite database. It cannot be undone.
+
+### Delete TTS cache
+
+**Settings → Privacy → Clear TTS cache**  
+or  
+```
+rm -rf ~/.convsim/tts-cache/
+```
+
+### Delete all local data
+
+To remove everything Conversation Simulator has stored:
+
+```bash
+rm -rf ~/.convsim/
+```
+
+This removes all transcripts, model files, packs, logs, and cache. After
+this, the app will prompt you to reinstall a model on next launch.
+
+---
+
+## Verifying local-only operation
+
+You can confirm that a play session makes no outbound connections using the
+built-in offline smoke test:
+
+```bash
+# Run against an official pack (no model download needed)
+npx convsim offline-smoke-test packs/official/job-interview-basic
+
+# Machine-readable output for CI
+npx convsim offline-smoke-test --json packs/official/job-interview-basic
+```
+
+**What the test does:**
+
+1. Loads the first scenario from the pack.
+2. Runs a scripted conversation with a local fake runtime (no real model
+   inference needed).
+3. Generates a local debrief.
+4. Asserts that no outbound TCP connection was attempted during play.
+
+**Expected output (success):**
+
+```
+convsim offline-smoke-test
+  pack:     packs/official/job-interview-basic
+  scenario: behavioral-q1
+  turns:    3
+  network:  no outbound connections detected
+  result:   PASS
+```
+
+**Expected output (failure):**
+
+```
+convsim offline-smoke-test
+  pack:     packs/official/job-interview-basic
+  scenario: behavioral-q1
+  network:  OUTBOUND CONNECTION DETECTED
+    subsystem: tts
+    host:      api.example.com
+    port:      443
+  result:   FAIL — subsystem 'tts' made an outbound connection during play.
+             Check that the TTS runtime is configured for local synthesis only.
+```
+
+The command exits nonzero on failure, making it suitable as a CI gate.
+
+The same verification is performed programmatically in
+`services/convsim-core/tests/test_network_policy.py` on every CI run.
+
+---
+
+## Privacy preferences reference
+
+The following preferences are available in **Settings → Privacy**:
+
+| Preference | Default | Effect |
+|---|---|---|
+| Save transcripts | Off | When on, conversation text is written to the local SQLite database. |
+| Save raw audio | Off | When on (dev setting only), microphone audio is written to a local temp directory. |
+| Save TTS cache | On | When off, synthesized audio clips are discarded after each session. |
+
+All preferences are stored locally in the browser's `localStorage` under
+the `convsim.privacy.*` namespace. They are never transmitted.
+
+---
+
+## Questions and concerns
+
+If you have a privacy question or believe a data boundary has been violated,
+open a GitHub issue with the `privacy` label. If you believe you have found
+a security vulnerability, follow the responsible disclosure process described
+in [`SECURITY.md`](../SECURITY.md).

--- a/docs/safety-policy.md
+++ b/docs/safety-policy.md
@@ -1,11 +1,206 @@
 <!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Safety policy
 
-This document covers the local layered safety system that routes, refuses, or
-stops unsafe content without relying on cloud moderation.
+This document covers:
+
+1. [Content policy](#content-policy) — what is and is not permitted, for users and scenario creators.
+2. [Pack sandboxing and prompt injection](#pack-sandboxing-and-prompt-injection) — how packs are isolated.
+3. [Safety architecture](#architecture) — how the local layered system enforces policy at runtime.
+4. [Writing a safety policy for your pack](#writing-a-safety-policy-for-your-pack) — creator guide.
+5. [Creator guide: understanding validation rejections](#creator-guide-understanding-validation-rejections)
 
 For the JSON schema definition, see [`schemas/safety.schema.json`](../schemas/safety.schema.json).  
+For the privacy and data-handling policy, see [`privacy.md`](privacy.md).  
 For the full technical specification, see [`SPEC.md`](SPEC.md) — section 13 covers content safety.
+
+---
+
+## Content policy
+
+These rules apply to all scenario packs, including official packs, community
+packs, and locally created packs. They cannot be overridden at the pack level.
+
+### What Conversation Simulator is for
+
+Conversation Simulator is a **practice tool** for realistic one-on-one
+conversations: job interviews, negotiations, language practice, difficult
+professional and personal conversations, and social confidence building.
+
+It is not an AI companion, not a chat platform, and not an adult content tool.
+
+### Prohibited content in MVP
+
+The following content categories are **prohibited** in all packs submitted to
+or distributed through Conversation Simulator. The validator and runtime both
+enforce these limits.
+
+| Prohibited content | Why |
+|---|---|
+| NSFW sexual content | Platform safety, reputational risk, and moderation complexity. |
+| Erotic roleplay | Same. |
+| Romantic or sexual content involving minors | Hard prohibition. No exceptions. |
+| Real-person impersonation packs | Rights, consent, and trust. You may not build a pack where the NPC is a named identifiable living or recently deceased real person. |
+| Voice cloning or voice deepfaking | Rights abuse and non-consensual impersonation risk. |
+| Therapy or mental-health diagnosis | The NPC is not a therapist. Positioning the product as therapy creates harm, false trust, and regulatory exposure. |
+| Medical diagnosis or prescription advice | Same principle. The NPC must not present itself as a medical professional. |
+| Professional legal advice | The NPC must not present itself as legal counsel or render binding legal opinions. |
+| Instructional criminal content | Scenarios must not instruct players in how to perform criminal acts or cause physical harm. |
+| Unreviewed executable code in packs | Packs are declarative YAML/JSON — no scripts. See [Pack sandboxing](#pack-sandboxing-and-prompt-injection). |
+
+These categories map to the validator's `content_categories` field in the
+safety policy schema. The canonical names are:
+
+```
+nsfw_sexual_content
+minors_romantic_or_sexual
+real_person_impersonation
+voice_cloning_request
+medical_or_therapy_claim
+legal_claim
+criminal_instruction
+```
+
+### Allowed practice content
+
+The following content is explicitly within scope for Conversation Simulator:
+
+- **Job interviews** — behavioral, technical, situational; supportive or hostile interviewer.
+- **Negotiations** — salary, freelance rates, purchases, lease renewals, customer service.
+- **Language practice** — conversational practice in any language with realistic social scenarios.
+- **Difficult conversations** — giving feedback, navigating conflict, apologizing, setting boundaries,
+  requesting a raise.
+- **Social confidence** — small talk, networking events, introductions, leaving conversations gracefully.
+- **Dating-confidence practice** — see the [dating-confidence boundary](#dating-confidence-scenarios) below.
+
+Packs can portray realistic tension, rejection, conflict, and emotional difficulty —
+these are the situations players need practice with. The constraint is on
+explicit sexual content, real-person impersonation, and content that presents
+the NPC as a professional healthcare or legal provider.
+
+### Dating-confidence scenarios
+
+Dating-confidence scenarios are permitted at **PG-13** and below, provided they
+remain framed as conversation practice:
+
+- Asking someone out, handling a "no," small talk on a first date, reading social cues,
+  active listening, and respectful interest are all within scope.
+- Content must remain social and conversational. No erotic escalation, no explicit
+  sexual content, no coercive framing, and no sexualized descriptions.
+- All parties must be presented as adults. Age must never be ambiguous in a
+  romantic-context scenario.
+
+Set `content_rating_cap: PG-13` in your safety policy when writing these scenarios.
+The pack manifest must also declare `content_rating: PG-13`.
+
+### Real-person packs — full prohibition
+
+You may not create a pack where:
+
+- The NPC is identified as, or clearly based on, a specific living or recently
+  deceased identifiable individual (public figure or private person).
+- The pack uses the real person's voice, likeness, quotes, or biographical facts
+  in a way that could be mistaken for authentic speech from that person.
+
+This rule exists because non-consensual simulation of real people creates
+reputational harm, misinformation risk, and potential legal liability. Even
+positive or educational portrayals require the subject's consent.
+
+**Fictional archetypes** (a "tough-but-fair interviewer," a "confident colleague")
+are fine — they just cannot be associated with a real, identifiable individual.
+
+### Voice cloning prohibition
+
+Conversation Simulator ships with a fixed set of synthetic TTS voices. Packs
+must not:
+
+- Request that the app clone, copy, or reproduce a specific person's voice.
+- Include prompts designed to elicit a voice-cloning instruction from the player.
+- Include audio assets that are a replica of a real person's voice without
+  explicit documented consent from that person.
+
+The `voice_cloning_request` safety category is enforced at the input router
+level. Any player input matching voice-cloning intent triggers a `refuse` or
+`stop` action before the NPC runtime is called.
+
+### Therapy, diagnosis, and legal positioning — explicitly disallowed
+
+The app must never present the NPC as a licensed professional offering real
+clinical or legal services:
+
+- The NPC can **play the role** of a therapist, doctor, or lawyer in a practice
+  scenario (e.g., practicing how to talk to your doctor, mock legal interview).
+- The NPC must **not diagnose**, prescribe, advise on legal strategy, or claim
+  professional authority over real-world decisions.
+- Packs must not use positioning language like "talk to our AI therapist" or
+  "get real legal advice."
+- The `medical_or_therapy_claim` and `legal_claim` categories both fire a
+  `redirect` or `refuse` action when professional-authority language appears.
+
+If you want to practice a conversation with a healthcare or legal professional,
+the scenario should be framed as "practice talking to your doctor" rather than
+"get a diagnosis."
+
+---
+
+## Pack sandboxing and prompt injection
+
+### Packs are declarative data, not code
+
+Scenario packs are **declarative YAML and JSON files** — they contain no
+executable scripts, no evaluated expressions, and no network calls. The pack
+schema (`schemas/pack.schema.json`) explicitly rejects any manifest that
+declares a `scripts` field.
+
+This design is intentional: packs must not be able to execute arbitrary code
+on the player's machine. A pack is closer to a game level than a plugin.
+
+### What a pack can and cannot do
+
+| Pack capability | Allowed | Notes |
+|---|---|---|
+| Define NPC persona, goals, hidden state | Yes | Declarative YAML only. |
+| Set safety policy categories and actions | Yes | Within the permitted action set; global non-overridable rules still apply. |
+| Reference local asset files (audio, images) | Yes | Must be within the pack directory. |
+| Reference external URLs for assets | **No** | `allow_external_urls` must be `false`. Validator rejects `true`. |
+| Include executable JavaScript or Python | **No** | Schema rejects `scripts`. |
+| Override global non-overridable safety rules | **No** | `minors_romantic_or_sexual` and `self_harm_crisis` cannot be weakened. |
+| Call external APIs during play | **No** | The app's outbound network policy blocks this during a session. |
+
+### Prompt injection risks and mitigations
+
+NPC personas are defined in YAML and composed into prompts by the prompt
+construction layer. This creates a surface for **prompt injection** — a pack
+author could try to embed instructions in the NPC persona that cause the model
+to behave outside the intended safety policy.
+
+The following mitigations are applied:
+
+1. **Safety policy layer is injected last.** The prompt construction pipeline
+   inserts the safety policy system prompt after the NPC persona. If the NPC
+   persona attempts to "override" the safety rules, the safety layer instruction
+   follows and takes precedence (models tend to follow later system instructions).
+
+2. **Output validator rejects out-of-schema responses.** The NPC runtime must
+   produce a structured JSON output. Any response that does not parse as valid
+   `TurnOutput` is rejected and retried or ended.
+
+3. **Category-level enforcement is pre-inference.** The input router applies
+   safety category matching **before** calling the NPC runtime. A maliciously
+   crafted player input is caught before the model ever sees it.
+
+4. **Pack validator runs at load time.** Community packs are validated against
+   the schema when loaded. The validator rejects packs with unexpected fields,
+   unknown action types, or asset references outside the pack directory.
+
+5. **No executable persona fields.** Persona YAML does not support template
+   evaluation, macros, or computed expressions. It is plain text passed verbatim
+   to the prompt composer.
+
+### Reporting pack safety issues
+
+If you find a pack in the official registry that violates this policy or
+appears to exploit prompt injection, open a GitHub issue with the `safety`
+label. Include the pack ID, the specific field, and the concern.
 
 ---
 
@@ -176,3 +371,70 @@ MVP names by the safety policy service.
 | `crisis_content` | `self_harm_crisis` |
 
 Update new packs to use the canonical names.
+
+---
+
+## Creator guide: understanding validation rejections
+
+When you run `convsim validate-pack` and your pack fails a safety check,
+this section explains what triggered the rejection and how to fix it.
+
+### Schema validation failures
+
+Your safety policy YAML is validated against `schemas/safety.schema.json` at
+load time. Common causes:
+
+| Rejection message | Cause | Fix |
+|---|---|---|
+| `Unknown category: <name>` | A category name is not in the schema. | Check the spelling; see the [MVP categories table](#mvp-safety-categories-spec-132). Use canonical names, not legacy aliases, in new packs. |
+| `Invalid action '<action>' for category '<name>'` | The action is not in the category's allowed set. | See the allowed actions column in the categories table. |
+| `Missing required field: content_rating_cap` | The field is absent from your YAML. | Add `content_rating_cap: G`, `PG`, or `PG-13`. |
+| `Additional properties are not allowed: scripts` | Your pack manifest declares a `scripts` field. | Remove it — packs are declarative data, not code. |
+
+### Content policy rejections
+
+If the validator rejects your pack or an NPC persona for content policy reasons:
+
+**`real_person_impersonation` triggered**  
+The NPC name, bio, or persona text refers to an identifiable real person. 
+Rename the NPC to a fictional character. You can keep the archetype 
+(e.g., "a tech CEO who came from engineering") without naming a real person.
+
+**`voice_cloning_request` blocked**  
+The scenario or NPC description instructs the player to provide a voice
+sample or requests a voice that "sounds like" a real person. Remove this.
+
+**`medical_or_therapy_claim` in persona prompt**  
+The NPC persona claims to be a licensed therapist, doctor, or psychiatrist
+*providing real clinical services*. Reframe: the NPC can be a character who
+*plays* a doctor in a practice scenario; they should not claim professional
+authority over the player's health.
+
+**`legal_claim` in persona prompt**  
+Same principle for legal roles. "Practice talking to a lawyer" is fine;
+"get real legal advice from an AI lawyer" is not.
+
+**Content rating mismatch**  
+The pack manifest declares `content_rating: G` but the safety policy sets
+`content_rating_cap: PG-13`. These must be consistent.
+
+### Why certain content is rejected
+
+The safety category system exists for three reasons:
+
+1. **User safety.** The app may be used by people in vulnerable states.
+   Self-harm and crisis language must always surface real crisis resources.
+   Minors must always be protected from sexual content.
+
+2. **Legal and ethical boundaries.** Medical diagnoses, legal opinions, and
+   real-person impersonation all carry real-world legal and ethical risk that
+   the app cannot manage on a per-pack basis.
+
+3. **Ecosystem trust.** If community packs could circumvent safety rules, the
+   Conversation Simulator ecosystem would become unsafe for all users. The
+   constraints protect the entire community, not just one scenario.
+
+Scenario creators are building practice tools, not unrestricted AI experiences.
+The constraints are narrow: they target a specific set of harmful content
+categories while leaving a wide space for realistic, challenging, and even
+uncomfortable practice scenarios.


### PR DESCRIPTION
## Summary

- Expands `docs/safety-policy.md` with user-facing and creator-facing content policy sections.
- Creates `docs/privacy.md` documenting all data categories, retention defaults, deletion, and local-mode verification.
- Updates `README.md` with explicit no-telemetry/no-cloud-inference language and a link to the privacy doc.

## What changed

### `docs/safety-policy.md`

Added five new sections before the existing technical architecture:

- **Content policy** — overview of what the app is for and who these rules apply to.
- **Prohibited content in MVP** — table of nine prohibited categories (NSFW sexual content, minors, real-person packs, voice cloning, therapy/diagnosis, legal positioning, criminal instruction, etc.) with reasons and their canonical safety-category names.
- **Allowed practice content** — explicit list of what is in-scope (interviews, negotiations, language practice, difficult conversations, social confidence, dating-confidence practice).
- **Dating-confidence scenarios** — PG-13 boundary: social/conversational framing is OK, no erotic escalation, all parties must be adults.
- **Real-person packs — full prohibition** — explains why (rights, consent, misinformation risk) and clarifies fictional archetypes are fine.
- **Voice cloning prohibition** — explains what is blocked and that `voice_cloning_request` fires before the NPC runtime.
- **Therapy, diagnosis, and legal positioning — explicitly disallowed** — distinguishes "practice talking to your doctor" (OK) from "get a real diagnosis" (not OK).
- **Pack sandboxing and prompt injection** — documents that packs are declarative YAML/JSON only (no scripts field allowed), lists what packs can and cannot do, and explains the five prompt-injection mitigations (safety layer injected last, output validator, pre-inference input router, load-time schema validation, no executable persona fields).

Added **Creator guide: understanding validation rejections** at the bottom, covering schema validation error messages, content policy rejection causes and fixes, and a clear explanation of why the constraints exist.

### `docs/privacy.md` (new)

Covers every data category:

| Category | Default | Storage |
|---|---|---|
| Conversation transcripts | Saved locally | Local SQLite (`~/.convsim/db/`) |
| Raw audio | Never saved | In-memory only during STT processing |
| TTS cache | Saved | Local `~/.convsim/tts-cache/` |
| Runtime logs | Saved | Local `~/.convsim/logs/`; raw player text never logged |
| Telemetry | **Absent from MVP** | Nothing transmitted |
| Crash reports | Not transmitted | Local log only |
| Exports | User-initiated | Local file; nothing transmitted |
| Model files | User-initiated download | Local `~/.convsim/models/` |

Also documents:
- How to delete all data (`rm -rf ~/.convsim/`)
- The offline smoke test command and its expected output (pass and fail)
- The privacy preferences reference (`convsim.privacy.*` localStorage keys)

### `README.md`

Expanded the "Local-first promise" section with a bulleted list making the no-telemetry/no-cloud-inference/no-transcript-by-default guarantees explicit and reusable, plus a link to `docs/privacy.md`.

## How it was tested

- Safety category names verified against `services/convsim-core/convsim_core/input_router.py` and `schemas/safety.schema.json`.
- Privacy constants cross-checked against `services/convsim-core/convsim_core/privacy.py` (`LOCAL_FIRST_STATEMENT`, `TELEMETRY_POLICY`, `TRANSCRIPT_SAVING_NOTICE`, `RAW_AUDIO_NOTICE`, `TTS_CACHE_NOTICE`, `CRASH_LOG_NOTICE`).
- API endpoints (clear, export) verified against `apps/api/src/routes/privacy.ts`.
- Privacy preference keys verified against `apps/web/src/privacyPrefs.ts`.
- Offline smoke test command and output verified against existing `README.md` documentation.
- Pack sandboxing details verified against `schemas/pack.schema.json` (`"not": {"required": ["scripts"]}`, `allow_external_urls: false`).

Closes #74