### PR TITLE
Write public roadmap with MVP boundaries and future non-goals

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,9 @@ Every session runs through a layered safety system before and after the model is
 | 4 | Local voice output (TTS with Kokoro / sherpa-onnx) | Planned |
 | 5 | Polished playable alpha | Planned |
 
-> [ROADMAP.md](ROADMAP.md) &nbsp;·&nbsp;
+**[ROADMAP.md](ROADMAP.md)** — MVP acceptance criteria, build order, what is
+deliberately out of scope, and links to the acceptance suite and docs.
+
 > [GitHub Milestones](https://github.com/outrightmental/ConversationSimulator/milestones) &nbsp;·&nbsp;
 > [Full specification](docs/SPEC.md)
 

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Every session runs through a layered safety system before and after the model is
 | 5 | Polished playable alpha | Planned |
 
 **[ROADMAP.md](ROADMAP.md)** — MVP acceptance criteria, build order, what is
-deliberately out of scope, and links to the acceptance suite and docs.
+deliberately out of scope, and links to the acceptance criteria and docs.
 
 > [GitHub Milestones](https://github.com/outrightmental/ConversationSimulator/milestones) &nbsp;·&nbsp;
 > [Full specification](docs/SPEC.md)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -137,7 +137,7 @@ must not compromise offline-first, local-model, or open-source principles.
 
 ## Links
 
-- [Acceptance suite](docs/acceptance-suite.md) — runnable tests that gate each milestone
+- [Acceptance criteria](docs/SPEC.md#24-mvp-acceptance-criteria) — the player, creator, developer, and concept tests that gate the MVP
 - [Architecture](docs/architecture.md) — service layout and port assignments
 - [Scenario authoring guide](docs/scenario-authoring.md) — how to write a pack
 - [Pack validation](docs/pack-validation.md) — schema rules and the validator CLI

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -52,7 +52,7 @@ criteria.
 - [x] Model registry with checksums and explicit license disclosure flow
 - [x] Local TTS adapter (Kokoro / sherpa-onnx, synthetic voices, no voice cloning)
 - [x] Text-only workbench — chat panel + live state inspector
-- [x] Job Interview Basics official pack — four playable scenarios
+- [x] Four official packs — Job Interview Basics, Everyday Negotiation, Language Café, Difficult Conversations (four playable scenarios each)
 - [x] README rewritten for instant GitHub comprehension
 
 ### In progress — Milestone 1 (text conversation loop)
@@ -73,7 +73,6 @@ criteria.
 - [ ] Whisper STT integration (voice input, local, no audio uploads)
 - [ ] Full TTS playback connected to scenario engine (voice output)
 - [ ] Workbench: turn replay, state diff, rubric live preview
-- [ ] Everyday Negotiation, Language Café, Difficult Conversations packs
 - [ ] Polished demo GIF and README launch assets
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,33 +1,147 @@
 <!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Roadmap
 
-For the authoritative milestone breakdown, see
-[GitHub Milestones](https://github.com/outrightmental/ConversationSimulator/milestones)
-and the [full specification](docs/SPEC.md).
+> **Purpose of this document:** Keep contributors focused on the breakthrough —
+> local extensible conversation simulation — not on scope that would compromise
+> that focus. If a proposal fits this document's MVP criteria, it belongs here.
+> If it belongs in a "not now" section, it should wait.
 
-## Milestone overview
+---
 
-| Milestone | Goal                            | Status   |
-| --------- | ------------------------------- | -------- |
-| 0         | Monorepo skeleton and dev setup | Complete |
-| 1         | Text-only local simulator       | TODO     |
-| 2         | Scenario pack system            | TODO     |
-| 3         | Local voice input (Whisper)     | TODO     |
-| 4         | Local voice output (TTS)        | TODO     |
-| 5         | Polished playable alpha         | TODO     |
+## MVP acceptance criteria
 
-## Milestone 0 — Monorepo skeleton (current)
+A build qualifies as MVP when **every item below is true**:
 
-- [x] Directory structure, licensing, tooling
-- [x] Developer scripts (`setup.sh`, `dev.sh`)
-- [x] Model registry placeholder
-- [x] Community files (this file)
+1. A player can open a scenario, have a complete text conversation with an NPC, and reach a scored debrief — entirely offline, on a mid-spec laptop.
+2. Scenario packs are plain YAML. A non-programmer can fork and edit one without writing code.
+3. The schema validator catches malformed packs at import time and prints an actionable error.
+4. At least one official scenario pack ships with four distinct, playable scenarios.
+5. Voice input (Whisper STT) and voice output (Kokoro / sherpa-onnx TTS) work as opt-in features on the same local machine.
+6. A workbench UI lets a contributor inspect live state, replay a turn, and validate a pack without touching the CLI.
+7. No outbound network call is made during play. The [offline smoke test](docs/privacy.md) exits zero.
+8. The README and docs are accurate enough that a new contributor can run the project from `git clone` to first conversation in under 15 minutes.
 
-## Milestone 1 — Text-only local simulator
+---
 
-The first working build: a browser UI, Python backend, and local LLM working
-together to run a single conversation scenario from start to debrief.
+## Build order
 
-No voice, no desktop packaging. Text only.
+Work proceeds in this sequence. Later items depend on earlier items shipping and
+being stable. Do not start an item before its predecessor passes its acceptance
+criteria.
 
-See [docs/SPEC.md](docs/SPEC.md) for the full technical requirements.
+| # | Item | Why first |
+|---|------|-----------|
+| 1 | **Text conversation loop** | Everything else is UI on top of this |
+| 2 | **Schema / validator** | Pack authors need a contract before writing content |
+| 3 | **One excellent scenario** | Proves the loop works end-to-end with real content |
+| 4 | **Model manager** | Stable download + version-lock before adding more dependencies |
+| 5 | **Voice input (Whisper STT)** | Adds a new input mode without changing the core loop |
+| 6 | **Voice output (Kokoro / sherpa-onnx TTS)** | Closes the full local audio loop |
+| 7 | **Workbench UI** | Tooling for contributors; requires stable loop and schema |
+| 8 | **More official packs** | Content diversity once the system is proven |
+| 9 | **README / demo polish** | Final surface for GitHub launch |
+
+---
+
+## Status
+
+### Done
+
+- [x] Monorepo skeleton — directory structure, licensing, tooling
+- [x] Developer scripts (`setup.sh`, `dev.sh`, PowerShell equivalents)
+- [x] Model registry with checksums and explicit license disclosure flow
+- [x] Local TTS adapter (Kokoro / sherpa-onnx, synthetic voices, no voice cloning)
+- [x] Text-only workbench — chat panel + live state inspector
+- [x] Job Interview Basics official pack — four playable scenarios
+- [x] README rewritten for instant GitHub comprehension
+
+### In progress — Milestone 1 (text conversation loop)
+
+- [ ] Core conversation loop: player turn → LLM inference → NPC response → state update
+- [ ] Debrief generation from rubric scores
+- [ ] Browser UI connected to Python backend via WebSocket
+
+### Next — Milestone 2 (schema, validator, pack tooling)
+
+- [ ] JSON Schema covering scenarios, NPCs, rubrics, scenes, safety policies
+- [ ] Pack validator CLI (`npx convsim validate-pack <path>`)
+- [ ] Pack import flow in the browser workbench
+- [ ] Offline smoke test CI gate
+
+### After that — Milestones 3–5
+
+- [ ] Whisper STT integration (voice input, local, no audio uploads)
+- [ ] Full TTS playback connected to scenario engine (voice output)
+- [ ] Workbench: turn replay, state diff, rubric live preview
+- [ ] Everyday Negotiation, Language Café, Difficult Conversations packs
+- [ ] Polished demo GIF and README launch assets
+
+---
+
+## Future work — outside MVP, not forgotten
+
+These areas are intentionally **out of scope for MVP**. They are listed here so
+contributors know they have been considered and deferred, not overlooked.
+
+Recording them here does **not** create a commitment to build them. Any future
+work in these areas needs its own proposal, design, and acceptance criteria.
+
+### Visual upgrades
+
+- Animated NPC avatars or portrait art
+- Scene backgrounds and atmospheric overlays
+- Custom fonts, themes, or visual design systems beyond the base UI
+
+### Advanced conversation features
+
+- Multi-NPC scenes (more than one NPC active at once)
+- Branching dialogue trees with author-defined decision nodes
+- Long-term memory across sessions (persistent relationship state)
+- Emotion-to-voice prosody mapping (anger, warmth, uncertainty in TTS)
+
+### UGC ecosystem
+
+- In-app pack browser / discovery feed
+- Community ratings and reviews
+- Pack signing and trust tiers
+- Hosted pack registry (CDN or P2P distribution)
+
+### Education and enterprise
+
+- Classroom dashboard (instructor sees student session aggregates)
+- LMS integration (SCORM / xAPI export)
+- Analytics and cohort reporting
+- Enterprise SSO or managed deployment
+
+---
+
+## Not now
+
+The following are explicitly **out of scope** and should not be proposed as MVP
+additions. A future proposal can revisit them, but the bar is high: any yes
+must not compromise offline-first, local-model, or open-source principles.
+
+| Topic | Why not now |
+|-------|-------------|
+| **VR / AR** | Requires platform-specific SDKs, hardware, and a whole second rendering stack — incompatible with MVP simplicity |
+| **Multiplayer** | Server infrastructure, latency, identity — all the things MVP deliberately avoids |
+| **Cloud inference** | Contradicts the local-first promise; would require an account and send user content to a third party |
+| **Mobile apps** | App store rules, on-device model size, and touch UI are a separate product effort |
+| **Marketplace / monetization** | Payment rails, refund policy, fraud, curation burden — not a developer tool concern |
+| **NSFW content** | Above PG-13 is a hard platform boundary; the safety system enforces this at the validator level |
+| **Celebrity or public-figure packs** | Defamation, right-of-publicity, and likeness risk with no upside for the simulator's core use case |
+| **Complex character animation** | Requires a game-engine-class renderer; out of proportion for a conversation tool |
+| **Therapy / law / medical positioning** | These are licensed professions; shipping a product that implies clinical efficacy creates liability without benefit |
+
+---
+
+## Links
+
+- [Acceptance suite](docs/acceptance-suite.md) — runnable tests that gate each milestone
+- [Architecture](docs/architecture.md) — service layout and port assignments
+- [Scenario authoring guide](docs/scenario-authoring.md) — how to write a pack
+- [Pack validation](docs/pack-validation.md) — schema rules and the validator CLI
+- [Safety policy](docs/safety-policy.md) — content boundaries and the layered safety system
+- [Privacy and data policy](docs/privacy.md) — what stays local and how to verify it
+- [GitHub Milestones](https://github.com/outrightmental/ConversationSimulator/milestones) — issue tracking
+- [Full specification](docs/SPEC.md) — technical requirements per milestone


### PR DESCRIPTION
## Summary

This PR establishes a public roadmap that clarifies MVP boundaries, build sequencing, and intentionally deferred work. The document serves to keep contributors focused on the breakthrough — local, extensible conversation simulation — by creating clear acceptance criteria for the MVP and explicit "out of scope" sections for features that would compromise that focus.

## Changes

**ROADMAP.md** — Complete restructure:
- **MVP acceptance criteria** (8 concrete items): player can run an offline scenario and reach a debrief; scenario packs are plain YAML; validator catches errors; four official packs ship; voice I/O works locally; workbench UI available; zero outbound network calls; docs are new-contributor friendly
- **Build order** (9-item sequence): establishes dependencies so later items only start after predecessors stabilize
- **Status tracking**: moved from basic milestones to detailed "Done", "In Progress", and "Next" sections, clarifying what has shipped (including the four official packs)
- **Future work** (deferred, not rejected): visual upgrades, advanced conversation features, UGC ecosystem, education/enterprise use cases — explicitly listed so contributors know they were considered and are waiting
- **Not now** (hard boundaries): VR/AR, multiplayer, cloud inference, mobile apps, marketplace, NSFW, celebrity packs, complex animation, therapy/medical positioning — with clear reasoning for each

**README.md** — Improved link presentation:
- Made the roadmap link more prominent and descriptive
- Clarified that the roadmap documents MVP criteria, build order, and out-of-scope work

## Why this matters

Before this PR, the roadmap was a sparse milestone list with no guidance on what constitutes MVP or why features were deferred. This created ambiguity for contributors proposing work: is this in scope? What's the right time to do this?

This roadmap fixes that by:
1. **Removing ambiguity**: MVP acceptance criteria are explicit and non-negotiable
2. **Establishing sequence**: dependencies are clear, so teams know what to wait for
3. **Honoring deferred ideas**: future work areas are listed with reasoning, so rejected proposals aren't just killed — they're recorded as "not now", inviting a future revisit
4. **Setting platform boundaries**: the "Not now" section creates a shared understanding of what this simulator will never be (therapy tool, multiplayer platform, cloud-based, etc.)

Closes #76