### PR TITLE
Write architecture, runtime adapter, and scenario engine documentation

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,7 +99,7 @@ Player text (HTTP POST /api/sessions/{id}/turn)
         │     which classifies input against global non-overridable rules
         │     (minors, self-harm crisis) and policy-configurable rules
         │     (NSFW, criminal, etc.) into ok | redirect | refuse | stop |
-        │     stop_with_resource. It is not yet wired into this pipeline.
+        │     stop_with_resource_message. It is not yet wired into this pipeline.
         │
         ▼ 3. Build prompt  (convsim_prompt.compose_turn_prompt)
         │     scenario context, NPC persona, state variables,
@@ -233,8 +233,9 @@ The WebSocket endpoint is at `ws://127.0.0.1:7355/ws/session/{id}`, served by
 the API layer (`apps/api`). On connect the server always sends the current
 `session.state` so a reconnecting client can resync.
 
-Pass `?after_seq=0` to also replay the recent durable events for the session
-(NPC turns and the ending, capped at the 50 most recent). Per-`seq` resume —
+Pass `?after_seq=0` to also replay the durable events for the session in
+chronological order (NPC opening, NPC turns, and the ending, capped at the
+first 50 by `event_id`). Per-`seq` resume —
 passing the last received `seq` to receive only events after it — is **not yet
 implemented**; any non-zero `after_seq` value is silently ignored because the
 persisted events are keyed by `event_id`, a different number space from the WS

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -229,8 +229,17 @@ was already recorded.
 
 ## WebSocket events
 
-The WebSocket endpoint is at `ws://127.0.0.1:7355/ws/session/{id}`.
-On reconnect, pass `?after_seq={seq}` to resume after the last received event.
+The WebSocket endpoint is at `ws://127.0.0.1:7355/ws/session/{id}`, served by
+the API layer (`apps/api`). On connect the server always sends the current
+`session.state` so a reconnecting client can resync.
+
+Pass `?after_seq=0` to also replay the recent durable events for the session
+(NPC turns and the ending, capped at the 50 most recent). Per-`seq` resume —
+passing the last received `seq` to receive only events after it — is **not yet
+implemented**; any non-zero `after_seq` value is silently ignored because the
+persisted events are keyed by `event_id`, a different number space from the WS
+`seq`. Until seq-mapped replay lands, a client that detects a gap should
+re-fetch full state via `GET /api/sessions/{id}`.
 
 Every message is a JSON object with these base fields:
 
@@ -244,9 +253,9 @@ Every message is a JSON object with these base fields:
 }
 ```
 
-`seq` is a monotonically increasing per-session counter. Gaps in `seq` on
-reconnect indicate missed events; the client should re-fetch state via
-`GET /api/sessions/{id}`.
+`seq` is a monotonically increasing per-session counter assigned by the server
+as each event is sent. Gaps in `seq` indicate missed events; the client should
+re-fetch state via `GET /api/sessions/{id}`.
 
 ### Event types
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,42 +1,401 @@
 <!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Architecture
 
-> **Status:** Placeholder. Will be expanded in Milestone 1 (text-only simulator).
+This document gives a developer-level overview of the Conversation Simulator system.
+It covers the service topology, turn pipeline, session state machine, WebSocket event
+contract, and the pack-loading security boundary.
 
-For the full technical specification, see [SPEC.md](SPEC.md) — sections 5 and 16
-cover the high-level architecture and recommended repository layout.
+For runtime adapter details see [runtime-adapters.md](runtime-adapters.md).
+For the full technical specification see [SPEC.md](SPEC.md).
 
-## Overview
+---
+
+## Service topology
+
+All services bind to `127.0.0.1` only. No traffic leaves the machine unless the
+user explicitly enables LAN access (`CONVSIM_LAN_ACCESS_ENABLED=true`).
 
 ```
-Browser UI (React/TypeScript/Vite)
-        │ localhost WebSocket/HTTP
-        ▼
-convsim-core (Python FastAPI)
+┌──────────────────────────────────────────────────────────────────┐
+│                        Developer machine                         │
+│                                                                  │
+│  ┌──────────────────────┐                                        │
+│  │  Browser             │  React/TypeScript/Vite                 │
+│  │  convsim-ui :7354    │                                        │
+│  └──────────┬───────────┘                                        │
+│             │  HTTP REST + WebSocket (localhost)                 │
+│             ▼                                                    │
+│  ┌──────────────────────┐   SQLite                              │
+│  │  convsim-core :7355  │◄──────────────────┐                   │
+│  │  Python / FastAPI    │                   │                   │
+│  └──────────┬───────────┘             ~/.convsim/               │
+│             │                          convsim.db               │
+│    ┌────────┼─────────────────┐                                 │
+│    ▼        ▼                 ▼                                 │
+│  :7356    :7357             :7358                               │
+│  LLM      STT               TTS                                 │
+│  llama-   whisper.cpp       Kokoro /                            │
+│  server   worker            sherpa-onnx                         │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### Service ports
+
+| Service       | Port  | Responsibility                          |
+|---------------|-------|-----------------------------------------|
+| convsim-ui    | 7354  | Browser UI (Vite dev server)            |
+| convsim-core  | 7355  | Main API, scenario engine, WebSocket    |
+| convsim-llm   | 7356  | Local LLM server (llama-server)         |
+| convsim-stt   | 7357  | Speech-to-text worker (whisper.cpp)     |
+| convsim-tts   | 7358  | Text-to-speech worker (Kokoro/sherpa)   |
+
+### Key directories
+
+| Path                         | Contents                              |
+|------------------------------|---------------------------------------|
+| `services/convsim-core/`     | Python FastAPI backend                |
+| `apps/web/`                  | React frontend                        |
+| `apps/api/`                  | TypeScript/Fastify API proxy layer    |
+| `packages/`                  | Shared TS packages (types, UI, CLI)   |
+| `runtimes/`                  | LLM/STT binary integration helpers   |
+| `packs/`                     | Official first-party scenario packs   |
+| `schemas/`                   | JSON Schema definitions               |
+| `~/.convsim/`                | Runtime data root (db, packs, logs)   |
+
+---
+
+## Design principles
+
+- **Provider abstraction.** The scenario engine calls `ChatRuntime`, never a
+  specific LLM library. New runtimes (Ollama, llama.cpp, future providers)
+  implement the same interface without touching engine code.
+
+- **Declarative packs.** Scenario content is YAML/JSON data, never executable
+  code. The validator enforces this at import time (see [Pack security](#pack-security)).
+
+- **Local-only inference.** No LLM, STT, or TTS call leaves the machine.
+  SQLite holds all session state and transcripts.
+
+- **Layered safety.** Deterministic keyword checks precede the LLM call;
+  the LLM itself applies policy-scoped content rules; output validation
+  can reject or fall back on malformed responses.
+
+---
+
+## Turn pipeline
+
+A single player turn passes through nine ordered steps inside
+`convsim_core/services/turn_pipeline.py`.
+
+```
+Player text (HTTP POST /api/sessions/{id}/turn)
         │
-        ├── LLM runtime (llama.cpp / Ollama)  :7356
-        ├── STT runtime (whisper.cpp)          :7357
-        ├── TTS runtime (Kokoro / sherpa-onnx) :7358
-        └── SQLite database
+        ▼ 1. Normalize & validate
+        │     strip whitespace, reject empty, reject > 2000 chars
+        │
+        ▼ 2. Safety precheck  (input_router.route_player_input)
+        │     global non-overridable rules → minors, self-harm crisis
+        │     policy-configurable rules   → NSFW, criminal, etc.
+        │     → ok | redirect | refuse | stop | stop_with_resource
+        │
+        ▼ 3. Build prompt  (convsim_prompt.compose_turn_prompt)
+        │     scenario context, NPC persona, state variables,
+        │     last 12 transcript turns, safety policy, player utterance
+        │
+        ▼ 4. Call ChatRuntime  (runtime.chat_stream)
+        │     streams ChatToken chunks, receives ChatFinal
+        │
+        ▼ 5. Validate / repair / fallback  (convsim_prompt.parse_turn_output)
+        │     JSON schema validation; fallback utterance on parse failure:
+        │     "I didn't quite catch that. Can you say that again?"
+        │
+        ▼ 6. Apply bounded state deltas  (scenario_state.apply_state_delta)
+        │     reject unknown keys, clamp per-turn delta, clamp to [min,max]
+        │
+        ▼ 7. Evaluate event triggers & ending conditions
+        │     (scenario_state.evaluate_event_triggers / evaluate_ending_condition)
+        │     variable_above / variable_below / max_turns / flag conditions
+        │     ending priority: safety_stop → player_exit → success → failure → timeout
+        │
+        ▼ 8. Persist atomically  (SQLite transaction)
+        │     player turn row, NPC turn row, state_delta event,
+        │     scenario_event rows, safety events, ending event,
+        │     FTS entries (if save_transcript=true),
+        │     update turn_sessions.state_vars_json / flow_state
+        │
+        ▼ 9. Return TurnPipelineResult
+              → HTTP response with events array
 ```
 
-## Service ports
+**Error policy.** `TurnInputError` (steps 1–2) surfaces as HTTP 400.
+Model errors (step 4) are absorbed; the safe fallback utterance is used
+instead and `used_fallback=true` is set in the result.
 
-| Service       | Port | Responsibility                          |
-| ------------- | ---- | --------------------------------------- |
-| convsim-ui    | 7354 | Browser UI (dev mode)                   |
-| convsim-core  | 7355 | Main server, scenario engine, WebSocket |
-| convsim-llm   | 7356 | Local LLM server (llama-server)         |
-| convsim-stt   | 7357 | Speech-to-text worker                   |
-| convsim-tts   | 7358 | Text-to-speech worker                   |
+---
 
-All services bind to `127.0.0.1` only. LAN access is an opt-in advanced setting.
+## Session state machine
 
-## Key design principles
+Sessions progress through a linear set of states stored in
+`turn_sessions.flow_state`. The full set of valid states is defined in
+`packages/shared/src/types/session.ts`.
 
-- The scenario engine speaks to a `ChatRuntime` abstraction, not directly to
-  any one LLM provider. New runtimes (Ollama, llama.cpp, future providers)
-  implement the same interface.
-- Scenario packs are declarative data (YAML/JSON), never executable code.
-- All inference, transcription, and synthesis runs locally on the user's machine.
-- SQLite stores all session state, transcripts, and installed pack metadata.
+```
+NotStarted
+    │  POST /api/sessions/{id}/start
+    ▼
+PlayerTurnListening   ◄──────────────────────────┐
+    │  POST /api/sessions/{id}/turn               │
+    ▼                                             │
+ (turn pipeline runs)                             │
+    │                                             │
+    ├─── ending_type = null ──────────────────────┘  (session continues)
+    │
+    └─── ending_type set ──► Ended
+                               │
+                               │  POST /api/sessions/{id}/debrief
+                               ▼
+                         DebriefGenerating
+                               │
+                               ▼
+                         DebriefReady
+```
+
+Additional states used by the frontend state machine (not persisted
+in the DB, managed client-side):
+
+| State              | Description                                      |
+|--------------------|--------------------------------------------------|
+| `LoadingModel`     | Waiting for the LLM runtime to become ready      |
+| `LoadingScenario`  | Fetching scenario data from the API              |
+| `Briefing`         | Showing the player role briefing before start    |
+| `NpcOpening`       | Displaying the NPC opening line                  |
+| `PlayerTurnReview` | Player has typed; confirming before submit       |
+| `NpcThinking`      | Waiting for first NPC token                      |
+| `NpcSpeaking`      | Streaming NPC tokens to the UI                   |
+| `ScenarioEvent`    | A scenario narrative event is being displayed    |
+| `Error`            | Unrecoverable error; debrief may still be tried  |
+
+### Ending types
+
+| Ending type    | Cause                                                 |
+|----------------|-------------------------------------------------------|
+| `success`      | Scenario success condition met                        |
+| `failure`      | Scenario failure condition met                        |
+| `timeout`      | `max_turns` reached without success or failure        |
+| `safety_stop`  | Input safety precheck or NPC output triggered stop    |
+| `player_exit`  | Player called `POST /api/sessions/{id}/end`           |
+
+---
+
+## REST API summary
+
+Base URL: `http://127.0.0.1:7355`
+
+### Sessions
+
+| Method | Path                              | Description                              |
+|--------|-----------------------------------|------------------------------------------|
+| POST   | `/api/sessions`                   | Create a session (`NotStarted`)          |
+| GET    | `/api/sessions/{id}`              | Get current state                        |
+| POST   | `/api/sessions/{id}/start`        | Deliver NPC opening; → `PlayerTurnListening` |
+| POST   | `/api/sessions/{id}/turn`         | Submit player turn; runs full pipeline   |
+| POST   | `/api/sessions/{id}/end`          | End session; → `Ended`                   |
+| POST   | `/api/sessions/{id}/debrief`      | Generate debrief; → `DebriefReady`       |
+| GET    | `/api/sessions/{id}/transcript`   | Retrieve full transcript                 |
+| GET    | `/api/sessions/{id}/export`       | Export session JSON (turns + events + debrief) |
+| DELETE | `/api/sessions/{id}`              | Delete session and transcript            |
+
+**Idempotency note.** `POST /turn` is not idempotent. Before retrying after
+a network failure, call `GET /api/sessions/{id}` to check whether the turn
+was already recorded.
+
+### Other routes
+
+| Prefix          | Description                           |
+|-----------------|---------------------------------------|
+| `/api/health`   | Liveness and runtime health check     |
+| `/api/settings` | User settings (key-value)             |
+| `/api/models`   | Model manager (list, install, status) |
+| `/api/packs`    | Pack import, validation, browsing     |
+| `/api/scenarios`| Scenario catalog and metadata         |
+| `/api/stt`      | STT worker control                    |
+| `/api/sidecar`  | llama-server sidecar control          |
+| `/api/diag`     | Diagnostics and system info           |
+
+---
+
+## WebSocket events
+
+The WebSocket endpoint is at `ws://127.0.0.1:7355/ws/sessions/{id}`.
+
+Every message is a JSON object with these base fields:
+
+```json
+{
+  "seq": 42,
+  "session_id": "sess-abc123",
+  "type": "npc.token",
+  "ts": "2025-01-01T00:00:00.000Z",
+  "payload": { ... }
+}
+```
+
+`seq` is a monotonically increasing per-session counter. Gaps in `seq` on
+reconnect indicate missed events; the client should re-fetch state via
+`GET /api/sessions/{id}`.
+
+### Event types
+
+| Type                    | When emitted                                        | Key payload fields                               |
+|-------------------------|-----------------------------------------------------|--------------------------------------------------|
+| `session.state`         | Any state transition                                | `state`, `state_vars?`, `ending_type?`           |
+| `npc.token`             | Each streamed LLM token                             | `text`                                           |
+| `npc.final`             | NPC response complete                               | `content`, `emotion`, `state_delta`, `event_flags` |
+| `scenario.state_delta`  | State variables updated after a turn                | `delta`, `state_vars`                            |
+| `scenario.event`        | A scenario narrative event fired                    | `flags`                                          |
+| `safety.redirect`       | Input safety redirected the conversation            | `reason`                                         |
+| `error`                 | Processing error (may or may not be fatal)          | `code`, `message`, `details?`                    |
+
+Reserved for future speech support (clients should accept and ignore):
+
+| Type               | Planned purpose                              |
+|--------------------|----------------------------------------------|
+| `stt.partial`      | Interim speech-to-text transcript            |
+| `stt.final`        | Final speech-to-text transcript              |
+| `tts.audio_chunk`  | Base64-encoded audio chunk                   |
+
+---
+
+## Scenario state variables
+
+Every session maintains a state dictionary of integer variables clamped
+to `[min, max]`. Six baseline variables are present in every scenario:
+
+| Variable            | Default | Visibility | Description                    |
+|---------------------|---------|------------|--------------------------------|
+| `trust`             | 50      | visible    | NPC trust in the player        |
+| `patience`          | 75      | visible    | NPC tolerance for misbehavior  |
+| `pressure`          | 25      | **hidden** | Situational pressure on NPC    |
+| `rapport`           | 50      | visible    | Conversational warmth          |
+| `openness`          | 50      | visible    | NPC willingness to share       |
+| `objective_progress`| 0       | visible    | Progress toward scenario goal  |
+
+Scenario packs can override baseline defaults or add custom variables via
+the `state.variables` block in the scenario YAML. Each variable also carries
+`max_delta_per_turn` (default 20) which caps how much the LLM can move it
+per turn. Unknown variable names proposed by the LLM are rejected silently
+and logged at WARNING.
+
+---
+
+## Pack security
+
+Scenario packs are **untrusted data**. The validator and importer apply
+multiple security layers before any pack content reaches the engine.
+
+### What is enforced at import time
+
+1. **No executable content.** Forbidden extensions include `.exe`, `.bat`,
+   `.cmd`, `.sh`, `.ps1`, `.py`, `.js`, `.ts`, `.jar`, `.so`, `.dll`,
+   `.dylib`, `.wasm`. Files are also inspected for magic bytes (ELF,
+   Mach-O, PE, WebAssembly, shebangs) regardless of extension.
+
+2. **No symlinks in zip archives.** `safe_extract_zip` rejects symlinks
+   and any path that would escape the extraction directory (zip-slip
+   protection).
+
+3. **Size cap.** ZIP archives may not expand beyond 500 MB.
+
+4. **Schema validation.** Every YAML file is validated against a
+   corresponding JSON Schema (pack manifest, scenario, NPC, rubric,
+   safety policy, scene). Validation errors block import.
+
+5. **Prompt injection scanning.** Scenario text is scanned for patterns
+   that attempt to override the system prompt, switch roles, or escape
+   delimiters. Findings are reported as warnings or errors.
+
+6. **Path escape check.** The computed install directory is verified to
+   stay within `~/.convsim/packs/`.
+
+7. **Conflict check.** Importing a pack whose `pack_id` is already
+   installed is rejected (HTTP 409).
+
+### What packs can and cannot do
+
+| Packs can                                   | Packs cannot                            |
+|---------------------------------------------|-----------------------------------------|
+| Define NPC personas, goals, and tone        | Execute arbitrary code                  |
+| Configure state variables and their limits  | Override global safety rules            |
+| Add custom scenario events                  | Install files outside the pack dir      |
+| Specify a content rating cap (G/PG/PG-13)   | Claim a content rating higher than PG-13|
+| Define per-category safety policy actions   | Disable minors or self-harm rules       |
+| Include images, audio, and text assets      | Embed external URLs in assets           |
+
+### Runtime separation
+
+System-level prompts (NPC persona framing, safety policy, output schema)
+are composed by `convsim_prompt.compose_turn_prompt` from structured
+fields, not from raw pack strings interpolated into the prompt verbatim.
+Pack text that reaches the prompt is placed inside clearly delimited
+content sections, reducing the blast radius of injection attempts.
+
+---
+
+## Debrief engine
+
+After a session ends, `POST /api/sessions/{id}/debrief` calls
+`services/debrief_engine.generate_debrief`:
+
+1. Load all turns and raw LLM output from the database.
+2. Aggregate rubric observations (score deltas per dimension from each turn).
+3. Compute weighted per-dimension and overall scores (baseline 50, range 0–100).
+4. Identify turning points: significant state changes, event flags, safety events.
+5. Build a debrief prompt (scenario context + full transcript + rubric scores).
+6. Call `ChatRuntime.chat_stream` with the debrief JSON schema.
+7. Persist and return the debrief document.
+
+Language guardrails in the prompt prohibit clinical advice, performance
+guarantees, and invented quotes. Evidence is cited by turn number only.
+
+---
+
+## Database schema (SQLite)
+
+The database lives at `~/.convsim/convsim.db` with WAL mode and
+`PRAGMA foreign_keys = ON`.
+
+| Table                  | Purpose                                              |
+|------------------------|------------------------------------------------------|
+| `packs`                | Installed pack metadata                              |
+| `scenarios`            | Scenario catalog (one row per scenario)              |
+| `scenario_versions`    | Versioned scenario JSON content                      |
+| `turn_sessions`        | Active and completed sessions                        |
+| `turn_session_turns`   | Individual player and NPC turns                      |
+| `turn_session_events`  | Per-turn events (state_delta, scenario_event, etc.)  |
+| `session_debriefs`     | Generated debrief documents (JSON)                   |
+| `installed_models`     | Downloaded model files and install status            |
+| `model_registry`       | Curated model definitions with checksums             |
+| `asset_index`          | Pack asset catalog                                   |
+| `user_settings`        | Key-value user preferences                           |
+
+Full-text search tables (FTS5): `session_transcript_fts`, `scenario_fts`,
+`pack_readme_fts`.
+
+---
+
+## Future / non-MVP areas
+
+The following areas are planned but not implemented in the current milestone:
+
+- **Voice input/output (STT/TTS).** Ports 7357 and 7358 are reserved;
+  the WebSocket `stt.*` and `tts.*` event types are defined but not
+  yet emitted.
+- **Godot / VR client.** The WebSocket protocol is designed to support
+  non-browser clients; a Godot adapter is a planned future target.
+- **Pack marketplace.** Import currently supports local folders and zip
+  uploads. A curated marketplace with signed packs is planned.
+- **Model classifier safety hook.** The `_safety_precheck` function in
+  `turn_pipeline.py` is a placeholder; a local model classifier will
+  replace the regex-only approach.
+- **LAN multiplayer.** `CONVSIM_LAN_ACCESS_ENABLED=true` unlocks LAN
+  binding, but multi-user session management is not yet implemented.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,8 +28,8 @@ user explicitly enables LAN access (`CONVSIM_LAN_ACCESS_ENABLED=true`).
 │  ┌──────────────────────┐   SQLite                              │
 │  │  convsim-core :7355  │◄──────────────────┐                   │
 │  │  Python / FastAPI    │                   │                   │
-│  └──────────┬───────────┘             ~/.convsim/               │
-│             │                          convsim.db               │
+│  └──────────┬───────────┘          ~/.convsim/db/               │
+│             │                       convsim.sqlite              │
 │    ┌────────┼─────────────────┐                                 │
 │    ▼        ▼                 ▼                                 │
 │  :7356    :7357             :7358                               │
@@ -93,10 +93,13 @@ Player text (HTTP POST /api/sessions/{id}/turn)
         ▼ 1. Normalize & validate
         │     strip whitespace, reject empty, reject > 2000 chars
         │
-        ▼ 2. Safety precheck  (input_router.route_player_input)
-        │     global non-overridable rules → minors, self-harm crisis
-        │     policy-configurable rules   → NSFW, criminal, etc.
-        │     → ok | redirect | refuse | stop | stop_with_resource
+        ▼ 2. Input safety precheck  (turn_pipeline._safety_precheck)
+        │     currently a placeholder no-op (accepts all input).
+        │     The intended enforcement point is input_router.route_player_input,
+        │     which classifies input against global non-overridable rules
+        │     (minors, self-harm crisis) and policy-configurable rules
+        │     (NSFW, criminal, etc.) into ok | redirect | refuse | stop |
+        │     stop_with_resource. It is not yet wired into this pipeline.
         │
         ▼ 3. Build prompt  (convsim_prompt.compose_turn_prompt)
         │     scenario context, NPC persona, state variables,
@@ -107,7 +110,7 @@ Player text (HTTP POST /api/sessions/{id}/turn)
         │
         ▼ 5. Validate / repair / fallback  (convsim_prompt.parse_turn_output)
         │     JSON schema validation; fallback utterance on parse failure:
-        │     "I didn't quite catch that. Can you say that again?"
+        │     "I'm not sure what to say right now. Could you repeat that?"
         │
         ▼ 6. Apply bounded state deltas  (scenario_state.apply_state_delta)
         │     reject unknown keys, clamp per-turn delta, clamp to [min,max]
@@ -127,7 +130,7 @@ Player text (HTTP POST /api/sessions/{id}/turn)
               → HTTP response with events array
 ```
 
-**Error policy.** `TurnInputError` (steps 1–2) surfaces as HTTP 400.
+**Error policy.** `TurnInputError` (raised in step 1) surfaces as HTTP 400.
 Model errors (step 4) are absorbed; the safe fallback utterance is used
 instead and `used_fallback=true` is set in the result.
 
@@ -226,7 +229,8 @@ was already recorded.
 
 ## WebSocket events
 
-The WebSocket endpoint is at `ws://127.0.0.1:7355/ws/sessions/{id}`.
+The WebSocket endpoint is at `ws://127.0.0.1:7355/ws/session/{id}`.
+On reconnect, pass `?after_seq={seq}` to resume after the last received event.
 
 Every message is a JSON object with these base fields:
 
@@ -361,7 +365,7 @@ guarantees, and invented quotes. Evidence is cited by turn number only.
 
 ## Database schema (SQLite)
 
-The database lives at `~/.convsim/convsim.db` with WAL mode and
+The database lives at `~/.convsim/db/convsim.sqlite` with WAL mode and
 `PRAGMA foreign_keys = ON`.
 
 | Table                  | Purpose                                              |
@@ -395,7 +399,8 @@ The following areas are planned but not implemented in the current milestone:
 - **Pack marketplace.** Import currently supports local folders and zip
   uploads. A curated marketplace with signed packs is planned.
 - **Model classifier safety hook.** The `_safety_precheck` function in
-  `turn_pipeline.py` is a placeholder; a local model classifier will
-  replace the regex-only approach.
+  `turn_pipeline.py` is a no-op placeholder today. The deterministic
+  `input_router.route_player_input` classifier plus a future local model
+  classifier will be wired in as the real input-safety enforcement point.
 - **LAN multiplayer.** `CONVSIM_LAN_ACCESS_ENABLED=true` unlocks LAN
   binding, but multi-user session management is not yet implemented.

--- a/docs/runtime-adapters.md
+++ b/docs/runtime-adapters.md
@@ -112,8 +112,9 @@ class MyRuntime(ChatRuntime):
 ```
 
 The active runtime id is chosen by the `CONVSIM_RUNTIME_ID` environment
-variable (default: `"llama_cpp"`). Valid values are the ids of all
-registered runtimes.
+variable (default: `"fake"`, so the app runs with no model installed).
+Set `CONVSIM_RUNTIME_ID=llama_cpp` (or `ollama`) to use a real local model.
+Valid values are the ids of all registered runtimes.
 
 ---
 

--- a/docs/runtime-adapters.md
+++ b/docs/runtime-adapters.md
@@ -1,16 +1,428 @@
 <!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Runtime adapters
 
-> **Status:** Placeholder. Will be completed in Milestone 1 (text-only simulator).
+This document explains how the `ChatRuntime` abstraction works, describes each
+built-in adapter, and walks through adding a new runtime.
 
-This document will cover:
+For the system overview see [architecture.md](architecture.md).
 
-- The `ChatRuntime` abstraction interface
-- llama.cpp adapter (primary runtime via llama-server)
-- Ollama adapter (alternative runtime)
-- How to add a new runtime adapter
-- Runtime selection and fallback logic
-- Structured output / JSON schema enforcement per runtime
+---
 
-For the runtime directory, see [runtimes/](../runtimes/).
-For the architecture overview, see [architecture.md](architecture.md).
+## The `ChatRuntime` interface
+
+All LLM integrations implement `ChatRuntime`, defined in
+`services/convsim-core/convsim_core/runtime/base.py`.
+
+```python
+class ChatRuntime(ABC):
+    @property
+    @abstractmethod
+    def id(self) -> str: ...            # stable machine id, e.g. "llama_cpp"
+
+    @property
+    @abstractmethod
+    def display_name(self) -> str: ...  # human label shown in UI
+
+    @property
+    @abstractmethod
+    def capabilities(self) -> RuntimeCapabilities: ...
+
+    @abstractmethod
+    async def list_models(self) -> list[ModelInfo]: ...
+
+    @abstractmethod
+    def chat_stream(self, request: ChatRequest) \
+        -> AsyncIterator[ChatToken | ChatFinal]: ...
+
+    @abstractmethod
+    async def health(self) -> RuntimeHealth: ...
+```
+
+### Types
+
+**`RuntimeCapabilities`** — feature flags the engine uses to decide how to
+call the runtime:
+
+```python
+class RuntimeCapabilities(BaseModel):
+    streaming: bool   # yields ChatToken chunks before ChatFinal
+    json_schema: bool # can enforce a JSON Schema on the response
+    grammar: bool     # supports GBNF/BNF grammar constraints (future)
+    tool_calling: bool
+    embeddings: bool
+```
+
+**`ChatRequest`** — what the engine sends:
+
+```python
+class ChatRequest(BaseModel):
+    messages: list[ChatMessage]       # role: "system" | "user" | "assistant"
+    model_id: str | None              # None → runtime picks the loaded model
+    max_tokens: int = 512
+    temperature: float = 0.8
+    json_schema: dict | None          # if set and json_schema=True, enforce it
+```
+
+**Streaming contract.** `chat_stream` must yield zero or more `ChatToken`
+objects followed by exactly one `ChatFinal`. `ChatFinal.text` is the
+authoritative complete response; callers may build a preview from tokens
+but must not append to `ChatFinal.text`.
+
+```python
+class ChatToken(BaseModel):
+    type: Literal["token"] = "token"
+    text: str
+
+class ChatFinal(BaseModel):
+    type: Literal["final"] = "final"
+    text: str
+    model_id: str
+    input_tokens: int
+    output_tokens: int
+    structured: dict | None    # parsed JSON when json_schema was set
+```
+
+**`RuntimeHealth`** — returned by `health()`:
+
+```python
+class RuntimeHealth(BaseModel):
+    runtime_id: str
+    runtime_name: str
+    status: RuntimeStatus    # UNAVAILABLE | STARTING | READY | DEGRADED | ERROR
+    model_id: str | None
+    latency_ms: float | None
+    message: str | None
+    checked_at: str          # ISO 8601
+```
+
+---
+
+## Runtime registry
+
+Adapters self-register using the `@register(runtime_id)` decorator from
+`convsim_core/runtime/registry.py`. The application instantiates the
+selected runtime at startup via `build_runtime(runtime_id)`.
+
+```python
+from convsim_core.runtime.registry import register
+
+@register("my_runtime")
+class MyRuntime(ChatRuntime):
+    ...
+```
+
+The active runtime id is chosen by the `CONVSIM_RUNTIME_ID` environment
+variable (default: `"llama_cpp"`). Valid values are the ids of all
+registered runtimes.
+
+---
+
+## Built-in adapters
+
+### llama.cpp (primary)
+
+**Module:** `convsim_core/runtime/llama_cpp.py`  
+**Runtime id:** `llama_cpp`  
+**Display name:** `llama.cpp (local)`
+
+Connects to a running `llama-server` instance using its OpenAI-compatible
+HTTP API. `llama-server` is the inference binary from the llama.cpp project.
+
+**Capabilities:**
+
+| Capability   | Supported |
+|--------------|-----------|
+| streaming    | Yes       |
+| json_schema  | Yes (via `response_format.json_schema`) |
+| grammar      | No        |
+| tool_calling | No        |
+| embeddings   | No        |
+
+**Configuration** (environment variables, all prefixed `CONVSIM_LLAMA_CPP_`):
+
+| Variable                          | Default                     | Description                        |
+|-----------------------------------|-----------------------------|------------------------------------|
+| `CONVSIM_LLAMA_CPP_BASE_URL`      | `http://127.0.0.1:7356`     | llama-server base URL              |
+| `CONVSIM_LLAMA_CPP_MODEL_ID`      | `None` (server default)     | Model id to pass in requests       |
+| `CONVSIM_LLAMA_CPP_CONTEXT_LENGTH`| `None`                      | Context length hint for `list_models` |
+| `CONVSIM_LLAMA_CPP_TEMPERATURE`   | `0.8`                       | Default temperature                |
+| `CONVSIM_LLAMA_CPP_TOP_P`         | `0.95`                      | top-p sampling                     |
+| `CONVSIM_LLAMA_CPP_REPEAT_PENALTY`| `1.1`                       | Repetition penalty                 |
+| `CONVSIM_LLAMA_CPP_THREADS`       | `None`                      | CPU thread count                   |
+| `CONVSIM_LLAMA_CPP_GPU_LAYERS`    | `None`                      | Layers to offload to GPU           |
+| `CONVSIM_LLAMA_CPP_TIMEOUT`       | `30.0`                      | HTTP request timeout (seconds)     |
+| `CONVSIM_LLAMA_CPP_JSON_SCHEMA_ENABLED` | `True`              | Enable structured output           |
+
+**Health check.** Calls `GET /health` on the llama-server. HTTP 200 → READY;
+HTTP 503 → STARTING (model still loading); connection error → UNAVAILABLE.
+
+**Starting llama-server manually:**
+
+```sh
+llama-server --port 7356 --model /path/to/model.gguf
+```
+
+**JSON schema enforcement.** When `json_schema` is set on the request,
+the adapter wraps it in the `response_format.json_schema` OpenAI field.
+`strict` is set to `False` to avoid rejecting slightly out-of-spec responses.
+The adapter attempts `json.loads(full_text)` and sets `ChatFinal.structured`
+on success; parse failure leaves `structured=None` (the pipeline uses its
+own fallback logic).
+
+---
+
+### Ollama
+
+**Module:** `convsim_core/runtime/ollama_adapter.py`  
+**Runtime id:** `ollama`  
+**Display name:** `Ollama (local)`
+
+Connects to a local Ollama server using its native REST API (`/api/chat`
+and `/api/tags`). Does **not** depend on the `ollama` PyPI package, keeping
+`convsim_core` importable without Ollama installed.
+
+**Capabilities:**
+
+| Capability   | Supported |
+|--------------|-----------|
+| streaming    | Yes       |
+| json_schema  | Yes (via `format` field) |
+| grammar      | No        |
+| tool_calling | No        |
+| embeddings   | No        |
+
+**Configuration:**
+
+| Variable                    | Default                        | Description            |
+|-----------------------------|--------------------------------|------------------------|
+| `CONVSIM_OLLAMA_BASE_URL`   | `http://127.0.0.1:11434`       | Ollama server base URL |
+
+The Ollama port (11434) is Ollama's default and is separate from the
+Conversation Simulator port range.
+
+**Model selection.** If `ChatRequest.model_id` is `None`, the adapter
+calls `list_models()` and picks the first available model. If Ollama is
+reachable but has no models, it raises `RuntimeError` with instructions
+to run `ollama pull <model>`. If Ollama is unreachable, it raises with
+instructions to run `ollama serve`.
+
+**Health check.** Calls `GET /` on the Ollama server. READY if reachable
+and at least one model is installed; DEGRADED if reachable but no models;
+UNAVAILABLE on connection failure.
+
+**Starting Ollama:**
+
+```sh
+ollama serve         # start the server
+ollama pull llama3.2 # pull a compatible model
+```
+
+---
+
+### Fake (deterministic)
+
+**Module:** `convsim_core/runtime/fake.py`  
+**Runtime id:** `fake`  
+**Display name:** `Fake (deterministic)`
+
+A test double that never calls a real model. Used in automated tests and
+for running the UI without any LLM installed.
+
+**Behavior:**
+
+- Always returns the same fixed response so test assertions are stable.
+- When `json_schema` is absent: returns a plain text sentence.
+- When `json_schema` is present and contains `replay_suggestions` in
+  its `properties`: returns a canned debrief narrative JSON.
+- Otherwise: returns a canned NPC turn JSON with `npc_utterance`,
+  `npc_emotion`, `state_delta`, `event_flags`, `rubric_observations`,
+  `safety`, and `session_control`.
+- Streams tokens word-by-word with `asyncio.sleep(0)` between each
+  (yields control, no actual delay).
+- Health always returns READY with `latency_ms=0.0`.
+
+**Models exposed:** `fake-small` (4 096 context) and `fake-large` (32 768 context).
+
+Enable it by setting `CONVSIM_RUNTIME_ID=fake`.
+
+---
+
+## Adding a new runtime adapter
+
+Follow these steps to add a runtime that is not yet supported.
+
+### 1. Create the module
+
+Add a new file under `services/convsim-core/convsim_core/runtime/`.
+Name it after the runtime id, e.g. `my_provider.py`.
+
+```python
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import AsyncGenerator
+
+from convsim_core.runtime.base import ChatRuntime
+from convsim_core.runtime.registry import register
+from convsim_core.runtime.types import (
+    ChatFinal, ChatRequest, ChatToken,
+    ModelInfo, RuntimeCapabilities, RuntimeHealth, RuntimeStatus,
+)
+
+
+@register("my_provider")
+class MyProviderRuntime(ChatRuntime):
+    """One-line description of this runtime."""
+
+    @property
+    def id(self) -> str:
+        return "my_provider"
+
+    @property
+    def display_name(self) -> str:
+        return "My Provider (local)"
+
+    @property
+    def capabilities(self) -> RuntimeCapabilities:
+        return RuntimeCapabilities(
+            streaming=True,
+            json_schema=True,   # set to False if the backend cannot enforce schemas
+        )
+
+    async def list_models(self) -> list[ModelInfo]:
+        # Return the models available through this runtime.
+        # Return [] on connection error so callers can detect gracefully.
+        return []
+
+    def chat_stream(self, request: ChatRequest) -> AsyncGenerator[ChatToken | ChatFinal, None]:
+        return self._stream(request)
+
+    async def _stream(
+        self, request: ChatRequest
+    ) -> AsyncGenerator[ChatToken | ChatFinal, None]:
+        # Yield ChatToken chunks while the response streams.
+        # Yield exactly one ChatFinal at the end.
+        yield ChatToken(text="Hello ")
+        yield ChatToken(text="world.")
+        yield ChatFinal(
+            text="Hello world.",
+            model_id=request.model_id or "my-model",
+            input_tokens=10,
+            output_tokens=2,
+            structured=None,
+        )
+
+    async def health(self) -> RuntimeHealth:
+        checked_at = datetime.now(timezone.utc).isoformat()
+        # Probe the backend and return the appropriate status.
+        return RuntimeHealth(
+            runtime_id=self.id,
+            runtime_name=self.display_name,
+            status=RuntimeStatus.READY,
+            checked_at=checked_at,
+        )
+```
+
+### 2. Import the module at startup
+
+The `@register` decorator only fires when the module is imported.
+Add an import to `convsim_core/runtime/__init__.py`:
+
+```python
+from convsim_core.runtime import my_provider  # noqa: F401
+```
+
+Or import it in `app.py` before `build_runtime` is called — whichever
+pattern the other adapters follow in that file.
+
+### 3. Wire configuration
+
+If the runtime needs configuration (base URL, API key, etc.), use a
+Pydantic `BaseSettings` subclass with an appropriate env-var prefix,
+following the same pattern as `LlamaCppConfig` in `llama_cpp.py`.
+
+### 4. Add tests
+
+Add a test file at
+`services/convsim-core/tests/test_<runtime_id>_runtime.py`.
+
+At minimum, test:
+
+- `list_models()` returns `ModelInfo` objects.
+- `chat_stream()` yields at least one `ChatToken` and exactly one `ChatFinal`.
+- `health()` returns `RuntimeStatus.READY` when the backend is reachable.
+- `health()` returns `RuntimeStatus.UNAVAILABLE` when the backend is down
+  (mock the HTTP client with `respx` or `pytest-httpx`).
+
+See `tests/test_llama_cpp_runtime.py` and `tests/test_ollama_runtime.py`
+for examples.
+
+### 5. Select at runtime
+
+Set the environment variable before starting convsim-core:
+
+```sh
+CONVSIM_RUNTIME_ID=my_provider uvicorn convsim_core.app:app --port 7355
+```
+
+Or add it to the `.env` file in the service root.
+
+---
+
+## Runtime selection and fallback logic
+
+The active runtime is chosen once at application startup:
+
+```
+CONVSIM_RUNTIME_ID (env) → build_runtime(id) → ChatRuntime instance
+```
+
+There is no automatic fallback to another runtime if the selected one is
+unhealthy. Health status is reported to the UI via `GET /api/health` so the
+user can take corrective action (e.g. start `llama-server`).
+
+The `GET /api/models` endpoint proxies `runtime.list_models()` and
+`GET /api/health` proxies `runtime.health()`. Both are polled periodically
+by the UI home screen.
+
+---
+
+## Structured output and JSON schema enforcement
+
+The turn pipeline always passes `NPC_TURN_OUTPUT_SCHEMA` (from
+`convsim_prompt`) as `ChatRequest.json_schema`. This schema defines the
+expected NPC response format including `npc_utterance`, `npc_emotion`,
+`state_delta`, `event_flags`, `rubric_observations`, `safety`, and
+`session_control`.
+
+When `RuntimeCapabilities.json_schema` is `True`, the adapter encodes the
+schema in a backend-specific way:
+
+- **llama.cpp:** `response_format.json_schema` field in the
+  `/v1/chat/completions` request body.
+- **Ollama:** `format` field in the `/api/chat` request body.
+- **Fake:** returns a hard-coded valid JSON string regardless of schema.
+
+When `json_schema` is `False` (a future plain-text runtime, for example),
+the pipeline relies entirely on `convsim_prompt.parse_turn_output` to
+extract structured fields from free text, with the safe fallback utterance
+as the error case.
+
+---
+
+## Future adapters
+
+These are noted as non-MVP candidates:
+
+| Runtime id (proposed)    | Backend                              |
+|--------------------------|--------------------------------------|
+| `openai_compatible`      | Any OpenAI-API-compatible server     |
+| `mlx`                    | Apple MLX inference (Apple Silicon)  |
+| `tgi`                    | HuggingFace Text Generation Inference|
+| `vllm`                   | vLLM (for multi-GPU dev machines)    |
+
+Because all engine code is decoupled from adapter code via the
+`ChatRuntime` interface, adding any of these requires only steps 1–5
+above without changing the scenario engine, turn pipeline, or
+debrief engine.


### PR DESCRIPTION
Replaces placeholder stubs in `docs/architecture.md` and `docs/runtime-adapters.md` with complete developer-facing documentation derived directly from the source code.

## What changed

### `docs/architecture.md`
- Service topology ASCII diagram with all five ports (7354–7358) and their roles
- Key directory map for the monorepo
- Nine-step turn pipeline (normalize → safety precheck → prompt → runtime → validate → state delta → event triggers → atomic persist → return result) with code-level references
- Session state machine covering both persisted DB states and client-side UI states
- Full REST API route table for all session, pack, model, and diagnostic endpoints
- WebSocket event contract: base fields, `seq` gap detection on reconnect, all event types with payload shapes, reserved STT/TTS types
- Scenario state variable table (baseline set, visibility, per-turn delta cap)
- Pack security model: what is enforced at import time (executable content, zip-slip, size cap, schema validation, injection scanning, path escape, conflict check), and a clear table of what packs can vs. cannot do
- Debrief engine processing steps
- SQLite schema overview (all 10 tables + FTS)
- Future/non-MVP areas clearly identified (STT/TTS, Godot/VR, marketplace, classifier hook, LAN multiplayer)

### `docs/runtime-adapters.md`
- Full `ChatRuntime` abstract interface with all method signatures and type definitions (`RuntimeCapabilities`, `ChatRequest`, `ChatToken`, `ChatFinal`, `RuntimeHealth`, `RuntimeStatus`)
- Streaming contract: zero-or-more `ChatToken` then exactly one `ChatFinal`
- Registry `@register` decorator pattern and how `build_runtime` works
- `llama_cpp` adapter: capabilities table, all 10 `CONVSIM_LLAMA_CPP_*` env vars, health check logic, JSON schema enforcement approach
- `ollama` adapter: capabilities, `CONVSIM_OLLAMA_BASE_URL`, model auto-selection, health logic, startup commands
- `fake` adapter: deterministic behavior, schema-type detection, use in tests and text-only demo
- Five-step guide to adding a new runtime adapter (module, import, config, tests, selection)
- Runtime selection and fallback policy
- Structured output enforcement per adapter
- Table of future adapter candidates (OpenAI-compatible, MLX, TGI, vLLM)

## How it was tested

All documented port numbers, env var names, route paths, state names, event types, and type signatures were verified directly against the source files:
- `convsim_core/runtime/base.py`, `types.py`, `registry.py`, `llama_cpp.py`, `ollama_adapter.py`, `fake.py`
- `convsim_core/services/turn_pipeline.py`
- `convsim_core/input_router.py`
- `convsim_core/scenario_state.py`
- `convsim_core/routers/sessions.py`
- `packages/shared/src/types/ws-events.ts`, `session.ts`
- `convsim_core/packs/importer.py`
- `convsim_core/config.py`

Closes #73