### PR TITLE
Write install, quickstart, local model, and troubleshooting docs

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -161,7 +161,7 @@ The expected checksum is listed on the GitHub release page alongside each downlo
 | `~/.convsim/logs/` | Runtime logs |
 | `~/.convsim/models/llm/` | Downloaded model weights |
 
-Override any of these with environment variables: `CONVSIM_DB_DIR`, `CONVSIM_DATA_DIR`, `CONVSIM_LOG_DIR`.
+Override any of these with environment variables: `CONVSIM_DB_DIR`, `CONVSIM_DATA_DIR`, `CONVSIM_LOG_DIR`, `CONVSIM_MODELS_DIR`.
 
 ---
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -114,9 +114,10 @@ See [local-models.md](local-models.md) for model recommendations by hardware.
 
 ### 7. Verify the installation
 
-Run the offline smoke test to confirm no service makes outbound network calls during play:
+Run the offline smoke test to confirm no service makes outbound network calls during play. The smoke test ships as the `convsim` CLI (`@convsim/cli`), which must be built once before first use:
 
 ```bash
+pnpm --filter @convsim/cli build
 npx convsim offline-smoke-test packs/official/job-interview-basic
 ```
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,17 +1,172 @@
 <!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Installation guide
 
-> **Status:** Placeholder. Will be completed in Milestone 1 (text-only simulator).
+Conversation Simulator runs entirely on your computer — no cloud inference, no telemetry. You need a local model before any conversation can start; the app downloads it on first run after you accept its license.
 
-This document will cover:
+Two install paths are available:
 
-- System requirements (OS, CPU, RAM, GPU)
-- Installing Python 3.10+
-- Installing Node.js 18+
-- Cloning the repository
-- Running `./scripts/setup.sh`
-- Installing a local LLM model
-- Starting local dev with `./scripts/dev.sh`
-- Verifying the installation
+- **Path A — developer install:** clone the source and run the dev services locally. Suitable for contributors and users who want full control.
+- **Path B — alpha app install:** download and run the pre-built desktop application (planned for a future milestone; see below).
 
-For now, see the [quickstart](quickstart.md) and the root [README](../README.md).
+---
+
+## System requirements
+
+| Requirement | Minimum | Notes |
+|---|---|---|
+| OS | macOS 12+, Ubuntu 22.04+, Windows 10 | |
+| CPU | Any 64-bit x86 or Apple Silicon | Apple Silicon recommended for CPU inference |
+| RAM | 8 GB | 16 GB recommended for standard-tier models |
+| GPU VRAM | 0 GB (CPU fallback available) | 4 GB+ for starter model; see [local-models.md](local-models.md) |
+| Disk | 20 GB free | 3–15 GB for model weights plus app data |
+| Python | 3.10 or newer | Path A only |
+| Node.js | 18 LTS or newer | Path A only |
+
+---
+
+## Path A — developer install
+
+### 1. Install system dependencies
+
+**Python 3.10+**
+
+- macOS: `brew install python@3.11`
+- Ubuntu/Debian: `sudo apt install python3.11 python3.11-venv`
+- Windows: download from <https://www.python.org/downloads/>
+
+**Node.js 18 LTS+**
+
+- All platforms: download from <https://nodejs.org/>
+- Or use a version manager: `nvm install 18` / `fnm install 18`
+
+**pnpm (recommended) or npm**
+
+pnpm is faster for a monorepo workspace. npm (bundled with Node.js) also works.
+
+```bash
+npm install -g pnpm
+```
+
+### 2. Clone the repository
+
+```bash
+git clone https://github.com/outrightmental/ConversationSimulator
+cd ConversationSimulator
+```
+
+### 3. Run setup
+
+**macOS / Linux:**
+
+```bash
+./scripts/setup.sh
+```
+
+**Windows (PowerShell):**
+
+```powershell
+.\scripts\setup.ps1
+```
+
+The setup script:
+
+- Confirms Python 3.10+ and Node.js 18+ are present.
+- Installs frontend packages (`pnpm install` or `npm install`).
+- Creates the Python virtual environment for `convsim-core` under `services/convsim-core/.venv/`.
+- Creates local data directories under `~/.convsim/`.
+
+It does **not** modify global state or download model files. No model weights are bundled.
+
+### 4. Start local dev
+
+**macOS / Linux:**
+
+```bash
+./scripts/dev.sh
+```
+
+**Windows (PowerShell):**
+
+```powershell
+.\scripts\dev.ps1
+```
+
+This starts the browser UI and the API server and prints their URLs. If a port is already occupied the script reports which process is blocking it.
+
+| Service | URL | Responsibility |
+|---|---|---|
+| convsim-ui | <http://127.0.0.1:7354> | Browser UI (dev mode) |
+| convsim-core | <http://127.0.0.1:7355> | Main server, API, WebSocket |
+
+Press **Ctrl-C** to stop everything cleanly. Logs are written to `~/.convsim/logs/`.
+
+### 5. Open the app
+
+Navigate to <http://127.0.0.1:7354> in your browser. The home screen shows the status of each service and whether a model is loaded.
+
+### 6. Install a local model
+
+On first run the home screen shows a **"No model loaded"** banner. Click **Install model** or go to **Settings → Models**.
+
+The in-app model manager lists curated models with license, size, and hardware requirements. You must accept the license before a download begins. The downloaded file is verified against its SHA-256 checksum before loading.
+
+See [local-models.md](local-models.md) for model recommendations by hardware.
+
+### 7. Verify the installation
+
+Run the offline smoke test to confirm no service makes outbound network calls during play:
+
+```bash
+npx convsim offline-smoke-test packs/official/job-interview-basic
+```
+
+The command exits 0 on success and prints an actionable error if any subsystem attempted an external connection during the scripted play session.
+
+---
+
+## Path B — alpha app install
+
+> **Status:** The packaged desktop application is planned for a future milestone. This section describes how to install it when it becomes available.
+
+When a release is published on the [GitHub releases page](https://github.com/outrightmental/ConversationSimulator/releases):
+
+1. Download the installer for your platform (`.dmg` on macOS, `.exe` on Windows, `.AppImage` on Linux).
+2. Open the installer and follow the prompts.
+3. Launch **Conversation Simulator** from your Applications folder or Start Menu.
+4. On first launch the app prompts you to install a local model. No model weights are bundled with the installer.
+
+To verify the installer download before running it:
+
+```bash
+# macOS / Linux — replace the filename and checksum with values from the release page
+shasum -a 256 ConversationSimulator-1.0.0.dmg
+```
+
+```powershell
+# Windows PowerShell
+Get-FileHash "ConversationSimulator-1.0.0.exe" -Algorithm SHA256
+```
+
+The expected checksum is listed on the GitHub release page alongside each download.
+
+---
+
+## Data locations
+
+| Path | Purpose |
+|---|---|
+| `~/.convsim/db/` | Session database (SQLite) |
+| `~/.convsim/data/` | Exported data and pack cache |
+| `~/.convsim/logs/` | Runtime logs |
+| `~/.convsim/models/` | Downloaded model weights |
+
+Override any of these with environment variables: `CONVSIM_DB_DIR`, `CONVSIM_DATA_DIR`, `CONVSIM_LOG_DIR`.
+
+---
+
+## Next steps
+
+- [Quickstart](quickstart.md) — run your first conversation
+- [Local models](local-models.md) — choose a model for your hardware
+- [Troubleshooting](troubleshooting.md) — common setup problems
+- [README](../README.md) — project overview

--- a/docs/install.md
+++ b/docs/install.md
@@ -158,7 +158,7 @@ The expected checksum is listed on the GitHub release page alongside each downlo
 | `~/.convsim/db/` | Session database (SQLite) |
 | `~/.convsim/data/` | Exported data and pack cache |
 | `~/.convsim/logs/` | Runtime logs |
-| `~/.convsim/models/` | Downloaded model weights |
+| `~/.convsim/models/llm/` | Downloaded model weights |
 
 Override any of these with environment variables: `CONVSIM_DB_DIR`, `CONVSIM_DATA_DIR`, `CONVSIM_LOG_DIR`.
 

--- a/docs/local-models.md
+++ b/docs/local-models.md
@@ -1,14 +1,183 @@
 <!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Local models
 
-> **Status:** Placeholder. Will be completed in Milestone 1 (text-only simulator).
+Conversation Simulator requires a local language model to run NPC dialogue. No model weights are bundled with the application — you download exactly what you need after reading and accepting the model's license.
 
-This document will cover:
+All inference happens on your computer. No prompts, transcripts, or model outputs are sent to any external server during play. See [privacy.md](privacy.md) for the full data-handling policy and [network-security.md](network-security.md) for how the local-only guarantee is enforced.
 
-- Choosing a local LLM for your hardware (VRAM tiers, CPU fallback)
-- Installing a model through the in-app model manager
-- Understanding the model registry (`model-registry/registry.yaml`)
-- Advanced: adding a custom GGUF model
-- Updating and removing models
+---
 
-For the current model registry, see [model-registry/README.md](../model-registry/README.md).
+## How the model manager works
+
+Open **Settings → Models** or click **Install model** on the home screen.
+
+The model manager shows curated models from the registry (`model-registry/registry.yaml`). For each model it displays:
+
+- Full name, model family, and quantization level
+- File size and approximate download time
+- License name with a link to the full license text
+- VRAM requirement and CPU-fallback note
+- SHA-256 checksum (verified after download)
+
+You must accept the license before a download begins. After downloading, the app verifies the SHA-256 checksum before loading the file. If the checksum does not match, the file is discarded and an error is shown — the app never loads a file whose integrity cannot be confirmed.
+
+Downloaded models are stored in `~/.convsim/models/`.
+
+---
+
+## Hardware tiers
+
+| Tier | Model | Size | Min VRAM | CPU fallback |
+|---|---|---|---|---|
+| Starter | Qwen3 4B Instruct Q4_K_M | ~2.6 GB | 4 GB | Yes (slow) |
+| Standard | Qwen3 8B Instruct Q4_K_M | ~5.0 GB | 6 GB | Yes (very slow) |
+| High-quality | Qwen3 14B Instruct Q4_K_M | ~9.0 GB | 10 GB | Not practical |
+| High-quality | Mistral Small 3.1 24B Q4_K_M | ~14.8 GB | 16 GB | Not practical |
+| User-supplied | Any GGUF | varies | varies | Depends on model |
+
+**Apple Silicon:** Metal acceleration works out of the box through llama.cpp. Use the VRAM column as a guide for unified memory (M1/M2/M3/M4 chips share CPU and GPU memory).
+
+**CPU fallback:** any model can run on CPU without a GPU, but inference is significantly slower — expect 15–60 seconds per turn instead of 1–5 seconds. The Qwen3 4B starter model is the only practical choice for CPU-only machines.
+
+**Partial VRAM fit:** if you have less VRAM than the minimum, the model can still load with a reduced number of GPU-offloaded layers. Inference will be slower but may be acceptable. See [troubleshooting](troubleshooting.md#low-vram-or-slow-inference).
+
+---
+
+## Recommended models
+
+### Qwen3 4B Instruct Q4_K_M — starter
+
+- **License:** Apache-2.0
+- **Size:** ~2.6 GB
+- **Best for:** machines with 4–6 GB VRAM, or CPU-only installs
+- **Context length:** 8 192 tokens
+- **Notes:** Fastest model in the registry. Suitable for all text-only scenarios. NPC responses may be shorter and less contextually rich than larger models.
+
+### Qwen3 8B Instruct Q4_K_M — standard (recommended for most users)
+
+- **License:** Apache-2.0
+- **Size:** ~5.0 GB
+- **Best for:** machines with 6–8 GB VRAM
+- **Context length:** 8 192 tokens
+- **Notes:** Good balance of quality and speed. Handles complex multi-turn conversations well.
+
+### Qwen3 14B Instruct Q4_K_M — high-quality
+
+- **License:** Apache-2.0
+- **Size:** ~9.0 GB
+- **Best for:** machines with 10–12 GB VRAM
+- **Context length:** 8 192 tokens
+- **Notes:** Noticeably more coherent NPC behaviour in emotionally complex scenarios.
+
+### Mistral Small 3.1 24B Instruct Q4_K_M — high-quality
+
+- **License:** Apache-2.0
+- **Size:** ~14.8 GB
+- **Best for:** machines with 16–24 GB VRAM
+- **Context length:** 32 768 tokens
+- **Notes:** Longest context window in the registry. Best for long negotiations or scenarios with many tracked state variables.
+
+---
+
+## Using Ollama
+
+If you already have [Ollama](https://ollama.com/) installed with a compatible model, you can use it as the LLM runtime instead of the built-in llama.cpp server.
+
+### 1. Start Ollama
+
+```bash
+ollama serve
+```
+
+### 2. Pull a compatible model
+
+```bash
+ollama pull qwen3:8b
+```
+
+Any Ollama model that supports system prompts and structured JSON output should work. The qwen3 and mistral families are tested.
+
+### 3. Select the Ollama runtime
+
+In the model manager, click **Use Ollama model** and select the model from the list. The app connects to `http://127.0.0.1:11434` by default.
+
+Or set the runtime before starting:
+
+```bash
+CONVSIM_RUNTIME_ID=ollama ./scripts/dev.sh
+```
+
+Override the Ollama server URL with `CONVSIM_OLLAMA_BASE_URL` if Ollama is listening on a different address.
+
+---
+
+## GGUF format
+
+All registry models use the GGUF format — the standard container for quantized models compatible with llama.cpp. A GGUF file is self-contained: weights and metadata are stored in a single file.
+
+### Quantization
+
+The registry uses Q4_K_M quantization for all curated models. This offers a good balance of model quality and file size. Other quantization levels (Q2_K, Q5_K_M, Q8_0, F16) are available from model providers if you want to trade quality for smaller size or more precision.
+
+### Verifying a GGUF file manually
+
+```bash
+# macOS / Linux
+shasum -a 256 ~/.convsim/models/qwen3-4b-instruct-q4_k_m.gguf
+```
+
+```powershell
+# Windows PowerShell
+Get-FileHash "$env:USERPROFILE\.convsim\models\qwen3-4b-instruct-q4_k_m.gguf" -Algorithm SHA256
+```
+
+Compare the output against the checksum in `model-registry/registry.yaml`.
+
+---
+
+## Using a custom GGUF model
+
+To use a GGUF file you obtained independently:
+
+1. Place the file in `~/.convsim/models/`.
+2. In the model manager, click **Use custom GGUF**.
+3. Enter the full path to the file (e.g., `~/.convsim/models/my-model.gguf`).
+
+The app loads the file without checksum verification — only registry-managed models have known checksums. Ensure you have the right to use the model under its license; the application cannot verify the license of a user-supplied file.
+
+---
+
+## Licenses
+
+All models in the curated registry are released under Apache-2.0. Model weights are never bundled with the application installer — they are downloaded separately, and the license is shown in full before any download begins.
+
+If you supply your own GGUF file, you are responsible for complying with its license.
+
+---
+
+## Updating and removing models
+
+**Update:** re-download the model from the model manager. The old file is replaced only after the new download and checksum verification succeed.
+
+**Remove:** delete the file from `~/.convsim/models/` and select a different model in the model manager.
+
+---
+
+## Runtime environment variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `CONVSIM_RUNTIME_ID` | `llama_cpp` | Select runtime: `llama_cpp`, `ollama`, or `fake` |
+| `CONVSIM_LLAMA_CPP_BASE_URL` | `http://127.0.0.1:7356` | llama-server URL |
+| `CONVSIM_OLLAMA_BASE_URL` | `http://127.0.0.1:11434` | Ollama server URL |
+
+The `fake` runtime returns scripted responses and requires no model file. It is used for offline smoke tests and CI.
+
+---
+
+## Next steps
+
+- [Quickstart](quickstart.md) — run your first conversation
+- [Troubleshooting](troubleshooting.md) — model load failures, slow inference, low VRAM
+- [runtime-adapters.md](runtime-adapters.md) — technical detail on the LLM runtime abstraction
+- [model-registry/registry.yaml](../model-registry/registry.yaml) — full list of registry entries with checksums

--- a/docs/local-models.md
+++ b/docs/local-models.md
@@ -21,7 +21,7 @@ The model manager shows curated models from the registry (`model-registry/regist
 
 You must accept the license before a download begins. After downloading, the app verifies the SHA-256 checksum before loading the file. If the checksum does not match, the file is discarded and an error is shown — the app never loads a file whose integrity cannot be confirmed.
 
-Downloaded models are stored in `~/.convsim/models/`.
+Downloaded models are stored in `~/.convsim/models/llm/`.
 
 ---
 
@@ -123,12 +123,12 @@ The registry uses Q4_K_M quantization for all curated models. This offers a good
 
 ```bash
 # macOS / Linux
-shasum -a 256 ~/.convsim/models/qwen3-4b-instruct-q4_k_m.gguf
+shasum -a 256 ~/.convsim/models/llm/qwen3-4b-instruct-q4_k_m.gguf
 ```
 
 ```powershell
 # Windows PowerShell
-Get-FileHash "$env:USERPROFILE\.convsim\models\qwen3-4b-instruct-q4_k_m.gguf" -Algorithm SHA256
+Get-FileHash "$env:USERPROFILE\.convsim\models\llm\qwen3-4b-instruct-q4_k_m.gguf" -Algorithm SHA256
 ```
 
 Compare the output against the checksum in `model-registry/registry.yaml`.
@@ -139,9 +139,9 @@ Compare the output against the checksum in `model-registry/registry.yaml`.
 
 To use a GGUF file you obtained independently:
 
-1. Place the file in `~/.convsim/models/`.
+1. Place the file in `~/.convsim/models/llm/`.
 2. In the model manager, click **Use custom GGUF**.
-3. Enter the full path to the file (e.g., `~/.convsim/models/my-model.gguf`).
+3. Enter the full path to the file (e.g., `~/.convsim/models/llm/my-model.gguf`).
 
 The app loads the file without checksum verification — only registry-managed models have known checksums. Ensure you have the right to use the model under its license; the application cannot verify the license of a user-supplied file.
 
@@ -159,7 +159,7 @@ If you supply your own GGUF file, you are responsible for complying with its lic
 
 **Update:** re-download the model from the model manager. The old file is replaced only after the new download and checksum verification succeed.
 
-**Remove:** delete the file from `~/.convsim/models/` and select a different model in the model manager.
+**Remove:** delete the file from `~/.convsim/models/llm/` and select a different model in the model manager.
 
 ---
 
@@ -167,7 +167,7 @@ If you supply your own GGUF file, you are responsible for complying with its lic
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `CONVSIM_RUNTIME_ID` | `llama_cpp` | Select runtime: `llama_cpp`, `ollama`, or `fake` |
+| `CONVSIM_RUNTIME_ID` | `fake` | Select runtime: `llama_cpp`, `ollama`, or `fake`. Set to `llama_cpp` to use a downloaded local model. |
 | `CONVSIM_LLAMA_CPP_BASE_URL` | `http://127.0.0.1:7356` | llama-server URL |
 | `CONVSIM_OLLAMA_BASE_URL` | `http://127.0.0.1:11434` | Ollama server URL |
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,30 +1,107 @@
 <!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Quickstart
 
-> **Status:** Placeholder. Will be completed in Milestone 1 (text-only simulator).
+This guide walks through your first conversation. Complete [installation](install.md) before starting.
 
-## Current state
+---
 
-The repository contains the monorepo skeleton. Services are not yet implemented.
-You can check your environment setup with:
+## 1. Start the services
 
-```bash
-./scripts/setup.sh
-```
-
-This prints the next dependency to install or confirms that your environment
-meets the requirements.
-
-## Once Milestone 1 is complete
+**macOS / Linux:**
 
 ```bash
-git clone https://github.com/outrightmental/ConversationSimulator
-cd ConversationSimulator
-./scripts/setup.sh
 ./scripts/dev.sh
 ```
 
-Then open `http://127.0.0.1:7354` in your browser.
+**Windows (PowerShell):**
 
-The first run will prompt you to install a local LLM. The recommended starter
-is Qwen3 8B Instruct Q4_K_M (approximately 5 GB, Apache-2.0 licensed).
+```powershell
+.\scripts\dev.ps1
+```
+
+Open <http://127.0.0.1:7354> in your browser. The home screen shows green status indicators when convsim-core and the LLM runtime are ready.
+
+---
+
+## 2. Install a model (first run only)
+
+If no model is loaded the home screen shows a **"No model loaded"** banner. Click **Install model** or go to **Settings → Models**.
+
+The in-app model manager:
+
+1. Lists curated models from the registry with size, license, and hardware requirements.
+2. Shows the license text and asks you to accept before downloading.
+3. Downloads the model file, verifies its SHA-256 checksum, and loads it.
+
+The recommended starter is **Qwen3 4B Instruct Q4_K_M** (~2.6 GB, Apache-2.0 licensed). It works on machines with as little as 4 GB of GPU VRAM, or runs on CPU with no GPU at all.
+
+No internet connection is needed after the model is downloaded. See [local-models.md](local-models.md) for all available models and hardware recommendations.
+
+---
+
+## 3. Choose a scenario
+
+From the home screen, click **Browse scenarios** (or the scenario icon in the sidebar).
+
+Some scenarios to get started:
+
+| Pack | Scenario | What it practices |
+|---|---|---|
+| Job Interview Basics | Standard behavioral interview | STAR responses under pressure |
+| Everyday Negotiation | Used car negotiation | Opening offers, counteroffers |
+| Language Café | Spanish small talk | Casual vocabulary, greetings |
+| Difficult Conversations | Giving critical feedback | Staying calm, being specific |
+
+Click a scenario card to see its description, then click **Start conversation**.
+
+---
+
+## 4. Play through a conversation
+
+The conversation screen shows:
+
+- The NPC's current dialogue
+- A text input at the bottom for your responses
+- A turn counter and scenario progress bar
+
+Type your response and press **Enter** (or click **Send**). The NPC responds in one to five seconds, depending on your hardware and model.
+
+The scenario ends automatically when the NPC reaches a terminal state. You can also click **End conversation** at any time.
+
+---
+
+## 5. Review the debrief
+
+After the conversation the debrief screen shows:
+
+- A turn-by-turn transcript
+- State changes tracked during play (e.g., *pressure +8, patience −3*)
+- Rubric scores where the scenario defines them
+- Suggested follow-up scenarios or remixes
+
+You can export the transcript to a text file from the debrief screen. Transcripts are stored locally in `~/.convsim/db/` and are never uploaded anywhere.
+
+---
+
+## What to try next
+
+- **Remix the scenario** — adjust NPC difficulty or starting state from the scenario setup screen before starting.
+- **Create a custom scenario** — see the [scenario authoring guide](scenario-authoring.md).
+- **Upgrade your model** — if responses feel slow or generic, try a larger model; see [local-models.md](local-models.md).
+
+---
+
+## Keyboard shortcuts
+
+| Key | Action |
+|---|---|
+| Enter | Send message |
+| Shift+Enter | New line in input |
+
+---
+
+## Next steps
+
+- [Local models](local-models.md) — choose the right model for your hardware
+- [Troubleshooting](troubleshooting.md) — if something does not work
+- [README](../README.md) — project overview

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -141,7 +141,7 @@ When STT is available, a microphone icon will appear in the conversation input. 
 
 **"Voice output unavailable" on the conversation screen**
 
-Text-to-speech (TTS) requires the Silero TTS runtime. In the first milestone, TTS is not yet implemented. The conversation screen shows NPC dialogue as text automatically.
+Text-to-speech (TTS) requires the Kokoro TTS runtime. In the first milestone, TTS is not yet implemented. The conversation screen shows NPC dialogue as text automatically.
 
 When TTS is available, a speaker icon will appear in the conversation settings. If it is greyed out, confirm convsim-tts is running on port 7358.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -157,9 +157,10 @@ If the home screen shows a network error:
 2. **Pack metadata:** packs are bundled with the application and do not require a network connection. If pack loading fails, this is a bug — open a GitHub issue.
 3. **Stale browser cache:** a hard reload (`Ctrl+Shift+R` / `Cmd+Shift+R`) clears any stale service worker state.
 
-To verify that play is truly offline, run the built-in smoke test:
+To verify that play is truly offline, run the built-in smoke test. It ships as the `convsim` CLI (`@convsim/cli`); build it once first if you have not already:
 
 ```bash
+pnpm --filter @convsim/cli build
 npx convsim offline-smoke-test packs/official/job-interview-basic
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,46 +1,197 @@
 <!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Troubleshooting
 
-> **Status:** Placeholder. Will be expanded as services are implemented.
+Common problems and solutions. If your issue is not listed here, open a [GitHub issue](https://github.com/outrightmental/ConversationSimulator/issues).
+
+---
 
 ## Setup issues
 
 **`./scripts/setup.sh` fails with "Python 3.10+ is required"**
 
-Install Python 3.10 or newer from <https://www.python.org/downloads/>.
-On macOS, `brew install python@3.11` works. On Ubuntu: `sudo apt install python3.11`.
+Install Python 3.10 or newer:
+
+- macOS: `brew install python@3.11`
+- Ubuntu/Debian: `sudo apt install python3.11 python3.11-venv`
+- Windows: download from <https://www.python.org/downloads/>
+
+If Python 3.10+ is already installed but the script still fails, check which binary is on your `PATH`:
+
+```bash
+which python3
+python3 --version
+```
+
+If a system-managed Python is shadowing your installed version, use a version manager such as `pyenv` or `mise`.
 
 **`./scripts/setup.sh` fails with "Node.js 18+ is required"**
 
-Install Node.js 18 LTS or newer from <https://nodejs.org/>.
+Install Node.js 18 LTS or newer from <https://nodejs.org/>. Or use a version manager:
 
-## Dev server issues
+```bash
+nvm install 18 && nvm use 18
+```
 
-> Services are not yet implemented. This section will be expanded in Milestone 1.
+**`pip install` fails during setup**
+
+Try upgrading pip inside the virtual environment first:
+
+```bash
+services/convsim-core/.venv/bin/pip install --upgrade pip
+./scripts/setup.sh
+```
+
+---
+
+## Model load failure
+
+**"No model loaded" banner on the home screen**
+
+A model must be installed before conversations can start. Open **Settings → Models** and install a model from the registry. See [local-models.md](local-models.md) for hardware requirements and recommendations.
+
+**"Model failed to load" error in the model manager**
+
+Possible causes:
+
+1. **Insufficient VRAM:** the model requires more GPU memory than is available. Try the starter model (Qwen3 4B, ~2.6 GB, 4 GB VRAM minimum). To force CPU-only mode and bypass the GPU entirely, set `CONVSIM_LLAMA_CPP_ARGS="-ngl 0"` before starting the dev server. Inference will be slower but the model will load.
+
+2. **Corrupted download:** delete the file from `~/.convsim/models/` and re-download through the model manager.
+
+3. **llama-server binary not found:** the llama.cpp binary must be present before the LLM runtime can start. Run `./runtimes/llama_cpp/download-runtime.sh` to fetch the binary for your platform. If that script is not yet available, check the [GitHub releases](https://github.com/outrightmental/ConversationSimulator/releases) page for pre-built binaries.
+
+**"Checksum mismatch" during model download**
+
+The downloaded file does not match the expected SHA-256 checksum. The file has been discarded automatically. Try downloading again — the most common cause is a partial or interrupted download. If the error repeats, open a GitHub issue; the registry entry may need updating.
+
+**Model loads but NPC responses are empty or malformed**
+
+The model is loaded but producing unexpected output. Try:
+
+1. Switching to a larger model from the registry.
+2. Reducing context length: open **Settings → Advanced**, lower the context length to 4 096, and restart the app.
+3. Checking `~/.convsim/logs/` for errors from convsim-core or the LLM runtime.
+
+---
+
+## Low VRAM or slow inference
+
+**Inference is very slow (30+ seconds per turn)**
+
+The model is likely running entirely on CPU. This is expected on machines without a discrete GPU or with insufficient VRAM. Options:
+
+- **Switch to the starter model:** Qwen3 4B (~2.6 GB, 4 GB VRAM minimum) is the most practical choice for CPU-only or low-VRAM machines.
+- **Reduce GPU layers:** if you have some VRAM but not enough for the full model, lower `n_gpu_layers` in **Settings → Advanced**. Partial GPU offload is faster than full CPU.
+- **Reduce context length:** a shorter context (`n_ctx=4096`) uses less memory and allows more model layers to fit on the GPU.
+
+**"Out of memory" error when loading model**
+
+Not enough VRAM, or insufficient system RAM for CPU mode. Recommended model by available memory:
+
+| Available VRAM / RAM | Recommendation |
+|---|---|
+| < 4 GB VRAM, ≥ 8 GB RAM | Qwen3 4B on CPU (`-ngl 0`) |
+| 4–6 GB VRAM | Qwen3 4B (starter) |
+| 6–8 GB VRAM | Qwen3 8B (standard) |
+| 10–12 GB VRAM | Qwen3 14B (high-quality) |
+| 16+ GB VRAM | Mistral Small 3.1 24B or Qwen3 14B |
+
+For Apple Silicon, unified memory acts as VRAM — treat the total RAM figure as available VRAM.
+
+---
+
+## Port conflicts
+
+**`./scripts/dev.sh` fails with "Port XXXX is already in use by PID YYYY (process-name)"**
+
+The script reports exactly which process is blocking the port. Stop that process and try again.
+
+```bash
+# macOS / Linux — find and kill the blocking process
+lsof -i :7354
+lsof -i :7355
+kill <PID>
+```
+
+```powershell
+# Windows PowerShell
+Get-NetTCPConnection -LocalPort 7354 | Select-Object OwningProcess
+Stop-Process -Id <PID>
+```
+
+Common culprits:
+
+- A previous `./scripts/dev.sh` that was not stopped cleanly — run `pkill -f uvicorn` and `pkill -f vite` to clean up.
+- Another application using ports in the 7354–7358 range.
+
+> Note: custom port numbers via environment variable are not yet implemented in the dev scripts. Stopping the conflicting process is the current workaround.
+
+---
+
+## STT / TTS unavailable
+
+**"Speech input unavailable" on the conversation screen**
+
+Speech-to-text (STT) requires the whisper.cpp runtime. In the first milestone (text-only simulator), STT is not yet implemented. The conversation screen falls back to text input automatically — no action is needed.
+
+When STT is available, a microphone icon will appear in the conversation input. If it is greyed out:
+
+1. Check that your browser has microphone permission for `127.0.0.1`.
+2. Confirm convsim-stt is running on port 7357 — look for it in the `./scripts/dev.sh` output.
+3. Check `~/.convsim/logs/` for errors from the STT service.
+
+**"Voice output unavailable" on the conversation screen**
+
+Text-to-speech (TTS) requires the Silero TTS runtime. In the first milestone, TTS is not yet implemented. The conversation screen shows NPC dialogue as text automatically.
+
+When TTS is available, a speaker icon will appear in the conversation settings. If it is greyed out, confirm convsim-tts is running on port 7358.
+
+---
+
+## Offline mode
+
+Conversation Simulator is designed to work fully offline after initial setup and model download.
+
+If the home screen shows a network error:
+
+1. **Model not downloaded:** install a model through the model manager while connected to the internet. After that, play is fully offline.
+2. **Pack metadata:** packs are bundled with the application and do not require a network connection. If pack loading fails, this is a bug — open a GitHub issue.
+3. **Stale browser cache:** a hard reload (`Ctrl+Shift+R` / `Cmd+Shift+R`) clears any stale service worker state.
+
+To verify that play is truly offline, run the built-in smoke test:
+
+```bash
+npx convsim offline-smoke-test packs/official/job-interview-basic
+```
+
+This runs a scripted conversation with the fake runtime and confirms that no outbound TCP connection was attempted during play. The command exits nonzero with a specific error message if any subsystem (LLM inference, STT, TTS, telemetry, asset fetch) attempted to reach an external host.
+
+---
 
 ## Developer debug drawer
 
-The conversation screen includes a collapsible debug drawer that shows raw model output, applied state deltas, event flags, and hidden NPC agenda fields. It is intended for developers diagnosing model drift or unexpected scenario behaviour and is **never shown to normal players**.
+The conversation screen includes a collapsible debug drawer for diagnosing model drift or unexpected NPC behaviour. It is never shown during normal play.
 
 **How to enable:**
 
-- **Build-time flag:** set `VITE_DEV_TOOLS=true` in your `.env.local` before running `pnpm dev`. The drawer will appear for all sessions in that build.
-- **Per-device toggle:** open **Settings → Advanced → Developer debug mode**. The change takes effect after reloading the conversation screen.
+- **Build-time flag:** set `VITE_DEV_TOOLS=true` in `.env.local` before running `pnpm dev`. The drawer appears for all sessions in that build.
+- **Per-device toggle:** open **Settings → Advanced → Developer debug mode**. Takes effect after reloading the conversation screen.
 
 **What the drawer shows per turn:**
 
 - Raw model JSON payload (the full `npc_opening` / `npc_turn` event payload as returned by the backend).
-- Applied state delta for that turn (the numeric changes actually committed to tracked NPC state variables).
-- Rejected state delta (a red `⊘ rejected` badge and section) when the model requests changes to variables the simulator does not track — these are dropped, never applied. This is a common model-drift signal.
-- An amber `agenda` badge and highlighted field list when the payload contains hidden NPC fields (`agenda`, `hidden_state`, `prompt_metadata`, etc.).
+- Applied state delta committed to tracked NPC state variables for that turn.
+- Rejected state delta (red `⊘ rejected` badge) — changes the model requested for variables the simulator does not track; these are dropped and never applied. This is a common model-drift signal.
+- Amber `agenda` badge when the payload contains hidden NPC fields (`agenda`, `hidden_state`, `prompt_metadata`).
 
-**Copy to clipboard:** each entry has a copy button. Raw audio fields (`audio`, `audio_data`, `tts_audio`, `raw_audio`) and `secret` fields are redacted before writing to the clipboard. A persistent warning label marks this redaction.
+**Copy to clipboard:** raw audio fields (`audio`, `audio_data`, `tts_audio`, `raw_audio`) and `secret` fields are redacted before copying. A persistent warning label marks the redaction.
 
-**Security note:** the drawer is not mounted in the DOM in normal mode — hidden NPC fields cannot be accessed through browser developer tools when the setting is off. Disable developer debug mode before sharing your screen or recording sessions.
+**Security note:** the drawer is not mounted in the DOM in normal mode — hidden NPC fields cannot be read through browser developer tools when the setting is off. Disable developer debug mode before sharing your screen or recording a session.
+
+---
 
 ## Where to get help
 
-- Open a [GitHub Issue](https://github.com/outrightmental/ConversationSimulator/issues)
-  for bugs or missing documentation.
+- Open a [GitHub issue](https://github.com/outrightmental/ConversationSimulator/issues) for bugs or missing documentation.
 - See [install.md](install.md) for installation steps.
 - See [quickstart.md](quickstart.md) for first-run instructions.
+- See [local-models.md](local-models.md) for model selection and hardware guidance.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -53,9 +53,9 @@ A model must be installed before conversations can start. Open **Settings → Mo
 
 Possible causes:
 
-1. **Insufficient VRAM:** the model requires more GPU memory than is available. Try the starter model (Qwen3 4B, ~2.6 GB, 4 GB VRAM minimum). To force CPU-only mode and bypass the GPU entirely, set `CONVSIM_LLAMA_CPP_ARGS="-ngl 0"` before starting the dev server. Inference will be slower but the model will load.
+1. **Insufficient VRAM:** the model requires more GPU memory than is available. Try the starter model (Qwen3 4B, ~2.6 GB, 4 GB VRAM minimum). To force CPU-only mode and bypass the GPU entirely, open **Settings → Advanced**, set GPU layers (`n_gpu_layers`) to 0, and reload the model. Inference will be slower but the model will load.
 
-2. **Corrupted download:** delete the file from `~/.convsim/models/` and re-download through the model manager.
+2. **Corrupted download:** delete the file from `~/.convsim/models/llm/` and re-download through the model manager.
 
 3. **llama-server binary not found:** the llama.cpp binary must be present before the LLM runtime can start. Run `./runtimes/llama_cpp/download-runtime.sh` to fetch the binary for your platform. If that script is not yet available, check the [GitHub releases](https://github.com/outrightmental/ConversationSimulator/releases) page for pre-built binaries.
 
@@ -89,7 +89,7 @@ Not enough VRAM, or insufficient system RAM for CPU mode. Recommended model by a
 
 | Available VRAM / RAM | Recommendation |
 |---|---|
-| < 4 GB VRAM, ≥ 8 GB RAM | Qwen3 4B on CPU (`-ngl 0`) |
+| < 4 GB VRAM, ≥ 8 GB RAM | Qwen3 4B on CPU (GPU layers = 0) |
 | 4–6 GB VRAM | Qwen3 4B (starter) |
 | 6–8 GB VRAM | Qwen3 8B (standard) |
 | 10–12 GB VRAM | Qwen3 14B (high-quality) |


### PR DESCRIPTION
## Summary

Replaces the four Milestone 1 placeholder documentation files with complete, production-ready content covering installation, quickstart, model selection, and troubleshooting. Includes four follow-up corrections to ensure all commands and paths match the actual runtime configuration.

## What changed

### `docs/install.md`
Covers **Path A** (developer source install) and **Path B** (alpha app install, marked as a future milestone). Includes exact commands from `scripts/setup.sh` and `scripts/dev.sh`, complete system requirements table, local data directory locations with environment variable overrides, and verification via the offline smoke test. Windows PowerShell equivalents provided throughout.

### `docs/quickstart.md`
End-to-end first-conversation walkthrough: starting the dev services, installing a model on first run, choosing a scenario pack, playing through a conversation turn-by-turn, and reviewing the debrief screen with transcript and state-change annotations. Links to follow-on documentation for model upgrades and scenario authoring.

### `docs/local-models.md`
Hardware tier table (Starter/Standard/High-quality/User-supplied) with per-model license, file size, context length, and VRAM requirements. Covers Ollama runtime setup as an alternative to the bundled llama.cpp, GGUF format and quantization explanation, custom GGUF import path, manual SHA-256 checksum verification commands for macOS/Linux/PowerShell, and full runtime environment variable reference. Explicitly states that no model weights are bundled and that the license text must be accepted before any download begins.

### `docs/troubleshooting.md`
Expands the existing placeholder with coverage of:
- Model load failure (insufficient VRAM, corrupted download, missing llama-server binary)
- Checksum mismatch during download
- Empty or malformed NPC responses
- Low VRAM or slow inference with a recommended-model-by-memory table
- Port conflicts with per-platform kill commands (lsof/kill on macOS/Linux, Get-NetTCPConnection/Stop-Process on PowerShell)
- STT/TTS unavailable (annotated as Milestone 1 status)
- Offline mode verification with the smoke-test command
- Preserves and expands the existing developer debug drawer section

## Cross-references verified

- All script commands matched against `scripts/setup.sh`, `scripts/dev.sh`, `scripts/setup.ps1`, `scripts/dev.ps1`
- Model names, sizes, VRAM requirements, context lengths, and licenses cross-referenced against `model-registry/registry.yaml`
- Port numbers and service URLs verified against `scripts/dev.sh` and README service table
- Runtime configuration names verified against `convsim_core/runtime/` adapter code
- Environment variable names and defaults verified against `config.py`

## Follow-up corrections

- **d0e7b83:** Fixed inaccurate environment variable names and model paths (CONVSIM_RUNTIME_ID default, GPU layer control, model directory structure)
- **9528089:** Corrected TTS runtime name from Silero to Kokoro
- **73cfd95:** Added required `pnpm --filter @convsim/cli build` step before smoke-test invocation so the clean-clone install verification works as written
- **7259be7:** Added `CONVSIM_MODELS_DIR` environment variable override to the data-locations table

Closes #72