### PR TITLE
Add transcript review panel so players can edit STT output before submitting a turn

### DIFF
--- a/apps/web/src/__tests__/Conversation.test.tsx
+++ b/apps/web/src/__tests__/Conversation.test.tsx
@@ -28,8 +28,9 @@ vi.mock('../api/client', () => ({
   },
 }))
 
-import { api } from '../api/client'
+import { api, apiClient } from '../api/client'
 const mockApi = vi.mocked(api)
+const mockApiClient = vi.mocked(apiClient)
 
 const SESSION_ID = 'sess-demo0001'
 const SCENARIO_ID = 'scenario-job-interview'
@@ -122,6 +123,7 @@ beforeEach(() => {
   // Default: connectSession returns a no-op connection; getScenario returns null
   mockApi.connectSession.mockReturnValue({ close: vi.fn() })
   mockApi.getScenario.mockResolvedValue(null as unknown as ScenarioInfo)
+  mockApiClient.uploadAudio.mockResolvedValue({ transcript: null, status: 'unavailable' })
 })
 
 describe('Conversation screen', () => {
@@ -800,7 +802,26 @@ describe('Conversation screen', () => {
       fireEvent.change(textarea, { target: { value: 'My answer.' } })
       fireEvent.click(screen.getByRole('button', { name: /submit/i }))
 
-      await waitFor(() => expect(screen.getByText('2 entries')).toBeInTheDocument())
+      // Opening entry + player entry + NPC entry = 3 entries
+      await waitFor(() => expect(screen.getByText('3 entries')).toBeInTheDocument())
+    })
+
+    it('creates a player debug entry when a turn is submitted in dev mode', async () => {
+      localStorage.setItem('convsim.devMode', 'true')
+      mockApi.startSession.mockResolvedValue(startResponse)
+      mockApi.submitTurn.mockResolvedValue(turnResponse)
+      renderConversation()
+      await waitFor(() =>
+        expect(screen.getByRole('textbox', { name: /your response/i })).toBeInTheDocument(),
+      )
+
+      fireEvent.change(screen.getByRole('textbox', { name: /your response/i }), {
+        target: { value: 'My answer.' },
+      })
+      fireEvent.click(screen.getByRole('button', { name: /submit/i }))
+
+      // 3 entries: opening + player turn + NPC turn
+      await waitFor(() => expect(screen.getByText('3 entries')).toBeInTheDocument())
     })
 
     it('debug drawer is not rendered (not just hidden) in normal mode', async () => {

--- a/apps/web/src/__tests__/TranscriptReviewPanel.test.tsx
+++ b/apps/web/src/__tests__/TranscriptReviewPanel.test.tsx
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import TranscriptReviewPanel from '../components/TranscriptReviewPanel'
+
+function renderPanel(overrides: Partial<Parameters<typeof TranscriptReviewPanel>[0]> = {}) {
+  const onConfirm = vi.fn()
+  const onCancel = vi.fn()
+  const onRetry = vi.fn()
+  render(
+    <TranscriptReviewPanel
+      transcript="hello world"
+      onConfirm={onConfirm}
+      onCancel={onCancel}
+      onRetry={onRetry}
+      {...overrides}
+    />,
+  )
+  return { onConfirm, onCancel, onRetry }
+}
+
+describe('TranscriptReviewPanel — rendering', () => {
+  it('renders the review panel with aria region label', () => {
+    renderPanel()
+    expect(screen.getByRole('region', { name: /transcript review/i })).toBeInTheDocument()
+  })
+
+  it('shows the transcript text in the editable textarea', () => {
+    renderPanel()
+    expect(screen.getByRole('textbox', { name: /edit transcript/i })).toHaveValue('hello world')
+  })
+
+  it('renders Submit, Retry, and Cancel buttons', () => {
+    renderPanel()
+    expect(screen.getByRole('button', { name: /submit transcript/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /retry recording/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /cancel and discard transcript/i })).toBeInTheDocument()
+  })
+
+  it('does not show hints section when language and confidence are absent', () => {
+    renderPanel()
+    expect(screen.queryByTestId('transcript-hints')).not.toBeInTheDocument()
+  })
+
+  it('shows the language hint when language is provided', () => {
+    renderPanel({ language: 'en' })
+    expect(screen.getByTestId('transcript-hints')).toHaveTextContent('Language: en')
+  })
+
+  it('shows the confidence hint when confidence is provided', () => {
+    renderPanel({ confidence: 0.87 })
+    expect(screen.getByTestId('transcript-hints')).toHaveTextContent('Confidence: 87%')
+  })
+
+  it('shows both language and confidence when both are provided', () => {
+    renderPanel({ language: 'fr', confidence: 0.93 })
+    const hints = screen.getByTestId('transcript-hints')
+    expect(hints).toHaveTextContent('Language: fr')
+    expect(hints).toHaveTextContent('Confidence: 93%')
+  })
+
+  it('rounds confidence to the nearest percent', () => {
+    renderPanel({ confidence: 0.956 })
+    expect(screen.getByTestId('transcript-hints')).toHaveTextContent('Confidence: 96%')
+  })
+})
+
+describe('TranscriptReviewPanel — submit action', () => {
+  it('calls onConfirm with the original transcript when Submit is clicked', () => {
+    const { onConfirm } = renderPanel()
+    fireEvent.click(screen.getByRole('button', { name: /submit transcript/i }))
+    expect(onConfirm).toHaveBeenCalledWith('hello world')
+  })
+
+  it('calls onConfirm with edited text when the transcript is modified', () => {
+    const { onConfirm } = renderPanel()
+    const textarea = screen.getByRole('textbox', { name: /edit transcript/i })
+    fireEvent.change(textarea, { target: { value: 'hello there' } })
+    fireEvent.click(screen.getByRole('button', { name: /submit transcript/i }))
+    expect(onConfirm).toHaveBeenCalledWith('hello there')
+  })
+
+  it('trims surrounding whitespace before calling onConfirm', () => {
+    const { onConfirm } = renderPanel()
+    const textarea = screen.getByRole('textbox', { name: /edit transcript/i })
+    fireEvent.change(textarea, { target: { value: '  hello  ' } })
+    fireEvent.click(screen.getByRole('button', { name: /submit transcript/i }))
+    expect(onConfirm).toHaveBeenCalledWith('hello')
+  })
+
+  it('disables the Submit button when the textarea is empty', () => {
+    renderPanel()
+    const textarea = screen.getByRole('textbox', { name: /edit transcript/i })
+    fireEvent.change(textarea, { target: { value: '' } })
+    expect(screen.getByRole('button', { name: /submit transcript/i })).toBeDisabled()
+  })
+
+  it('disables the Submit button when the textarea contains only whitespace', () => {
+    renderPanel()
+    const textarea = screen.getByRole('textbox', { name: /edit transcript/i })
+    fireEvent.change(textarea, { target: { value: '   ' } })
+    expect(screen.getByRole('button', { name: /submit transcript/i })).toBeDisabled()
+  })
+
+  it('calls onConfirm on Ctrl+Enter in the textarea', () => {
+    const { onConfirm } = renderPanel()
+    const textarea = screen.getByRole('textbox', { name: /edit transcript/i })
+    fireEvent.keyDown(textarea, { key: 'Enter', ctrlKey: true })
+    expect(onConfirm).toHaveBeenCalledWith('hello world')
+  })
+
+  it('calls onConfirm on Meta+Enter (Cmd+Enter) in the textarea', () => {
+    const { onConfirm } = renderPanel()
+    const textarea = screen.getByRole('textbox', { name: /edit transcript/i })
+    fireEvent.keyDown(textarea, { key: 'Enter', metaKey: true })
+    expect(onConfirm).toHaveBeenCalledWith('hello world')
+  })
+
+  it('does not call onConfirm on plain Enter (without Ctrl/Meta)', () => {
+    const { onConfirm } = renderPanel()
+    const textarea = screen.getByRole('textbox', { name: /edit transcript/i })
+    fireEvent.keyDown(textarea, { key: 'Enter' })
+    expect(onConfirm).not.toHaveBeenCalled()
+  })
+})
+
+describe('TranscriptReviewPanel — cancel action', () => {
+  it('calls onCancel when the Cancel button is clicked', () => {
+    const { onCancel } = renderPanel()
+    fireEvent.click(screen.getByRole('button', { name: /cancel and discard transcript/i }))
+    expect(onCancel).toHaveBeenCalledOnce()
+  })
+
+  it('calls onCancel on Escape key in the textarea', () => {
+    const { onCancel } = renderPanel()
+    const textarea = screen.getByRole('textbox', { name: /edit transcript/i })
+    fireEvent.keyDown(textarea, { key: 'Escape' })
+    expect(onCancel).toHaveBeenCalledOnce()
+  })
+})
+
+describe('TranscriptReviewPanel — retry action', () => {
+  it('calls onRetry when the Retry button is clicked', () => {
+    const { onRetry } = renderPanel()
+    fireEvent.click(screen.getByRole('button', { name: /retry recording/i }))
+    expect(onRetry).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/web/src/__tests__/VoiceInput.test.tsx
+++ b/apps/web/src/__tests__/VoiceInput.test.tsx
@@ -314,7 +314,25 @@ describe('VoiceInput — audio upload flow', () => {
     expect(vi.mocked(apiClient.uploadAudio)).toHaveBeenCalledWith(blob, undefined)
   })
 
-  it('calls onSubmit with the transcript when uploadAudio returns one', async () => {
+  it('shows the transcript review panel when uploadAudio returns a transcript', async () => {
+    let capturedOnAudioReady: ((blob: Blob) => void) | undefined
+    vi.mocked(useMicCapture).mockImplementation((cb) => {
+      capturedOnAudioReady = cb
+      return makeMicState()
+    })
+    vi.mocked(apiClient.uploadAudio).mockResolvedValueOnce({ transcript: 'hello world', status: 'ok' })
+
+    render(<VoiceInput />)
+
+    await act(async () => {
+      capturedOnAudioReady?.(new Blob(['audio'], { type: 'audio/webm' }))
+    })
+
+    expect(screen.getByTestId('transcript-review-panel')).toBeInTheDocument()
+    expect(screen.getByRole('textbox', { name: /edit transcript/i })).toHaveValue('hello world')
+  })
+
+  it('calls onSubmit with the transcript when user confirms in the review panel', async () => {
     const onSubmit = vi.fn()
     let capturedOnAudioReady: ((blob: Blob) => void) | undefined
     vi.mocked(useMicCapture).mockImplementation((cb) => {
@@ -329,7 +347,92 @@ describe('VoiceInput — audio upload flow', () => {
       capturedOnAudioReady?.(new Blob(['audio'], { type: 'audio/webm' }))
     })
 
+    fireEvent.click(screen.getByRole('button', { name: /submit transcript/i }))
+
     expect(onSubmit).toHaveBeenCalledWith('hello world')
+  })
+
+  it('calls onSubmit with edited text when user modifies the transcript before confirming', async () => {
+    const onSubmit = vi.fn()
+    let capturedOnAudioReady: ((blob: Blob) => void) | undefined
+    vi.mocked(useMicCapture).mockImplementation((cb) => {
+      capturedOnAudioReady = cb
+      return makeMicState()
+    })
+    vi.mocked(apiClient.uploadAudio).mockResolvedValueOnce({ transcript: 'hello world', status: 'ok' })
+
+    render(<VoiceInput onSubmit={onSubmit} />)
+
+    await act(async () => {
+      capturedOnAudioReady?.(new Blob(['audio'], { type: 'audio/webm' }))
+    })
+
+    const textarea = screen.getByRole('textbox', { name: /edit transcript/i })
+    fireEvent.change(textarea, { target: { value: 'hello there' } })
+    fireEvent.click(screen.getByRole('button', { name: /submit transcript/i }))
+
+    expect(onSubmit).toHaveBeenCalledWith('hello there')
+  })
+
+  it('cancels the review panel and returns to normal input when cancel is clicked', async () => {
+    let capturedOnAudioReady: ((blob: Blob) => void) | undefined
+    vi.mocked(useMicCapture).mockImplementation((cb) => {
+      capturedOnAudioReady = cb
+      return makeMicState()
+    })
+    vi.mocked(apiClient.uploadAudio).mockResolvedValueOnce({ transcript: 'hello world', status: 'ok' })
+
+    render(<VoiceInput />)
+
+    await act(async () => {
+      capturedOnAudioReady?.(new Blob(['audio'], { type: 'audio/webm' }))
+    })
+
+    expect(screen.getByTestId('transcript-review-panel')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /cancel and discard transcript/i }))
+
+    expect(screen.queryByTestId('transcript-review-panel')).not.toBeInTheDocument()
+    expect(screen.getByRole('textbox', { name: /your response/i })).toBeInTheDocument()
+  })
+
+  it('dismisses the review panel and returns to normal input when retry is clicked', async () => {
+    let capturedOnAudioReady: ((blob: Blob) => void) | undefined
+    vi.mocked(useMicCapture).mockImplementation((cb) => {
+      capturedOnAudioReady = cb
+      return makeMicState()
+    })
+    vi.mocked(apiClient.uploadAudio).mockResolvedValueOnce({ transcript: 'hello world', status: 'ok' })
+
+    render(<VoiceInput />)
+
+    await act(async () => {
+      capturedOnAudioReady?.(new Blob(['audio'], { type: 'audio/webm' }))
+    })
+
+    expect(screen.getByTestId('transcript-review-panel')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /retry recording/i }))
+
+    expect(screen.queryByTestId('transcript-review-panel')).not.toBeInTheDocument()
+    expect(screen.getByRole('textbox', { name: /your response/i })).toBeInTheDocument()
+  })
+
+  it('does not call onSubmit directly — it goes through review panel', async () => {
+    const onSubmit = vi.fn()
+    let capturedOnAudioReady: ((blob: Blob) => void) | undefined
+    vi.mocked(useMicCapture).mockImplementation((cb) => {
+      capturedOnAudioReady = cb
+      return makeMicState()
+    })
+    vi.mocked(apiClient.uploadAudio).mockResolvedValueOnce({ transcript: 'hello world', status: 'ok' })
+
+    render(<VoiceInput onSubmit={onSubmit} />)
+
+    await act(async () => {
+      capturedOnAudioReady?.(new Blob(['audio'], { type: 'audio/webm' }))
+    })
+
+    // onSubmit must not be called until user confirms in the review panel
+    expect(onSubmit).not.toHaveBeenCalled()
   })
 
   it('does not call onSubmit when transcript is null', async () => {
@@ -434,7 +537,7 @@ describe('VoiceInput — audio upload flow', () => {
     expect(screen.getByRole('alert')).toHaveTextContent(/failed to process audio/i)
   })
 
-  it('does not call onSubmit with transcript when disabled, but populates the text input', async () => {
+  it('shows review panel when disabled, then populates text input after confirmation', async () => {
     const onSubmit = vi.fn()
     let capturedOnAudioReady: ((blob: Blob) => void) | undefined
     vi.mocked(useMicCapture).mockImplementation((cb) => {
@@ -449,8 +552,16 @@ describe('VoiceInput — audio upload flow', () => {
       capturedOnAudioReady?.(new Blob(['audio'], { type: 'audio/webm' }))
     })
 
+    // Review panel should appear even when disabled
+    expect(screen.getByTestId('transcript-review-panel')).toBeInTheDocument()
+
+    // Confirming while disabled should NOT call onSubmit — it populates the text box
+    fireEvent.click(screen.getByRole('button', { name: /submit transcript/i }))
+
     expect(onSubmit).not.toHaveBeenCalled()
-    expect(screen.getByRole('textbox')).toHaveValue('hello world')
+    expect(screen.queryByTestId('transcript-review-panel')).not.toBeInTheDocument()
+    // After confirm, the text input (the standard response field) gets the transcript value
+    expect(screen.getByRole('textbox', { name: /your response/i })).toHaveValue('hello world')
   })
 })
 

--- a/apps/web/src/components/DebugDrawer.tsx
+++ b/apps/web/src/components/DebugDrawer.tsx
@@ -3,12 +3,14 @@ import { useState } from 'react'
 
 export interface DebugTurnEntry {
   turnId: number
-  role: 'npc_opening' | 'npc'
+  role: 'npc_opening' | 'npc' | 'player'
   rawPayload: Record<string, unknown>
   /** Delta entries that were committed to tracked NPC state variables. */
-  appliedDelta: Record<string, number>
+  appliedDelta?: Record<string, number>
   /** Delta entries the model requested for unknown variables — dropped, never applied. */
   rejectedDelta?: Record<string, number>
+  /** Raw STT transcript before user edits (player turns only, when transcript was corrected). */
+  rawStt?: string
 }
 
 // Fields that may contain hidden NPC agenda — highlighted so they can't be missed
@@ -121,7 +123,7 @@ function CopyButton({ payload }: { payload: Record<string, unknown> }) {
 
 function DebugTurnItem({ entry, index }: { entry: DebugTurnEntry; index: number }) {
   const agendaFields = Object.keys(entry.rawPayload).filter((k) => AGENDA_FIELDS.has(k))
-  const hasDelta = Object.keys(entry.appliedDelta).length > 0
+  const hasDelta = Object.keys(entry.appliedDelta ?? {}).length > 0
   const rejectedDelta = entry.rejectedDelta ?? {}
   const hasRejected = Object.keys(rejectedDelta).length > 0
 
@@ -186,6 +188,21 @@ function DebugTurnItem({ entry, index }: { entry: DebugTurnEntry; index: number 
             ⊘ rejected
           </span>
         )}
+        {entry.rawStt !== undefined && (
+          <span
+            aria-label="Contains raw STT transcript"
+            style={{
+              fontSize: '0.6rem',
+              padding: '0 0.3rem',
+              background: 'rgba(167,139,250,0.12)',
+              border: '1px solid rgba(167,139,250,0.35)',
+              borderRadius: 3,
+              color: '#a78bfa',
+            }}
+          >
+            STT
+          </span>
+        )}
       </summary>
 
       <div style={{ marginTop: '0.4rem', display: 'flex', flexDirection: 'column', gap: '0.4rem', paddingLeft: '0.5rem' }}>
@@ -210,6 +227,15 @@ function DebugTurnItem({ entry, index }: { entry: DebugTurnEntry; index: number 
           <div style={{ fontSize: '0.65rem', color: '#52525b', marginBottom: 2 }}>Raw payload</div>
           <JsonBlock data={entry.rawPayload} />
         </div>
+
+        {entry.rawStt !== undefined && (
+          <div>
+            <div style={{ fontSize: '0.65rem', color: '#a78bfa', marginBottom: 2 }}>
+              Raw STT (before user edits)
+            </div>
+            <JsonBlock data={entry.rawStt} />
+          </div>
+        )}
 
         {hasDelta && (
           <div>

--- a/apps/web/src/components/TranscriptReviewPanel.tsx
+++ b/apps/web/src/components/TranscriptReviewPanel.tsx
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: Apache-2.0
+import { useState, useEffect, useRef } from 'react'
+
+export interface TranscriptReviewPanelProps {
+  transcript: string
+  language?: string | null
+  confidence?: number | null
+  onConfirm: (text: string) => void
+  onCancel: () => void
+  onRetry: () => void
+}
+
+export default function TranscriptReviewPanel({
+  transcript,
+  language,
+  confidence,
+  onConfirm,
+  onCancel,
+  onRetry,
+}: TranscriptReviewPanelProps) {
+  const [editedText, setEditedText] = useState(transcript)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  useEffect(() => {
+    const el = textareaRef.current
+    if (!el) return
+    el.focus()
+    el.setSelectionRange(el.value.length, el.value.length)
+  }, [])
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      onCancel()
+    }
+    if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+      e.preventDefault()
+      const trimmed = editedText.trim()
+      if (trimmed) onConfirm(trimmed)
+    }
+  }
+
+  const trimmed = editedText.trim()
+
+  return (
+    <div
+      role="region"
+      aria-label="Transcript review"
+      data-testid="transcript-review-panel"
+      style={panelStyle}
+    >
+      <div style={headerStyle}>
+        <span style={labelStyle}>Review speech transcript</span>
+        {(language || confidence != null) && (
+          <span style={hintsStyle} data-testid="transcript-hints">
+            {language && <span>Language: {language}</span>}
+            {confidence != null && (
+              <span style={language ? { marginLeft: 8 } : undefined}>
+                Confidence: {Math.round(confidence * 100)}%
+              </span>
+            )}
+          </span>
+        )}
+      </div>
+
+      <textarea
+        ref={textareaRef}
+        value={editedText}
+        onChange={(e) => setEditedText(e.target.value)}
+        onKeyDown={handleKeyDown}
+        aria-label="Edit transcript"
+        rows={3}
+        style={textareaStyle}
+      />
+
+      <div style={actionsStyle}>
+        <button
+          type="button"
+          onClick={() => { if (trimmed) onConfirm(trimmed) }}
+          disabled={!trimmed}
+          aria-label="Submit transcript"
+          style={{ ...buttonBase, background: '#2563eb', color: '#fff', fontWeight: 600 }}
+        >
+          Submit
+        </button>
+        <button
+          type="button"
+          onClick={onRetry}
+          aria-label="Retry recording"
+          style={{ ...buttonBase, background: '#27272a', color: '#a1a1aa', border: '1px solid #3f3f46' }}
+        >
+          Retry
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          aria-label="Cancel and discard transcript"
+          style={{ ...buttonBase, background: 'transparent', color: '#71717a', border: '1px solid #3f3f46' }}
+        >
+          Cancel
+        </button>
+        <span style={kbdHintStyle}>
+          <kbd style={kbdStyle}>Ctrl+Enter</kbd> submit &nbsp;
+          <kbd style={kbdStyle}>Esc</kbd> cancel
+        </span>
+      </div>
+    </div>
+  )
+}
+
+const panelStyle: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.5rem',
+  padding: '0.75rem',
+  borderRadius: 8,
+  border: '1px solid #3f3f46',
+  background: '#18181b',
+}
+
+const headerStyle: React.CSSProperties = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  flexWrap: 'wrap',
+  gap: '0.25rem',
+}
+
+const labelStyle: React.CSSProperties = {
+  fontSize: '0.8rem',
+  color: '#a78bfa',
+  fontWeight: 600,
+  textTransform: 'uppercase',
+  letterSpacing: '0.05em',
+}
+
+const hintsStyle: React.CSSProperties = {
+  fontSize: '0.75rem',
+  color: '#71717a',
+}
+
+const textareaStyle: React.CSSProperties = {
+  width: '100%',
+  padding: '0.5rem 0.75rem',
+  borderRadius: 6,
+  border: '1px solid #3f3f46',
+  background: '#09090b',
+  color: '#e4e4e7',
+  fontSize: '0.95rem',
+  resize: 'vertical',
+  fontFamily: 'inherit',
+  boxSizing: 'border-box',
+}
+
+const actionsStyle: React.CSSProperties = {
+  display: 'flex',
+  gap: '0.5rem',
+  alignItems: 'center',
+  flexWrap: 'wrap',
+}
+
+const buttonBase: React.CSSProperties = {
+  padding: '0.4rem 0.9rem',
+  borderRadius: 6,
+  border: 'none',
+  cursor: 'pointer',
+  fontSize: '0.875rem',
+}
+
+const kbdHintStyle: React.CSSProperties = {
+  marginLeft: 'auto',
+  fontSize: '0.75rem',
+  color: '#52525b',
+}
+
+const kbdStyle: React.CSSProperties = {
+  padding: '0.1rem 0.3rem',
+  borderRadius: 3,
+  border: '1px solid #52525b',
+  fontFamily: 'monospace',
+  fontSize: '0.7rem',
+  background: '#27272a',
+}

--- a/apps/web/src/components/VoiceInput.tsx
+++ b/apps/web/src/components/VoiceInput.tsx
@@ -6,9 +6,24 @@ import { useVad } from '../hooks/useVad'
 import MicButton from './MicButton'
 import VadStatusIndicator from './VadStatusIndicator'
 import VadCalibration from './VadCalibration'
+import TranscriptReviewPanel from './TranscriptReviewPanel'
+
+export interface SttReviewMeta {
+  rawTranscript: string
+  finalTranscript: string
+  language?: string | null
+  confidence?: number | null
+}
+
+type ReviewState = {
+  transcript: string
+  language?: string | null
+  confidence?: number | null
+}
 
 interface VoiceInputProps {
   onSubmit?: (text: string) => void
+  onRawStt?: (meta: SttReviewMeta) => void
   disabled?: boolean
   language?: string
 }
@@ -19,11 +34,12 @@ function isInteractiveElement(el: Element | null): boolean {
   return tag === 'input' || tag === 'textarea' || tag === 'select' || tag === 'button' || tag === 'a'
 }
 
-export default function VoiceInput({ onSubmit, disabled = false, language }: VoiceInputProps) {
+export default function VoiceInput({ onSubmit, onRawStt, disabled = false, language }: VoiceInputProps) {
   const [textValue, setTextValue] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [uploadError, setUploadError] = useState<string | null>(null)
   const [showCalibration, setShowCalibration] = useState(false)
+  const [reviewState, setReviewState] = useState<ReviewState | null>(null)
 
   const vad = useVad()
   const isHandsFree = vad.settings.mode === 'hands-free'
@@ -40,11 +56,11 @@ export default function VoiceInput({ onSubmit, disabled = false, language }: Voi
         } else if (result.status === 'unavailable') {
           setUploadError('Speech-to-text is not installed. Please type your response.')
         } else if (result.transcript) {
-          if (!disabled) {
-            onSubmit?.(result.transcript)
-          } else {
-            setTextValue(result.transcript)
-          }
+          setReviewState({
+            transcript: result.transcript,
+            language: result.language,
+            confidence: result.confidence,
+          })
         } else if (result.status === 'ok' && !result.transcript) {
           setUploadError('No speech detected. Please try again or type your response.')
         }
@@ -55,7 +71,7 @@ export default function VoiceInput({ onSubmit, disabled = false, language }: Voi
         setIsSubmitting(false)
       }
     },
-    [onSubmit, disabled, language],
+    [language],
   )
 
   const {
@@ -96,6 +112,32 @@ export default function VoiceInput({ onSubmit, disabled = false, language }: Voi
     if (!isRecording) stopSilenceDetection()
   }, [isRecording, stopSilenceDetection])
 
+  function handleReviewConfirm(finalText: string) {
+    const raw = reviewState
+    setReviewState(null)
+    if (raw) {
+      onRawStt?.({
+        rawTranscript: raw.transcript,
+        finalTranscript: finalText,
+        language: raw.language,
+        confidence: raw.confidence,
+      })
+    }
+    if (!disabled) {
+      onSubmit?.(finalText)
+    } else {
+      setTextValue(finalText)
+    }
+  }
+
+  function handleReviewCancel() {
+    setReviewState(null)
+  }
+
+  function handleReviewRetry() {
+    setReviewState(null)
+  }
+
   // Global Space hotkey for PTT — skips when any interactive element is focused, mic is
   // unavailable, a prior recording is still being uploaded, or the component is disabled.
   useEffect(() => {
@@ -103,6 +145,8 @@ export default function VoiceInput({ onSubmit, disabled = false, language }: Voi
       if (e.code !== 'Space' || e.repeat) return
       if (isInteractiveElement(document.activeElement)) return
       if (permission !== 'granted' || isSubmitting || disabled) return
+      // Don't start recording while the transcript review panel is open.
+      if (reviewState !== null) return
       // In hands-free mode Space starts recording; once recording, VAD drives the stop so
       // we ignore further presses to avoid resetting the auto-stop countdown.
       if (isHandsFree && isRecording) return
@@ -125,7 +169,7 @@ export default function VoiceInput({ onSubmit, disabled = false, language }: Voi
       document.removeEventListener('keydown', handleKeyDown)
       document.removeEventListener('keyup', handleKeyUp)
     }
-  }, [startRecording, stopRecording, permission, isRecording, isSubmitting, disabled, isHandsFree])
+  }, [startRecording, stopRecording, permission, isRecording, isSubmitting, disabled, isHandsFree, reviewState])
 
   const handleTextSubmit = (e: React.FormEvent) => {
     e.preventDefault()
@@ -171,85 +215,98 @@ export default function VoiceInput({ onSubmit, disabled = false, language }: Voi
         </p>
       )}
 
-      <div style={inputRowStyle}>
-        <MicButton
-          permission={permission}
-          isRecording={isRecording}
-          recordingSeconds={recordingSeconds}
-          isSubmitting={isSubmitting}
-          disabled={disabled}
-          isHandsFree={isHandsFree}
-          onRequestPermission={requestPermission}
-          onRecordStart={startRecording}
-          onRecordStop={isHandsFree ? () => {} : stopRecording}
+      {reviewState ? (
+        <TranscriptReviewPanel
+          transcript={reviewState.transcript}
+          language={reviewState.language}
+          confidence={reviewState.confidence}
+          onConfirm={handleReviewConfirm}
+          onCancel={handleReviewCancel}
+          onRetry={handleReviewRetry}
         />
+      ) : (
+        <>
+          <div style={inputRowStyle}>
+            <MicButton
+              permission={permission}
+              isRecording={isRecording}
+              recordingSeconds={recordingSeconds}
+              isSubmitting={isSubmitting}
+              disabled={disabled}
+              isHandsFree={isHandsFree}
+              onRequestPermission={requestPermission}
+              onRecordStart={startRecording}
+              onRecordStop={isHandsFree ? () => {} : stopRecording}
+            />
 
-        <form onSubmit={handleTextSubmit} style={{ display: 'flex', flex: 1, gap: '0.5rem' }}>
-          <input
-            type="text"
-            value={textValue}
-            onChange={(e) => setTextValue(e.target.value)}
-            placeholder={
-              permission === 'denied' || permission === 'unsupported'
-                ? 'Type your response…'
-                : isHandsFree
-                  ? 'Type or press the mic to record (auto-stops on silence)'
-                  : 'Type or hold the mic button to record'
-            }
-            disabled={disabled || isRecording}
-            aria-label="Your response"
-            style={textInputStyle}
-          />
-          <button
-            type="submit"
-            disabled={disabled || !textValue.trim() || isRecording}
-            style={sendButtonStyle}
-          >
-            Submit
-          </button>
-        </form>
-      </div>
+            <form onSubmit={handleTextSubmit} style={{ display: 'flex', flex: 1, gap: '0.5rem' }}>
+              <input
+                type="text"
+                value={textValue}
+                onChange={(e) => setTextValue(e.target.value)}
+                placeholder={
+                  permission === 'denied' || permission === 'unsupported'
+                    ? 'Type your response…'
+                    : isHandsFree
+                      ? 'Type or press the mic to record (auto-stops on silence)'
+                      : 'Type or hold the mic button to record'
+                }
+                disabled={disabled || isRecording}
+                aria-label="Your response"
+                style={textInputStyle}
+              />
+              <button
+                type="submit"
+                disabled={disabled || !textValue.trim() || isRecording}
+                style={sendButtonStyle}
+              >
+                Submit
+              </button>
+            </form>
+          </div>
 
-      {/* Hands-free controls row */}
-      {permission === 'granted' && (
-        <div style={hfRowStyle}>
-          <button
-            type="button"
-            onClick={handleModeToggle}
-            aria-pressed={isHandsFree}
-            style={isHandsFree ? modeActiveStyle : modeInactiveStyle}
-            title={isHandsFree ? 'Switch to push-to-talk' : 'Switch to hands-free (auto-stop on silence)'}
-          >
-            {isHandsFree ? '🤲 Hands-free' : '👆 Push-to-talk'}
-          </button>
-
-          {isHandsFree && (
-            <>
-              <VadStatusIndicator state={vad.vadState} />
+          {/* Hands-free controls row */}
+          {permission === 'granted' && (
+            <div style={hfRowStyle}>
               <button
                 type="button"
-                onClick={() => setShowCalibration((v) => !v)}
-                style={calibrateBtnStyle}
-                title="Calibrate noise threshold"
+                onClick={handleModeToggle}
+                aria-pressed={isHandsFree}
+                style={isHandsFree ? modeActiveStyle : modeInactiveStyle}
+                title={isHandsFree ? 'Switch to push-to-talk' : 'Switch to hands-free (auto-stop on silence)'}
               >
-                {vad.settings.calibratedAt ? 'Recalibrate' : 'Calibrate noise'}
+                {isHandsFree ? '🤲 Hands-free' : '👆 Push-to-talk'}
               </button>
-            </>
-          )}
-        </div>
-      )}
 
-      {/* Calibration panel */}
-      {showCalibration && isHandsFree && (
-        <VadCalibration
-          vad={vad}
-          stream={stream}
-          onDone={() => setShowCalibration(false)}
-        />
+              {isHandsFree && (
+                <>
+                  <VadStatusIndicator state={vad.vadState} />
+                  <button
+                    type="button"
+                    onClick={() => setShowCalibration((v) => !v)}
+                    style={calibrateBtnStyle}
+                    title="Calibrate noise threshold"
+                  >
+                    {vad.settings.calibratedAt ? 'Recalibrate' : 'Calibrate noise'}
+                  </button>
+                </>
+              )}
+            </div>
+          )}
+
+          {/* Calibration panel */}
+          {showCalibration && isHandsFree && (
+            <VadCalibration
+              vad={vad}
+              stream={stream}
+              onDone={() => setShowCalibration(false)}
+            />
+          )}
+        </>
       )}
 
       {/* PTT hint */}
-      {permission === 'granted' && !isRecording && !isSubmitting && !isHandsFree && (
+      {permission === 'granted' && !isRecording && !isSubmitting && !isHandsFree && !reviewState && (
         <p style={hintStyle}>
           Press <kbd style={kbdStyle}>Space</kbd> to record when not typing, or hold the mic
           button. Max {MAX_RECORDING_SECONDS}s.
@@ -257,7 +314,7 @@ export default function VoiceInput({ onSubmit, disabled = false, language }: Voi
       )}
 
       {/* Hands-free hint */}
-      {permission === 'granted' && !isRecording && !isSubmitting && isHandsFree && (
+      {permission === 'granted' && !isRecording && !isSubmitting && isHandsFree && !reviewState && (
         <p style={hintStyle}>
           Press <kbd style={kbdStyle}>Space</kbd> or tap the mic — recording stops automatically
           after silence.{' '}

--- a/apps/web/src/screens/Conversation.tsx
+++ b/apps/web/src/screens/Conversation.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'react'
 import { useParams, useNavigate, useLocation } from 'react-router-dom'
 import { api } from '../api/client'
 import type { ScenarioInfo, WsEvent } from '@convsim/shared'
-import VoiceInput from '../components/VoiceInput'
+import VoiceInput, { type SttReviewMeta } from '../components/VoiceInput'
 import DebugDrawer, { type DebugTurnEntry } from '../components/DebugDrawer'
 import { isDevModeEnabled } from '../privacyPrefs'
 
@@ -97,6 +97,7 @@ export default function Conversation() {
   const streamingRef = useRef('')
   const phaseRef = useRef<Phase>('starting')
   const npcTurnCommittedRef = useRef(false)
+  const pendingRawSttRef = useRef<SttReviewMeta | null>(null)
   phaseRef.current = phase
 
   // Fetch scenario for NPC panel and scene card — best effort
@@ -242,6 +243,11 @@ export default function Conversation() {
               { id: ++bannerUidRef.current, kind: 'safety', text: event.payload.reason },
             ])
             break
+          case 'stt.partial':
+          case 'stt.final':
+            // STT streaming events — handled by VoiceInput via REST; these WS events
+            // are emitted by future streaming STT backends and are safe to ignore here.
+            break
         }
       })
     } catch {
@@ -264,6 +270,10 @@ export default function Conversation() {
   async function handleSubmit(text: string) {
     if (!text || phase !== 'active') return
 
+    // Capture any pending STT metadata before resetting it (set synchronously by onRawStt).
+    const rawSttMeta = pendingRawSttRef.current
+    pendingRawSttRef.current = null
+
     // Add the player turn immediately so it appears before the NPC response
     // regardless of whether the NPC turn is committed by WebSocket or REST.
     const playerTurnId = ++turnUidRef.current
@@ -277,6 +287,18 @@ export default function Conversation() {
         turnNum: playerTurnNum,
       },
     ])
+
+    if (devMode) {
+      const playerDebugEntry: DebugTurnEntry = {
+        turnId: playerTurnId,
+        role: 'player',
+        rawPayload: { content: text },
+        ...(rawSttMeta && rawSttMeta.rawTranscript !== rawSttMeta.finalTranscript
+          ? { rawStt: rawSttMeta.rawTranscript }
+          : {}),
+      }
+      setDebugEntries((prev) => [...prev, playerDebugEntry])
+    }
 
     setPhase('submitting')
     setError(null)
@@ -814,6 +836,7 @@ export default function Conversation() {
       ) : (
         <VoiceInput
           onSubmit={(text) => void handleSubmit(text)}
+          onRawStt={devMode ? (meta) => { pendingRawSttRef.current = meta } : undefined}
           disabled={!isIdle}
           language={language}
         />


### PR DESCRIPTION
## Summary

- Adds a `TranscriptReviewPanel` component that appears after speech-to-text transcription, letting the player edit, confirm, retry, or cancel before the text is sent to the NPC.
- `VoiceInput` now routes STT results through the review panel instead of immediately calling `onSubmit`; the Space PTT hotkey is suppressed while the panel is open; on confirm with `disabled=true` (NPC thinking), the confirmed text falls back to populating the text input.
- `DebugDrawer` extended to support player-turn entries with an optional `rawStt` field; a purple STT badge appears in the summary row when the user edited the transcript before confirming.
- `Conversation` screen adds a player-turn debug entry per submitted turn in dev mode, captures `onRawStt` metadata from `VoiceInput`, and adds no-op handlers for the reserved `stt.partial` / `stt.final` WebSocket events.
- Language and confidence hints from the STT response are displayed in the panel header.
- Keyboard accessible: `Ctrl+Enter` submits, `Esc` cancels.

## Test plan

- [x] 19 new `TranscriptReviewPanel` unit tests covering submit, edit, cancel, retry, keyboard shortcuts, and hint rendering.
- [x] Updated `VoiceInput` audio-upload tests to exercise the review-panel flow (show panel, confirm with original text, confirm with edited text, cancel, retry, disabled-state fallback).
- [x] Updated `Conversation` debug-entry tests to include player-turn entries created per submitted turn in dev mode.
- [x] TypeScript type-checks clean.

Closes #60