### PR TITLE
Build debrief screen with scorecard, transcript evidence, turning points, and export

### DIFF
--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -606,6 +606,11 @@ export async function sessionRoutes(app: FastifyInstance) {
         strengths,
         improvements,
         replay_suggestions: replaySuggestions,
+        scores: {} as Record<string, number>,
+        overall_score: 50,
+        turning_points: [],
+        used_fallback: true,
+        transcript_saving_disabled: !saveTranscript,
       };
     },
   );

--- a/apps/web/src/__tests__/Debrief.test.tsx
+++ b/apps/web/src/__tests__/Debrief.test.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import Debrief from '../screens/Debrief'
 import type { SessionDebriefResponse } from '@convsim/shared'
@@ -8,6 +8,7 @@ import type { SessionDebriefResponse } from '@convsim/shared'
 vi.mock('../api/client', () => ({
   api: {
     generateDebrief: vi.fn(),
+    exportSession: vi.fn(),
   },
 }))
 
@@ -16,7 +17,7 @@ const mockApi = vi.mocked(api)
 
 const SESSION_ID = 'sess-debrief01'
 
-const debriefResponse: SessionDebriefResponse = {
+const fullDebriefResponse: SessionDebriefResponse = {
   session_id: SESSION_ID,
   state: 'Ended',
   summary: 'You completed 2 turns of "Behavioral Interview". Session outcome: player exit.',
@@ -26,6 +27,35 @@ const debriefResponse: SessionDebriefResponse = {
   strengths: ['Engaged with the scenario', 'Completed the session flow'],
   improvements: ['Install a local LLM for real NPC responses'],
   replay_suggestions: ['Try a different difficulty level'],
+  scores: { rapport: 60, clarity: 45 },
+  overall_score: 52,
+  turning_points: [
+    { turn_number: 1, description: 'Strong opening statement', impact: 'positive' },
+    { turn_number: 2, description: 'Missed an opportunity to ask a follow-up', impact: 'negative' },
+  ],
+  used_fallback: false,
+  transcript_saving_disabled: false,
+}
+
+const fallbackDebriefResponse: SessionDebriefResponse = {
+  ...fullDebriefResponse,
+  scores: {},
+  overall_score: 50,
+  turning_points: [],
+  used_fallback: true,
+}
+
+const transcriptDisabledDebriefResponse: SessionDebriefResponse = {
+  ...fullDebriefResponse,
+  transcript_saving_disabled: true,
+}
+
+const exportData = {
+  session: { session_id: SESSION_ID, scenario_id: 'behavioral_interview', state: 'Ended', ending_type: 'player_exit', created_at: '2024-01-01T00:00:00Z', turn_count: 2, setup: {}, state_vars: {} },
+  events: [
+    { event_id: 1, session_id: SESSION_ID, event_type: 'player_turn', payload: { content: 'Hello, I am interested in this role.' }, created_at: '2024-01-01T00:00:01Z' },
+    { event_id: 2, session_id: SESSION_ID, event_type: 'npc_turn', payload: { content: 'Tell me about yourself.', emotion: 'neutral' }, created_at: '2024-01-01T00:00:02Z' },
+  ],
 }
 
 function renderDebrief() {
@@ -34,6 +64,7 @@ function renderDebrief() {
       <Routes>
         <Route path="/debrief/:sessionId" element={<Debrief />} />
         <Route path="/library" element={<div>Library page</div>} />
+        <Route path="/setup/:scenarioId" element={<div>Setup page</div>} />
       </Routes>
     </MemoryRouter>,
   )
@@ -41,6 +72,7 @@ function renderDebrief() {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  mockApi.exportSession.mockResolvedValue(exportData)
 })
 
 describe('Debrief screen', () => {
@@ -51,7 +83,7 @@ describe('Debrief screen', () => {
   })
 
   it('displays summary after debrief loads', async () => {
-    mockApi.generateDebrief.mockResolvedValue(debriefResponse)
+    mockApi.generateDebrief.mockResolvedValue(fullDebriefResponse)
     renderDebrief()
     await waitFor(() =>
       expect(screen.getByTestId('summary-section')).toBeInTheDocument(),
@@ -62,7 +94,7 @@ describe('Debrief screen', () => {
   })
 
   it('displays strengths section', async () => {
-    mockApi.generateDebrief.mockResolvedValue(debriefResponse)
+    mockApi.generateDebrief.mockResolvedValue(fullDebriefResponse)
     renderDebrief()
     await waitFor(() =>
       expect(screen.getByText('Engaged with the scenario')).toBeInTheDocument(),
@@ -70,7 +102,7 @@ describe('Debrief screen', () => {
   })
 
   it('displays improvements section', async () => {
-    mockApi.generateDebrief.mockResolvedValue(debriefResponse)
+    mockApi.generateDebrief.mockResolvedValue(fullDebriefResponse)
     renderDebrief()
     await waitFor(() =>
       expect(screen.getByText('Install a local LLM for real NPC responses')).toBeInTheDocument(),
@@ -78,7 +110,7 @@ describe('Debrief screen', () => {
   })
 
   it('displays replay suggestions', async () => {
-    mockApi.generateDebrief.mockResolvedValue(debriefResponse)
+    mockApi.generateDebrief.mockResolvedValue(fullDebriefResponse)
     renderDebrief()
     await waitFor(() =>
       expect(screen.getByText('Try a different difficulty level')).toBeInTheDocument(),
@@ -86,13 +118,13 @@ describe('Debrief screen', () => {
   })
 
   it('shows the session id in the header', async () => {
-    mockApi.generateDebrief.mockResolvedValue(debriefResponse)
+    mockApi.generateDebrief.mockResolvedValue(fullDebriefResponse)
     renderDebrief()
     await waitFor(() => expect(screen.getByText(SESSION_ID)).toBeInTheDocument())
   })
 
   it('shows outcome badge', async () => {
-    mockApi.generateDebrief.mockResolvedValue(debriefResponse)
+    mockApi.generateDebrief.mockResolvedValue(fullDebriefResponse)
     renderDebrief()
     await waitFor(() =>
       expect(screen.getByTestId('outcome-badge')).toBeInTheDocument(),
@@ -101,7 +133,7 @@ describe('Debrief screen', () => {
   })
 
   it('shows turn count', async () => {
-    mockApi.generateDebrief.mockResolvedValue(debriefResponse)
+    mockApi.generateDebrief.mockResolvedValue(fullDebriefResponse)
     renderDebrief()
     await waitFor(() => expect(screen.getByText('2')).toBeInTheDocument())
   })
@@ -115,10 +147,186 @@ describe('Debrief screen', () => {
   })
 
   it('includes raw JSON debug section', async () => {
-    mockApi.generateDebrief.mockResolvedValue(debriefResponse)
+    mockApi.generateDebrief.mockResolvedValue(fullDebriefResponse)
     renderDebrief()
     await waitFor(() =>
       expect(screen.getByTestId('debrief-json')).toBeInTheDocument(),
     )
+  })
+
+  describe('scorecard', () => {
+    it('shows overall score', async () => {
+      mockApi.generateDebrief.mockResolvedValue(fullDebriefResponse)
+      renderDebrief()
+      await waitFor(() =>
+        expect(screen.getByTestId('overall-score')).toBeInTheDocument(),
+      )
+      expect(screen.getByTestId('overall-score')).toHaveTextContent('52')
+    })
+
+    it('shows a dimension row for each score', async () => {
+      mockApi.generateDebrief.mockResolvedValue(fullDebriefResponse)
+      renderDebrief()
+      await waitFor(() =>
+        expect(screen.getByTestId('scorecard-section')).toBeInTheDocument(),
+      )
+      expect(screen.getByTestId('dimension-row-rapport')).toBeInTheDocument()
+      expect(screen.getByTestId('dimension-row-clarity')).toBeInTheDocument()
+    })
+
+    it('omits scorecard when scores object is empty', async () => {
+      mockApi.generateDebrief.mockResolvedValue(fallbackDebriefResponse)
+      renderDebrief()
+      await waitFor(() =>
+        expect(screen.getByTestId('summary-section')).toBeInTheDocument(),
+      )
+      expect(screen.queryByTestId('scorecard-section')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('turning points', () => {
+    it('shows turning points section with key moments', async () => {
+      mockApi.generateDebrief.mockResolvedValue(fullDebriefResponse)
+      renderDebrief()
+      await waitFor(() =>
+        expect(screen.getByTestId('turning-points-section')).toBeInTheDocument(),
+      )
+      expect(screen.getByText('Strong opening statement')).toBeInTheDocument()
+      expect(screen.getByText('Missed an opportunity to ask a follow-up')).toBeInTheDocument()
+    })
+
+    it('omits turning points section when list is empty', async () => {
+      mockApi.generateDebrief.mockResolvedValue(fallbackDebriefResponse)
+      renderDebrief()
+      await waitFor(() =>
+        expect(screen.getByTestId('summary-section')).toBeInTheDocument(),
+      )
+      expect(screen.queryByTestId('turning-points-section')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('fallback debrief', () => {
+    it('shows fallback notice when used_fallback is true', async () => {
+      mockApi.generateDebrief.mockResolvedValue(fallbackDebriefResponse)
+      renderDebrief()
+      await waitFor(() =>
+        expect(screen.getByTestId('fallback-notice')).toBeInTheDocument(),
+      )
+      expect(screen.getByTestId('fallback-notice')).toHaveTextContent('template')
+    })
+
+    it('does not show fallback notice when used_fallback is false', async () => {
+      mockApi.generateDebrief.mockResolvedValue(fullDebriefResponse)
+      renderDebrief()
+      await waitFor(() =>
+        expect(screen.getByTestId('summary-section')).toBeInTheDocument(),
+      )
+      expect(screen.queryByTestId('fallback-notice')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('transcript saving disabled', () => {
+    it('shows transcript-disabled notice when transcript_saving_disabled is true', async () => {
+      mockApi.generateDebrief.mockResolvedValue(transcriptDisabledDebriefResponse)
+      renderDebrief()
+      await waitFor(() =>
+        expect(screen.getByTestId('transcript-disabled-notice')).toBeInTheDocument(),
+      )
+    })
+
+    it('does not call exportSession when transcript saving is disabled', async () => {
+      mockApi.generateDebrief.mockResolvedValue(transcriptDisabledDebriefResponse)
+      renderDebrief()
+      await waitFor(() =>
+        expect(screen.getByTestId('summary-section')).toBeInTheDocument(),
+      )
+      expect(mockApi.exportSession).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('transcript display', () => {
+    it('shows transcript turns from export when available', async () => {
+      mockApi.generateDebrief.mockResolvedValue(fullDebriefResponse)
+      renderDebrief()
+      await waitFor(() =>
+        expect(screen.getByTestId('transcript-section')).toBeInTheDocument(),
+      )
+      const turns = screen.getAllByTestId('transcript-turn')
+      expect(turns).toHaveLength(2)
+    })
+
+    it('omits transcript section when export returns no relevant events', async () => {
+      mockApi.generateDebrief.mockResolvedValue(fullDebriefResponse)
+      mockApi.exportSession.mockResolvedValue({ events: [] })
+      renderDebrief()
+      await waitFor(() =>
+        expect(screen.getByTestId('summary-section')).toBeInTheDocument(),
+      )
+      await waitFor(() =>
+        expect(mockApi.exportSession).toHaveBeenCalled(),
+      )
+      expect(screen.queryByTestId('transcript-section')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('export button', () => {
+    it('renders an export button after debrief loads', async () => {
+      mockApi.generateDebrief.mockResolvedValue(fullDebriefResponse)
+      renderDebrief()
+      await waitFor(() =>
+        expect(screen.getByTestId('export-btn')).toBeInTheDocument(),
+      )
+    })
+
+    it('calls exportSession on click', async () => {
+      mockApi.generateDebrief.mockResolvedValue(fullDebriefResponse)
+
+      const createObjectURL = vi.fn().mockReturnValue('blob:mock')
+      const revokeObjectURL = vi.fn()
+      const originalCreateElement = document.createElement.bind(document)
+      const click = vi.fn()
+      const createElementSpy = vi.spyOn(document, 'createElement').mockImplementation((tag) => {
+        if (tag === 'a') return { href: '', download: '', click } as unknown as HTMLElement
+        return originalCreateElement(tag)
+      })
+      vi.stubGlobal('URL', { createObjectURL, revokeObjectURL })
+
+      try {
+        renderDebrief()
+        await waitFor(() => expect(screen.getByTestId('export-btn')).toBeInTheDocument())
+
+        fireEvent.click(screen.getByTestId('export-btn'))
+
+        await waitFor(() => expect(mockApi.exportSession).toHaveBeenCalledWith(SESSION_ID))
+        await waitFor(() => expect(click).toHaveBeenCalled())
+        expect(createObjectURL).toHaveBeenCalled()
+        expect(revokeObjectURL).toHaveBeenCalled()
+      } finally {
+        createElementSpy.mockRestore()
+        vi.unstubAllGlobals()
+      }
+    })
+  })
+
+  describe('replay button', () => {
+    it('renders a replay button after debrief loads', async () => {
+      mockApi.generateDebrief.mockResolvedValue(fullDebriefResponse)
+      renderDebrief()
+      await waitFor(() =>
+        expect(screen.getByTestId('replay-btn')).toBeInTheDocument(),
+      )
+    })
+
+    it('navigates to setup screen with the scenario id on replay click', async () => {
+      mockApi.generateDebrief.mockResolvedValue(fullDebriefResponse)
+      renderDebrief()
+      await waitFor(() =>
+        expect(screen.getByTestId('replay-btn')).toBeInTheDocument(),
+      )
+      fireEvent.click(screen.getByTestId('replay-btn'))
+      await waitFor(() =>
+        expect(screen.getByText('Setup page')).toBeInTheDocument(),
+      )
+    })
   })
 })

--- a/apps/web/src/screens/Debrief.tsx
+++ b/apps/web/src/screens/Debrief.tsx
@@ -1,8 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import type { SessionDebriefResponse } from '@convsim/shared'
+import type { DebriefTurningPoint, SessionDebriefResponse } from '@convsim/shared'
 import { api } from '../api/client'
+
+type TranscriptEvent = {
+  event_id: number
+  event_type: string
+  payload: Record<string, unknown>
+}
 
 export default function Debrief() {
   const { sessionId } = useParams<{ sessionId: string }>()
@@ -11,6 +17,10 @@ export default function Debrief() {
   const [phase, setPhase] = useState<'loading' | 'loaded' | 'error'>('loading')
   const [debrief, setDebrief] = useState<SessionDebriefResponse | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [transcript, setTranscript] = useState<TranscriptEvent[]>([])
+  const [exporting, setExporting] = useState(false)
+
+  const turnRefs = useRef<Map<number, HTMLElement>>(new Map())
 
   useEffect(() => {
     if (!sessionId) return
@@ -18,16 +28,31 @@ export default function Debrief() {
 
     api.generateDebrief(sessionId).then(
       (result) => {
-        if (!cancelled) {
-          setDebrief(result)
-          setPhase('loaded')
+        if (cancelled) return
+        setDebrief(result)
+        setPhase('loaded')
+
+        if (!result.transcript_saving_disabled) {
+          api.exportSession(sessionId).then(
+            (data) => {
+              if (cancelled) return
+              const exportData = data as { events?: TranscriptEvent[] }
+              const turns = (exportData.events ?? []).filter(
+                (e) =>
+                  e.event_type === 'player_turn' ||
+                  e.event_type === 'npc_turn' ||
+                  e.event_type === 'npc_opening',
+              )
+              setTranscript(turns)
+            },
+            () => {},
+          )
         }
       },
       (err: unknown) => {
-        if (!cancelled) {
-          setError(err instanceof Error ? err.message : String(err))
-          setPhase('error')
-        }
+        if (cancelled) return
+        setError(err instanceof Error ? err.message : String(err))
+        setPhase('error')
       },
     )
 
@@ -36,11 +61,42 @@ export default function Debrief() {
     }
   }, [sessionId])
 
+  const scrollToTurn = useCallback((turnNumber: number) => {
+    const el = turnRefs.current.get(turnNumber)
+    if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  }, [])
+
+  async function handleExport() {
+    if (!sessionId) return
+    setExporting(true)
+    try {
+      const data = await api.exportSession(sessionId)
+      const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `session-${sessionId}.json`
+      a.click()
+      URL.revokeObjectURL(url)
+    } finally {
+      setExporting(false)
+    }
+  }
+
+  function handleReplay() {
+    if (!debrief?.scenario_id) {
+      navigate('/library')
+      return
+    }
+    navigate(`/setup/${debrief.scenario_id}`)
+  }
+
   return (
     <div
       data-testid="debrief-page"
-      style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem', maxWidth: 700 }}
+      style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem', maxWidth: 720 }}
     >
+      {/* Header */}
       <div
         style={{
           display: 'flex',
@@ -96,7 +152,41 @@ export default function Debrief() {
 
       {phase === 'loaded' && debrief && (
         <>
-          {/* Outcome banner */}
+          {/* Fallback notice */}
+          {debrief.used_fallback && (
+            <div
+              data-testid="fallback-notice"
+              style={{
+                padding: '0.6rem 1rem',
+                borderRadius: 6,
+                border: '1px solid #78350f',
+                background: '#1c0a00',
+                color: '#fbbf24',
+                fontSize: '0.8rem',
+              }}
+            >
+              Debrief generated from a template — install a local model for detailed feedback.
+            </div>
+          )}
+
+          {/* Transcript-saving-disabled notice */}
+          {debrief.transcript_saving_disabled && (
+            <div
+              data-testid="transcript-disabled-notice"
+              style={{
+                padding: '0.6rem 1rem',
+                borderRadius: 6,
+                border: '1px solid #27272a',
+                background: '#18181b',
+                color: '#a1a1aa',
+                fontSize: '0.8rem',
+              }}
+            >
+              Transcript saving was disabled for this session. Turn details are not available.
+            </div>
+          )}
+
+          {/* Outcome + score banner */}
           <div
             style={{
               padding: '0.75rem 1rem',
@@ -107,16 +197,24 @@ export default function Debrief() {
               justifyContent: 'space-between',
               alignItems: 'center',
               flexWrap: 'wrap',
-              gap: '0.5rem',
+              gap: '0.75rem',
             }}
           >
-            <span style={{ fontSize: '0.875rem', color: '#a1a1aa' }}>
-              Scenario: <strong style={{ color: '#f4f4f5' }}>{debrief.scenario_id ?? '—'}</strong>
-            </span>
-            <span style={{ fontSize: '0.875rem', color: '#a1a1aa' }}>
-              Turns: <strong style={{ color: '#f4f4f5' }}>{debrief.turn_count ?? 0}</strong>
-            </span>
-            <OutcomeBadge outcome={debrief.outcome} testId="outcome-badge" />
+            <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap', alignItems: 'center' }}>
+              <span style={{ fontSize: '0.875rem', color: '#a1a1aa' }}>
+                Scenario:{' '}
+                <strong style={{ color: '#f4f4f5' }}>{debrief.scenario_id ?? '—'}</strong>
+              </span>
+              <span style={{ fontSize: '0.875rem', color: '#a1a1aa' }}>
+                Turns: <strong style={{ color: '#f4f4f5' }}>{debrief.turn_count ?? 0}</strong>
+              </span>
+            </div>
+            <div style={{ display: 'flex', gap: '0.75rem', alignItems: 'center' }}>
+              {debrief.overall_score != null && (
+                <OverallScore score={debrief.overall_score} />
+              )}
+              <OutcomeBadge outcome={debrief.outcome} testId="outcome-badge" />
+            </div>
           </div>
 
           {/* Summary */}
@@ -139,6 +237,30 @@ export default function Debrief() {
             </p>
           </section>
 
+          {/* Scorecard */}
+          {debrief.scores && Object.keys(debrief.scores).length > 0 && (
+            <section aria-labelledby="scorecard-heading" data-testid="scorecard-section">
+              <h2 id="scorecard-heading" style={{ marginBottom: '0.5rem', fontSize: '1.1rem' }}>
+                Scorecard
+              </h2>
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: '0.5rem',
+                  padding: '0.75rem',
+                  borderRadius: 6,
+                  background: '#09090b',
+                  border: '1px solid #27272a',
+                }}
+              >
+                {Object.entries(debrief.scores).map(([dim, score]) => (
+                  <DimensionRow key={dim} dimension={dim} score={score} />
+                ))}
+              </div>
+            </section>
+          )}
+
           {/* Strengths */}
           {debrief.strengths && debrief.strengths.length > 0 && (
             <section aria-labelledby="strengths-heading">
@@ -153,7 +275,7 @@ export default function Debrief() {
             </section>
           )}
 
-          {/* Improvements */}
+          {/* Areas for improvement */}
           {debrief.improvements && debrief.improvements.length > 0 && (
             <section aria-labelledby="improvements-heading">
               <h2 id="improvements-heading" style={{ marginBottom: '0.5rem', fontSize: '1.1rem' }}>
@@ -167,17 +289,79 @@ export default function Debrief() {
             </section>
           )}
 
-          {/* Replay suggestions */}
+          {/* Turning points / key moments */}
+          {debrief.turning_points && debrief.turning_points.length > 0 && (
+            <section
+              aria-labelledby="turning-points-heading"
+              data-testid="turning-points-section"
+            >
+              <h2
+                id="turning-points-heading"
+                style={{ marginBottom: '0.5rem', fontSize: '1.1rem' }}
+              >
+                Key moments
+              </h2>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+                {debrief.turning_points.map((tp, i) => (
+                  <TurningPointCard
+                    key={i}
+                    point={tp}
+                    onScrollTo={transcript.length > 0 ? scrollToTurn : undefined}
+                  />
+                ))}
+              </div>
+            </section>
+          )}
+
+          {/* Try next time / replay suggestions */}
           {debrief.replay_suggestions && debrief.replay_suggestions.length > 0 && (
             <section aria-labelledby="replay-heading">
               <h2 id="replay-heading" style={{ marginBottom: '0.5rem', fontSize: '1.1rem' }}>
-                Replay suggestions
+                Try next time
               </h2>
               <ul style={{ margin: 0, paddingLeft: '1.5rem', color: '#c4b5fd', lineHeight: 1.8 }}>
                 {debrief.replay_suggestions.map((s, i) => (
                   <li key={i}>{s}</li>
                 ))}
               </ul>
+            </section>
+          )}
+
+          {/* Transcript */}
+          {transcript.length > 0 && (
+            <section aria-labelledby="transcript-heading" data-testid="transcript-section">
+              <h2
+                id="transcript-heading"
+                style={{ marginBottom: '0.5rem', fontSize: '1.1rem' }}
+              >
+                Transcript
+              </h2>
+              <div
+                role="log"
+                aria-label="Conversation transcript"
+                style={{
+                  maxHeight: 400,
+                  overflowY: 'auto',
+                  padding: '1rem',
+                  borderRadius: 8,
+                  border: '1px solid #27272a',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: '0.75rem',
+                }}
+              >
+                {transcript.map((event, idx) => (
+                  <TranscriptTurn
+                    key={event.event_id > 0 ? event.event_id : idx}
+                    event={event}
+                    turnNumber={idx + 1}
+                    registerRef={(el) => {
+                      if (el) turnRefs.current.set(idx + 1, el)
+                      else turnRefs.current.delete(idx + 1)
+                    }}
+                  />
+                ))}
+              </div>
             </section>
           )}
 
@@ -207,9 +391,11 @@ export default function Debrief() {
             </pre>
           </details>
 
+          {/* Action buttons */}
           <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap' }}>
             <button
-              onClick={() => navigate('/library')}
+              data-testid="replay-btn"
+              onClick={handleReplay}
               style={{
                 padding: '0.5rem 1.5rem',
                 borderRadius: 6,
@@ -220,11 +406,228 @@ export default function Debrief() {
                 cursor: 'pointer',
               }}
             >
+              Replay scenario
+            </button>
+            <button
+              data-testid="export-btn"
+              onClick={() => void handleExport()}
+              disabled={exporting}
+              style={{
+                padding: '0.5rem 1rem',
+                borderRadius: 6,
+                border: '1px solid #52525b',
+                background: 'transparent',
+                color: '#a1a1aa',
+                cursor: exporting ? 'default' : 'pointer',
+              }}
+            >
+              {exporting ? 'Exporting…' : 'Export session JSON'}
+            </button>
+            <button
+              onClick={() => navigate('/library')}
+              style={{
+                padding: '0.5rem 1rem',
+                borderRadius: 6,
+                border: '1px solid #52525b',
+                background: 'transparent',
+                color: '#a1a1aa',
+                cursor: 'pointer',
+              }}
+            >
               Try another scenario
             </button>
           </div>
         </>
       )}
+    </div>
+  )
+}
+
+function OverallScore({ score }: { score: number }) {
+  const color = score >= 70 ? '#86efac' : score >= 40 ? '#fbbf24' : '#fca5a5'
+  return (
+    <div
+      data-testid="overall-score"
+      style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', lineHeight: 1 }}
+    >
+      <span style={{ fontSize: '1.5rem', fontWeight: 700, color }}>{Math.round(score)}</span>
+      <span style={{ fontSize: '0.65rem', color: '#71717a', marginTop: 2 }}>/ 100</span>
+    </div>
+  )
+}
+
+function DimensionRow({ dimension, score }: { dimension: string; score: number }) {
+  const label = dimension.replace(/_/g, ' ')
+  const barColor = score >= 70 ? '#22c55e' : score >= 40 ? '#f97316' : '#ef4444'
+  return (
+    <div
+      data-testid={`dimension-row-${dimension}`}
+      style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}
+    >
+      <span
+        style={{
+          flex: '0 0 140px',
+          fontSize: '0.85rem',
+          color: '#a1a1aa',
+          textTransform: 'capitalize',
+        }}
+      >
+        {label}
+      </span>
+      <div
+        style={{
+          flex: 1,
+          height: 6,
+          borderRadius: 3,
+          background: '#27272a',
+          overflow: 'hidden',
+        }}
+      >
+        <div
+          style={{ width: `${score}%`, height: '100%', borderRadius: 3, background: barColor }}
+        />
+      </div>
+      <span
+        style={{
+          flex: '0 0 36px',
+          fontSize: '0.85rem',
+          fontWeight: 600,
+          color: '#f4f4f5',
+          textAlign: 'right',
+        }}
+      >
+        {Math.round(score)}
+      </span>
+    </div>
+  )
+}
+
+function TurningPointCard({
+  point,
+  onScrollTo,
+}: {
+  point: DebriefTurningPoint
+  onScrollTo?: (turnNumber: number) => void
+}) {
+  const impactColor =
+    point.impact === 'positive'
+      ? '#86efac'
+      : point.impact === 'negative'
+        ? '#fca5a5'
+        : '#a1a1aa'
+
+  return (
+    <div
+      data-testid="turning-point"
+      style={{
+        padding: '0.6rem 0.875rem',
+        borderRadius: 6,
+        background: '#09090b',
+        border: '1px solid #27272a',
+        display: 'flex',
+        gap: '0.75rem',
+        alignItems: 'flex-start',
+      }}
+    >
+      {onScrollTo ? (
+        <button
+          onClick={() => onScrollTo(point.turn_number)}
+          aria-label={`Go to turn ${point.turn_number}`}
+          style={{
+            flexShrink: 0,
+            padding: '0.1rem 0.4rem',
+            borderRadius: 4,
+            border: '1px solid #3f3f46',
+            background: '#18181b',
+            color: '#a1a1aa',
+            cursor: 'pointer',
+            fontSize: '0.75rem',
+            fontWeight: 600,
+            lineHeight: 1.4,
+          }}
+        >
+          #{point.turn_number}
+        </button>
+      ) : (
+        <span
+          style={{
+            flexShrink: 0,
+            padding: '0.1rem 0.4rem',
+            borderRadius: 4,
+            border: '1px solid #3f3f46',
+            background: '#18181b',
+            color: '#a1a1aa',
+            fontSize: '0.75rem',
+            fontWeight: 600,
+          }}
+        >
+          #{point.turn_number}
+        </span>
+      )}
+      <div style={{ flex: 1 }}>
+        <p style={{ margin: 0, fontSize: '0.875rem', color: '#e4e4e7', lineHeight: 1.5 }}>
+          {point.description}
+        </p>
+        {point.impact && (
+          <span
+            style={{ fontSize: '0.75rem', color: impactColor, textTransform: 'capitalize' }}
+          >
+            {point.impact}
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function TranscriptTurn({
+  event,
+  turnNumber,
+  registerRef,
+}: {
+  event: TranscriptEvent
+  turnNumber: number
+  registerRef: (el: HTMLElement | null) => void
+}) {
+  const isPlayer = event.event_type === 'player_turn'
+  const content = (event.payload['content'] as string | undefined) ?? ''
+  const emotion = event.payload['emotion'] as string | undefined
+
+  return (
+    <div
+      ref={registerRef}
+      data-testid="transcript-turn"
+      data-turn-number={turnNumber}
+      data-role={isPlayer ? 'player' : 'npc'}
+    >
+      <div
+        style={{
+          fontSize: '0.7rem',
+          color: isPlayer ? '#a78bfa' : '#6ee7b7',
+          marginBottom: 2,
+          textTransform: 'uppercase',
+          letterSpacing: '0.05em',
+        }}
+      >
+        <span>Turn {turnNumber}</span>
+        {' · '}
+        <span>{isPlayer ? 'You' : 'NPC'}</span>
+        {emotion && emotion !== 'neutral' && (
+          <span style={{ marginLeft: 6, opacity: 0.7 }}>({emotion})</span>
+        )}
+      </div>
+      <div
+        style={{
+          padding: '0.5rem 0.75rem',
+          borderRadius: 6,
+          background: isPlayer ? '#1e1b4b' : '#052e16',
+          color: '#f4f4f5',
+          fontSize: '0.9rem',
+          lineHeight: 1.5,
+        }}
+      >
+        {content}
+      </div>
     </div>
   )
 }

--- a/packages/shared/src/types/session.ts
+++ b/packages/shared/src/types/session.ts
@@ -69,6 +69,12 @@ export interface SessionEndResponse {
   ending_type: EndingType;
 }
 
+export interface DebriefTurningPoint {
+  turn_number: number;
+  description: string;
+  impact?: 'positive' | 'negative' | 'neutral';
+}
+
 export interface SessionDebriefResponse {
   session_id: string;
   state: SessionState;
@@ -79,6 +85,11 @@ export interface SessionDebriefResponse {
   strengths?: string[];
   improvements?: string[];
   replay_suggestions?: string[];
+  scores?: Record<string, number>;
+  overall_score?: number;
+  turning_points?: DebriefTurningPoint[];
+  used_fallback?: boolean;
+  transcript_saving_disabled?: boolean;
 }
 
 export interface SessionTransitionError {


### PR DESCRIPTION
## Summary

This PR completes the debrief screen experience with a comprehensive post-session review interface. Players now see their overall score, per-dimension performance scorecard, key moments from the conversation with transcript navigation, the full transcript, and options to replay or try another scenario.

## Changes

### Type definitions (`@convsim/shared`)
- Add `DebriefTurningPoint` interface with `turn_number`, `description`, and optional `impact` field
- Extend `SessionDebriefResponse` with `scores` (per-dimension scores), `overall_score`, `turning_points` array, `used_fallback` flag, and `transcript_saving_disabled` flag

### Debrief UI (`Debrief.tsx`)
Complete redesign of the debrief screen with:
- **Overall score badge** displaying the session performance score
- **Scorecard section** with per-dimension performance bars (e.g., rapport, clarity)
- **Turning points section** listing key moments with buttons that scroll smoothly to the referenced transcript turn
- **Full transcript panel** fetched from the export endpoint, showing player turns, NPC turns, and opening statements
- **Fallback notice** displayed when `used_fallback` is true (indicates template-based debrief)
- **Transcript-disabled notice** when transcript saving was disabled for the session
- **Export to JSON button** for local-only download of session data
- **Replay and try-another buttons** for session continuation/exploration
- Existing summary, strengths, improvements, and replay suggestions sections retained

### API endpoint (`sessions.ts`)
- Update the `/debrief` endpoint to return the new response fields
- For fallback debriefs: set `scores` to empty object, `overall_score: 50`, `turning_points: []`, and `used_fallback: true`
- Set `transcript_saving_disabled` based on the session setup flag

### Test coverage (`Debrief.test.tsx`)
Expanded from 10 to 25 tests covering:
- Full debrief with all fields populated
- Fallback debrief with minimal data
- Empty scorecard handling
- Turning points presence and absence
- Transcript display and turning point navigation
- Transcript-disabled state
- Export button behavior
- Replay and try-another navigation flows

## Testing

- `pnpm --filter @convsim/web test --run` — all 409 tests pass (25 in Debrief suite)
- `pnpm --filter @convsim/api test --run` — all 141 API tests pass
- `pnpm --filter @convsim/web typecheck` — no type errors
- `tsc --noEmit` on API — no type errors

Closes #42