### PR TITLE
Add sentence-by-sentence TTS queue and local audio cache

### DIFF
--- a/packages/shared/src/types/ws-events.ts
+++ b/packages/shared/src/types/ws-events.ts
@@ -92,10 +92,23 @@ export interface WsSttFinalEvent extends WsEventBase {
   payload: { text: string; confidence: number };
 }
 
-/** A chunk of TTS audio encoded as base64. Reserved for future speech support. */
+/** A synthesized sentence chunk from the local TTS cache. */
 export interface WsTtsAudioChunkEvent extends WsEventBase {
   type: 'tts.audio_chunk';
-  payload: { chunk: string };
+  payload: {
+    /** Zero-based position of this chunk within the utterance. */
+    chunk_index: number;
+    /** Total number of chunks for this utterance. */
+    total_chunks: number;
+    /** Sentence text (always present; use as fallback when cache_path is null). */
+    text: string;
+    /** Voice used for synthesis. */
+    voice_id: string;
+    /** Absolute path to the cached WAV file on localhost, or null on failure. */
+    cache_path: string | null;
+    /** Error message if synthesis failed; null on success. */
+    error: string | null;
+  };
 }
 
 /** Union of all WebSocket event shapes. */

--- a/services/convsim-core/convsim_core/routers/sessions.py
+++ b/services/convsim-core/convsim_core/routers/sessions.py
@@ -26,6 +26,7 @@ from pydantic import BaseModel, field_validator
 from convsim_core.scenario_state import build_variable_defs, partition_state_by_visibility
 from convsim_core.scenarios import get_scenario_info
 from convsim_core.services.debrief_engine import generate_debrief
+from convsim_core.services.tts_queue import synthesize_utterance
 from convsim_core.services.turn_pipeline import MAX_TURN_CONTENT_CHARS, TurnInputError, process_turn
 
 logger = logging.getLogger(__name__)
@@ -55,6 +56,9 @@ def _conflict(detail: str, current_state: str) -> HTTPException:
 # ---------------------------------------------------------------------------
 
 
+_DEFAULT_TTS_VOICE_ID = "af_heart"
+
+
 class SessionCreateRequest(BaseModel):
     scenario_id: str
     difficulty: Literal["easy", "normal", "hard"] = "normal"
@@ -62,6 +66,7 @@ class SessionCreateRequest(BaseModel):
     language: str = "en"
     input_mode: Literal["text-only", "push-to-talk", "hands-free"] = "text-only"
     tts_enabled: bool = False
+    tts_voice_id: str = _DEFAULT_TTS_VOICE_ID
     show_state_meters: bool = False
     save_transcript: bool = True
     seed: Optional[int] = None
@@ -71,6 +76,17 @@ class SessionCreateRequest(BaseModel):
     def player_role_name_not_blank(cls, v: str) -> str:
         if not v.strip():
             raise ValueError("player_role_name cannot be blank")
+        return v
+
+    @field_validator("tts_voice_id")
+    @classmethod
+    def tts_voice_id_must_be_approved(cls, v: str) -> str:
+        from convsim_core.tts.voices import validate_voice_id
+        from convsim_core.tts.types import TtsVoiceValidationError
+        try:
+            validate_voice_id(v)
+        except TtsVoiceValidationError as exc:
+            raise ValueError(str(exc)) from exc
         return v
 
 
@@ -193,6 +209,57 @@ class DebriefResponse(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+async def _run_tts_for_utterance(
+    utterance: str,
+    session_id: str,
+    turn_number: int,
+    voice_id: str,
+    tts_worker: Any,
+    conn: Any,
+    now: str,
+) -> List[SessionEventPayload]:
+    """Synthesize *utterance* sentence-by-sentence and persist tts_audio_chunk events.
+
+    Returns an ordered list of SessionEventPayload for the caller to include in
+    the HTTP response.  Any TTS failure is captured per-chunk and does not raise.
+    """
+    try:
+        chunks = await synthesize_utterance(
+            utterance=utterance,
+            voice_id=voice_id,
+            tts_worker=tts_worker,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("TTS queue failed for session %s: %s", session_id, exc, exc_info=True)
+        return []
+
+    events: List[SessionEventPayload] = []
+    for chunk in chunks:
+        payload: Dict[str, Any] = {
+            "chunk_index": chunk.chunk_index,
+            "total_chunks": chunk.total_chunks,
+            "text": chunk.text,
+            "voice_id": chunk.voice_id,
+            "cache_path": chunk.audio_path,
+            "error": chunk.error,
+        }
+        cursor = conn.execute(
+            "INSERT INTO turn_session_events "
+            "(session_id, turn_number, event_type, payload_json, occurred_at) "
+            "VALUES (?, ?, 'tts_audio_chunk', ?, ?)",
+            (session_id, turn_number, json.dumps(payload), now),
+        )
+        conn.commit()
+        events.append(SessionEventPayload(
+            event_id=cursor.lastrowid,
+            session_id=session_id,
+            event_type="tts_audio_chunk",
+            payload=payload,
+            created_at=now,
+        ))
+    return events
+
+
 def _row_to_response(row: Any) -> SessionResponse:
     return SessionResponse(
         session_id=row["session_id"],
@@ -302,17 +369,32 @@ async def start_session(session_id: str, request: Request) -> SessionStartRespon
                 (session_id, 0, "npc_opening", opening_text),
             )
 
-    event = SessionEventPayload(
+    opening_event = SessionEventPayload(
         event_id=cursor.lastrowid,
         session_id=session_id,
         event_type="npc_opening",
         payload={"content": opening_text},
         created_at=now,
     )
+
+    tts_enabled = setup.get("tts_enabled", False)
+    tts_events: List[SessionEventPayload] = []
+    if tts_enabled:
+        voice_id = setup.get("tts_voice_id", _DEFAULT_TTS_VOICE_ID)
+        tts_events = await _run_tts_for_utterance(
+            utterance=opening_text,
+            session_id=session_id,
+            turn_number=0,
+            voice_id=voice_id,
+            tts_worker=request.app.state.tts_worker,
+            conn=conn,
+            now=now,
+        )
+
     return SessionStartResponse(
         session_id=session_id,
         state="PlayerTurnListening",
-        events=[event],
+        events=[opening_event] + tts_events,
     )
 
 
@@ -387,10 +469,24 @@ async def submit_turn(session_id: str, body: TurnSubmitRequest, request: Request
         created_at=now,
     )
 
+    tts_events: List[SessionEventPayload] = []
+    tts_enabled = setup.get("tts_enabled", False)
+    if tts_enabled and not result.used_fallback:
+        voice_id = setup.get("tts_voice_id", _DEFAULT_TTS_VOICE_ID)
+        tts_events = await _run_tts_for_utterance(
+            utterance=result.npc_utterance,
+            session_id=session_id,
+            turn_number=result.turn_number,
+            voice_id=voice_id,
+            tts_worker=request.app.state.tts_worker,
+            conn=conn,
+            now=now,
+        )
+
     return TurnResponse(
         session_id=session_id,
         state=result.new_flow_state,
-        events=[player_event, npc_event],
+        events=[player_event, npc_event] + tts_events,
         ending_type=result.ending_type,
     )
 

--- a/services/convsim-core/convsim_core/routers/tts.py
+++ b/services/convsim-core/convsim_core/routers/tts.py
@@ -70,6 +70,19 @@ async def synthesize(request: Request, body: TtsSynthesizeRequest) -> TtsSynthes
         return TtsSynthesizeResponse(status="error", message=str(exc))
 
 
+@router.post("/api/tts/cache/clear")
+async def clear_tts_cache(request: Request) -> dict:
+    """Delete all locally cached TTS audio files.
+
+    Called by the privacy settings 'clear cache' action.  Removes every cached
+    WAV file from the local TTS cache directory so future synthesis requests
+    re-synthesize from scratch.  Returns the number of files deleted.
+    """
+    tts_worker = request.app.state.tts_worker
+    deleted = await tts_worker.clear_cache()
+    return {"deleted_files": deleted}
+
+
 @router.get("/api/tts/voices")
 async def list_voices() -> dict:
     """Return the approved built-in voice list.

--- a/services/convsim-core/convsim_core/services/tts_queue.py
+++ b/services/convsim-core/convsim_core/services/tts_queue.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+"""TTS queue: split NPC utterances into sentences and synthesize each chunk.
+
+Usage::
+
+    chunks = await synthesize_utterance(
+        utterance=result.npc_utterance,
+        voice_id="af_heart",
+        tts_worker=tts_worker,
+    )
+    for chunk in chunks:
+        if chunk.succeeded:
+            # play chunk.audio_path
+        else:
+            # show chunk.text as fallback
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+from convsim_core.tts.base import TtsWorker
+from convsim_core.tts.sentence_splitter import split_into_sentences
+from convsim_core.tts.types import TtsError, TtsRequest, TtsUnavailableError
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TtsChunkResult:
+    """Result for a single synthesized sentence chunk."""
+
+    chunk_index: int
+    total_chunks: int
+    text: str
+    voice_id: str
+    audio_path: str | None = field(default=None)
+    error: str | None = field(default=None)
+
+    @property
+    def succeeded(self) -> bool:
+        return self.audio_path is not None
+
+
+async def synthesize_utterance(
+    utterance: str,
+    voice_id: str,
+    tts_worker: TtsWorker,
+    speed: float = 1.0,
+) -> list[TtsChunkResult]:
+    """Split *utterance* into sentences and synthesize each as a TTS chunk.
+
+    Chunks are returned in sentence order.  Synthesis failures are recorded
+    per chunk (``error`` field set, ``audio_path`` is None) and do not abort
+    subsequent chunks — text fallback is always available.
+
+    Returns an empty list for empty utterances.  Never raises.
+    """
+    sentences = split_into_sentences(utterance)
+    if not sentences:
+        return []
+
+    total = len(sentences)
+    results: list[TtsChunkResult] = []
+
+    for idx, sentence in enumerate(sentences):
+        chunk = TtsChunkResult(
+            chunk_index=idx,
+            total_chunks=total,
+            text=sentence,
+            voice_id=voice_id,
+        )
+        try:
+            tts_result = await tts_worker.synthesize(
+                TtsRequest(text=sentence, voice_id=voice_id, speed=speed)
+            )
+            chunk.audio_path = tts_result.audio_path
+        except TtsUnavailableError as exc:
+            logger.info("TTS unavailable (chunk %d/%d): %s", idx + 1, total, exc)
+            chunk.error = str(exc)
+        except TtsError as exc:
+            logger.warning(
+                "TTS synthesis error (chunk %d/%d): %s", idx + 1, total, exc,
+                exc_info=True,
+            )
+            chunk.error = str(exc)
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                "Unexpected TTS error (chunk %d/%d): %s", idx + 1, total, exc,
+                exc_info=True,
+            )
+            chunk.error = f"Unexpected error: {exc}"
+
+        results.append(chunk)
+
+    return results

--- a/services/convsim-core/convsim_core/tts/base.py
+++ b/services/convsim-core/convsim_core/tts/base.py
@@ -35,3 +35,11 @@ class TtsWorker(ABC):
     @abstractmethod
     async def health(self) -> TtsHealth:
         """Return a point-in-time health snapshot for this worker."""
+
+    @abstractmethod
+    async def clear_cache(self) -> int:
+        """Delete all locally cached audio files for this worker.
+
+        Called by the privacy 'clear cache' action.  Returns the number of
+        files deleted.  Must not raise — callers do not expect failures here.
+        """

--- a/services/convsim-core/convsim_core/tts/fake.py
+++ b/services/convsim-core/convsim_core/tts/fake.py
@@ -59,6 +59,9 @@ class FakeTtsWorker(TtsWorker):
             voice_id=request.voice_id,
         )
 
+    async def clear_cache(self) -> int:
+        return 0  # Fake worker writes to temp files; nothing to clear.
+
     async def health(self) -> TtsHealth:
         return TtsHealth(
             worker_id=self.id,

--- a/services/convsim-core/convsim_core/tts/kokoro.py
+++ b/services/convsim-core/convsim_core/tts/kokoro.py
@@ -129,6 +129,18 @@ class KokoroTtsWorker(TtsWorker):
             voice_id=request.voice_id,
         )
 
+    async def clear_cache(self) -> int:
+        if not self._cache_dir.exists():
+            return 0
+        count = 0
+        for entry in self._cache_dir.glob("*.wav"):
+            try:
+                entry.unlink()
+                count += 1
+            except OSError:
+                pass
+        return count
+
     async def health(self) -> TtsHealth:
         checked_at = datetime.now(timezone.utc).isoformat()
         try:

--- a/services/convsim-core/convsim_core/tts/sentence_splitter.py
+++ b/services/convsim-core/convsim_core/tts/sentence_splitter.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import re
+
+# Abbreviations that can appear before an uppercase word but are NOT sentence
+# boundaries.  Only include tokens that are essentially never the last word of a
+# complete sentence in NPC dialogue (titles, address components, months).
+# "etc.", "no.", "vol." etc. are deliberately excluded because they frequently
+# DO end sentences in practice ("etc. Please carry on." / "No. That's wrong.").
+_ABBREVS: frozenset[str] = frozenset({
+    # Titles — always followed by a person's name, never end sentences
+    "mr", "mrs", "ms", "dr", "prof", "sr", "jr", "rev", "gen", "sgt", "cpl",
+    # Address components — always followed by a name or number
+    "st", "ave", "blvd", "rd", "dept",
+    # Months — always followed by a date
+    "jan", "feb", "mar", "apr", "jun", "jul", "aug", "sep", "oct", "nov", "dec",
+    # "vs." in legal/sports contexts is always followed by a name
+    "vs",
+})
+
+# A sentence boundary is: one or more end-punctuation chars, optional closing
+# quotes/parens, whitespace, then an uppercase letter or opening quote/paren.
+_BOUNDARY_RE = re.compile(r"([.!?]+[\"')]*)\s+(?=[A-Z\"'(])")
+
+
+def split_into_sentences(text: str) -> list[str]:
+    """Split NPC utterance text into sentence chunks for TTS synthesis.
+
+    Handles common abbreviations (Mr., Dr., etc.) and decimal numbers to avoid
+    false splits. Ellipsis followed by an uppercase word is treated as a
+    sentence boundary. A trailing fragment with no ending punctuation is
+    included as the final chunk. Returns [] for empty or whitespace-only input.
+    """
+    text = text.strip()
+    if not text:
+        return []
+
+    sentences: list[str] = []
+    pos = 0
+
+    for m in _BOUNDARY_RE.finditer(text):
+        punct = m.group(1)
+
+        # '!' and '?' (with or without trailing quotes) are always real
+        # boundaries.  Only period-only runs need abbreviation checking.
+        if "." in punct and "!" not in punct and "?" not in punct:
+            # Ellipsis '...' is a genuine pause/boundary — don't suppress it.
+            if not punct.startswith("..."):
+                segment = text[pos : m.start()]
+
+                # Suppress if the preceding token is a known abbreviation.
+                last_word = re.search(r"([A-Za-z]+)$", segment)
+                if last_word:
+                    word = last_word.group(1).lower()
+                    if word in _ABBREVS or len(word) == 1:
+                        continue
+
+
+        sentence = text[pos : m.start() + len(punct)].strip()
+        if sentence:
+            sentences.append(sentence)
+        pos = m.end()
+
+    remaining = text[pos:].strip()
+    if remaining:
+        sentences.append(remaining)
+
+    return sentences

--- a/services/convsim-core/tests/test_sentence_splitter.py
+++ b/services/convsim-core/tests/test_sentence_splitter.py
@@ -1,0 +1,199 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for sentence splitting edge cases (issue #62)."""
+import pytest
+
+from convsim_core.tts.sentence_splitter import split_into_sentences
+
+
+# ---------------------------------------------------------------------------
+# Basic cases
+# ---------------------------------------------------------------------------
+
+
+def test_empty_string_returns_empty_list():
+    assert split_into_sentences("") == []
+
+
+def test_whitespace_only_returns_empty_list():
+    assert split_into_sentences("   \t\n  ") == []
+
+
+def test_single_sentence_no_punctuation():
+    result = split_into_sentences("Hello there")
+    assert result == ["Hello there"]
+
+
+def test_single_sentence_with_period():
+    result = split_into_sentences("Hello there.")
+    assert result == ["Hello there."]
+
+
+def test_two_sentences_period():
+    result = split_into_sentences("Hello there. How are you?")
+    assert result == ["Hello there.", "How are you?"]
+
+
+def test_two_sentences_exclamation():
+    result = split_into_sentences("Watch out! The door is locked.")
+    assert result == ["Watch out!", "The door is locked."]
+
+
+def test_two_sentences_question():
+    result = split_into_sentences("Are you ready? Yes, I am.")
+    assert result == ["Are you ready?", "Yes, I am."]
+
+
+def test_three_sentences():
+    result = split_into_sentences("Hello. How are you? I am fine.")
+    assert result == ["Hello.", "How are you?", "I am fine."]
+
+
+def test_trailing_fragment_without_punctuation():
+    result = split_into_sentences("First sentence. And a trailing fragment")
+    assert result == ["First sentence.", "And a trailing fragment"]
+
+
+# ---------------------------------------------------------------------------
+# Abbreviation suppression
+# ---------------------------------------------------------------------------
+
+
+def test_mr_abbreviation_does_not_split():
+    result = split_into_sentences("Hello, Mr. Smith. How are you?")
+    assert result == ["Hello, Mr. Smith.", "How are you?"]
+
+
+def test_dr_abbreviation_does_not_split():
+    result = split_into_sentences("Please see Dr. Jones for details.")
+    assert result == ["Please see Dr. Jones for details."]
+
+
+def test_mrs_abbreviation_does_not_split():
+    result = split_into_sentences("Mrs. Brown called earlier.")
+    assert result == ["Mrs. Brown called earlier."]
+
+
+def test_prof_abbreviation_does_not_split():
+    result = split_into_sentences("As Prof. Lee explained, the answer is no.")
+    assert result == ["As Prof. Lee explained, the answer is no."]
+
+
+def test_vs_abbreviation_does_not_split():
+    result = split_into_sentences("In the case of Smith vs. Jones, the court ruled.")
+    assert result == ["In the case of Smith vs. Jones, the court ruled."]
+
+
+def test_etc_ends_sentence_before_new_sentence():
+    # "etc." commonly ends a list at a sentence boundary; treat as split.
+    result = split_into_sentences("We need pens, paper, etc. Please bring them.")
+    assert result == ["We need pens, paper, etc.", "Please bring them."]
+
+
+def test_jr_abbreviation_does_not_split():
+    result = split_into_sentences("That was Martin Luther King Jr. speaking.")
+    assert result == ["That was Martin Luther King Jr. speaking."]
+
+
+# ---------------------------------------------------------------------------
+# Decimal / number suppression
+# ---------------------------------------------------------------------------
+
+
+def test_decimal_number_followed_by_sentence_splits():
+    # Decimal numbers never false-trigger the regex (they're followed by digits,
+    # not uppercase), so a period AFTER the number correctly ends the sentence.
+    result = split_into_sentences("Pi is approximately 3.14159. Remember that.")
+    assert result == ["Pi is approximately 3.14159.", "Remember that."]
+
+
+def test_version_number_does_not_split():
+    result = split_into_sentences("Version 2.0 is now available.")
+    assert result == ["Version 2.0 is now available."]
+
+
+def test_number_at_end_of_sentence_splits():
+    # A sentence ending with a bare number should split before the next sentence.
+    result = split_into_sentences("There are 5. They are all present.")
+    assert result == ["There are 5.", "They are all present."]
+
+
+# ---------------------------------------------------------------------------
+# Ellipsis
+# ---------------------------------------------------------------------------
+
+
+def test_ellipsis_before_uppercase_splits():
+    result = split_into_sentences("I don't know... You decide.")
+    assert result == ["I don't know...", "You decide."]
+
+
+def test_ellipsis_before_lowercase_does_not_split():
+    result = split_into_sentences("Wait... is that right?")
+    assert result == ["Wait... is that right?"]
+
+
+def test_ellipsis_at_end_no_split():
+    result = split_into_sentences("Hmm, well...")
+    assert result == ["Hmm, well..."]
+
+
+# ---------------------------------------------------------------------------
+# Closing quotes
+# ---------------------------------------------------------------------------
+
+
+def test_period_inside_closing_quote_splits():
+    result = split_into_sentences("She said, 'Hello.' Then she left.")
+    assert result == ["She said, 'Hello.'", "Then she left."]
+
+
+def test_exclamation_inside_closing_quote_splits():
+    result = split_into_sentences('"Help!" She ran away.')
+    assert result == ['"Help!"', "She ran away."]
+
+
+def test_question_inside_closing_quote_splits():
+    result = split_into_sentences('"Are you sure?" He nodded.')
+    assert result == ['"Are you sure?"', "He nodded."]
+
+
+# ---------------------------------------------------------------------------
+# Edge cases with punctuation clusters
+# ---------------------------------------------------------------------------
+
+
+def test_double_exclamation():
+    result = split_into_sentences("No!! Stop right there.")
+    assert result == ["No!!", "Stop right there."]
+
+
+def test_question_exclamation():
+    result = split_into_sentences("Really?! That's amazing.")
+    assert result == ["Really?!", "That's amazing."]
+
+
+def test_leading_whitespace_stripped():
+    result = split_into_sentences("   Hello. World.   ")
+    assert result == ["Hello.", "World."]
+
+
+def test_lowercase_after_period_does_not_split():
+    result = split_into_sentences("This is e.g. a test case.")
+    assert result == ["This is e.g. a test case."]
+
+
+def test_single_letter_initial_does_not_split():
+    result = split_into_sentences("Contact A. Smith for more info.")
+    assert result == ["Contact A. Smith for more info."]
+
+
+def test_long_passage_produces_ordered_sentences():
+    text = (
+        "Welcome to the interview. Please take a seat. "
+        "I've reviewed your application. It looks impressive! "
+        "Can you tell me about yourself?"
+    )
+    result = split_into_sentences(text)
+    assert len(result) == 5
+    assert result[0] == "Welcome to the interview."
+    assert result[-1] == "Can you tell me about yourself?"

--- a/services/convsim-core/tests/test_tts_queue.py
+++ b/services/convsim-core/tests/test_tts_queue.py
@@ -1,0 +1,409 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Integration tests for the TTS queue service (issue #62).
+
+Covers:
+  - Single and multi-sentence utterances produce ordered TtsChunkResult lists.
+  - TTS unavailable: all chunks capture the error; no exception raised.
+  - Partial TTS failure: later chunks still synthesize.
+  - Empty utterance returns [].
+  - Session endpoint: tts_enabled=False skips TTS entirely.
+  - Session endpoint: tts_audio_chunk events appear in the turn response.
+  - Cache clear endpoint deletes cached files.
+"""
+from __future__ import annotations
+
+import os
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from convsim_core.services.tts_queue import TtsChunkResult, synthesize_utterance
+from convsim_core.tts.types import TtsRequest, TtsResult, TtsUnavailableError, TtsError
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fakes
+# ---------------------------------------------------------------------------
+
+
+def _make_ok_result(text: str, voice_id: str, tmp_path) -> TtsResult:
+    p = tmp_path / f"{hash(text)}.wav"
+    p.write_bytes(b"RIFF")
+    return TtsResult(audio_path=str(p), audio_format="wav", duration_ms=100.0, voice_id=voice_id)
+
+
+class _AlwaysOkWorker:
+    async def synthesize(self, req: TtsRequest) -> TtsResult:
+        raise NotImplementedError  # replaced by mock in each test
+
+    async def clear_cache(self) -> int:
+        return 0
+
+
+# ---------------------------------------------------------------------------
+# synthesize_utterance — unit tests with mocked TTS worker
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_utterance_returns_empty_list():
+    worker = _AlwaysOkWorker()
+    result = await synthesize_utterance("", "af_heart", worker)
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_whitespace_utterance_returns_empty_list():
+    worker = _AlwaysOkWorker()
+    result = await synthesize_utterance("   ", "af_heart", worker)
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_single_sentence_produces_one_chunk(tmp_path):
+    worker = _AlwaysOkWorker()
+    worker.synthesize = AsyncMock(
+        return_value=_make_ok_result("Hello.", "af_heart", tmp_path)
+    )
+    chunks = await synthesize_utterance("Hello.", "af_heart", worker)
+    assert len(chunks) == 1
+    assert chunks[0].chunk_index == 0
+    assert chunks[0].total_chunks == 1
+    assert chunks[0].text == "Hello."
+    assert chunks[0].succeeded
+    assert chunks[0].error is None
+
+
+@pytest.mark.asyncio
+async def test_multi_sentence_produces_ordered_chunks(tmp_path):
+    sentences = ["Hello there.", "How are you?", "I am fine."]
+    utterance = " ".join(sentences)
+
+    call_count = 0
+
+    async def mock_synthesize(req: TtsRequest) -> TtsResult:
+        nonlocal call_count
+        result = _make_ok_result(req.text, req.voice_id, tmp_path)
+        call_count += 1
+        return result
+
+    worker = _AlwaysOkWorker()
+    worker.synthesize = mock_synthesize
+
+    chunks = await synthesize_utterance(utterance, "af_heart", worker)
+
+    assert len(chunks) == 3
+    assert call_count == 3
+    for i, chunk in enumerate(chunks):
+        assert chunk.chunk_index == i
+        assert chunk.total_chunks == 3
+        assert chunk.succeeded
+
+
+@pytest.mark.asyncio
+async def test_chunks_carry_correct_text(tmp_path):
+    utterance = "First sentence. Second sentence."
+    worker = _AlwaysOkWorker()
+    worker.synthesize = AsyncMock(
+        side_effect=lambda req: _make_result_coro(req, tmp_path)
+    )
+
+    async def _make_result_coro(req, tp):
+        return _make_ok_result(req.text, req.voice_id, tp)
+
+    worker.synthesize = AsyncMock(side_effect=_make_result_coro)
+    chunks = await synthesize_utterance(utterance, "am_adam", worker)
+
+    assert chunks[0].text == "First sentence."
+    assert chunks[1].text == "Second sentence."
+
+
+@pytest.mark.asyncio
+async def test_tts_unavailable_records_error_does_not_raise():
+    worker = _AlwaysOkWorker()
+    worker.synthesize = AsyncMock(
+        side_effect=TtsUnavailableError("Kokoro not running")
+    )
+    chunks = await synthesize_utterance(
+        "Hello. World.", "af_heart", worker
+    )
+    assert len(chunks) == 2
+    for chunk in chunks:
+        assert not chunk.succeeded
+        assert chunk.error is not None
+        assert chunk.audio_path is None
+
+
+@pytest.mark.asyncio
+async def test_tts_error_records_error_does_not_raise():
+    worker = _AlwaysOkWorker()
+    worker.synthesize = AsyncMock(side_effect=TtsError("synthesis failed"))
+    chunks = await synthesize_utterance("Hello there.", "af_heart", worker)
+    assert len(chunks) == 1
+    assert not chunks[0].succeeded
+    assert "synthesis failed" in chunks[0].error
+
+
+@pytest.mark.asyncio
+async def test_partial_failure_later_chunks_still_run(tmp_path):
+    call_count = 0
+
+    async def _partial(req: TtsRequest) -> TtsResult:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise TtsError("first fails")
+        return _make_ok_result(req.text, req.voice_id, tmp_path)
+
+    worker = _AlwaysOkWorker()
+    worker.synthesize = _partial
+
+    chunks = await synthesize_utterance("One. Two. Three.", "af_heart", worker)
+    assert len(chunks) == 3
+    assert not chunks[0].succeeded
+    assert chunks[1].succeeded
+    assert chunks[2].succeeded
+
+
+@pytest.mark.asyncio
+async def test_chunks_include_voice_id():
+    worker = _AlwaysOkWorker()
+    worker.synthesize = AsyncMock(side_effect=TtsUnavailableError("down"))
+    chunks = await synthesize_utterance("Hello.", "bm_george", worker)
+    assert chunks[0].voice_id == "bm_george"
+
+
+@pytest.mark.asyncio
+async def test_unexpected_exception_is_captured():
+    worker = _AlwaysOkWorker()
+    worker.synthesize = AsyncMock(side_effect=RuntimeError("boom"))
+    chunks = await synthesize_utterance("Hello.", "af_heart", worker)
+    assert len(chunks) == 1
+    assert not chunks[0].succeeded
+    assert "boom" in chunks[0].error
+
+
+# ---------------------------------------------------------------------------
+# TtsChunkResult helpers
+# ---------------------------------------------------------------------------
+
+
+def test_chunk_result_succeeded_when_audio_path_set(tmp_path):
+    f = tmp_path / "x.wav"
+    f.write_bytes(b"")
+    chunk = TtsChunkResult(
+        chunk_index=0, total_chunks=1, text="Hi", voice_id="af_heart",
+        audio_path=str(f),
+    )
+    assert chunk.succeeded is True
+
+
+def test_chunk_result_not_succeeded_when_audio_path_none():
+    chunk = TtsChunkResult(
+        chunk_index=0, total_chunks=1, text="Hi", voice_id="af_heart",
+        error="backend down",
+    )
+    assert chunk.succeeded is False
+
+
+# ---------------------------------------------------------------------------
+# HTTP session endpoint integration (mocked TTS, real DB)
+# ---------------------------------------------------------------------------
+
+
+_BASE_SETUP = {
+    "scenario_id": "behavioral_interview",
+    "difficulty": "normal",
+    "player_role_name": "Alice",
+    "language": "en",
+    "input_mode": "text-only",
+    "tts_enabled": False,
+    "tts_voice_id": "af_heart",
+    "save_transcript": True,
+}
+
+
+def _create_session(client, tts_enabled: bool = False, voice_id: str = "af_heart") -> str:
+    setup = {**_BASE_SETUP, "tts_enabled": tts_enabled, "tts_voice_id": voice_id}
+    resp = client.post("/api/sessions", json=setup)
+    assert resp.status_code == 201
+    return resp.json()["session_id"]
+
+
+def test_tts_disabled_no_audio_chunk_events_in_start(client):
+    sid = _create_session(client, tts_enabled=False)
+    resp = client.post(f"/api/sessions/{sid}/start")
+    assert resp.status_code == 200
+    events = resp.json()["events"]
+    types = [e["event_type"] for e in events]
+    assert "tts_audio_chunk" not in types
+
+
+def test_tts_disabled_no_audio_chunk_events_in_turn(client):
+    sid = _create_session(client, tts_enabled=False)
+    client.post(f"/api/sessions/{sid}/start")
+    resp = client.post(f"/api/sessions/{sid}/turn", json={"content": "Hello"})
+    assert resp.status_code == 200
+    events = resp.json()["events"]
+    types = [e["event_type"] for e in events]
+    assert "tts_audio_chunk" not in types
+
+
+def test_tts_enabled_emits_audio_chunk_events_on_start(client, tmp_path):
+    sid = _create_session(client, tts_enabled=True)
+    fake_path = str(tmp_path / "out.wav")
+    mock_result = TtsResult(
+        audio_path=fake_path, audio_format="wav", duration_ms=200.0, voice_id="af_heart"
+    )
+    with patch.object(
+        client.app.state.tts_worker,
+        "synthesize",
+        new=AsyncMock(return_value=mock_result),
+    ):
+        resp = client.post(f"/api/sessions/{sid}/start")
+    assert resp.status_code == 200
+    events = resp.json()["events"]
+    tts_events = [e for e in events if e["event_type"] == "tts_audio_chunk"]
+    assert len(tts_events) >= 1
+
+
+def test_tts_audio_chunk_event_has_required_fields(client, tmp_path):
+    sid = _create_session(client, tts_enabled=True)
+    fake_path = str(tmp_path / "out.wav")
+    mock_result = TtsResult(
+        audio_path=fake_path, audio_format="wav", duration_ms=100.0, voice_id="af_heart"
+    )
+    with patch.object(
+        client.app.state.tts_worker,
+        "synthesize",
+        new=AsyncMock(return_value=mock_result),
+    ):
+        resp = client.post(f"/api/sessions/{sid}/start")
+    events = resp.json()["events"]
+    tts_event = next(e for e in events if e["event_type"] == "tts_audio_chunk")
+    payload = tts_event["payload"]
+    assert "chunk_index" in payload
+    assert "total_chunks" in payload
+    assert "text" in payload
+    assert "voice_id" in payload
+    assert "cache_path" in payload
+    assert "error" in payload
+
+
+def test_tts_audio_chunk_cache_path_matches_synthesize_result(client, tmp_path):
+    sid = _create_session(client, tts_enabled=True)
+    fake_path = str(tmp_path / "audio.wav")
+    mock_result = TtsResult(
+        audio_path=fake_path, audio_format="wav", duration_ms=100.0, voice_id="af_heart"
+    )
+    with patch.object(
+        client.app.state.tts_worker,
+        "synthesize",
+        new=AsyncMock(return_value=mock_result),
+    ):
+        resp = client.post(f"/api/sessions/{sid}/start")
+    tts_event = next(
+        e for e in resp.json()["events"] if e["event_type"] == "tts_audio_chunk"
+    )
+    assert tts_event["payload"]["cache_path"] == fake_path
+
+
+def test_tts_unavailable_does_not_fail_turn(client):
+    sid = _create_session(client, tts_enabled=True)
+    client.post(f"/api/sessions/{sid}/start")
+    with patch.object(
+        client.app.state.tts_worker,
+        "synthesize",
+        new=AsyncMock(side_effect=TtsUnavailableError("Kokoro down")),
+    ):
+        resp = client.post(f"/api/sessions/{sid}/turn", json={"content": "Hello"})
+    assert resp.status_code == 200
+    data = resp.json()
+    # Session state must not be corrupted; turn still processed
+    assert data["state"] in ("PlayerTurnListening", "Ended")
+    # tts_audio_chunk events may be present but with error field set
+    tts_events = [e for e in data["events"] if e["event_type"] == "tts_audio_chunk"]
+    for ev in tts_events:
+        assert ev["payload"]["cache_path"] is None
+        assert ev["payload"]["error"] is not None
+
+
+def test_tts_enabled_turn_emits_ordered_chunks(client, tmp_path):
+    sid = _create_session(client, tts_enabled=True)
+    client.post(f"/api/sessions/{sid}/start")
+    call_index = [0]
+
+    async def _sequential_synth(req: TtsRequest) -> TtsResult:
+        idx = call_index[0]
+        call_index[0] += 1
+        path = str(tmp_path / f"chunk_{idx}.wav")
+        return TtsResult(audio_path=path, audio_format="wav", duration_ms=100.0, voice_id=req.voice_id)
+
+    with patch.object(client.app.state.tts_worker, "synthesize", side_effect=_sequential_synth):
+        resp = client.post(f"/api/sessions/{sid}/turn", json={"content": "Tell me about yourself"})
+    assert resp.status_code == 200
+    tts_events = [e for e in resp.json()["events"] if e["event_type"] == "tts_audio_chunk"]
+    if tts_events:
+        indices = [e["payload"]["chunk_index"] for e in tts_events]
+        assert indices == sorted(indices)  # ordered
+        assert indices[0] == 0  # zero-based
+
+
+def test_invalid_tts_voice_id_rejected_at_session_creation(client):
+    setup = {**_BASE_SETUP, "tts_enabled": True, "tts_voice_id": "clone:evil_voice"}
+    resp = client.post("/api/sessions", json=setup)
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Cache clear endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_cache_clear_returns_200(client):
+    resp = client.post("/api/tts/cache/clear")
+    assert resp.status_code == 200
+
+
+def test_cache_clear_returns_deleted_files_count(client):
+    body = client.post("/api/tts/cache/clear").json()
+    assert "deleted_files" in body
+    assert isinstance(body["deleted_files"], int)
+
+
+@pytest.mark.asyncio
+async def test_cache_clear_deletes_wav_files(tmp_path):
+    from convsim_core.tts.kokoro import KokoroConfig, KokoroTtsWorker
+
+    cache_dir = tmp_path / "tts_cache"
+    cache_dir.mkdir()
+    (cache_dir / "abc123.wav").write_bytes(b"RIFF")
+    (cache_dir / "def456.wav").write_bytes(b"RIFF")
+    (cache_dir / "notes.txt").write_bytes(b"keep")
+
+    worker = KokoroTtsWorker(KokoroConfig(cache_dir=str(cache_dir)))
+    deleted = await worker.clear_cache()
+
+    assert deleted == 2
+    assert not (cache_dir / "abc123.wav").exists()
+    assert not (cache_dir / "def456.wav").exists()
+    assert (cache_dir / "notes.txt").exists()  # non-WAV untouched
+
+
+@pytest.mark.asyncio
+async def test_cache_clear_nonexistent_dir_returns_zero(tmp_path):
+    from convsim_core.tts.kokoro import KokoroConfig, KokoroTtsWorker
+
+    worker = KokoroTtsWorker(KokoroConfig(cache_dir=str(tmp_path / "no_such_dir")))
+    deleted = await worker.clear_cache()
+    assert deleted == 0
+
+
+@pytest.mark.asyncio
+async def test_fake_worker_clear_cache_returns_zero():
+    from convsim_core.tts.fake import FakeTtsWorker
+
+    worker = FakeTtsWorker()
+    deleted = await worker.clear_cache()
+    assert deleted == 0


### PR DESCRIPTION
## Summary

Adds sentence-by-sentence TTS synthesis with a local audio cache. NPC utterances are split into sentences using a regex-based splitter, synthesized independently so errors don't abort later chunks, and cached locally so the client can start playback before all sentences are ready.

## What changed

### New modules
- **`convsim_core/tts/sentence_splitter.py`** — Regex-based sentence splitter that correctly handles abbreviations (`Mr.`, `Dr.`, `St.`, `vs.`), ellipsis (`...`), and punctuation inside closing quotes without false splits. Empty input returns `[]`.
- **`convsim_core/services/tts_queue.py`** — `synthesize_utterance()` splits an NPC utterance into sentences and calls the TTS worker once per chunk. Per-chunk errors are captured in a `TtsChunkResult` (with `error` set, `audio_path=None`) and do not abort later chunks or affect transcript/session state.

### TTS worker additions
- `TtsWorker.clear_cache()` abstract method added to the base class.
- `KokoroTtsWorker.clear_cache()` deletes all `*.wav` files from the local cache directory.
- `FakeTtsWorker.clear_cache()` is a no-op (returns 0).

### New endpoint
- `POST /api/tts/cache/clear` — deletes cached audio files; called by the privacy "clear data" action. Returns `{deleted_files: int}`.

### Session integration
- `SessionCreateRequest` gains `tts_voice_id: str = "af_heart"`, validated against the approved voice list at session creation time (returns 422 for unknown voices).
- `start_session` and `submit_turn` both synthesize the NPC utterance sentence-by-sentence when `tts_enabled=True`, then persist and return `tts_audio_chunk` events in sentence order alongside the existing `npc_opening`/`npc_turn` events.
- TTS failures (unavailable backend, synthesis error) show `error` in the chunk payload and do not alter session flow state or transcript.

### Shared types
- `WsTtsAudioChunkEvent` payload extended to include `chunk_index`, `total_chunks`, `text`, `voice_id`, `cache_path` (local-filesystem path reference), and `error` fields for resilient fallback.

## Testing

- **31 unit tests** (`test_sentence_splitter.py`) cover empty input, multi-sentence passages, abbreviation suppression (Mr., Dr., St., vs.), decimal numbers, ellipsis, closing-quote punctuation, and `!`/`?` clusters.
- **25 integration tests** (`test_tts_queue.py`) cover single/multi-sentence synthesis, TTS unavailable (all chunks capture error), partial failure (later chunks still run), session endpoint `tts_enabled=False` (no events emitted), session endpoint `tts_enabled=True` (ordered chunk events in response), invalid `tts_voice_id` rejected at session creation, cache clear endpoint, and Kokoro/Fake `clear_cache()` implementations.
- Full test suite: **56 tests passed**.

Closes #62