### PR TITLE
Add runtime settings UI for provider, model, context, GPU layers, and health

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -12,6 +12,7 @@ import { sessionWsRoutes } from './routes/session-ws.js';
 import { privacyRoutes, setDataFolderPath } from './routes/privacy.js';
 import { workbenchRoutes, setWorkbenchRoots } from './routes/workbench.js';
 import { modelsRoutes } from './routes/models.js';
+import { runtimeSettingsRoutes } from './routes/runtime-settings.js';
 import { initDb } from './db.js';
 import { getListenConfig } from './config.js';
 
@@ -42,6 +43,7 @@ export async function buildApp() {
   await app.register(packRoutes);
   await app.register(workbenchRoutes);
   await app.register(modelsRoutes);
+  await app.register(runtimeSettingsRoutes);
 
   return app;
 }

--- a/apps/api/src/routes/models.ts
+++ b/apps/api/src/routes/models.ts
@@ -18,6 +18,8 @@ import type {
   RegisterGgufRequest,
   RegisterGgufResponse,
   DetectedOllamaModel,
+  BenchmarkRequest,
+  BenchmarkResponse,
 } from '@convsim/shared';
 import { getDb } from '../db.js';
 
@@ -321,6 +323,13 @@ export async function modelsRoutes(app: FastifyInstance): Promise<void> {
       fake: 'Fake (deterministic)',
     };
 
+    const lastBenchmarkRow = db
+      .prepare<[], ModelConfigRow>("SELECT key, value FROM model_config WHERE key='last_benchmark'")
+      .get();
+    const last_benchmark: BenchmarkResponse | null = lastBenchmarkRow
+      ? (JSON.parse(lastBenchmarkRow.value) as BenchmarkResponse)
+      : null;
+
     return {
       registry: REGISTRY_ENTRIES,
       installed,
@@ -338,6 +347,7 @@ export async function modelsRoutes(app: FastifyInstance): Promise<void> {
         checked_at: new Date().toISOString(),
       },
       total: REGISTRY_ENTRIES.length,
+      last_benchmark,
     };
   });
 
@@ -590,6 +600,109 @@ export async function modelsRoutes(app: FastifyInstance): Promise<void> {
         host: '127.0.0.1',
         port: 7356,
       };
+    },
+  );
+
+  // POST /api/models/benchmark
+  app.post<{ Body: BenchmarkRequest }>(
+    '/api/models/benchmark',
+    {
+      schema: {
+        body: {
+          type: 'object',
+          properties: {
+            model_id: { type: ['string', 'null'] },
+          },
+        },
+      },
+    },
+    async (req, reply): Promise<BenchmarkResponse> => {
+      const db = getDb();
+      const active = getActiveConfig();
+
+      if (!active.runtime_id || !active.model_id) {
+        reply.status(409);
+        throw new Error(
+          'No model is currently configured. Set up a model before benchmarking.',
+        );
+      }
+
+      const modelId = req.body.model_id ?? active.model_id;
+      const runtimeId = active.runtime_id;
+      const warnings: string[] = [];
+      let tokensPerSec = 0;
+      let contextLength: number | null = null;
+      let outputTokens = 0;
+
+      try {
+        if (runtimeId === 'ollama') {
+          const res = await fetch('http://127.0.0.1:11434/api/generate', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ model: modelId, prompt: 'Say hello.', stream: false }),
+            signal: AbortSignal.timeout(30000),
+          });
+          if (res.ok) {
+            const data = (await res.json()) as {
+              eval_count?: number;
+              eval_duration?: number;
+              context?: number[];
+            };
+            outputTokens = data.eval_count ?? 0;
+            const durationNs = data.eval_duration ?? 0;
+            if (outputTokens > 0 && durationNs > 0) {
+              tokensPerSec = Math.round((outputTokens / (durationNs / 1e9)) * 10) / 10;
+            }
+            contextLength = data.context?.length ?? null;
+          } else {
+            warnings.push('Ollama returned an error. Ensure the model is loaded.');
+          }
+        } else if (runtimeId === 'llama_cpp') {
+          const startMs = Date.now();
+          const res = await fetch('http://127.0.0.1:7356/v1/completions', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ prompt: 'Say hello.', max_tokens: 5 }),
+            signal: AbortSignal.timeout(30000),
+          });
+          if (res.ok) {
+            const data = (await res.json()) as { usage?: { completion_tokens?: number } };
+            outputTokens = data.usage?.completion_tokens ?? 0;
+            const elapsedSec = (Date.now() - startMs) / 1000;
+            if (outputTokens > 0 && elapsedSec > 0) {
+              tokensPerSec = Math.round((outputTokens / elapsedSec) * 10) / 10;
+            }
+          } else {
+            warnings.push('llama.cpp server returned an error. Ensure the sidecar is running.');
+          }
+        } else {
+          warnings.push('Benchmark is not available for the demo runtime.');
+        }
+      } catch {
+        if (runtimeId === 'ollama') {
+          warnings.push('Could not reach Ollama. Ensure Ollama is running on port 11434.');
+        } else if (runtimeId === 'llama_cpp') {
+          warnings.push('Could not reach the llama.cpp server. Start the sidecar first.');
+        } else {
+          warnings.push('Benchmark failed. Check that the runtime is running.');
+        }
+      }
+
+      const result: BenchmarkResponse = {
+        model_id: modelId,
+        runtime_id: runtimeId,
+        tokens_per_sec: tokensPerSec,
+        context_length: contextLength,
+        warnings,
+        output_tokens: outputTokens,
+        benchmarked_at: new Date().toISOString(),
+      };
+
+      db.prepare(
+        "INSERT OR REPLACE INTO model_config (key, value) VALUES ('last_benchmark', ?)",
+      ).run(JSON.stringify(result));
+
+      return result;
     },
   );
 }

--- a/apps/api/src/routes/runtime-settings.test.ts
+++ b/apps/api/src/routes/runtime-settings.test.ts
@@ -1,0 +1,343 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { buildApp } from '../index.js';
+import { resetDb, getDb } from '../db.js';
+import type { FastifyInstance } from 'fastify';
+import type { RuntimeSettingsResponse } from '@convsim/shared';
+
+let app: FastifyInstance;
+
+beforeEach(async () => {
+  resetDb();
+  app = await buildApp();
+});
+
+afterEach(async () => {
+  await app.close();
+});
+
+// ── GET /api/runtime/settings ─────────────────────────────────────────────────
+
+describe('GET /api/runtime/settings', () => {
+  it('returns 200 with all null settings on a fresh DB', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/runtime/settings' });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<RuntimeSettingsResponse>();
+    expect(body.settings.context_length).toBeNull();
+    expect(body.settings.gpu_layers).toBeNull();
+    expect(body.settings.threads).toBeNull();
+    expect(body.settings.temperature).toBeNull();
+    expect(body.settings.top_p).toBeNull();
+    expect(body.settings.repeat_penalty).toBeNull();
+  });
+
+  it('returns requires_restart: false on initial GET', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/runtime/settings' });
+    const body = res.json<RuntimeSettingsResponse>();
+    expect(body.requires_restart).toBe(false);
+  });
+
+  it('returns recommended field with all nulls', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/runtime/settings' });
+    const body = res.json<RuntimeSettingsResponse>();
+    expect(body.recommended).toMatchObject({
+      context_length: null,
+      gpu_layers: null,
+      threads: null,
+      temperature: null,
+      top_p: null,
+      repeat_penalty: null,
+    });
+  });
+});
+
+// ── PUT /api/runtime/settings ─────────────────────────────────────────────────
+
+describe('PUT /api/runtime/settings', () => {
+  it('returns 200 and updated settings', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/runtime/settings',
+      payload: { context_length: 4096, temperature: 0.7 },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<RuntimeSettingsResponse>();
+    expect(body.settings.context_length).toBe(4096);
+    expect(body.settings.temperature).toBe(0.7);
+  });
+
+  it('persists settings across requests', async () => {
+    await app.inject({
+      method: 'PUT',
+      url: '/api/runtime/settings',
+      payload: { gpu_layers: 32, threads: 8 },
+    });
+    const res = await app.inject({ method: 'GET', url: '/api/runtime/settings' });
+    const body = res.json<RuntimeSettingsResponse>();
+    expect(body.settings.gpu_layers).toBe(32);
+    expect(body.settings.threads).toBe(8);
+  });
+
+  it('returns requires_restart: true when context_length changes', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/runtime/settings',
+      payload: { context_length: 8192 },
+    });
+    const body = res.json<RuntimeSettingsResponse>();
+    expect(body.requires_restart).toBe(true);
+  });
+
+  it('returns requires_restart: true when gpu_layers changes', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/runtime/settings',
+      payload: { gpu_layers: -1 },
+    });
+    const body = res.json<RuntimeSettingsResponse>();
+    expect(body.requires_restart).toBe(true);
+  });
+
+  it('returns requires_restart: false when only temperature changes', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/runtime/settings',
+      payload: { temperature: 0.9 },
+    });
+    const body = res.json<RuntimeSettingsResponse>();
+    expect(body.requires_restart).toBe(false);
+  });
+
+  it('returns requires_restart: false when only top_p changes', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/runtime/settings',
+      payload: { top_p: 0.95 },
+    });
+    const body = res.json<RuntimeSettingsResponse>();
+    expect(body.requires_restart).toBe(false);
+  });
+
+  it('returns requires_restart: false when only repeat_penalty changes', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/runtime/settings',
+      payload: { repeat_penalty: 1.1 },
+    });
+    const body = res.json<RuntimeSettingsResponse>();
+    expect(body.requires_restart).toBe(false);
+  });
+
+  it('allows setting fields back to null', async () => {
+    await app.inject({
+      method: 'PUT',
+      url: '/api/runtime/settings',
+      payload: { context_length: 4096 },
+    });
+    await app.inject({
+      method: 'PUT',
+      url: '/api/runtime/settings',
+      payload: { context_length: null },
+    });
+    const res = await app.inject({ method: 'GET', url: '/api/runtime/settings' });
+    expect(res.json<RuntimeSettingsResponse>().settings.context_length).toBeNull();
+  });
+
+  it('accepts -1 as a valid gpu_layers value', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/runtime/settings',
+      payload: { gpu_layers: -1 },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json<RuntimeSettingsResponse>().settings.gpu_layers).toBe(-1);
+  });
+});
+
+// ── PUT /api/runtime/settings — server-side validation ───────────────────────
+
+describe('PUT /api/runtime/settings — validation', () => {
+  it('returns 422 when context_length is below 512', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/runtime/settings',
+      payload: { context_length: 128 },
+    });
+    expect(res.statusCode).toBe(422);
+  });
+
+  it('returns 422 when context_length is above 131072', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/runtime/settings',
+      payload: { context_length: 200000 },
+    });
+    expect(res.statusCode).toBe(422);
+  });
+
+  it('returns 422 when gpu_layers is below -1', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/runtime/settings',
+      payload: { gpu_layers: -5 },
+    });
+    expect(res.statusCode).toBe(422);
+  });
+
+  it('returns 422 when gpu_layers is above 256', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/runtime/settings',
+      payload: { gpu_layers: 512 },
+    });
+    expect(res.statusCode).toBe(422);
+  });
+
+  it('returns 422 when threads is 0', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/runtime/settings',
+      payload: { threads: 0 },
+    });
+    expect(res.statusCode).toBe(422);
+  });
+
+  it('returns 422 when threads is above 64', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/runtime/settings',
+      payload: { threads: 128 },
+    });
+    expect(res.statusCode).toBe(422);
+  });
+
+  it('returns 422 when temperature is negative', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/runtime/settings',
+      payload: { temperature: -0.1 },
+    });
+    expect(res.statusCode).toBe(422);
+  });
+
+  it('returns 422 when temperature exceeds 2.0', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/runtime/settings',
+      payload: { temperature: 3.0 },
+    });
+    expect(res.statusCode).toBe(422);
+  });
+
+  it('returns 422 when top_p exceeds 1.0', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/runtime/settings',
+      payload: { top_p: 1.5 },
+    });
+    expect(res.statusCode).toBe(422);
+  });
+
+  it('returns 422 when repeat_penalty is below 1.0', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/runtime/settings',
+      payload: { repeat_penalty: 0.5 },
+    });
+    expect(res.statusCode).toBe(422);
+  });
+
+  it('returns 422 when repeat_penalty exceeds 2.0', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/runtime/settings',
+      payload: { repeat_penalty: 3.0 },
+    });
+    expect(res.statusCode).toBe(422);
+  });
+
+  it('includes a descriptive message in 422 responses', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/runtime/settings',
+      payload: { context_length: 100 },
+    });
+    const body = res.json<{ message: string }>();
+    expect(body.message).toMatch(/512/);
+  });
+
+  it('does not persist settings when validation fails', async () => {
+    await app.inject({
+      method: 'PUT',
+      url: '/api/runtime/settings',
+      payload: { context_length: 100 },
+    });
+    const res = await app.inject({ method: 'GET', url: '/api/runtime/settings' });
+    expect(res.json<RuntimeSettingsResponse>().settings.context_length).toBeNull();
+  });
+});
+
+// ── POST /api/runtime/settings/reset ─────────────────────────────────────────
+
+describe('POST /api/runtime/settings/reset', () => {
+  it('returns 200 with all null settings', async () => {
+    await app.inject({
+      method: 'PUT',
+      url: '/api/runtime/settings',
+      payload: { context_length: 4096, temperature: 0.7, gpu_layers: 32 },
+    });
+    const res = await app.inject({ method: 'POST', url: '/api/runtime/settings/reset' });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<RuntimeSettingsResponse>();
+    expect(body.settings.context_length).toBeNull();
+    expect(body.settings.temperature).toBeNull();
+    expect(body.settings.gpu_layers).toBeNull();
+  });
+
+  it('returns requires_restart: true after reset', async () => {
+    const res = await app.inject({ method: 'POST', url: '/api/runtime/settings/reset' });
+    const body = res.json<RuntimeSettingsResponse>();
+    expect(body.requires_restart).toBe(true);
+  });
+
+  it('GET /api/runtime/settings returns nulls after reset', async () => {
+    await app.inject({
+      method: 'PUT',
+      url: '/api/runtime/settings',
+      payload: { threads: 8, top_p: 0.95 },
+    });
+    await app.inject({ method: 'POST', url: '/api/runtime/settings/reset' });
+    const res = await app.inject({ method: 'GET', url: '/api/runtime/settings' });
+    const body = res.json<RuntimeSettingsResponse>();
+    expect(body.settings.threads).toBeNull();
+    expect(body.settings.top_p).toBeNull();
+  });
+});
+
+// ── Persistence across buildApp calls (simulating restarts) ──────────────────
+
+describe('runtime settings — persistence across restarts', () => {
+  it('settings survive a simulated restart (new app instance, same DB)', async () => {
+    const db = getDb();
+
+    await app.inject({
+      method: 'PUT',
+      url: '/api/runtime/settings',
+      payload: { context_length: 16384, temperature: 0.8 },
+    });
+    await app.close();
+
+    // Build a new app instance with the same DB
+    const app2 = await buildApp();
+    // Swap the module-level DB reference to the existing one
+    db.pragma('integrity_check');
+
+    const res = await app2.inject({ method: 'GET', url: '/api/runtime/settings' });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<RuntimeSettingsResponse>();
+    expect(body.settings.context_length).toBe(16384);
+    expect(body.settings.temperature).toBe(0.8);
+
+    await app2.close();
+  });
+});

--- a/apps/api/src/routes/runtime-settings.ts
+++ b/apps/api/src/routes/runtime-settings.ts
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { FastifyInstance } from 'fastify';
+import { getDb } from '../db.js';
+import type {
+  RuntimeSettings,
+  RuntimeSettingsResponse,
+  RuntimeSettingsRequest,
+  RuntimeSettingsFieldError,
+} from '@convsim/shared';
+
+const SETTING_KEYS: (keyof RuntimeSettings)[] = [
+  'context_length',
+  'gpu_layers',
+  'threads',
+  'temperature',
+  'top_p',
+  'repeat_penalty',
+];
+
+const RESTART_REQUIRED: Set<keyof RuntimeSettings> = new Set(['context_length', 'gpu_layers']);
+
+const NULL_SETTINGS: RuntimeSettings = {
+  context_length: null,
+  gpu_layers: null,
+  threads: null,
+  temperature: null,
+  top_p: null,
+  repeat_penalty: null,
+};
+
+interface ModelConfigRow { key: string; value: string }
+
+export function loadRuntimeSettings(): RuntimeSettings {
+  const db = getDb();
+  const rows = db
+    .prepare<[], ModelConfigRow>("SELECT key, value FROM model_config WHERE key LIKE 'setting.%'")
+    .all();
+  const map: Record<string, string> = {};
+  for (const r of rows) map[r.key.slice('setting.'.length)] = r.value;
+
+  function num(k: string): number | null {
+    const v = map[k];
+    if (v === undefined || v === '' || v === 'null') return null;
+    const n = parseFloat(v);
+    return isNaN(n) ? null : n;
+  }
+
+  return {
+    context_length: num('context_length'),
+    gpu_layers: num('gpu_layers'),
+    threads: num('threads'),
+    temperature: num('temperature'),
+    top_p: num('top_p'),
+    repeat_penalty: num('repeat_penalty'),
+  };
+}
+
+function saveRuntimeSettings(patch: Partial<RuntimeSettings>): void {
+  const db = getDb();
+  const stmt = db.prepare(
+    'INSERT OR REPLACE INTO model_config (key, value) VALUES (?, ?)',
+  );
+  db.transaction(() => {
+    for (const k of SETTING_KEYS) {
+      if (!(k in patch)) continue;
+      const v = patch[k];
+      stmt.run(`setting.${k}`, v === null || v === undefined ? 'null' : String(v));
+    }
+  })();
+}
+
+function validate(req: RuntimeSettingsRequest): RuntimeSettingsFieldError[] {
+  const errs: RuntimeSettingsFieldError[] = [];
+
+  const cl = req.context_length;
+  if (cl !== null && cl !== undefined) {
+    if (!Number.isInteger(cl) || cl < 512 || cl > 131072) {
+      errs.push({
+        field: 'context_length',
+        message: 'Context length must be an integer between 512 and 131072.',
+      });
+    }
+  }
+
+  const gl = req.gpu_layers;
+  if (gl !== null && gl !== undefined) {
+    if (!Number.isInteger(gl) || gl < -1 || gl > 256) {
+      errs.push({
+        field: 'gpu_layers',
+        message: 'GPU layers must be an integer between -1 (all layers to GPU) and 256.',
+      });
+    }
+  }
+
+  const th = req.threads;
+  if (th !== null && th !== undefined) {
+    if (!Number.isInteger(th) || th < 1 || th > 64) {
+      errs.push({
+        field: 'threads',
+        message: 'Thread count must be an integer between 1 and 64.',
+      });
+    }
+  }
+
+  const temp = req.temperature;
+  if (temp !== null && temp !== undefined) {
+    if (temp < 0.0 || temp > 2.0) {
+      errs.push({ field: 'temperature', message: 'Temperature must be between 0.0 and 2.0.' });
+    }
+  }
+
+  const tp = req.top_p;
+  if (tp !== null && tp !== undefined) {
+    if (tp < 0.0 || tp > 1.0) {
+      errs.push({ field: 'top_p', message: 'Top-P must be between 0.0 and 1.0.' });
+    }
+  }
+
+  const rp = req.repeat_penalty;
+  if (rp !== null && rp !== undefined) {
+    if (rp < 1.0 || rp > 2.0) {
+      errs.push({
+        field: 'repeat_penalty',
+        message: 'Repeat penalty must be between 1.0 and 2.0.',
+      });
+    }
+  }
+
+  return errs;
+}
+
+function needsRestart(patch: Partial<RuntimeSettings>, current: RuntimeSettings): boolean {
+  return SETTING_KEYS.some(
+    (k) => RESTART_REQUIRED.has(k) && k in patch && patch[k] !== current[k],
+  );
+}
+
+export async function runtimeSettingsRoutes(app: FastifyInstance): Promise<void> {
+  // GET /api/runtime/settings
+  app.get('/api/runtime/settings', async (): Promise<RuntimeSettingsResponse> => {
+    return {
+      settings: loadRuntimeSettings(),
+      recommended: NULL_SETTINGS,
+      requires_restart: false,
+    };
+  });
+
+  // PUT /api/runtime/settings
+  app.put<{ Body: RuntimeSettingsRequest }>(
+    '/api/runtime/settings',
+    {
+      schema: {
+        body: {
+          type: 'object',
+          properties: {
+            context_length: { type: ['integer', 'null'] },
+            gpu_layers: { type: ['integer', 'null'] },
+            threads: { type: ['integer', 'null'] },
+            temperature: { type: ['number', 'null'] },
+            top_p: { type: ['number', 'null'] },
+            repeat_penalty: { type: ['number', 'null'] },
+          },
+        },
+      },
+    },
+    async (req, reply): Promise<RuntimeSettingsResponse> => {
+      const errs = validate(req.body);
+      if (errs.length > 0) {
+        const msg = errs.map((e) => e.message).join(' ');
+        reply.status(422);
+        throw Object.assign(new Error(msg), { errors: errs });
+      }
+
+      const current = loadRuntimeSettings();
+      const restart = needsRestart(req.body, current);
+      saveRuntimeSettings(req.body);
+
+      return {
+        settings: loadRuntimeSettings(),
+        recommended: NULL_SETTINGS,
+        requires_restart: restart,
+      };
+    },
+  );
+
+  // POST /api/runtime/settings/reset
+  app.post('/api/runtime/settings/reset', async (): Promise<RuntimeSettingsResponse> => {
+    saveRuntimeSettings(NULL_SETTINGS);
+    return {
+      settings: NULL_SETTINGS,
+      recommended: NULL_SETTINGS,
+      requires_restart: true,
+    };
+  });
+}

--- a/apps/web/src/__tests__/RuntimeSettingsPanel.test.tsx
+++ b/apps/web/src/__tests__/RuntimeSettingsPanel.test.tsx
@@ -1,0 +1,543 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import RuntimeSettingsPanel from '../components/RuntimeSettingsPanel'
+import type { ModelsResponse, RuntimeSettingsResponse } from '@convsim/shared'
+
+vi.mock('../api/client', () => ({
+  api: {
+    getModels: vi.fn(),
+    getRuntimeSettings: vi.fn(),
+    useModel: vi.fn(),
+    updateRuntimeSettings: vi.fn(),
+    resetRuntimeSettings: vi.fn(),
+  },
+}))
+
+import { api } from '../api/client'
+const mockApi = vi.mocked(api)
+
+function makeModels(overrides: Partial<ModelsResponse> = {}): ModelsResponse {
+  return {
+    registry: [],
+    installed: [],
+    ollama_models: [],
+    active: { runtime_id: 'llama_cpp', model_id: null },
+    runtime_health: {
+      runtime_id: 'llama_cpp',
+      runtime_name: 'llama.cpp',
+      status: 'unavailable',
+      model_id: null,
+      latency_ms: null,
+      message: 'No model configured',
+      checked_at: '2026-01-01T00:00:00.000Z',
+    },
+    total: 0,
+    last_benchmark: null,
+    ...overrides,
+  }
+}
+
+function makeSettings(overrides: Partial<RuntimeSettingsResponse> = {}): RuntimeSettingsResponse {
+  return {
+    settings: {
+      context_length: null,
+      gpu_layers: null,
+      threads: null,
+      temperature: null,
+      top_p: null,
+      repeat_penalty: null,
+    },
+    recommended: {
+      context_length: null,
+      gpu_layers: null,
+      threads: null,
+      temperature: null,
+      top_p: null,
+      repeat_penalty: null,
+    },
+    requires_restart: false,
+    ...overrides,
+  }
+}
+
+async function renderPanel() {
+  render(<RuntimeSettingsPanel />)
+  await waitFor(() => {
+    expect(mockApi.getModels).toHaveBeenCalled()
+    expect(mockApi.getRuntimeSettings).toHaveBeenCalled()
+  })
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  vi.clearAllMocks()
+  mockApi.getModels.mockResolvedValue(makeModels())
+  mockApi.getRuntimeSettings.mockResolvedValue(makeSettings())
+  mockApi.useModel.mockResolvedValue({
+    runtime_id: 'llama_cpp',
+    model_id: null,
+    runtime_name: 'llama.cpp',
+    status: 'unavailable',
+    message: null,
+  })
+  mockApi.updateRuntimeSettings.mockResolvedValue(makeSettings())
+  mockApi.resetRuntimeSettings.mockResolvedValue(makeSettings())
+})
+
+// ── Loading and error states ──────────────────────────────────────────────────
+
+describe('RuntimeSettingsPanel — loading', () => {
+  it('shows loading state while data is being fetched', () => {
+    mockApi.getModels.mockReturnValue(new Promise(() => {}))
+    render(<RuntimeSettingsPanel />)
+    expect(screen.getByText(/loading/i)).toBeInTheDocument()
+  })
+
+  it('shows error when load fails', async () => {
+    mockApi.getModels.mockRejectedValue(new Error('network error'))
+    await renderPanel()
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/network error/i),
+    )
+  })
+})
+
+// ── Basic settings — provider and model ──────────────────────────────────────
+
+describe('RuntimeSettingsPanel — basic settings', () => {
+  it('shows a provider selector', async () => {
+    await renderPanel()
+    expect(screen.getByRole('combobox', { name: /provider/i })).toBeInTheDocument()
+  })
+
+  it('shows the active provider selected by default', async () => {
+    mockApi.getModels.mockResolvedValue(makeModels({ active: { runtime_id: 'ollama', model_id: 'llama3:latest' } }))
+    await renderPanel()
+    await waitFor(() =>
+      expect(screen.getByRole('combobox', { name: /provider/i })).toHaveValue('ollama'),
+    )
+  })
+
+  it('shows llama.cpp, Ollama, and Fake options in the provider dropdown', async () => {
+    await renderPanel()
+    const select = screen.getByRole('combobox', { name: /provider/i })
+    expect(select).toContainHTML('llama.cpp')
+    expect(select).toContainHTML('Ollama')
+    expect(select).toContainHTML('Fake')
+  })
+
+  it('shows a model selector when provider is not fake', async () => {
+    await renderPanel()
+    await waitFor(() => expect(screen.getByRole('combobox', { name: /model/i })).toBeInTheDocument())
+  })
+
+  it('hides the model selector when fake provider is selected', async () => {
+    await renderPanel()
+    fireEvent.change(screen.getByRole('combobox', { name: /provider/i }), { target: { value: 'fake' } })
+    await waitFor(() =>
+      expect(screen.queryByRole('combobox', { name: /model/i })).not.toBeInTheDocument(),
+    )
+  })
+
+  it('populates model dropdown with installed llama.cpp models', async () => {
+    mockApi.getModels.mockResolvedValue(makeModels({
+      installed: [{
+        id: 1,
+        registry_id: 'qwen3-4b-instruct-q4_k_m',
+        filename: 'qwen3-4b.gguf',
+        file_path: '/home/user/.convsim/models/llm/qwen3-4b.gguf',
+        size_bytes: 2_800_000_000,
+        install_status: 'ready',
+        progress_bytes: null,
+        error_message: null,
+        verified_sha256: null,
+        installed_at: '2026-01-01T00:00:00.000Z',
+      }],
+    }))
+    await renderPanel()
+    const modelSelect = await screen.findByRole('combobox', { name: /model/i })
+    expect(modelSelect).toContainHTML('qwen3-4b.gguf')
+  })
+
+  it('populates model dropdown with Ollama models when Ollama is selected', async () => {
+    mockApi.getModels.mockResolvedValue(makeModels({
+      ollama_models: [{ id: 'llama3:latest', name: 'llama3:latest', size_category: 'medium' }],
+    }))
+    await renderPanel()
+    fireEvent.change(screen.getByRole('combobox', { name: /provider/i }), { target: { value: 'ollama' } })
+    await waitFor(() =>
+      expect(screen.getByRole('combobox', { name: /model/i })).toContainHTML('llama3:latest'),
+    )
+  })
+
+  it('shows an Apply button for basic settings', async () => {
+    await renderPanel()
+    expect(screen.getByRole('button', { name: /apply provider and model/i })).toBeInTheDocument()
+  })
+
+  it('calls useModel when Apply is clicked', async () => {
+    await renderPanel()
+    fireEvent.click(screen.getByRole('button', { name: /apply provider and model/i }))
+    await waitFor(() =>
+      expect(mockApi.useModel).toHaveBeenCalledWith({ runtime_id: 'llama_cpp', model_id: null }),
+    )
+  })
+
+  it('shows success message after provider/model is applied', async () => {
+    await renderPanel()
+    fireEvent.click(screen.getByRole('button', { name: /apply provider and model/i }))
+    await waitFor(() =>
+      expect(screen.getByText(/provider and model updated/i)).toBeInTheDocument(),
+    )
+  })
+
+  it('shows error when useModel fails', async () => {
+    mockApi.useModel.mockRejectedValue(new Error('runtime not available'))
+    await renderPanel()
+    fireEvent.click(screen.getByRole('button', { name: /apply provider and model/i }))
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/runtime not available/i),
+    )
+  })
+})
+
+// ── Health status display ─────────────────────────────────────────────────────
+
+describe('RuntimeSettingsPanel — health display', () => {
+  it('shows the runtime health status', async () => {
+    mockApi.getModels.mockResolvedValue(makeModels({
+      runtime_health: {
+        runtime_id: 'ollama',
+        runtime_name: 'Ollama',
+        status: 'ready',
+        model_id: 'llama3:latest',
+        latency_ms: 150,
+        message: null,
+        checked_at: '2026-01-01T00:00:00.000Z',
+      },
+    }))
+    await renderPanel()
+    await waitFor(() =>
+      expect(screen.getByLabelText(/runtime health/i)).toHaveTextContent(/Ollama/),
+    )
+  })
+
+  it('shows the model ID in the health status', async () => {
+    mockApi.getModels.mockResolvedValue(makeModels({
+      active: { runtime_id: 'ollama', model_id: 'llama3:latest' },
+      runtime_health: {
+        runtime_id: 'ollama',
+        runtime_name: 'Ollama',
+        status: 'ready',
+        model_id: 'llama3:latest',
+        latency_ms: null,
+        message: null,
+        checked_at: '2026-01-01T00:00:00.000Z',
+      },
+    }))
+    await renderPanel()
+    await waitFor(() =>
+      expect(screen.getByLabelText(/runtime health/i)).toHaveTextContent(/llama3:latest/),
+    )
+  })
+
+  it('shows the last benchmark result when available', async () => {
+    mockApi.getModels.mockResolvedValue(makeModels({
+      last_benchmark: {
+        model_id: 'llama3:latest',
+        runtime_id: 'ollama',
+        tokens_per_sec: 18.7,
+        context_length: 4096,
+        warnings: [],
+        output_tokens: 5,
+        benchmarked_at: '2026-01-01T00:00:00.000Z',
+      },
+    }))
+    await renderPanel()
+    await waitFor(() =>
+      expect(screen.getByLabelText(/last benchmark result/i)).toHaveTextContent(/18.7/),
+    )
+  })
+
+  it('does not show the benchmark section when last_benchmark is null', async () => {
+    await renderPanel()
+    await waitFor(() => expect(mockApi.getModels).toHaveBeenCalled())
+    expect(screen.queryByLabelText(/last benchmark result/i)).not.toBeInTheDocument()
+  })
+})
+
+// ── Advanced settings — hidden by default ────────────────────────────────────
+
+describe('RuntimeSettingsPanel — advanced settings (hidden by default)', () => {
+  it('advanced runtime settings are hidden by default', async () => {
+    await renderPanel()
+    await waitFor(() => expect(mockApi.getModels).toHaveBeenCalled())
+    expect(screen.queryByRole('spinbutton', { name: /context length/i })).not.toBeInTheDocument()
+  })
+
+  it('shows a "Show advanced runtime settings" button', async () => {
+    await renderPanel()
+    expect(
+      screen.getByRole('button', { name: /show runtime advanced settings/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('reveals advanced inputs after clicking show advanced', async () => {
+    await renderPanel()
+    fireEvent.click(screen.getByRole('button', { name: /show runtime advanced settings/i }))
+    await waitFor(() =>
+      expect(screen.getByRole('spinbutton', { name: /context length/i })).toBeInTheDocument(),
+    )
+  })
+
+  it('collapses advanced section when hide advanced is clicked', async () => {
+    await renderPanel()
+    fireEvent.click(screen.getByRole('button', { name: /show runtime advanced settings/i }))
+    await waitFor(() => screen.getByRole('spinbutton', { name: /context length/i }))
+    fireEvent.click(screen.getByRole('button', { name: /hide runtime advanced settings/i }))
+    expect(
+      screen.queryByRole('spinbutton', { name: /context length/i }),
+    ).not.toBeInTheDocument()
+  })
+})
+
+// ── Advanced settings — inputs and validation ─────────────────────────────────
+
+describe('RuntimeSettingsPanel — advanced settings inputs', () => {
+  async function openAdvanced() {
+    await renderPanel()
+    fireEvent.click(screen.getByRole('button', { name: /show runtime advanced settings/i }))
+    await waitFor(() => screen.getByRole('spinbutton', { name: /context length/i }))
+  }
+
+  it('shows context length, GPU layers, threads, temperature, top-p, and repeat penalty inputs', async () => {
+    await openAdvanced()
+    expect(screen.getByRole('spinbutton', { name: /context length/i })).toBeInTheDocument()
+    expect(screen.getByRole('spinbutton', { name: /gpu layers/i })).toBeInTheDocument()
+    expect(screen.getByRole('spinbutton', { name: /cpu threads/i })).toBeInTheDocument()
+    expect(screen.getByRole('spinbutton', { name: /temperature/i })).toBeInTheDocument()
+    expect(screen.getByRole('spinbutton', { name: /top-p/i })).toBeInTheDocument()
+    expect(screen.getByRole('spinbutton', { name: /repeat penalty/i })).toBeInTheDocument()
+  })
+
+  it('pre-fills inputs from saved settings', async () => {
+    mockApi.getRuntimeSettings.mockResolvedValue(makeSettings({
+      settings: {
+        context_length: 4096,
+        gpu_layers: -1,
+        threads: 8,
+        temperature: 0.7,
+        top_p: 0.9,
+        repeat_penalty: 1.1,
+      },
+    }))
+    await openAdvanced()
+    expect(screen.getByRole('spinbutton', { name: /context length/i })).toHaveValue(4096)
+    expect(screen.getByRole('spinbutton', { name: /gpu layers/i })).toHaveValue(-1)
+    expect(screen.getByRole('spinbutton', { name: /cpu threads/i })).toHaveValue(8)
+  })
+
+  it('shows Apply and Reset to defaults buttons in advanced section', async () => {
+    await openAdvanced()
+    expect(screen.getByRole('button', { name: /apply advanced settings/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /reset to defaults/i })).toBeInTheDocument()
+  })
+
+  it('links to troubleshooting docs in the advanced section', async () => {
+    await openAdvanced()
+    expect(screen.getByRole('link', { name: /troubleshooting docs/i })).toBeInTheDocument()
+  })
+})
+
+// ── Client-side validation ────────────────────────────────────────────────────
+
+describe('RuntimeSettingsPanel — client-side validation', () => {
+  async function openAdvanced() {
+    await renderPanel()
+    fireEvent.click(screen.getByRole('button', { name: /show runtime advanced settings/i }))
+    await waitFor(() => screen.getByRole('spinbutton', { name: /context length/i }))
+  }
+
+  it('shows error for context length below 512', async () => {
+    await openAdvanced()
+    fireEvent.change(screen.getByRole('spinbutton', { name: /context length/i }), {
+      target: { value: '256' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /apply advanced settings/i }))
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/512/),
+    )
+    expect(mockApi.updateRuntimeSettings).not.toHaveBeenCalled()
+  })
+
+  it('shows error for context length above 131072', async () => {
+    await openAdvanced()
+    fireEvent.change(screen.getByRole('spinbutton', { name: /context length/i }), {
+      target: { value: '200000' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /apply advanced settings/i }))
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/131072/),
+    )
+  })
+
+  it('shows error for GPU layers below -1', async () => {
+    await openAdvanced()
+    fireEvent.change(screen.getByRole('spinbutton', { name: /gpu layers/i }), {
+      target: { value: '-5' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /apply advanced settings/i }))
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/-1/),
+    )
+  })
+
+  it('shows error for temperature above 2.0', async () => {
+    await openAdvanced()
+    fireEvent.change(screen.getByRole('spinbutton', { name: /temperature/i }), {
+      target: { value: '3.0' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /apply advanced settings/i }))
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/2\.0/),
+    )
+  })
+
+  it('shows error for top-p above 1.0', async () => {
+    await openAdvanced()
+    fireEvent.change(screen.getByRole('spinbutton', { name: /top-p/i }), {
+      target: { value: '1.5' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /apply advanced settings/i }))
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/1\.0/),
+    )
+  })
+
+  it('shows error for repeat penalty below 1.0', async () => {
+    await openAdvanced()
+    fireEvent.change(screen.getByRole('spinbutton', { name: /repeat penalty/i }), {
+      target: { value: '0.5' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /apply advanced settings/i }))
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/1\.0/),
+    )
+  })
+
+  it('calls updateRuntimeSettings when all fields are valid', async () => {
+    await openAdvanced()
+    fireEvent.change(screen.getByRole('spinbutton', { name: /context length/i }), {
+      target: { value: '8192' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /apply advanced settings/i }))
+    await waitFor(() =>
+      expect(mockApi.updateRuntimeSettings).toHaveBeenCalledWith(
+        expect.objectContaining({ context_length: 8192 }),
+      ),
+    )
+  })
+
+  it('sends null for empty fields', async () => {
+    await openAdvanced()
+    fireEvent.click(screen.getByRole('button', { name: /apply advanced settings/i }))
+    await waitFor(() =>
+      expect(mockApi.updateRuntimeSettings).toHaveBeenCalledWith(
+        expect.objectContaining({
+          context_length: null,
+          gpu_layers: null,
+          temperature: null,
+        }),
+      ),
+    )
+  })
+})
+
+// ── Restart required warning ──────────────────────────────────────────────────
+
+describe('RuntimeSettingsPanel — restart required warning', () => {
+  async function openAdvanced() {
+    await renderPanel()
+    fireEvent.click(screen.getByRole('button', { name: /show runtime advanced settings/i }))
+    await waitFor(() => screen.getByRole('spinbutton', { name: /context length/i }))
+  }
+
+  it('shows restart warning after applying context length change', async () => {
+    mockApi.updateRuntimeSettings.mockResolvedValue(makeSettings({ requires_restart: true }))
+    await openAdvanced()
+    fireEvent.change(screen.getByRole('spinbutton', { name: /context length/i }), {
+      target: { value: '4096' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /apply advanced settings/i }))
+    await waitFor(() =>
+      expect(screen.getByRole('status', { name: /restart required/i })).toBeInTheDocument(),
+    )
+  })
+
+  it('does not show restart warning when non-restart fields change', async () => {
+    mockApi.updateRuntimeSettings.mockResolvedValue(makeSettings({ requires_restart: false }))
+    await openAdvanced()
+    fireEvent.change(screen.getByRole('spinbutton', { name: /temperature/i }), {
+      target: { value: '0.7' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /apply advanced settings/i }))
+    await waitFor(() => expect(mockApi.updateRuntimeSettings).toHaveBeenCalled())
+    expect(screen.queryByRole('status', { name: /restart required/i })).not.toBeInTheDocument()
+  })
+
+  it('shows restart warning after reset', async () => {
+    mockApi.resetRuntimeSettings.mockResolvedValue(makeSettings({ requires_restart: true }))
+    await openAdvanced()
+    fireEvent.click(screen.getByRole('button', { name: /reset to defaults/i }))
+    await waitFor(() =>
+      expect(screen.getByRole('status', { name: /restart required/i })).toBeInTheDocument(),
+    )
+  })
+})
+
+// ── Apply advanced and reset ──────────────────────────────────────────────────
+
+describe('RuntimeSettingsPanel — apply advanced and reset', () => {
+  async function openAdvanced() {
+    await renderPanel()
+    fireEvent.click(screen.getByRole('button', { name: /show runtime advanced settings/i }))
+    await waitFor(() => screen.getByRole('spinbutton', { name: /context length/i }))
+  }
+
+  it('shows error when updateRuntimeSettings API fails', async () => {
+    mockApi.updateRuntimeSettings.mockRejectedValue(new Error('server error'))
+    await openAdvanced()
+    fireEvent.click(screen.getByRole('button', { name: /apply advanced settings/i }))
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/server error/i),
+    )
+  })
+
+  it('calls resetRuntimeSettings when Reset to defaults is clicked', async () => {
+    await openAdvanced()
+    fireEvent.click(screen.getByRole('button', { name: /reset to defaults/i }))
+    await waitFor(() => expect(mockApi.resetRuntimeSettings).toHaveBeenCalledOnce())
+  })
+
+  it('clears form fields after reset', async () => {
+    mockApi.getRuntimeSettings.mockResolvedValue(makeSettings({
+      settings: { context_length: 4096, gpu_layers: null, threads: null, temperature: null, top_p: null, repeat_penalty: null },
+    }))
+    await openAdvanced()
+    await waitFor(() => expect(screen.getByRole('spinbutton', { name: /context length/i })).toHaveValue(4096))
+    fireEvent.click(screen.getByRole('button', { name: /reset to defaults/i }))
+    await waitFor(() =>
+      expect(screen.getByRole('spinbutton', { name: /context length/i })).toHaveValue(null),
+    )
+  })
+
+  it('shows error when resetRuntimeSettings API fails', async () => {
+    mockApi.resetRuntimeSettings.mockRejectedValue(new Error('reset failed'))
+    await openAdvanced()
+    fireEvent.click(screen.getByRole('button', { name: /reset to defaults/i }))
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/reset failed/i),
+    )
+  })
+})

--- a/apps/web/src/__tests__/Settings.test.tsx
+++ b/apps/web/src/__tests__/Settings.test.tsx
@@ -11,11 +11,54 @@ vi.mock('../api/client', () => ({
     listSessions: vi.fn(),
     deleteSession: vi.fn(),
     exportSession: vi.fn(),
+    getModels: vi.fn(),
+    getRuntimeSettings: vi.fn(),
+    useModel: vi.fn(),
+    updateRuntimeSettings: vi.fn(),
+    resetRuntimeSettings: vi.fn(),
   },
 }))
 
 import { api } from '../api/client'
 const mockApi = vi.mocked(api)
+
+const STUB_MODELS = {
+  registry: [],
+  installed: [],
+  ollama_models: [],
+  active: { runtime_id: 'llama_cpp', model_id: null },
+  runtime_health: {
+    runtime_id: 'llama_cpp',
+    runtime_name: 'llama.cpp',
+    status: 'unavailable' as const,
+    model_id: null,
+    latency_ms: null,
+    message: 'No model configured',
+    checked_at: '2026-01-01T00:00:00.000Z',
+  },
+  total: 0,
+  last_benchmark: null,
+}
+
+const STUB_RUNTIME_SETTINGS = {
+  settings: {
+    context_length: null,
+    gpu_layers: null,
+    threads: null,
+    temperature: null,
+    top_p: null,
+    repeat_penalty: null,
+  },
+  recommended: {
+    context_length: null,
+    gpu_layers: null,
+    threads: null,
+    temperature: null,
+    top_p: null,
+    repeat_penalty: null,
+  },
+  requires_restart: false,
+}
 
 const SESSION_A = {
   session_id: 'sess-aaa',
@@ -35,12 +78,12 @@ const SESSION_B = {
 
 async function renderSettings() {
   render(<Settings />)
-  // Wait for both mount effects (getDataFolder + listSessions) to fire and
-  // flush their state updates inside act(), preventing act() warnings in tests
-  // that don't otherwise await async work.
+  // Wait for all mount effects to fire and flush state updates.
   await waitFor(() => {
     expect(mockApi.getDataFolder).toHaveBeenCalled()
     expect(mockApi.listSessions).toHaveBeenCalled()
+    expect(mockApi.getModels).toHaveBeenCalled()
+    expect(mockApi.getRuntimeSettings).toHaveBeenCalled()
   })
 }
 
@@ -50,6 +93,11 @@ beforeEach(() => {
   localStorage.clear()
   mockApi.getDataFolder.mockResolvedValue({ path: '/home/user/.convsim/db' })
   mockApi.listSessions.mockResolvedValue({ sessions: [] })
+  mockApi.getModels.mockResolvedValue(STUB_MODELS)
+  mockApi.getRuntimeSettings.mockResolvedValue(STUB_RUNTIME_SETTINGS)
+  mockApi.useModel.mockResolvedValue({ runtime_id: 'llama_cpp', model_id: null, runtime_name: 'llama.cpp', status: 'unavailable', message: null })
+  mockApi.updateRuntimeSettings.mockResolvedValue(STUB_RUNTIME_SETTINGS)
+  mockApi.resetRuntimeSettings.mockResolvedValue(STUB_RUNTIME_SETTINGS)
 })
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -20,6 +20,8 @@ import type {
   RegisterGgufResponse,
   BenchmarkRequest,
   BenchmarkResponse,
+  RuntimeSettingsResponse,
+  RuntimeSettingsRequest,
 } from '@convsim/shared';
 
 export type { HealthResponse };
@@ -277,6 +279,15 @@ export const api = {
   },
   benchmarkModel(request: BenchmarkRequest): Promise<BenchmarkResponse> {
     return post<BenchmarkResponse>('/models/benchmark', request)
+  },
+  getRuntimeSettings(): Promise<RuntimeSettingsResponse> {
+    return get<RuntimeSettingsResponse>('/runtime/settings')
+  },
+  updateRuntimeSettings(request: RuntimeSettingsRequest): Promise<RuntimeSettingsResponse> {
+    return put<RuntimeSettingsResponse>('/runtime/settings', request)
+  },
+  resetRuntimeSettings(): Promise<RuntimeSettingsResponse> {
+    return post<RuntimeSettingsResponse>('/runtime/settings/reset')
   },
   connectSession(
     sessionId: string,

--- a/apps/web/src/components/RuntimeSettingsPanel.tsx
+++ b/apps/web/src/components/RuntimeSettingsPanel.tsx
@@ -1,0 +1,676 @@
+// SPDX-License-Identifier: Apache-2.0
+import { useState, useEffect, useCallback } from 'react'
+import { api } from '../api/client'
+import type { ModelsResponse, RuntimeSettings } from '@convsim/shared'
+
+const DOCS_URL = 'https://github.com/outrightmental/ConversationSimulator/wiki'
+
+const PROVIDER_NAMES: Record<string, string> = {
+  llama_cpp: 'llama.cpp',
+  ollama: 'Ollama',
+  fake: 'Fake (Demo)',
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  ready: '#86efac',
+  starting: '#fbbf24',
+  degraded: '#fb923c',
+  error: '#f87171',
+  unavailable: '#71717a',
+}
+
+interface FieldError {
+  field: string
+  message: string
+}
+
+function parseFloat2(s: string): number | null {
+  if (s === '' || s === null || s === undefined) return null
+  const n = parseFloat(s)
+  return isNaN(n) ? null : n
+}
+
+function parseInt2(s: string): number | null {
+  if (s === '' || s === null || s === undefined) return null
+  const n = parseInt(s, 10)
+  return isNaN(n) ? null : n
+}
+
+function settingsToForm(s: RuntimeSettings): Record<keyof RuntimeSettings, string> {
+  return {
+    context_length: s.context_length !== null ? String(s.context_length) : '',
+    gpu_layers: s.gpu_layers !== null ? String(s.gpu_layers) : '',
+    threads: s.threads !== null ? String(s.threads) : '',
+    temperature: s.temperature !== null ? String(s.temperature) : '',
+    top_p: s.top_p !== null ? String(s.top_p) : '',
+    repeat_penalty: s.repeat_penalty !== null ? String(s.repeat_penalty) : '',
+  }
+}
+
+function validateForm(form: Record<keyof RuntimeSettings, string>): FieldError[] {
+  const errs: FieldError[] = []
+
+  const cl = parseInt2(form.context_length)
+  if (form.context_length !== '' && (cl === null || !Number.isInteger(cl) || cl < 512 || cl > 131072)) {
+    errs.push({ field: 'context_length', message: 'Must be an integer between 512 and 131072.' })
+  }
+
+  const gl = parseInt2(form.gpu_layers)
+  if (form.gpu_layers !== '' && (gl === null || !Number.isInteger(gl) || gl < -1 || gl > 256)) {
+    errs.push({ field: 'gpu_layers', message: 'Must be an integer between -1 (all layers to GPU) and 256.' })
+  }
+
+  const th = parseInt2(form.threads)
+  if (form.threads !== '' && (th === null || !Number.isInteger(th) || th < 1 || th > 64)) {
+    errs.push({ field: 'threads', message: 'Must be an integer between 1 and 64.' })
+  }
+
+  const temp = parseFloat2(form.temperature)
+  if (form.temperature !== '' && (temp === null || temp < 0.0 || temp > 2.0)) {
+    errs.push({ field: 'temperature', message: 'Must be between 0.0 and 2.0.' })
+  }
+
+  const tp = parseFloat2(form.top_p)
+  if (form.top_p !== '' && (tp === null || tp < 0.0 || tp > 1.0)) {
+    errs.push({ field: 'top_p', message: 'Must be between 0.0 and 1.0.' })
+  }
+
+  const rp = parseFloat2(form.repeat_penalty)
+  if (form.repeat_penalty !== '' && (rp === null || rp < 1.0 || rp > 2.0)) {
+    errs.push({ field: 'repeat_penalty', message: 'Must be between 1.0 and 2.0.' })
+  }
+
+  return errs
+}
+
+function formToRequest(form: Record<keyof RuntimeSettings, string>): Partial<RuntimeSettings> {
+  return {
+    context_length: parseInt2(form.context_length),
+    gpu_layers: parseInt2(form.gpu_layers),
+    threads: parseInt2(form.threads),
+    temperature: parseFloat2(form.temperature),
+    top_p: parseFloat2(form.top_p),
+    repeat_penalty: parseFloat2(form.repeat_penalty),
+  }
+}
+
+const inputStyle: React.CSSProperties = {
+  padding: '0.3rem 0.5rem',
+  borderRadius: '4px',
+  border: '1px solid rgba(255,255,255,0.15)',
+  background: 'rgba(255,255,255,0.05)',
+  color: 'inherit',
+  fontSize: '0.875rem',
+  width: '120px',
+}
+
+const selectStyle: React.CSSProperties = {
+  padding: '0.3rem 0.5rem',
+  borderRadius: '4px',
+  border: '1px solid rgba(255,255,255,0.15)',
+  background: '#1a1a1a',
+  color: 'inherit',
+  fontSize: '0.875rem',
+  minWidth: '160px',
+}
+
+const rowStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'flex-start',
+  gap: '0.75rem',
+  marginBottom: '0.75rem',
+  flexWrap: 'wrap',
+}
+
+const labelStyle: React.CSSProperties = {
+  fontSize: '0.875rem',
+  color: '#a1a1aa',
+  minWidth: '140px',
+  paddingTop: '0.35rem',
+}
+
+const noteStyle: React.CSSProperties = {
+  fontSize: '0.75rem',
+  color: '#71717a',
+  marginTop: '0.2rem',
+}
+
+const errorStyle: React.CSSProperties = {
+  fontSize: '0.75rem',
+  color: '#f87171',
+  marginTop: '0.2rem',
+}
+
+const btnStyle: React.CSSProperties = {
+  padding: '0.35rem 0.9rem',
+  borderRadius: '4px',
+  border: '1px solid rgba(255,255,255,0.15)',
+  background: 'rgba(255,255,255,0.06)',
+  color: 'inherit',
+  cursor: 'pointer',
+  fontSize: '0.875rem',
+  fontWeight: 500,
+}
+
+const primaryBtnStyle: React.CSSProperties = {
+  ...btnStyle,
+  background: 'rgba(99,102,241,0.2)',
+  border: '1px solid rgba(99,102,241,0.4)',
+  color: '#a5b4fc',
+}
+
+function FieldRow({
+  label,
+  children,
+  error,
+  note,
+}: {
+  label: string
+  children: React.ReactNode
+  error?: string
+  note?: string
+}) {
+  return (
+    <div style={rowStyle}>
+      <span style={labelStyle}>{label}</span>
+      <div>
+        {children}
+        {note && <div style={noteStyle}>{note}</div>}
+        {error && <div style={errorStyle} role="alert">{error}</div>}
+      </div>
+    </div>
+  )
+}
+
+export default function RuntimeSettingsPanel() {
+  const [modelsData, setModelsData] = useState<ModelsResponse | null>(null)
+  const [loadError, setLoadError] = useState<string | null>(null)
+
+  const [provider, setProvider] = useState<string>('llama_cpp')
+  const [modelId, setModelId] = useState<string>('')
+
+  const [basicApplying, setBasicApplying] = useState(false)
+  const [basicApplyError, setBasicApplyError] = useState<string | null>(null)
+  const [basicApplySuccess, setBasicApplySuccess] = useState(false)
+
+  const [showAdvanced, setShowAdvanced] = useState(false)
+  const [form, setForm] = useState<Record<keyof RuntimeSettings, string>>({
+    context_length: '',
+    gpu_layers: '',
+    threads: '',
+    temperature: '',
+    top_p: '',
+    repeat_penalty: '',
+  })
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({})
+  const [advApplying, setAdvApplying] = useState(false)
+  const [advApplyError, setAdvApplyError] = useState<string | null>(null)
+  const [requiresRestart, setRequiresRestart] = useState(false)
+  const [resetting, setResetting] = useState(false)
+  const [resetError, setResetError] = useState<string | null>(null)
+
+  const loadData = useCallback(() => {
+    setLoadError(null)
+    Promise.all([api.getModels(), api.getRuntimeSettings()])
+      .then(([models, runtimeSettings]) => {
+        setModelsData(models)
+        setProvider(models.active.runtime_id ?? 'llama_cpp')
+        setModelId(models.active.model_id ?? '')
+        setForm(settingsToForm(runtimeSettings.settings))
+        setRequiresRestart(false)
+      })
+      .catch((err) => {
+        setLoadError(err instanceof Error ? err.message : 'Failed to load runtime settings')
+      })
+  }, [])
+
+  useEffect(() => { loadData() }, [loadData])
+
+  const modelOptions = (() => {
+    if (!modelsData) return []
+    if (provider === 'ollama') {
+      return modelsData.ollama_models.map((m) => ({ value: m.id, label: m.name }))
+    }
+    if (provider === 'llama_cpp') {
+      return modelsData.installed
+        .filter((m) => m.install_status === 'ready')
+        .map((m) => ({ value: m.file_path, label: m.filename }))
+    }
+    return []
+  })()
+
+  async function handleBasicApply() {
+    setBasicApplying(true)
+    setBasicApplyError(null)
+    setBasicApplySuccess(false)
+    try {
+      await api.useModel({ runtime_id: provider, model_id: modelId || null })
+      setBasicApplySuccess(true)
+      loadData()
+    } catch (err) {
+      setBasicApplyError(err instanceof Error ? err.message : 'Failed to apply settings')
+    } finally {
+      setBasicApplying(false)
+    }
+  }
+
+  function handleFieldChange(field: keyof RuntimeSettings, value: string) {
+    setForm((prev) => ({ ...prev, [field]: value }))
+    setFieldErrors((prev) => {
+      const next = { ...prev }
+      delete next[field]
+      return next
+    })
+    setRequiresRestart(false)
+    setAdvApplyError(null)
+  }
+
+  async function handleAdvancedApply() {
+    const errs = validateForm(form)
+    if (errs.length > 0) {
+      const map: Record<string, string> = {}
+      for (const e of errs) map[e.field] = e.message
+      setFieldErrors(map)
+      return
+    }
+    setAdvApplying(true)
+    setAdvApplyError(null)
+    try {
+      const result = await api.updateRuntimeSettings(formToRequest(form))
+      setRequiresRestart(result.requires_restart)
+      setForm(settingsToForm(result.settings))
+    } catch (err) {
+      setAdvApplyError(err instanceof Error ? err.message : 'Failed to apply advanced settings')
+    } finally {
+      setAdvApplying(false)
+    }
+  }
+
+  async function handleReset() {
+    setResetting(true)
+    setResetError(null)
+    try {
+      const result = await api.resetRuntimeSettings()
+      setForm(settingsToForm(result.settings))
+      setFieldErrors({})
+      setRequiresRestart(result.requires_restart)
+      setAdvApplyError(null)
+    } catch (err) {
+      setResetError(err instanceof Error ? err.message : 'Failed to reset settings')
+    } finally {
+      setResetting(false)
+    }
+  }
+
+  const health = modelsData?.runtime_health
+  const lastBenchmark = modelsData?.last_benchmark
+
+  if (loadError) {
+    return (
+      <p role="alert" style={{ fontSize: '0.875rem', color: '#f87171' }}>
+        Could not load runtime settings: {loadError}
+      </p>
+    )
+  }
+
+  if (!modelsData) {
+    return <p style={{ fontSize: '0.875rem', color: '#a1a1aa' }}>Loading…</p>
+  }
+
+  return (
+    <div>
+      {/* Basic settings: provider + model */}
+      <div style={{ marginBottom: '1rem' }}>
+        <div style={rowStyle}>
+          <span style={labelStyle}>Provider</span>
+          <select
+            aria-label="provider"
+            value={provider}
+            onChange={(e) => { setProvider(e.target.value); setModelId('') }}
+            style={selectStyle}
+          >
+            <option value="llama_cpp">llama.cpp</option>
+            <option value="ollama">Ollama</option>
+            <option value="fake">Fake (Demo)</option>
+          </select>
+        </div>
+
+        {provider !== 'fake' && (
+          <div style={rowStyle}>
+            <span style={labelStyle}>Model</span>
+            <div>
+              <select
+                aria-label="model"
+                value={modelId}
+                onChange={(e) => setModelId(e.target.value)}
+                style={selectStyle}
+              >
+                <option value="">— none selected —</option>
+                {modelOptions.map((o) => (
+                  <option key={o.value} value={o.value}>{o.label}</option>
+                ))}
+              </select>
+              {modelOptions.length === 0 && (
+                <div style={noteStyle}>
+                  No {PROVIDER_NAMES[provider]} models found.{' '}
+                  {provider === 'llama_cpp' && (
+                    <a
+                      href="/models"
+                      style={{ color: '#818cf8' }}
+                    >
+                      Install a model
+                    </a>
+                  )}
+                  {provider === 'ollama' && (
+                    <>
+                      Ensure Ollama is running.{' '}
+                      <a
+                        href={DOCS_URL}
+                        target="_blank"
+                        rel="noreferrer"
+                        style={{ color: '#818cf8' }}
+                        aria-label="troubleshooting docs"
+                      >
+                        Troubleshooting docs
+                      </a>
+                    </>
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+
+        {basicApplyError && (
+          <p role="alert" style={{ fontSize: '0.875rem', color: '#f87171', marginBottom: '0.5rem' }}>
+            {basicApplyError}
+          </p>
+        )}
+        {basicApplySuccess && (
+          <p aria-live="polite" style={{ fontSize: '0.875rem', color: '#86efac', marginBottom: '0.5rem' }}>
+            Provider and model updated.
+          </p>
+        )}
+
+        <button
+          aria-label="apply provider and model"
+          onClick={handleBasicApply}
+          disabled={basicApplying}
+          style={{ ...primaryBtnStyle, cursor: basicApplying ? 'wait' : 'pointer' }}
+        >
+          {basicApplying ? 'Applying…' : 'Apply'}
+        </button>
+      </div>
+
+      {/* Health status */}
+      {health && (
+        <div
+          aria-label="runtime health"
+          style={{
+            padding: '0.6rem 0.75rem',
+            borderRadius: '6px',
+            background: 'rgba(255,255,255,0.04)',
+            border: '1px solid rgba(255,255,255,0.08)',
+            fontSize: '0.85rem',
+            marginBottom: '1rem',
+          }}
+        >
+          <span
+            style={{
+              display: 'inline-block',
+              width: '8px',
+              height: '8px',
+              borderRadius: '50%',
+              background: STATUS_COLORS[health.status] ?? '#71717a',
+              marginRight: '0.5rem',
+              verticalAlign: 'middle',
+            }}
+          />
+          <span style={{ color: STATUS_COLORS[health.status] ?? '#71717a', fontWeight: 500 }}>
+            {health.runtime_name}
+          </span>
+          {health.model_id && (
+            <span style={{ color: '#a1a1aa', marginLeft: '0.5rem' }}>
+              — {health.model_id}
+            </span>
+          )}
+          {health.message && (
+            <span style={{ color: '#71717a', marginLeft: '0.5rem', fontSize: '0.8rem' }}>
+              {health.message}
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Last benchmark */}
+      {lastBenchmark && (
+        <div
+          aria-label="last benchmark result"
+          style={{
+            padding: '0.5rem 0.75rem',
+            borderRadius: '6px',
+            background: 'rgba(255,255,255,0.03)',
+            border: '1px solid rgba(255,255,255,0.07)',
+            fontSize: '0.82rem',
+            color: '#a1a1aa',
+            marginBottom: '1rem',
+          }}
+        >
+          Last benchmark:{' '}
+          <span style={{ color: '#d4d4d8', fontWeight: 500 }}>
+            {lastBenchmark.tokens_per_sec.toFixed(1)} tokens/sec
+          </span>
+          {lastBenchmark.context_length != null && (
+            <span style={{ marginLeft: '0.5rem' }}>
+              · {lastBenchmark.context_length.toLocaleString()} token context
+            </span>
+          )}
+          {lastBenchmark.warnings.length > 0 && (
+            <span style={{ marginLeft: '0.5rem', color: '#fbbf24' }}>
+              · {lastBenchmark.warnings.length} warning{lastBenchmark.warnings.length > 1 ? 's' : ''}
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Advanced toggle */}
+      <button
+        onClick={() => setShowAdvanced((v) => !v)}
+        aria-expanded={showAdvanced}
+        aria-label={showAdvanced ? 'hide runtime advanced settings' : 'show runtime advanced settings'}
+        style={{
+          background: 'none',
+          border: 'none',
+          cursor: 'pointer',
+          color: '#71717a',
+          fontSize: '0.85rem',
+          padding: 0,
+          marginBottom: '0.75rem',
+        }}
+      >
+        {showAdvanced ? '▾ Hide runtime advanced settings' : '▸ Show runtime advanced settings'}
+      </button>
+
+      {showAdvanced && (
+        <div
+          style={{
+            borderLeft: '2px solid rgba(255,255,255,0.08)',
+            paddingLeft: '1rem',
+            marginBottom: '1rem',
+          }}
+        >
+          <FieldRow
+            label="Context length"
+            error={fieldErrors['context_length']}
+            note="Tokens the model can process at once. Leave blank to use the model default. Changing this requires a runtime restart."
+          >
+            <input
+              aria-label="context length"
+              type="number"
+              min={512}
+              max={131072}
+              step={512}
+              placeholder="model default"
+              value={form.context_length}
+              onChange={(e) => handleFieldChange('context_length', e.target.value)}
+              style={inputStyle}
+            />
+          </FieldRow>
+
+          <FieldRow
+            label="GPU layers"
+            error={fieldErrors['gpu_layers']}
+            note="-1 = all layers to GPU, 0 = CPU only. Leave blank for automatic. Changing this requires a runtime restart."
+          >
+            <input
+              aria-label="gpu layers"
+              type="number"
+              min={-1}
+              max={256}
+              step={1}
+              placeholder="auto"
+              value={form.gpu_layers}
+              onChange={(e) => handleFieldChange('gpu_layers', e.target.value)}
+              style={inputStyle}
+            />
+          </FieldRow>
+
+          <FieldRow
+            label="CPU threads"
+            error={fieldErrors['threads']}
+            note="Number of CPU threads for inference (1–64). Leave blank for automatic."
+          >
+            <input
+              aria-label="cpu threads"
+              type="number"
+              min={1}
+              max={64}
+              step={1}
+              placeholder="auto"
+              value={form.threads}
+              onChange={(e) => handleFieldChange('threads', e.target.value)}
+              style={inputStyle}
+            />
+          </FieldRow>
+
+          <FieldRow
+            label="Temperature"
+            error={fieldErrors['temperature']}
+            note="Sampling randomness (0.0–2.0). Higher = more creative. Leave blank for runtime default."
+          >
+            <input
+              aria-label="temperature"
+              type="number"
+              min={0}
+              max={2}
+              step={0.05}
+              placeholder="runtime default"
+              value={form.temperature}
+              onChange={(e) => handleFieldChange('temperature', e.target.value)}
+              style={inputStyle}
+            />
+          </FieldRow>
+
+          <FieldRow
+            label="Top-P"
+            error={fieldErrors['top_p']}
+            note="Nucleus sampling threshold (0.0–1.0). Leave blank for runtime default."
+          >
+            <input
+              aria-label="top-p"
+              type="number"
+              min={0}
+              max={1}
+              step={0.05}
+              placeholder="runtime default"
+              value={form.top_p}
+              onChange={(e) => handleFieldChange('top_p', e.target.value)}
+              style={inputStyle}
+            />
+          </FieldRow>
+
+          <FieldRow
+            label="Repeat penalty"
+            error={fieldErrors['repeat_penalty']}
+            note="Penalty for repeated tokens (1.0–2.0). Leave blank for runtime default."
+          >
+            <input
+              aria-label="repeat penalty"
+              type="number"
+              min={1}
+              max={2}
+              step={0.05}
+              placeholder="runtime default"
+              value={form.repeat_penalty}
+              onChange={(e) => handleFieldChange('repeat_penalty', e.target.value)}
+              style={inputStyle}
+            />
+          </FieldRow>
+
+          {requiresRestart && (
+            <div
+              role="status"
+              aria-label="restart required"
+              style={{
+                background: 'rgba(251,191,36,0.08)',
+                border: '1px solid rgba(251,191,36,0.3)',
+                borderRadius: '6px',
+                padding: '0.6rem 0.75rem',
+                marginBottom: '0.75rem',
+                fontSize: '0.875rem',
+                color: '#fcd34d',
+              }}
+            >
+              Context length and GPU layer changes require restarting the runtime to take effect.
+            </div>
+          )}
+
+          {advApplyError && (
+            <p role="alert" style={{ fontSize: '0.875rem', color: '#f87171', marginBottom: '0.5rem' }}>
+              {advApplyError}
+            </p>
+          )}
+          {resetError && (
+            <p role="alert" style={{ fontSize: '0.875rem', color: '#f87171', marginBottom: '0.5rem' }}>
+              {resetError}
+            </p>
+          )}
+
+          <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+            <button
+              aria-label="apply advanced settings"
+              onClick={handleAdvancedApply}
+              disabled={advApplying}
+              style={{ ...primaryBtnStyle, cursor: advApplying ? 'wait' : 'pointer' }}
+            >
+              {advApplying ? 'Applying…' : 'Apply'}
+            </button>
+            <button
+              aria-label="reset to defaults"
+              onClick={handleReset}
+              disabled={resetting}
+              style={{ ...btnStyle, cursor: resetting ? 'wait' : 'pointer' }}
+            >
+              {resetting ? 'Resetting…' : 'Reset to defaults'}
+            </button>
+            <a
+              href={DOCS_URL}
+              target="_blank"
+              rel="noreferrer"
+              aria-label="troubleshooting docs"
+              style={{
+                fontSize: '0.8rem',
+                color: '#71717a',
+                display: 'flex',
+                alignItems: 'center',
+                textDecoration: 'underline',
+              }}
+            >
+              Troubleshooting docs ↗
+            </a>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/screens/Settings.tsx
+++ b/apps/web/src/screens/Settings.tsx
@@ -2,6 +2,7 @@
 import { useState, useEffect, useCallback, type ReactNode } from 'react'
 import { api } from '../api/client'
 import { readPrivacyPref, writePrivacyPref, PRIVACY_KEYS, isDevModeEnabled } from '../privacyPrefs'
+import RuntimeSettingsPanel from '../components/RuntimeSettingsPanel'
 
 type ClearState = 'idle' | 'confirming' | 'clearing' | 'done' | 'error'
 
@@ -216,6 +217,15 @@ export default function Settings() {
             Not saved — transcript will be lost when this session ends.
           </p>
         )}
+      </section>
+
+      {/* Runtime settings */}
+      <section style={{ marginBottom: '2rem' }}>
+        <SectionHeading>Runtime</SectionHeading>
+        <p style={{ fontSize: '0.875rem', color: '#a1a1aa', marginBottom: '0.75rem' }}>
+          Select the active AI provider and model. Advanced knobs are hidden by default.
+        </p>
+        <RuntimeSettingsPanel />
       </section>
 
       {/* TTS cache */}

--- a/packages/shared/src/types/models.ts
+++ b/packages/shared/src/types/models.ts
@@ -130,3 +130,25 @@ export interface BenchmarkResponse {
   output_tokens: number;
   benchmarked_at: string;
 }
+
+export interface RuntimeSettings {
+  context_length: number | null;
+  gpu_layers: number | null;
+  threads: number | null;
+  temperature: number | null;
+  top_p: number | null;
+  repeat_penalty: number | null;
+}
+
+export interface RuntimeSettingsResponse {
+  settings: RuntimeSettings;
+  recommended: RuntimeSettings;
+  requires_restart: boolean;
+}
+
+export type RuntimeSettingsRequest = Partial<RuntimeSettings>;
+
+export interface RuntimeSettingsFieldError {
+  field: string;
+  message: string;
+}


### PR DESCRIPTION
## Summary

Adds a **Runtime** section to the Settings screen that lets advanced users control local inference parameters without exposing controls to normal users by default.

- **Basic settings** (always visible): provider dropdown (llama.cpp / Ollama / Fake), model selector populated from installed/detected models, Apply button calling `POST /api/models/use`, and a live health status badge showing the active runtime and model.
- **Advanced settings** (hidden behind "Show runtime advanced settings" toggle): context length (512–131,072), GPU layers (−1 to 256), CPU threads (1–64), temperature (0–2), top-P (0–1), and repeat penalty (1–2). Values are validated client-side before the API call, with field-level error messages. The backend validates the same constraints server-side (422) as a safety net.
- **Restart required warning**: applying context length or GPU layer changes shows a banner explaining that the runtime must be restarted for the change to take effect.
- **Reset to defaults**: clears all advanced parameters to `null` (model/runtime defaults) via `POST /api/runtime/settings/reset`, also showing the restart warning.
- **Persistence**: settings are stored in the existing `model_config` SQLite table (keys prefixed `setting.`) and survive app restarts.
- **Troubleshooting link**: the advanced panel links to the project wiki.
- **Last benchmark display**: the panel shows the most recent benchmark result (tokens/sec, context, warnings) when available.

### Backend additions

- `GET /api/runtime/settings` — returns current settings + recommended (null) defaults and a `requires_restart` flag.
- `PUT /api/runtime/settings` — validates and persists a partial settings patch; returns `requires_restart: true` when context_length or gpu_layers changed.
- `POST /api/runtime/settings/reset` — clears all settings to null.
- `POST /api/models/benchmark` — new endpoint (was referenced in shared types but not yet implemented); tries the active runtime and stores the result for `last_benchmark`.
- Fixed `GET /api/models` missing the `last_benchmark` field (TypeScript error).

### New shared types

`RuntimeSettings`, `RuntimeSettingsResponse`, `RuntimeSettingsRequest`, `RuntimeSettingsFieldError`, `BenchmarkRequest`, `BenchmarkResponse`.

## How it was tested

- **Frontend**: 40 new tests in `RuntimeSettingsPanel.test.tsx` covering loading state, provider/model selectors, health display, advanced toggle, all six input fields, client-side validation for every out-of-range value, restart-required warning, apply and reset flows, and API error handling. The existing Settings tests were updated to mock the new API methods.
- **Backend**: 29 new integration tests in `runtime-settings.test.ts` covering GET, PUT (including all validation boundaries), POST reset, and a cross-restart persistence scenario. All existing API tests continue to pass.
- **Manual**: restart-required flow can be verified by changing context_length or gpu_layers and confirming the yellow warning banner appears after Apply.

Closes #56