### PR TITLE
Add workbench import and export buttons for pack folders and zip files

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -14,10 +14,12 @@
     "@convsim/shared": "workspace:*",
     "@fastify/cors": "^11.2.0",
     "@fastify/websocket": "^11.2.0",
+    "adm-zip": "^0.5.16",
     "better-sqlite3": "^12.11.1",
     "fastify": "^5.0.0"
   },
   "devDependencies": {
+    "@types/adm-zip": "^0.5.7",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.0.0",
     "@types/ws": "^8.18.1",

--- a/apps/api/src/routes/workbench.test.ts
+++ b/apps/api/src/routes/workbench.test.ts
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, writeFileSync, rmSync, symlinkSync } from 'node:fs';
+import { mkdirSync, writeFileSync, rmSync, symlinkSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import AdmZip from 'adm-zip';
 import type { FastifyInstance } from 'fastify';
 import { buildApp } from '../index.js';
 import { setWorkbenchRoots } from './workbench.js';
@@ -617,5 +618,284 @@ describe('GET /api/workbench/packs/:kind/:slug/validate', () => {
       url: '/api/workbench/packs/official/does-not-exist/validate',
     });
     expect(res.statusCode).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helper: build a valid zip from the fixture pack in a temp directory
+// ---------------------------------------------------------------------------
+
+function buildValidZip(packDir: string): Buffer {
+  const zip = new AdmZip();
+  zip.addLocalFolder(packDir, '');
+  return zip.toBuffer();
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/workbench/packs/:kind/:slug/export
+// ---------------------------------------------------------------------------
+
+describe('GET /api/workbench/packs/:kind/:slug/export', () => {
+  it('returns a zip binary for a valid local-dev pack', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/workbench/packs/local-dev/my-pack/export',
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toContain('application/zip');
+    expect(res.headers['content-disposition']).toContain('.zip');
+    expect(res.rawPayload.length).toBeGreaterThan(0);
+
+    // Verify the zip is actually readable and contains key pack files.
+    const zip = new AdmZip(res.rawPayload);
+    const names = zip.getEntries().map((e) => e.entryName);
+    expect(names).toContain('manifest.yaml');
+    expect(names).toContain('README.md');
+  });
+
+  it('returns a zip for an official pack too', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/workbench/packs/official/sample-pack/export',
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toContain('application/zip');
+  });
+
+  it('zip entries use relative paths only — no absolute paths', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/workbench/packs/local-dev/my-pack/export',
+    });
+    expect(res.statusCode).toBe(200);
+    const zip = new AdmZip(res.rawPayload);
+    for (const entry of zip.getEntries()) {
+      // Entry names must be relative (never start with / or a Windows drive letter).
+      expect(entry.entryName).not.toMatch(/^[/\\]/);
+      expect(entry.entryName).not.toMatch(/^[A-Za-z]:\\/);
+    }
+  });
+
+  it('returns 422 with validation errors when the pack is invalid', async () => {
+    // Corrupt the manifest so validation fails.
+    writeFileSync(
+      join(localDevRoot, 'my-pack', 'manifest.yaml'),
+      `schema_version: "0.1"\npack_id: local.my_pack\n`,
+    );
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/workbench/packs/local-dev/my-pack/export',
+    });
+    expect(res.statusCode).toBe(422);
+    const body = res.json<{ valid: boolean; errors: unknown[] }>();
+    expect(body.valid).toBe(false);
+    expect(body.errors.length).toBeGreaterThan(0);
+  });
+
+  it('returns 404 for a non-existent pack', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/workbench/packs/local-dev/ghost/export',
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('returns 400 for an invalid kind', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/workbench/packs/community/sample-pack/export',
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/workbench/packs/import
+// ---------------------------------------------------------------------------
+
+describe('POST /api/workbench/packs/import', () => {
+  it('imports a valid zip and returns the new pack summary', async () => {
+    const packDir = join(officialRoot, 'sample-pack');
+    const zipBuffer = buildValidZip(packDir);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/workbench/packs/import',
+      headers: { 'content-type': 'application/zip' },
+      payload: zipBuffer,
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = res.json<{ kind: string; slug: string; editable: boolean; pack_id: string }>();
+    expect(body.kind).toBe('local-dev');
+    expect(body.editable).toBe(true);
+    expect(body.pack_id).toBe('official.sample_pack');
+
+    // Verify the pack actually landed in local-dev.
+    expect(existsSync(join(localDevRoot, body.slug))).toBe(true);
+    expect(existsSync(join(localDevRoot, body.slug, 'manifest.yaml'))).toBe(true);
+  });
+
+  it('appears in the pack list after import', async () => {
+    const zipBuffer = buildValidZip(join(officialRoot, 'sample-pack'));
+    await app.inject({
+      method: 'POST',
+      url: '/api/workbench/packs/import',
+      headers: { 'content-type': 'application/zip' },
+      payload: zipBuffer,
+    });
+
+    const listRes = await app.inject({ method: 'GET', url: '/api/workbench/packs' });
+    const packs = listRes.json<{ kind: string; slug: string }[]>();
+    expect(packs.some((p) => p.kind === 'local-dev' && p.slug.startsWith('official.sample_pack'))).toBe(true);
+  });
+
+  it('renames slug on conflict by default', async () => {
+    const zipBuffer = buildValidZip(join(officialRoot, 'sample-pack'));
+
+    const res1 = await app.inject({
+      method: 'POST',
+      url: '/api/workbench/packs/import',
+      headers: { 'content-type': 'application/zip' },
+      payload: zipBuffer,
+    });
+    const slug1 = res1.json<{ slug: string }>().slug;
+
+    const res2 = await app.inject({
+      method: 'POST',
+      url: '/api/workbench/packs/import',
+      headers: { 'content-type': 'application/zip' },
+      payload: zipBuffer,
+    });
+    expect(res2.statusCode).toBe(201);
+    const body2 = res2.json<{ slug: string; renamed_from?: string }>();
+    expect(body2.slug).not.toBe(slug1);
+    expect(body2.renamed_from).toBe(slug1);
+  });
+
+  it('overwrites existing pack when conflict=overwrite', async () => {
+    const zipBuffer = buildValidZip(join(officialRoot, 'sample-pack'));
+
+    const res1 = await app.inject({
+      method: 'POST',
+      url: '/api/workbench/packs/import',
+      headers: { 'content-type': 'application/zip' },
+      payload: zipBuffer,
+    });
+    const slug1 = res1.json<{ slug: string }>().slug;
+
+    const res2 = await app.inject({
+      method: 'POST',
+      url: '/api/workbench/packs/import?conflict=overwrite',
+      headers: { 'content-type': 'application/zip' },
+      payload: zipBuffer,
+    });
+    expect(res2.statusCode).toBe(201);
+    const body2 = res2.json<{ slug: string; renamed_from?: string }>();
+    // Same slug — no rename needed.
+    expect(body2.slug).toBe(slug1);
+    expect(body2.renamed_from).toBeUndefined();
+  });
+
+  it('returns 422 with validation errors for an invalid zip', async () => {
+    // Build a zip with an invalid manifest (missing required fields).
+    const zip = new AdmZip();
+    zip.addFile('manifest.yaml', Buffer.from(`schema_version: "0.1"\npack_id: bad.pack\n`));
+    const zipBuffer = zip.toBuffer();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/workbench/packs/import',
+      headers: { 'content-type': 'application/zip' },
+      payload: zipBuffer,
+    });
+    expect(res.statusCode).toBe(422);
+    const body = res.json<{ valid: boolean; errors: unknown[] }>();
+    expect(body.valid).toBe(false);
+    expect(body.errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects a zip containing a forbidden executable file', async () => {
+    const zip = new AdmZip();
+    zip.addFile('run.sh', Buffer.from('#!/bin/sh\necho hi\n'));
+    // Also add a plausible manifest so the zip extracts to something
+    zip.addFile('manifest.yaml', Buffer.from('schema_version: "0.1"\npack_id: evil.pack\n'));
+    const zipBuffer = zip.toBuffer();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/workbench/packs/import',
+      headers: { 'content-type': 'application/zip' },
+      payload: zipBuffer,
+    });
+    expect(res.statusCode).toBe(422);
+    const body = res.json<{ valid: boolean; errors: { rule_id: string }[] }>();
+    expect(body.valid).toBe(false);
+    const forbidden = body.errors.find((e) => e.rule_id === 'FORBIDDEN_FILE');
+    expect(forbidden).toBeDefined();
+  });
+
+  it('rejects a zip containing a zip-slip path', async () => {
+    const zip = new AdmZip();
+    zip.addFile('../escape.yaml', Buffer.from('evil: true\n'));
+    const zipBuffer = zip.toBuffer();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/workbench/packs/import',
+      headers: { 'content-type': 'application/zip' },
+      payload: zipBuffer,
+    });
+    expect(res.statusCode).toBe(422);
+  });
+
+  it('returns 400 when the body is not a zip', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/workbench/packs/import',
+      headers: { 'content-type': 'application/zip' },
+      payload: Buffer.from('not a zip file'),
+    });
+    expect(res.statusCode).toBe(422);
+  });
+
+  it('returns 400 when the body is empty', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/workbench/packs/import',
+      headers: { 'content-type': 'application/zip' },
+      payload: Buffer.alloc(0),
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('export then import round-trip produces an equivalent pack', async () => {
+    // Export the local-dev my-pack, then re-import it.
+    const exportRes = await app.inject({
+      method: 'GET',
+      url: '/api/workbench/packs/local-dev/my-pack/export',
+    });
+    expect(exportRes.statusCode).toBe(200);
+
+    const importRes = await app.inject({
+      method: 'POST',
+      url: '/api/workbench/packs/import',
+      headers: { 'content-type': 'application/zip' },
+      payload: exportRes.rawPayload,
+    });
+    expect(importRes.statusCode).toBe(201);
+    const imported = importRes.json<{ kind: string; pack_id: string; editable: boolean }>();
+    expect(imported.kind).toBe('local-dev');
+    expect(imported.pack_id).toBe('local.my_pack');
+    expect(imported.editable).toBe(true);
+
+    // The imported copy should validate cleanly.
+    const validateRes = await app.inject({
+      method: 'GET',
+      url: `/api/workbench/packs/local-dev/${importRes.json<{ slug: string }>().slug}/validate`,
+    });
+    expect(validateRes.statusCode).toBe(200);
+    expect(validateRes.json<{ valid: boolean }>().valid).toBe(true);
   });
 });

--- a/apps/api/src/routes/workbench.test.ts
+++ b/apps/api/src/routes/workbench.test.ts
@@ -850,7 +850,7 @@ describe('POST /api/workbench/packs/import', () => {
     expect(res.statusCode).toBe(422);
   });
 
-  it('returns 400 when the body is not a zip', async () => {
+  it('returns 422 when the body is not a valid zip archive', async () => {
     const res = await app.inject({
       method: 'POST',
       url: '/api/workbench/packs/import',

--- a/apps/api/src/routes/workbench.ts
+++ b/apps/api/src/routes/workbench.ts
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { FastifyInstance } from 'fastify';
 import fs from 'node:fs';
+import os from 'node:os';
 import { randomBytes } from 'node:crypto';
 import path from 'node:path';
+import AdmZip from 'adm-zip';
 import { getDb, WORKBENCH_TEST_SCENARIO_ID } from '../db.js';
 import { loadPack, PackLoaderError } from '@convsim/pack-loader';
 
@@ -35,9 +37,10 @@ function rootForKind(kind: PackKind): string {
   return kind === 'official' ? _officialRoot : _localDevRoot;
 }
 
-function readManifestBasics(packDir: string): { pack_id: string | null; name: string | null } {
+function readManifestBasics(packDir: string): { pack_id: string | null; name: string | null; version: string | null } {
   let pack_id: string | null = null;
   let name: string | null = null;
+  let version: string | null = null;
   try {
     const content = fs.readFileSync(path.join(packDir, 'manifest.yaml'), 'utf-8');
     for (const line of content.split('\n')) {
@@ -49,12 +52,16 @@ function readManifestBasics(packDir: string): { pack_id: string | null; name: st
         const m = /^name:\s*['"]?([^'"\n]+)['"]?\s*$/.exec(line);
         if (m) name = m[1].trim();
       }
-      if (pack_id && name) break;
+      if (!version) {
+        const m = /^version:\s*['"]?([^'"\n]+)['"]?\s*$/.exec(line);
+        if (m) version = m[1].trim();
+      }
+      if (pack_id && name && version) break;
     }
   } catch {
     // ignore — manifest may be missing or malformed
   }
-  return { pack_id, name };
+  return { pack_id, name, version };
 }
 
 function scanRoot(kind: PackKind): WorkbenchPackSummary[] {
@@ -328,7 +335,19 @@ function scanForbiddenFiles(packRoot: string): WorkbenchValidationIssue[] {
   return issues;
 }
 
+export interface WorkbenchImportResponse extends WorkbenchPackSummary {
+  /** Present when the pack was installed under a different slug than its pack_id to avoid a collision. */
+  renamed_from?: string;
+}
+
 export async function workbenchRoutes(app: FastifyInstance): Promise<void> {
+  // Register binary content-type parser for zip uploads (scoped to this plugin's routes).
+  app.addContentTypeParser(
+    'application/zip',
+    { parseAs: 'buffer' },
+    (_req, body, done) => { done(null, body as Buffer); },
+  );
+
   // GET /api/workbench/packs — list all packs from official and local-dev roots
   app.get('/api/workbench/packs', async (): Promise<WorkbenchPackSummary[]> => {
     return [...scanRoot('official'), ...scanRoot('local-dev')];
@@ -540,6 +559,195 @@ export async function workbenchRoutes(app: FastifyInstance): Promise<void> {
         npc_opening: 'Ready to test. Send a message to begin the conversation.',
         state_vars: baselineStateVars,
       };
+    },
+  );
+
+  // GET /api/workbench/packs/:kind/:slug/export — export a pack as a .zip archive
+  // Runs validation preflight; returns 422 with full issue list if the pack is invalid.
+  // No absolute local paths are included — all zip entries are relative to the pack root.
+  app.get<{ Params: { kind: string; slug: string } }>(
+    '/api/workbench/packs/:kind/:slug/export',
+    async (req, reply) => {
+      const { kind, slug } = req.params;
+      assertValidKind(kind, reply);
+      const packRoot = getPackRoot(kind, slug, reply);
+      if (!fs.existsSync(packRoot)) {
+        reply.status(404);
+        throw new Error(`Pack "${slug}" not found`);
+      }
+
+      // Validation preflight — identical two-phase approach as the validate endpoint.
+      const issues: WorkbenchValidationIssue[] = scanForbiddenFiles(packRoot);
+      const reportedSecurityFiles = new Set(issues.map((i) => i.file));
+      try {
+        loadPack(packRoot, kind);
+      } catch (e) {
+        if (e instanceof PackLoaderError) {
+          for (const issue of convertPackLoaderError(e, packRoot)) {
+            if (issue.category === 'security' && reportedSecurityFiles.has(issue.file)) continue;
+            issues.push(issue);
+          }
+        } else {
+          throw e;
+        }
+      }
+
+      const errors = issues.filter((i) => i.severity === 'error');
+      if (errors.length > 0) {
+        reply.status(422);
+        return reply.send({
+          valid: false,
+          errors,
+          warnings: issues.filter((i) => i.severity === 'warning'),
+        });
+      }
+
+      // Build the zip with paths relative to the pack root — no absolute paths leak out.
+      const { pack_id, version } = readManifestBasics(packRoot);
+      const safeName = (pack_id ?? slug).replace(/[^a-zA-Z0-9._-]/g, '_');
+      const filename = version ? `${safeName}-${version}.zip` : `${safeName}.zip`;
+
+      const zip = new AdmZip();
+      zip.addLocalFolder(packRoot, '');
+      const zipBuffer = zip.toBuffer();
+
+      return reply
+        .header('Content-Type', 'application/zip')
+        .header('Content-Disposition', `attachment; filename="${filename}"`)
+        .header('Content-Length', String(zipBuffer.length))
+        .send(zipBuffer);
+    },
+  );
+
+  // POST /api/workbench/packs/import — import a .zip file into local-dev
+  // Accepts a raw zip binary body (Content-Type: application/zip).
+  // Validates the pack; rejects with 422 + full issue list on failure.
+  // Handles slug conflicts by renaming (default) or overwriting (?conflict=overwrite).
+  app.post<{
+    Querystring: { conflict?: string };
+    Body: Buffer;
+  }>(
+    '/api/workbench/packs/import',
+    async (req, reply): Promise<WorkbenchImportResponse> => {
+      const body = req.body;
+      if (!Buffer.isBuffer(body) || body.length === 0) {
+        reply.status(400);
+        throw new Error('Request body must be a non-empty .zip file (Content-Type: application/zip)');
+      }
+
+      if (!_localDevRoot) {
+        reply.status(503);
+        throw new Error('Local-dev root is not configured');
+      }
+
+      const tmpDir = path.join(os.tmpdir(), `convsim-import-${randomBytes(4).toString('hex')}`);
+      try {
+        fs.mkdirSync(tmpDir, { recursive: true });
+
+        // Parse zip and check for zip-slip attacks before extracting anything.
+        let zip: AdmZip;
+        try {
+          zip = new AdmZip(body);
+        } catch {
+          reply.status(422);
+          throw new Error('Uploaded file is not a valid .zip archive');
+        }
+
+        const extractDir = path.join(tmpDir, 'extracted');
+        fs.mkdirSync(extractDir);
+        const normalExtract = path.normalize(extractDir);
+
+        for (const entry of zip.getEntries()) {
+          const entryPath = path.normalize(path.join(normalExtract, entry.entryName));
+          if (!entryPath.startsWith(normalExtract + path.sep) && entryPath !== normalExtract) {
+            reply.status(422);
+            throw new Error(`Unsafe path in zip: "${entry.entryName}"`);
+          }
+        }
+
+        zip.extractAllTo(extractDir, /* overwrite */ true);
+
+        // Single-subdir unwrap: if the zip contains exactly one top-level directory,
+        // treat that directory as the pack root (common convention for exported packs).
+        let packDir = extractDir;
+        const topEntries = fs.readdirSync(extractDir);
+        if (topEntries.length === 1) {
+          const candidate = path.join(extractDir, topEntries[0]);
+          if (fs.statSync(candidate).isDirectory()) {
+            packDir = candidate;
+          }
+        }
+
+        // Two-phase validation (mirrors the validate endpoint).
+        const issues: WorkbenchValidationIssue[] = scanForbiddenFiles(packDir);
+        const reportedSecurityFiles = new Set(issues.filter((i) => i.category === 'security').map((i) => i.file));
+        try {
+          loadPack(packDir, 'local-dev');
+        } catch (e) {
+          if (e instanceof PackLoaderError) {
+            for (const issue of convertPackLoaderError(e, packDir)) {
+              if (issue.category === 'security' && reportedSecurityFiles.has(issue.file)) continue;
+              issues.push(issue);
+            }
+          } else {
+            throw e;
+          }
+        }
+
+        const errors = issues.filter((i) => i.severity === 'error');
+        if (errors.length > 0) {
+          reply.status(422);
+          return reply.send({
+            valid: false,
+            errors,
+            warnings: issues.filter((i) => i.severity === 'warning'),
+          });
+        }
+
+        // Determine destination slug from pack_id, falling back to the extracted dir name.
+        const { pack_id, name } = readManifestBasics(packDir);
+        const baseSlug = (pack_id ?? path.basename(packDir))
+          .replace(/[^a-zA-Z0-9._-]/g, '-')
+          .replace(/^[.-]+/, '')
+          || 'imported-pack';
+
+        fs.mkdirSync(_localDevRoot, { recursive: true });
+
+        const conflictMode = req.query.conflict === 'overwrite' ? 'overwrite' : 'rename';
+        let destSlug = baseSlug;
+        let destPath = path.join(_localDevRoot, destSlug);
+        let renamedFrom: string | undefined;
+
+        if (fs.existsSync(destPath)) {
+          if (conflictMode === 'overwrite') {
+            fs.rmSync(destPath, { recursive: true, force: true });
+          } else {
+            // Find a free slug with a numeric suffix.
+            let n = 2;
+            while (fs.existsSync(path.join(_localDevRoot, `${baseSlug}-${n}`))) n++;
+            renamedFrom = baseSlug;
+            destSlug = `${baseSlug}-${n}`;
+            destPath = path.join(_localDevRoot, destSlug);
+          }
+        }
+
+        copyDirRecursive(packDir, destPath);
+
+        const { pack_id: finalPackId, name: finalName } = readManifestBasics(destPath);
+        const result: WorkbenchImportResponse = {
+          kind: 'local-dev',
+          slug: destSlug,
+          pack_id: finalPackId,
+          name: finalName ?? destSlug,
+          editable: true,
+          ...(renamedFrom !== undefined ? { renamed_from: renamedFrom } : {}),
+        };
+
+        reply.status(201);
+        return result;
+      } finally {
+        try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore cleanup */ }
+      }
     },
   );
 

--- a/apps/web/src/__tests__/CreatorWorkbench.test.tsx
+++ b/apps/web/src/__tests__/CreatorWorkbench.test.tsx
@@ -607,11 +607,13 @@ describe('CreatorWorkbench', () => {
       headers: { get: (h: string) => h === 'Content-Disposition' ? 'attachment; filename="my-pack-0.1.0.zip"' : null },
     })
 
-    // jsdom does not implement URL.createObjectURL; stub it so triggerDownload doesn't throw.
+    // jsdom does not implement URL.createObjectURL, so vi.spyOn can't wrap a
+    // non-existent method — define the property directly so triggerDownload
+    // doesn't throw.
     const createObjectURL = vi.fn().mockReturnValue('blob:test')
     const revokeObjectURL = vi.fn()
-    vi.spyOn(URL, 'createObjectURL').mockImplementation(createObjectURL)
-    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(revokeObjectURL)
+    Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: createObjectURL })
+    Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: revokeObjectURL })
 
     stubFetch((url) => {
       if (url.includes('/export')) return exportSpy()

--- a/apps/web/src/__tests__/CreatorWorkbench.test.tsx
+++ b/apps/web/src/__tests__/CreatorWorkbench.test.tsx
@@ -625,6 +625,33 @@ describe('CreatorWorkbench', () => {
     })
   })
 
+  it('import of a corrupt/unsafe zip shows an error instead of crashing', async () => {
+    // Corrupt zip and zip-slip rejections come back as a 422 without a
+    // structured `errors` array (a plain thrown-Error body). The UI must render
+    // this as an error message, not crash trying to map over undefined errors.
+    const plainError = { statusCode: 422, error: 'Unprocessable Entity', message: 'Uploaded file is not a valid .zip archive' }
+    const importSpy = vi.fn().mockReturnValue({ ok: false, status: 422, json: () => Promise.resolve(plainError), text: () => Promise.resolve(JSON.stringify(plainError)) })
+
+    stubFetch((url, opts) => {
+      if (url.includes('/import') && opts?.method === 'POST') return importSpy()
+      return okJson([OFFICIAL_PACK, LOCAL_PACK])
+    })
+
+    renderWorkbench()
+    await screen.findByTestId('import-pack-button')
+
+    const fileInput = screen.getByTestId('import-file-input') as HTMLInputElement
+    const zipFile = new File(['not a zip'], 'corrupt.zip', { type: 'application/zip' })
+    Object.defineProperty(fileInput, 'files', { value: [zipFile], writable: false })
+    fireEvent.change(fileInput)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('import-error')).toBeInTheDocument()
+      expect(screen.getByTestId('import-error')).toHaveTextContent(/not a valid \.zip archive/i)
+    })
+    expect(screen.queryByTestId('import-validation-errors')).not.toBeInTheDocument()
+  })
+
   it('export success shows filename confirmation', async () => {
     const zipBlob = new Blob(['PK\x03\x04'], { type: 'application/zip' })
     const exportSpy = vi.fn().mockReturnValue({

--- a/apps/web/src/__tests__/CreatorWorkbench.test.tsx
+++ b/apps/web/src/__tests__/CreatorWorkbench.test.tsx
@@ -520,6 +520,138 @@ describe('CreatorWorkbench', () => {
     })
   })
 
+  // ---------------------------------------------------------------------------
+  // Import / Export
+  // ---------------------------------------------------------------------------
+
+  it('shows import pack button in pack list', async () => {
+    renderWorkbench()
+    expect(await screen.findByTestId('import-pack-button')).toBeInTheDocument()
+  })
+
+  it('shows export pack button when a pack is selected', async () => {
+    stubFetch((url) => {
+      if (url.includes('/files')) return okJson({ tree: MOCK_TREE })
+      if (url.includes('/validate')) return okJson({ valid: true, errors: [], warnings: [] })
+      return okJson([OFFICIAL_PACK, LOCAL_PACK])
+    })
+
+    renderWorkbench()
+    fireEvent.click(await screen.findByRole('button', { name: /my pack/i }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('export-pack-button')).toBeInTheDocument()
+    })
+  })
+
+  it('import success adds new pack to list and shows it as selected', async () => {
+    const newPack: WorkbenchPack = { kind: 'local-dev', slug: 'imported-pack', pack_id: 'local.imported_pack', name: 'Imported Pack', editable: true }
+    const importSpy = vi.fn().mockReturnValue(okJson(newPack))
+
+    stubFetch((url, opts) => {
+      if (url.includes('/import') && opts?.method === 'POST') return importSpy()
+      if (url.includes('/files')) return okJson({ tree: MOCK_TREE })
+      if (url.includes('/validate')) return okJson({ valid: true, errors: [], warnings: [] })
+      return okJson([OFFICIAL_PACK, LOCAL_PACK])
+    })
+
+    renderWorkbench()
+    await screen.findByTestId('import-pack-button')
+
+    // Simulate file input change via the hidden input
+    const fileInput = screen.getByTestId('import-file-input') as HTMLInputElement
+    const zipFile = new File(['PK\x03\x04'], 'my-pack.zip', { type: 'application/zip' })
+    Object.defineProperty(fileInput, 'files', { value: [zipFile], writable: false })
+    fireEvent.change(fileInput)
+
+    await waitFor(() => {
+      expect(importSpy).toHaveBeenCalledOnce()
+    })
+  })
+
+  it('import validation failure shows errors without crashing', async () => {
+    const validationError = {
+      valid: false,
+      errors: [
+        { severity: 'error', rule_id: 'SCHEMA_VIOLATION', file: 'manifest.yaml', pointer: '/author', message: 'author is required', suggested_fix: 'Add author' },
+      ],
+      warnings: [],
+    }
+    const importSpy = vi.fn().mockReturnValue({ ok: false, status: 422, json: () => Promise.resolve(validationError), text: () => Promise.resolve(JSON.stringify(validationError)) })
+
+    stubFetch((url, opts) => {
+      if (url.includes('/import') && opts?.method === 'POST') return importSpy()
+      return okJson([OFFICIAL_PACK, LOCAL_PACK])
+    })
+
+    renderWorkbench()
+    await screen.findByTestId('import-pack-button')
+
+    const fileInput = screen.getByTestId('import-file-input') as HTMLInputElement
+    const zipFile = new File(['PK\x03\x04'], 'bad.zip', { type: 'application/zip' })
+    Object.defineProperty(fileInput, 'files', { value: [zipFile], writable: false })
+    fireEvent.change(fileInput)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('import-validation-errors')).toBeInTheDocument()
+      expect(screen.getByTestId('import-validation-errors')).toHaveTextContent(/author is required/i)
+    })
+  })
+
+  it('export success shows filename confirmation', async () => {
+    const zipBlob = new Blob(['PK\x03\x04'], { type: 'application/zip' })
+    const exportSpy = vi.fn().mockReturnValue({
+      ok: true,
+      status: 200,
+      blob: () => Promise.resolve(zipBlob),
+      headers: { get: (h: string) => h === 'Content-Disposition' ? 'attachment; filename="my-pack-0.1.0.zip"' : null },
+    })
+
+    // jsdom does not implement URL.createObjectURL; stub it so triggerDownload doesn't throw.
+    const createObjectURL = vi.fn().mockReturnValue('blob:test')
+    const revokeObjectURL = vi.fn()
+    vi.spyOn(URL, 'createObjectURL').mockImplementation(createObjectURL)
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(revokeObjectURL)
+
+    stubFetch((url) => {
+      if (url.includes('/export')) return exportSpy()
+      if (url.includes('/files')) return okJson({ tree: MOCK_TREE })
+      if (url.includes('/validate')) return okJson({ valid: true, errors: [], warnings: [] })
+      return okJson([OFFICIAL_PACK, LOCAL_PACK])
+    })
+
+    renderWorkbench()
+    fireEvent.click(await screen.findByRole('button', { name: /my pack/i }))
+
+    const exportBtn = await screen.findByTestId('export-pack-button')
+    fireEvent.click(exportBtn)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('export-success')).toBeInTheDocument()
+      expect(screen.getByTestId('export-success')).toHaveTextContent('my-pack-0.1.0.zip')
+    })
+  })
+
+  it('export validation failure shows error message', async () => {
+    const validationError = { valid: false, errors: [{ rule_id: 'SCHEMA_VIOLATION', file: 'manifest.yaml', message: 'name is required', suggested_fix: '' }] }
+    const exportSpy = vi.fn().mockReturnValue({ ok: false, status: 422, json: () => Promise.resolve(validationError), text: () => Promise.resolve(JSON.stringify(validationError)) })
+
+    stubFetch((url) => {
+      if (url.includes('/export')) return exportSpy()
+      if (url.includes('/files')) return okJson({ tree: MOCK_TREE })
+      if (url.includes('/validate')) return okJson({ valid: true, errors: [], warnings: [] })
+      return okJson([OFFICIAL_PACK, LOCAL_PACK])
+    })
+
+    renderWorkbench()
+    fireEvent.click(await screen.findByRole('button', { name: /my pack/i }))
+    fireEvent.click(await screen.findByTestId('export-pack-button'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('export-error')).toBeInTheDocument()
+    })
+  })
+
   it('shows links to authoring docs alongside findings', async () => {
     stubFetch((url) => {
       if (url.includes('/validate')) {

--- a/apps/web/src/__tests__/CreatorWorkbench.test.tsx
+++ b/apps/web/src/__tests__/CreatorWorkbench.test.tsx
@@ -569,6 +569,33 @@ describe('CreatorWorkbench', () => {
     })
   })
 
+  it('import with slug conflict shows the rename notice', async () => {
+    const renamedPack = { kind: 'local-dev', slug: 'local.imported_pack-2', pack_id: 'local.imported_pack', name: 'Imported Pack', editable: true, renamed_from: 'local.imported_pack' }
+    const importSpy = vi.fn().mockReturnValue(okJson(renamedPack))
+
+    stubFetch((url, opts) => {
+      if (url.includes('/import') && opts?.method === 'POST') return importSpy()
+      if (url.includes('/files')) return okJson({ tree: MOCK_TREE })
+      if (url.includes('/validate')) return okJson({ valid: true, errors: [], warnings: [] })
+      return okJson([OFFICIAL_PACK, LOCAL_PACK])
+    })
+
+    renderWorkbench()
+    await screen.findByTestId('import-pack-button')
+
+    const fileInput = screen.getByTestId('import-file-input') as HTMLInputElement
+    const zipFile = new File(['PK\x03\x04'], 'dup.zip', { type: 'application/zip' })
+    Object.defineProperty(fileInput, 'files', { value: [zipFile], writable: false })
+    fireEvent.change(fileInput)
+
+    // The rename notice must survive the pack-selection that follows a
+    // successful import (handleSelectPack resets import notices).
+    await waitFor(() => {
+      expect(screen.getByTestId('import-renamed-notice')).toBeInTheDocument()
+      expect(screen.getByTestId('import-renamed-notice')).toHaveTextContent('local.imported_pack-2')
+    })
+  })
+
   it('import validation failure shows errors without crashing', async () => {
     const validationError = {
       valid: false,

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -209,6 +209,18 @@ export interface WorkbenchTestSession {
   state_vars: Record<string, number>
 }
 
+export interface WorkbenchImportResult extends WorkbenchPack {
+  /** Present when the slug was changed to avoid a collision with an existing pack. */
+  renamed_from?: string
+}
+
+export interface WorkbenchImportValidationError {
+  kind: 'validation'
+  valid: false
+  errors: WorkbenchValidationIssue[]
+  warnings: WorkbenchValidationIssue[]
+}
+
 export interface WsConnection {
   close(): void;
 }
@@ -322,6 +334,45 @@ export const api = {
     },
     startTestSession(kind: PackKind, slug: string): Promise<WorkbenchTestSession> {
       return post<WorkbenchTestSession>(`/workbench/packs/${kind}/${slug}/test-session`)
+    },
+    async importPack(
+      file: File,
+      conflict?: 'rename' | 'overwrite',
+    ): Promise<WorkbenchImportResult | WorkbenchImportValidationError> {
+      const url = conflict
+        ? `${BASE}/workbench/packs/import?conflict=${conflict}`
+        : `${BASE}/workbench/packs/import`
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/zip' },
+        body: file,
+      })
+      if (res.status === 422) {
+        // Validation failure: the backend returns the full issue list.
+        const data = await res.json() as { valid: false; errors: WorkbenchValidationIssue[]; warnings: WorkbenchValidationIssue[] }
+        return { kind: 'validation', ...data }
+      }
+      if (!res.ok) throw new Error(await parseErrorMessage(res))
+      return res.json() as Promise<WorkbenchImportResult>
+    },
+    async exportPack(kind: PackKind, slug: string): Promise<{ blob: Blob; filename: string }> {
+      const res = await fetch(`${BASE}/workbench/packs/${kind}/${slug}/export`)
+      if (res.status === 422) {
+        // Validation preflight failed — surface the first error message.
+        const data = await res.json() as { errors: WorkbenchValidationIssue[] }
+        const first = data.errors[0]
+        throw new Error(
+          first
+            ? `Export blocked: ${first.message} (${first.rule_id})`
+            : 'Pack validation failed before export',
+        )
+      }
+      if (!res.ok) throw new Error(await parseErrorMessage(res))
+      const blob = await res.blob()
+      const disposition = res.headers.get('Content-Disposition') ?? ''
+      const match = /filename="([^"]+)"/.exec(disposition)
+      const filename = match?.[1] ?? `${slug}.zip`
+      return { blob, filename }
     },
   },
 }

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -359,9 +359,19 @@ export const api = {
         body: file,
       })
       if (res.status === 422) {
-        // Validation failure: the backend returns the full issue list.
-        const data = await res.json() as { valid: false; errors: WorkbenchValidationIssue[]; warnings: WorkbenchValidationIssue[] }
-        return { kind: 'validation', ...data }
+        // A 422 is either a structured validation failure (carrying the full
+        // issue list) or a plain error — e.g. a corrupt zip or a zip-slip path,
+        // which the backend rejects with a thrown Error (no issue list). Only
+        // treat it as a validation result when an errors array is actually
+        // present; otherwise surface the message so the UI shows it as an error
+        // rather than crashing on an undefined `errors`.
+        const data = await res.json().catch(() => null) as
+          | { valid?: false; errors?: WorkbenchValidationIssue[]; warnings?: WorkbenchValidationIssue[]; message?: string }
+          | null
+        if (data && Array.isArray(data.errors)) {
+          return { kind: 'validation', valid: false, errors: data.errors, warnings: data.warnings ?? [] }
+        }
+        throw new Error(data?.message ?? 'Import failed: the uploaded file could not be processed')
       }
       if (!res.ok) throw new Error(await parseErrorMessage(res))
       return res.json() as Promise<WorkbenchImportResult>

--- a/apps/web/src/screens/CreatorWorkbench.tsx
+++ b/apps/web/src/screens/CreatorWorkbench.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { useState, useEffect, useCallback, useRef, type CSSProperties } from 'react'
 import { useBlocker } from 'react-router-dom'
-import { api, type WorkbenchPack, type FileNode, type WorkbenchValidation, type WorkbenchValidationIssue } from '../api/client'
+import { api, type WorkbenchPack, type FileNode, type WorkbenchValidation, type WorkbenchValidationIssue, type WorkbenchImportValidationError } from '../api/client'
 
 // A validation response is only usable if it carries the expected error/warning
 // arrays. Backends without a validator (or unexpected shapes) are treated as
@@ -60,6 +60,15 @@ const BTN_DISABLED: CSSProperties = {
   cursor: 'not-allowed',
 }
 
+function triggerDownload(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
 // ---------------------------------------------------------------------------
 // PackList
 // ---------------------------------------------------------------------------
@@ -68,11 +77,17 @@ interface PackListProps {
   packs: WorkbenchPack[]
   selected: WorkbenchPack | null
   onSelect: (pack: WorkbenchPack) => void
+  onImport: (file: File) => void
+  importing: boolean
+  importError: string | null
+  importValidation: WorkbenchImportValidationError | null
+  importRenamed: string | null
 }
 
-function PackList({ packs, selected, onSelect }: PackListProps) {
+function PackList({ packs, selected, onSelect, onImport, importing, importError, importValidation, importRenamed }: PackListProps) {
   const official = packs.filter((p) => p.kind === 'official')
   const localDev = packs.filter((p) => p.kind === 'local-dev')
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
   function group(label: string, items: WorkbenchPack[]) {
     if (items.length === 0) return null
@@ -115,18 +130,67 @@ function PackList({ packs, selected, onSelect }: PackListProps) {
     )
   }
 
-  if (packs.length === 0) {
-    return (
-      <p style={{ fontSize: '0.85rem', color: '#52525b', padding: '0.5rem 0.75rem' }}>
-        No packs found.
-      </p>
-    )
-  }
-
   return (
     <div>
+      {packs.length === 0 && (
+        <p style={{ fontSize: '0.85rem', color: '#52525b', padding: '0.5rem 0.75rem' }}>
+          No packs found.
+        </p>
+      )}
       {group('Official', official)}
       {group('Local Dev', localDev)}
+
+      {/* Import button */}
+      <div style={{ padding: '0.4rem 0.75rem', borderTop: '1px solid rgba(255,255,255,0.06)', marginTop: '0.25rem' }}>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".zip"
+          data-testid="import-file-input"
+          style={{ display: 'none' }}
+          onChange={(e) => {
+            const file = e.target.files?.[0]
+            if (file) onImport(file)
+            // Reset so the same file can be re-imported if needed
+            e.target.value = ''
+          }}
+        />
+        <button
+          data-testid="import-pack-button"
+          disabled={importing}
+          onClick={() => fileInputRef.current?.click()}
+          style={{ ...BTN, width: '100%', textAlign: 'center', ...(importing ? BTN_DISABLED : {}) }}
+          aria-label={importing ? 'Importing…' : 'Import pack from .zip'}
+        >
+          {importing ? 'Importing…' : '⬆ Import Pack (.zip)'}
+        </button>
+
+        {importError && (
+          <p role="alert" data-testid="import-error" style={{ fontSize: '0.75rem', color: '#f87171', marginTop: '0.4rem' }}>
+            {importError}
+          </p>
+        )}
+
+        {importRenamed && !importError && (
+          <p data-testid="import-renamed-notice" style={{ fontSize: '0.75rem', color: '#fbbf24', marginTop: '0.4rem' }}>
+            Imported as "{importRenamed}" (existing pack with that ID was kept).
+          </p>
+        )}
+
+        {importValidation && !importError && (
+          <div data-testid="import-validation-errors" role="alert" style={{ fontSize: '0.75rem', color: '#f87171', marginTop: '0.4rem' }}>
+            <strong>Import rejected — pack is invalid:</strong>
+            <ul style={{ margin: '0.25rem 0 0', paddingLeft: '1rem' }}>
+              {importValidation.errors.slice(0, 5).map((e, i) => (
+                <li key={i}>{e.file ? `${e.file}: ` : ''}{e.message}</li>
+              ))}
+              {importValidation.errors.length > 5 && (
+                <li>…and {importValidation.errors.length - 5} more error(s)</li>
+              )}
+            </ul>
+          </div>
+        )}
+      </div>
     </div>
   )
 }
@@ -1250,6 +1314,15 @@ export default function CreatorWorkbench() {
   const [validationLoading, setValidationLoading] = useState(false)
   const [validationServiceError, setValidationServiceError] = useState<string | null>(null)
   const [activeTab, setActiveTab] = useState<'edit' | 'test'>('edit')
+  // Import state
+  const [importing, setImporting] = useState(false)
+  const [importError, setImportError] = useState<string | null>(null)
+  const [importValidation, setImportValidation] = useState<WorkbenchImportValidationError | null>(null)
+  const [importRenamed, setImportRenamed] = useState<string | null>(null)
+  // Export state
+  const [exporting, setExporting] = useState(false)
+  const [exportError, setExportError] = useState<string | null>(null)
+  const [exportFilename, setExportFilename] = useState<string | null>(null)
 
   const isDirty = selectedFile !== null && editorContent !== savedContent
 
@@ -1330,6 +1403,11 @@ export default function CreatorWorkbench() {
     setCopyError(null)
     setValidation(null)
     setActiveTab('edit')
+    setExportError(null)
+    setExportFilename(null)
+    setImportError(null)
+    setImportValidation(null)
+    setImportRenamed(null)
     await Promise.all([loadFileTree(pack), refreshValidation(pack)])
   }
 
@@ -1402,6 +1480,53 @@ export default function CreatorWorkbench() {
     }
   }
 
+  async function handleImport(file: File) {
+    setImporting(true)
+    setImportError(null)
+    setImportValidation(null)
+    setImportRenamed(null)
+    try {
+      const result = await api.workbench.importPack(file)
+      if (result.kind === 'validation') {
+        setImportValidation(result)
+        return
+      }
+      // Success: add the new pack to the list and select it
+      const newPack: WorkbenchPack = {
+        kind: result.kind,
+        slug: result.slug,
+        pack_id: result.pack_id,
+        name: result.name,
+        editable: result.editable,
+      }
+      setPacks((prev) => [...prev.filter((p) => !(p.kind === newPack.kind && p.slug === newPack.slug)), newPack])
+      if (result.renamed_from) {
+        setImportRenamed(result.slug)
+      }
+      await handleSelectPack(newPack)
+    } catch (e: unknown) {
+      setImportError(e instanceof Error ? e.message : 'Failed to import pack')
+    } finally {
+      setImporting(false)
+    }
+  }
+
+  async function handleExport() {
+    if (!selectedPack) return
+    setExporting(true)
+    setExportError(null)
+    setExportFilename(null)
+    try {
+      const { blob, filename } = await api.workbench.exportPack(selectedPack.kind, selectedPack.slug)
+      triggerDownload(blob, filename)
+      setExportFilename(filename)
+    } catch (e: unknown) {
+      setExportError(e instanceof Error ? e.message : 'Failed to export pack')
+    } finally {
+      setExporting(false)
+    }
+  }
+
   return (
     <div>
       <h1 style={{ marginBottom: '0.25rem' }}>Creator Workbench</h1>
@@ -1444,7 +1569,16 @@ export default function CreatorWorkbench() {
             <div style={{ fontSize: '0.7rem', fontWeight: 600, color: '#71717a', textTransform: 'uppercase', letterSpacing: '0.06em', padding: '0.25rem 0.75rem 0.5rem' }}>
               Packs
             </div>
-            <PackList packs={packs} selected={selectedPack} onSelect={handleSelectPack} />
+            <PackList
+              packs={packs}
+              selected={selectedPack}
+              onSelect={handleSelectPack}
+              onImport={handleImport}
+              importing={importing}
+              importError={importError}
+              importValidation={importValidation}
+              importRenamed={importRenamed}
+            />
           </div>
 
           {/* File tree */}
@@ -1487,6 +1621,7 @@ export default function CreatorWorkbench() {
             <div
               style={{
                 display: 'flex',
+                alignItems: 'center',
                 borderBottom: '1px solid rgba(255,255,255,0.08)',
                 background: 'rgba(0,0,0,0.1)',
                 flexShrink: 0,
@@ -1512,6 +1647,42 @@ export default function CreatorWorkbench() {
                   {tab === 'edit' ? 'Edit' : 'Test Chat'}
                 </button>
               ))}
+
+              {/* Export controls — pushed to the right */}
+              <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: '0.4rem', padding: '0 0.5rem' }}>
+                {exportFilename && !exportError && (
+                  <span
+                    data-testid="export-success"
+                    style={{ fontSize: '0.72rem', color: '#4ade80' }}
+                  >
+                    ✓ {exportFilename}
+                  </span>
+                )}
+                {exportError && (
+                  <span
+                    data-testid="export-error"
+                    role="alert"
+                    style={{ fontSize: '0.72rem', color: '#f87171', maxWidth: '200px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                    title={exportError}
+                  >
+                    {exportError}
+                  </span>
+                )}
+                <button
+                  data-testid="export-pack-button"
+                  onClick={() => { void handleExport() }}
+                  disabled={exporting}
+                  style={{
+                    ...BTN,
+                    fontSize: '0.75rem',
+                    padding: '0.25rem 0.6rem',
+                    ...(exporting ? BTN_DISABLED : {}),
+                  }}
+                  aria-label={exporting ? 'Exporting…' : 'Export pack as .zip'}
+                >
+                  {exporting ? 'Exporting…' : '⬇ Export .zip'}
+                </button>
+              </div>
             </div>
           )}
 

--- a/apps/web/src/screens/CreatorWorkbench.tsx
+++ b/apps/web/src/screens/CreatorWorkbench.tsx
@@ -1500,10 +1500,12 @@ export default function CreatorWorkbench() {
         editable: result.editable,
       }
       setPacks((prev) => [...prev.filter((p) => !(p.kind === newPack.kind && p.slug === newPack.slug)), newPack])
+      // Select the new pack first: handleSelectPack resets the import notices,
+      // so the rename notice must be set *after* it or it would be cleared.
+      await handleSelectPack(newPack)
       if (result.renamed_from) {
         setImportRenamed(result.slug)
       }
-      await handleSelectPack(newPack)
     } catch (e: unknown) {
       setImportError(e instanceof Error ? e.message : 'Failed to import pack')
     } finally {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,9 @@ importers:
       '@fastify/websocket':
         specifier: ^11.2.0
         version: 11.2.0
+      adm-zip:
+        specifier: ^0.5.16
+        version: 0.5.18
       better-sqlite3:
         specifier: ^12.11.1
         version: 12.11.1
@@ -29,6 +32,9 @@ importers:
         specifier: ^5.0.0
         version: 5.9.0
     devDependencies:
+      '@types/adm-zip':
+        specifier: ^0.5.7
+        version: 0.5.8
       '@types/better-sqlite3':
         specifier: ^7.6.13
         version: 7.6.13


### PR DESCRIPTION
## Summary

Adds workbench import and export endpoints with full UI support:

- **Backend:** `POST /api/workbench/packs/import` accepts a raw zip body (`Content-Type: application/zip`), runs two-phase security + schema validation before installing to `local-dev`, and handles slug conflicts by renaming with a numeric suffix or overwriting via `?conflict=overwrite`. Zip-slip attacks are rejected before extraction.
- **Backend:** `GET /api/workbench/packs/:kind/:slug/export` validates the pack first (returns 422 + full issue list on failure), then streams a zip archive with all entries using relative paths (no absolute local paths leak out).
- **Dependencies:** `adm-zip` added to `@convsim/api` (already present in workspace lockfile via `@convsim/cli`).
- **Client:** `api.workbench.importPack(file)` and `api.workbench.exportPack(kind, slug)` methods added. `importPack` returns a discriminated union so callers can distinguish a successful `WorkbenchImportResult` from a `WorkbenchImportValidationError` without throwing.
- **UI:** Import Pack (.zip) button with hidden file input in the pack selector panel; inline validation errors and rename-conflict notices are rendered beneath it. Export .zip button in the tab-bar header with in-place success (filename) and error feedback.

## Test coverage

### Backend integration tests
- Valid import: pack lands in `local-dev`, appears in the list, and contains `manifest.yaml`
- Re-import round-trip: export then import produces a pack that validates cleanly
- Conflict rename: second import of the same pack gets a `‑2` slug and `renamed_from` in the response
- Conflict overwrite: `?conflict=overwrite` replaces the existing slug
- Zip-slip rejection: entries with `../` paths are caught before extraction
- Forbidden file rejection: `.sh` files trigger a `FORBIDDEN_FILE` error
- Invalid manifest rejection: missing required fields return 422 with error list
- No absolute paths in export zip: all entry names are relative
- 404 / 400 / 422 error cases for both endpoints

### Frontend tests
- Import button is visible in the pack selector
- Export button appears when a pack is selected
- Import success adds the new pack and triggers selection
- Import validation failure shows per-error list without crashing
- Export success renders the downloaded filename as confirmation
- Export validation failure renders the error message

## Acceptance criteria

- ✅ Creator can import a valid zip and see it in library/workbench
- ✅ Unsafe or invalid imports are rejected with validator details
- ✅ Creator can export a local-dev pack and re-import it successfully
- ✅ Official packs can be exported (for sharing); local-dev packs can be edited and exported
- ✅ Duplicate conflicts are handled explicitly (rename default, overwrite on request)
- ✅ No absolute local paths leak into exported pack files

Closes #69