### PR TITLE
Add release workflow, first-run system checks, and platform documentation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,9 +132,12 @@ jobs:
         run: find release-artifacts -type f | sort
 
       - name: Generate SHA-256 checksums
+        # Record bare filenames (not the release-artifacts/... paths) so the
+        # manifest matches the flattened asset names on the release page and
+        # `sha256sum -c checksums-sha256.txt` works next to the downloads.
         run: |
           find release-artifacts -type f | sort | while IFS= read -r f; do
-            sha256sum "$f"
+            ( cd "$(dirname "$f")" && sha256sum "$(basename "$f")" )
           done > checksums-sha256.txt
           cat checksums-sha256.txt
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: Apache-2.0
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g. v0.1.0-alpha.1)'
+        required: true
+        type: string
+
+# Write permission needed to create GitHub releases and upload assets.
+permissions:
+  contents: write
+
+jobs:
+  # ── Smoke check ──────────────────────────────────────────────────────────────
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Smoke check
+        run: bash scripts/smoke-check.sh
+
+  # ── Cross-platform desktop builds ─────────────────────────────────────────────
+  build-desktop:
+    name: Desktop (${{ matrix.name }})
+    needs: validate
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Apple Silicon (arm64) — macos-latest is ARM since late 2024
+          - name: macOS-aarch64
+            runner: macos-latest
+          # Intel Mac — macos-13 is the last Intel runner
+          - name: macOS-x86_64
+            runner: macos-13
+          # Linux x86_64 — AppImage + .deb
+          - name: Linux-x86_64
+            runner: ubuntu-22.04
+          # Windows x86_64 — NSIS installer + MSI
+          - name: Windows-x86_64
+            runner: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # ── Linux system packages required by Tauri / WebKitGTK ──────────────────
+      - name: Install Linux system dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
+
+      # ── Node.js / pnpm ───────────────────────────────────────────────────────
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: pnpm
+
+      # ── Rust toolchain ───────────────────────────────────────────────────────
+      - name: Install Rust stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: apps/desktop/src-tauri -> target
+
+      # ── Frontend build ───────────────────────────────────────────────────────
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build shared TypeScript packages
+        run: |
+          pnpm --filter @convsim/shared-types build
+          pnpm --filter @convsim/scenario-schema build
+
+      - name: Build web frontend
+        run: pnpm --filter @convsim/web build
+
+      # ── Tauri desktop build ──────────────────────────────────────────────────
+      - name: Build Tauri desktop
+        run: pnpm --filter @convsim/desktop build
+
+      # ── Collect installers ───────────────────────────────────────────────────
+      # Tauri v2 places bundles under target/release/bundle/<format>/.
+      - name: Upload desktop installer artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-${{ matrix.name }}
+          # Glob patterns cover all known Tauri installer formats.
+          path: |
+            apps/desktop/src-tauri/target/release/bundle/**/*.dmg
+            apps/desktop/src-tauri/target/release/bundle/**/*.AppImage
+            apps/desktop/src-tauri/target/release/bundle/**/*.deb
+            apps/desktop/src-tauri/target/release/bundle/**/*.exe
+            apps/desktop/src-tauri/target/release/bundle/**/*.msi
+          if-no-files-found: warn
+          retention-days: 7
+
+  # ── Publish GitHub release ────────────────────────────────────────────────────
+  release:
+    name: Publish release
+    needs: build-desktop
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all desktop artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release-artifacts
+          pattern: desktop-*
+          merge-multiple: true
+
+      - name: List collected artifacts
+        run: find release-artifacts -type f | sort
+
+      - name: Generate SHA-256 checksums
+        run: |
+          find release-artifacts -type f | sort | while IFS= read -r f; do
+            sha256sum "$f"
+          done > checksums-sha256.txt
+          cat checksums-sha256.txt
+
+      - name: Create draft GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
+          name: >-
+            Conversation Simulator
+            ${{ github.event.inputs.tag || github.ref_name }}
+          body_path: docs/release-notes-template.md
+          draft: true
+          prerelease: true
+          files: |
+            release-artifacts/**
+            checksums-sha256.txt
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/install.md
+++ b/docs/install.md
@@ -6,7 +6,7 @@ Conversation Simulator runs entirely on your computer — no cloud inference, no
 Two install paths are available:
 
 - **Path A — developer install:** clone the source and run the dev services locally. Suitable for contributors and users who want full control.
-- **Path B — alpha app install:** download and run the pre-built desktop application (planned for a future milestone; see below).
+- **Path B — alpha app install:** download and run the pre-built desktop application (see below). Note that the alpha build wraps the web UI in a native window; the backend must still be started separately until the sidecar is bundled.
 
 ---
 
@@ -25,6 +25,26 @@ Two install paths are available:
 ---
 
 ## Path A — developer install
+
+### 0. Run the first-run check (optional)
+
+Before installing anything, confirm your system meets the requirements:
+
+**macOS / Linux:**
+
+```bash
+./scripts/first-run-check.sh
+```
+
+**Windows (PowerShell):**
+
+```powershell
+.\scripts\first-run-check.ps1
+```
+
+The check reports OS version, CPU architecture, RAM, disk space, audio device
+availability, and port conflicts. All items marked `FAIL` must be resolved
+before the app will work; `WARN` items are advisory.
 
 ### 1. Install system dependencies
 
@@ -127,28 +147,73 @@ The command exits 0 on success and prints an actionable error if any subsystem a
 
 ## Path B — alpha app install
 
-> **Status:** The packaged desktop application is planned for a future milestone. This section describes how to install it when it becomes available.
-
 When a release is published on the [GitHub releases page](https://github.com/outrightmental/ConversationSimulator/releases):
 
-1. Download the installer for your platform (`.dmg` on macOS, `.exe` on Windows, `.AppImage` on Linux).
-2. Open the installer and follow the prompts.
-3. Launch **Conversation Simulator** from your Applications folder or Start Menu.
-4. On first launch the app prompts you to install a local model. No model weights are bundled with the installer.
+### 1. Pre-flight check
 
-To verify the installer download before running it:
+Run the first-run check before downloading anything:
 
 ```bash
-# macOS / Linux — replace the filename and checksum with values from the release page
-shasum -a 256 ConversationSimulator-1.0.0.dmg
+./scripts/first-run-check.sh        # macOS / Linux
+.\scripts\first-run-check.ps1       # Windows PowerShell
+```
+
+### 2. Download and verify
+
+Download the installer for your platform:
+
+| Platform | File |
+|---|---|
+| macOS (Apple Silicon) | `ConversationSimulator_<version>_aarch64.dmg` |
+| macOS (Intel) | `ConversationSimulator_<version>_x64.dmg` |
+| Linux (x86_64) | `conversation-simulator_<version>_amd64.AppImage` |
+| Windows (x86_64) | `ConversationSimulator_<version>_x64-setup.exe` |
+
+Verify the download against the `checksums-sha256.txt` file on the release page:
+
+```bash
+# macOS / Linux
+shasum -a 256 ConversationSimulator_<version>_aarch64.dmg
 ```
 
 ```powershell
 # Windows PowerShell
-Get-FileHash "ConversationSimulator-1.0.0.exe" -Algorithm SHA256
+Get-FileHash "ConversationSimulator_<version>_x64-setup.exe" -Algorithm SHA256
 ```
 
-The expected checksum is listed on the GitHub release page alongside each download.
+### 3. Install and launch
+
+- **macOS:** open the `.dmg` and drag the app to `/Applications`. On first
+  launch, Gatekeeper may warn about an unidentified developer (alpha builds are
+  unsigned). Right-click the app → **Open** → **Open** to proceed.
+- **Windows:** run the `.exe` installer. SmartScreen may warn about an unrecognised
+  publisher — click **More info → Run anyway**.
+- **Linux:** `chmod +x *.AppImage` then run it directly. No installation needed.
+
+### 4. Start the backend
+
+> **Alpha limitation:** The desktop app wraps the browser UI but does not yet
+> launch the backend automatically. You must start `convsim-core` in a separate
+> terminal before using the app.
+
+```bash
+./scripts/dev.sh          # macOS / Linux
+.\scripts\dev.ps1         # Windows PowerShell
+```
+
+Then open the desktop app. The backend sidecar will be bundled in a future
+release, making this step unnecessary.
+
+### 5. Install a local model
+
+On first launch the app shows a **"No model loaded"** banner. Open **Settings →
+Models**, accept a model license, and start the download. No model weights are
+bundled with the installer.
+
+---
+
+> For platform-specific details (code signing, Gatekeeper, SmartScreen,
+> WebView2, audio permissions), see [platform-notes.md](platform-notes.md).
 
 ---
 

--- a/docs/platform-notes.md
+++ b/docs/platform-notes.md
@@ -1,0 +1,295 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+# Platform notes
+
+Platform-specific differences for building, running, and distributing
+Conversation Simulator on macOS and Windows.
+
+---
+
+## macOS
+
+### Supported versions
+
+macOS 12 Monterey or newer. Apple Silicon (M1+) and Intel are both supported
+with separate installer builds (`.dmg` files differ by architecture).
+
+### Build prerequisites
+
+```bash
+# Xcode Command Line Tools (provides clang, libtool, otool, etc.)
+xcode-select --install
+
+# Rust toolchain
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+# Node.js 18+, pnpm, Python 3.10+ via Homebrew (recommended)
+brew install node python@3.11
+npm install -g pnpm
+```
+
+For cross-compilation (building Apple Silicon on an Intel Mac or vice versa):
+
+```bash
+rustup target add aarch64-apple-darwin   # build for Apple Silicon
+rustup target add x86_64-apple-darwin    # build for Intel
+pnpm --filter @convsim/desktop tauri build --target aarch64-apple-darwin
+```
+
+### Installer format
+
+Tauri produces a `.dmg` disk image and a `.app.tar.gz` archive.
+The `.dmg` is the primary distributable for macOS.
+
+### Code signing and Gatekeeper
+
+Alpha builds are **not code-signed**. macOS Gatekeeper will block unsigned
+apps with "Apple cannot verify this app is free from malware." To open an
+unsigned build:
+
+1. Right-click (or Control-click) the `.app` → **Open** → **Open**.
+2. Or: **System Settings → Privacy & Security** → scroll down → **Open Anyway**.
+
+For distributable builds, sign with an Apple Developer ID certificate:
+
+```bash
+# Set these before running `tauri build`:
+export APPLE_CERTIFICATE="Developer ID Application: Your Name (TEAMID)"
+export APPLE_CERTIFICATE_PASSWORD="keychain-password"
+export APPLE_SIGNING_IDENTITY="Developer ID Application: Your Name (TEAMID)"
+export APPLE_ID="you@example.com"
+export APPLE_PASSWORD="app-specific-password"
+export APPLE_TEAM_ID="TEAMID"
+```
+
+Tauri's bundler handles signing and notarisation automatically when these
+environment variables are present. See
+[tauri.app/distribute/sign/macos](https://tauri.app/distribute/sign/macos).
+
+### Microphone permission
+
+The OS shows a standard permission dialog on first use of voice input.
+If denied, re-enable in **System Settings → Privacy & Security → Microphone**.
+
+### Data directories
+
+```
+~/.convsim/db/      — SQLite session database
+~/.convsim/data/    — exports and pack cache
+~/.convsim/logs/    — runtime logs
+~/.convsim/models/  — downloaded model weights (not in ~/Library to avoid iCloud sync)
+```
+
+Override with environment variables: `CONVSIM_DB_DIR`, `CONVSIM_DATA_DIR`,
+`CONVSIM_LOG_DIR`, `CONVSIM_MODELS_DIR`.
+
+### Port conflicts
+
+The app uses ports 7354–7358 (all bound to `127.0.0.1`). Find and stop
+conflicting processes:
+
+```bash
+lsof -i :7354
+lsof -i :7355
+kill <PID>
+```
+
+---
+
+## Windows
+
+### Supported versions
+
+Windows 10 (build 19041 / 20H1) or newer. Windows 11 is recommended.
+64-bit x86 only (`x86_64-pc-windows-msvc`).
+
+### Build prerequisites
+
+1. **Microsoft Visual Studio C++ Build Tools** — required by the Rust MSVC toolchain.
+   Install via [Build Tools for Visual Studio](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022)
+   and select the **"Desktop development with C++"** workload.
+
+2. **Rust toolchain** — install via [rustup.rs](https://rustup.rs/); the installer
+   detects Windows and installs the MSVC toolchain automatically.
+
+3. **WebView2 Runtime** — bundled with Windows 11 and Windows 10 21H2+. For older
+   Windows 10 builds, install the Evergreen Bootstrapper from
+   [developer.microsoft.com/en-us/microsoft-edge/webview2](https://developer.microsoft.com/en-us/microsoft-edge/webview2/).
+
+4. **Node.js 18+ and pnpm** — download from [nodejs.org](https://nodejs.org/) and
+   run `npm install -g pnpm` in a PowerShell terminal (as Administrator if needed).
+
+5. **Python 3.10+** — download from [python.org](https://www.python.org/downloads/).
+   During installation, check **"Add Python to PATH"**.
+
+Run the setup script from PowerShell:
+
+```powershell
+.\scripts\setup.ps1
+```
+
+### Installer format
+
+Tauri produces two Windows installers:
+
+- **NSIS `.exe`** — a classic setup wizard; recommended for most users.
+- **MSI (WiX)** — Microsoft Installer; better for enterprise/group-policy deployment.
+
+Both installers are self-contained; no separate runtime installation is needed
+(WebView2 is bundled with the NSIS installer if not already present).
+
+### Code signing (SmartScreen)
+
+Alpha builds are **not code-signed**. Windows Defender SmartScreen will warn
+"Windows protected your PC" with an **unrecognised publisher** message.
+To run an unsigned build:
+
+1. Click **More info** in the SmartScreen dialog.
+2. Click **Run anyway**.
+
+For distributable builds, sign with an Extended Validation (EV) or standard
+code-signing certificate. Set the Tauri signing environment variables before
+building:
+
+```powershell
+$env:TAURI_SIGNING_PRIVATE_KEY      = "path\to\private.key"
+$env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD = "key-password"
+```
+
+See [tauri.app/distribute/sign/windows](https://tauri.app/distribute/sign/windows).
+
+### Antivirus false positives
+
+Freshly compiled Rust/Tauri executables are occasionally flagged by antivirus
+engines as suspicious (heuristic detection). If this happens:
+
+1. Add the install directory to your antivirus exclusion list.
+2. Submit the executable for false-positive review through your AV vendor's portal.
+
+### Microphone permission
+
+Windows Security prompts for microphone access on first use. Allow it when
+prompted, or grant it in **Settings → Privacy & Security → Microphone**.
+
+### Data directories
+
+```
+%USERPROFILE%\.convsim\db\      — SQLite session database
+%USERPROFILE%\.convsim\data\    — exports and pack cache
+%USERPROFILE%\.convsim\logs\    — runtime logs
+%USERPROFILE%\.convsim\models\  — downloaded model weights
+```
+
+Override with environment variables: `CONVSIM_DB_DIR`, `CONVSIM_DATA_DIR`,
+`CONVSIM_LOG_DIR`, `CONVSIM_MODELS_DIR`.
+
+### Port conflicts
+
+Find and stop conflicting processes on Windows:
+
+```powershell
+Get-NetTCPConnection -LocalPort 7354 | Select-Object OwningProcess
+Stop-Process -Id <PID> -Force
+```
+
+### Paths with spaces
+
+If your user directory contains spaces (e.g. `C:\Users\Jane Doe\`), ensure
+that Python, Node.js, and Rust are installed in paths **without** spaces, or
+that their paths are correctly quoted in the environment. The setup script
+handles quoting automatically, but custom tool installations may not.
+
+### PowerShell execution policy
+
+To run `setup.ps1` and `dev.ps1`, the execution policy must allow local
+scripts. Run once in an elevated PowerShell:
+
+```powershell
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+```
+
+---
+
+## Linux
+
+### Supported distributions
+
+Ubuntu 22.04 LTS is the primary test target. Other glibc-based distros
+(Fedora 38+, Debian 12+, Arch) should work but are not regularly tested.
+
+### Build prerequisites
+
+```bash
+# Tauri system dependencies (Ubuntu / Debian)
+sudo apt-get install -y \
+  libwebkit2gtk-4.1-dev libgtk-3-dev \
+  libayatana-appindicator3-dev librsvg2-dev
+
+# Rust
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+# Node.js 18+ via NodeSource
+curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+sudo apt-get install -y nodejs
+npm install -g pnpm
+
+# Python 3.10+
+sudo apt-get install -y python3.11 python3.11-venv
+```
+
+### Installer format
+
+Tauri produces:
+- **`.AppImage`** — portable, runs on any x86_64 Linux without installation.
+- **`.deb`** — Debian/Ubuntu package for system-wide installation.
+
+### Microphone (PipeWire / PulseAudio)
+
+WebKit on Linux may require `xdg-desktop-portal` and a running PipeWire or
+PulseAudio session for the browser `getUserMedia` permission dialog to appear.
+On headless or minimal desktop environments, microphone access may silently
+fail; use text-only input mode in that case.
+
+---
+
+## Cross-platform differences summary
+
+| Feature | macOS | Windows | Linux |
+|---|---|---|---|
+| Installer format | `.dmg` | `.exe` (NSIS), `.msi` | `.AppImage`, `.deb` |
+| Code signing | Apple Developer ID | EV or OV certificate | Not applicable |
+| Runtime warning | Gatekeeper dialog | SmartScreen dialog | None |
+| WebView engine | WKWebView (Safari) | WebView2 (Chromium) | WebKitGTK |
+| Microphone prompt | System Settings | Windows Security | `xdg-desktop-portal` |
+| Data directory | `~/.convsim/` | `%USERPROFILE%\.convsim\` | `~/.convsim/` |
+| Dev script | `./scripts/dev.sh` | `.\scripts\dev.ps1` | `./scripts/dev.sh` |
+| First-run check | `./scripts/first-run-check.sh` | `.\scripts\first-run-check.ps1` | `./scripts/first-run-check.sh` |
+
+### WebKit differences
+
+The WebView engine varies by platform, which can surface subtle rendering and
+API differences:
+
+- **macOS (WKWebView):** uses the Safari rendering engine. Ensure Web Audio API
+  and `getUserMedia` behave as expected in Safari.
+- **Windows (WebView2 / Chromium-based):** closest to Chrome. Most modern Web
+  APIs work without polyfills.
+- **Linux (WebKitGTK):** an older Chromium-adjacent engine; some newer Web APIs
+  may be unavailable. Test voice input on real hardware.
+
+### llama.cpp binary
+
+The `runtimes/llama_cpp/download-runtime.sh` script downloads a pre-built
+`llama-server` binary for the current platform. On Windows, use WSL2 to run
+this script (the binary is the Linux x86_64 build) or build llama.cpp from
+source using MSVC:
+
+```powershell
+# Windows — build from source
+git clone https://github.com/ggml-org/llama.cpp
+cd llama.cpp
+cmake -B build
+cmake --build build --config Release
+```
+
+See [runtimes/llama_cpp/README.md](../runtimes/llama_cpp/README.md) for more
+details.

--- a/docs/release-notes-template.md
+++ b/docs/release-notes-template.md
@@ -1,0 +1,173 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- ─────────────────────────────────────────────────────────────────────────── -->
+<!-- RELEASE NOTES TEMPLATE                                                     -->
+<!-- Copy this file, replace each {{PLACEHOLDER}}, and delete these comments.  -->
+<!-- ─────────────────────────────────────────────────────────────────────────── -->
+
+# Conversation Simulator {{VERSION}} — Release Notes
+
+> **Alpha release** — This build is an early preview. Expect rough edges and
+> breaking changes between alpha versions. File bugs at
+> <https://github.com/outrightmental/ConversationSimulator/issues>.
+
+---
+
+## What's new in {{VERSION}}
+
+<!-- List the most important changes since the previous release. -->
+
+- {{CHANGE_1}}
+- {{CHANGE_2}}
+
+---
+
+## Download and verify
+
+Installers for this release:
+
+| Platform | File | SHA-256 |
+|---|---|---|
+| macOS (Apple Silicon) | `ConversationSimulator_{{VERSION}}_aarch64.dmg` | see `checksums-sha256.txt` |
+| macOS (Intel) | `ConversationSimulator_{{VERSION}}_x64.dmg` | see `checksums-sha256.txt` |
+| Linux (x86_64) | `conversation-simulator_{{VERSION}}_amd64.AppImage` | see `checksums-sha256.txt` |
+| Windows (x86_64) | `ConversationSimulator_{{VERSION}}_x64-setup.exe` | see `checksums-sha256.txt` |
+
+Verify before running:
+
+```bash
+# macOS / Linux
+shasum -a 256 <filename>
+```
+
+```powershell
+# Windows PowerShell
+Get-FileHash "<filename>" -Algorithm SHA256
+```
+
+Compare the output against `checksums-sha256.txt` attached to this release.
+
+---
+
+## System requirements
+
+| Requirement | Minimum | Recommended |
+|---|---|---|
+| OS | macOS 12, Ubuntu 22.04, Windows 10 (build 19041+) | Latest stable |
+| CPU | 64-bit x86 or Apple Silicon | Apple Silicon M1 or newer |
+| RAM | 8 GB | 16 GB |
+| Disk | 5 GB free | 20 GB free (headroom for multiple models) |
+| Microphone | Optional | Required for voice input |
+
+Run the pre-flight check before first launch:
+
+```bash
+./scripts/first-run-check.sh        # macOS / Linux
+.\scripts\first-run-check.ps1       # Windows PowerShell
+```
+
+---
+
+## Installation
+
+### macOS
+
+1. Download the `.dmg` for your chip (Apple Silicon = aarch64, Intel = x64).
+2. Open the `.dmg` and drag **Conversation Simulator** to `/Applications`.
+3. **First launch:** macOS Gatekeeper will warn that the app is from an
+   unidentified developer — this release is **not code-signed**. To open it:
+   - Right-click (or Control-click) the app icon → **Open** → **Open**.
+   - In System Settings → Privacy & Security → scroll down and click **Open Anyway**.
+
+### Windows
+
+1. Download `ConversationSimulator_{{VERSION}}_x64-setup.exe`.
+2. Run the installer. Windows Defender SmartScreen may warn about an
+   **unrecognised publisher** — click **More info → Run anyway**.
+3. Launch from the Start Menu.
+
+### Linux
+
+1. Download the `.AppImage` file.
+2. Make it executable: `chmod +x conversation-simulator_{{VERSION}}_amd64.AppImage`
+3. Run: `./conversation-simulator_{{VERSION}}_amd64.AppImage`
+
+---
+
+## Local model — not bundled
+
+No language model weights are included in the installer. On first launch, the
+app opens the **Model Manager**, which lists curated models with size, license,
+and hardware requirements. You must accept the model license before a download
+begins. The downloaded file is verified against its SHA-256 checksum before
+loading.
+
+**Why not bundled?** Model weights are large (2–15 GB), carry their own
+licenses (some restrict redistribution), and the right model depends on your
+hardware. Downloading on first run respects those licenses and keeps the
+installer small.
+
+---
+
+## Privacy and safety
+
+- **All inference runs locally.** No audio, text, or session data leaves your
+  computer during play. The app requires internet access only for the initial
+  model download and for optional pack updates.
+- **No telemetry.** The app does not phone home, collect crash reports, or send
+  usage statistics.
+- **Content filtering.** The simulator applies keyword pre-checks and output
+  validation before presenting NPC dialogue. See
+  [safety-policy.md](safety-policy.md) for details.
+- **Microphone permission.** The OS will prompt for microphone access on first
+  use of voice input. You can use the app in text-only mode without granting
+  this permission.
+- **Session data stays on your machine.** Session transcripts and debrief
+  reports are stored in `~/.convsim/` (macOS/Linux) or
+  `%USERPROFILE%\.convsim\` (Windows). You can delete this directory at any
+  time to remove all local data.
+
+---
+
+## Known limitations in this release
+
+- **Source install only for full functionality.** The packaged desktop app
+  wraps the web UI but does not yet bundle the backend server (`convsim-core`).
+  Backend-dependent features (Model Manager, Scenario Library, Conversation,
+  Debrief, Settings) require running `convsim-core` separately. See
+  [docs/install.md](install.md) for the developer install path.
+- **No auto-update.** Download new releases manually from the releases page.
+- **No code signing.** macOS and Windows will warn about unverified publishers
+  (see installation instructions above).
+- **Speech input / output** requires additional runtime downloads
+  (`./runtimes/whisper_cpp/download-runtime.sh` and
+  `./runtimes/kokoro/download-model.sh`). See [install.md](install.md).
+
+---
+
+## Source build
+
+To build from source on a clean checkout:
+
+```bash
+git clone https://github.com/outrightmental/ConversationSimulator
+cd ConversationSimulator
+./scripts/setup.sh            # install deps, create Python venv
+pnpm --filter @convsim/web build
+pnpm --filter @convsim/desktop build
+# installer appears in apps/desktop/src-tauri/target/release/bundle/
+```
+
+See [docs/install.md](install.md) and [docs/platform-notes.md](platform-notes.md)
+for full prerequisites and platform-specific notes.
+
+---
+
+## Reporting bugs
+
+Open an issue at <https://github.com/outrightmental/ConversationSimulator/issues>.
+Include:
+
+- OS and version
+- Output of `./scripts/first-run-check.sh` (or `first-run-check.ps1`)
+- Log files from `~/.convsim/logs/`
+- Steps to reproduce

--- a/docs/release-notes-template.md
+++ b/docs/release-notes-template.md
@@ -138,9 +138,9 @@ installer small.
 - **No auto-update.** Download new releases manually from the releases page.
 - **No code signing.** macOS and Windows will warn about unverified publishers
   (see installation instructions above).
-- **Speech input / output** requires additional runtime downloads
-  (`./runtimes/whisper_cpp/download-runtime.sh` and
-  `./runtimes/kokoro/download-model.sh`). See [install.md](install.md).
+- **Speech input / output** requires additional local runtimes. Speech-to-text
+  uses whisper.cpp (`./runtimes/whisper_cpp/download-runtime.sh`); text-to-speech
+  uses a local Kokoro server. See the runtime READMEs under `runtimes/` for setup.
 
 ---
 

--- a/scripts/first-run-check.ps1
+++ b/scripts/first-run-check.ps1
@@ -1,0 +1,241 @@
+# SPDX-License-Identifier: Apache-2.0
+# first-run-check.ps1 — Report system readiness for Conversation Simulator (Windows).
+#
+# Checks: OS version, CPU architecture, RAM, disk space, audio devices,
+#         and local port availability (7354-7358).
+#
+# Usage:   .\scripts\first-run-check.ps1
+# Exit 0:  all required checks passed (warnings may be present)
+# Exit 1:  one or more required checks failed
+
+$Errors   = 0
+$Warnings = 0
+
+function Status-Pass([string]$msg) { Write-Host "  PASS  $msg" -ForegroundColor Green }
+function Status-Warn([string]$msg) { Write-Host "  WARN  $msg" -ForegroundColor Yellow; $script:Warnings++ }
+function Status-Fail([string]$msg) { Write-Host "  FAIL  $msg" -ForegroundColor Red; $script:Errors++ }
+function Status-Info([string]$msg) { Write-Host "  INFO  $msg" }
+
+# ── OS and CPU architecture ───────────────────────────────────────────────────
+
+function Check-OsArch {
+    $os   = [System.Environment]::OSVersion
+    $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+
+    $winVer = $os.Version
+    if ($winVer.Major -lt 10) {
+        Status-Fail "OS: Windows $($winVer) — Windows 10 or newer required"
+    } else {
+        # Windows 10 build 19041 is 20H1 (minimum for WebView2 / Tauri).
+        $buildNum = $winVer.Build
+        if ($buildNum -lt 19041) {
+            Status-Warn "OS: Windows 10 build $buildNum — build 19041 (20H1) or newer recommended for WebView2"
+        } else {
+            Status-Pass "OS: Windows $($winVer.Major).$($winVer.Minor) build $buildNum"
+        }
+    }
+
+    switch ($arch) {
+        'X64'   { Status-Pass "CPU: 64-bit x86 ($arch)" }
+        'Arm64' { Status-Pass "CPU: 64-bit ARM ($arch)" }
+        default  { Status-Warn "CPU: $arch — may not have a pre-built binary; build from source if needed" }
+    }
+}
+
+# ── RAM ───────────────────────────────────────────────────────────────────────
+
+function Check-Ram {
+    try {
+        $mem = Get-CimInstance -ClassName Win32_PhysicalMemory -ErrorAction Stop |
+               Measure-Object -Property Capacity -Sum
+        $ramGb = [math]::Floor($mem.Sum / 1GB)
+        if ($ramGb -ge 16) {
+            Status-Pass "RAM: ${ramGb} GB (sufficient for standard-tier models)"
+        } elseif ($ramGb -ge 8) {
+            Status-Warn "RAM: ${ramGb} GB — minimum met; 16 GB recommended for smooth inference"
+        } else {
+            Status-Fail "RAM: ${ramGb} GB — 8 GB minimum required"
+        }
+    } catch {
+        Status-Warn "RAM: could not query physical memory — $_"
+    }
+}
+
+# ── Disk space ────────────────────────────────────────────────────────────────
+
+function Check-Disk {
+    $userProfile = $env:USERPROFILE
+    if (-not $userProfile) { $userProfile = "C:\" }
+
+    try {
+        $drive = Split-Path -Qualifier $userProfile
+        $disk  = Get-PSDrive -Name ($drive.TrimEnd(':')) -ErrorAction Stop
+        $freeGb = [math]::Floor($disk.Free / 1GB)
+        if ($freeGb -ge 20) {
+            Status-Pass "Disk: ${freeGb} GB free on $drive (model weights need up to 15 GB)"
+        } elseif ($freeGb -ge 5) {
+            Status-Warn "Disk: ${freeGb} GB free — 20 GB recommended; starter model needs ~3 GB"
+        } else {
+            Status-Fail "Disk: ${freeGb} GB free — at least 5 GB required for the starter model"
+        }
+    } catch {
+        Status-Warn "Disk: could not determine available space — $_"
+    }
+}
+
+# ── Audio devices — microphone and speaker ────────────────────────────────────
+
+function Check-Audio {
+    # Microphone
+    try {
+        $mics = Get-CimInstance -ClassName Win32_SoundDevice -ErrorAction Stop |
+                Where-Object { $_.StatusInfo -ne $null }
+        # Check for capture devices via WMI endpoint.
+        $micDevices = Get-PnpDevice -Class AudioEndpoint -ErrorAction SilentlyContinue |
+                      Where-Object { $_.FriendlyName -match 'Microphone|Headset|Line In|Capture' }
+        if ($micDevices) {
+            Status-Pass "Microphone: $($micDevices.Count) input device(s) detected"
+        } else {
+            Status-Warn "Microphone: no audio input device found — voice input requires a microphone"
+        }
+    } catch {
+        Status-Warn "Microphone: could not query audio devices — $_"
+    }
+
+    # Speaker / headphones
+    try {
+        $speakers = Get-PnpDevice -Class AudioEndpoint -ErrorAction SilentlyContinue |
+                    Where-Object { $_.FriendlyName -match 'Speaker|Headphone|Output|Playback' }
+        if ($speakers) {
+            Status-Pass "Speaker: $($speakers.Count) output device(s) detected"
+        } else {
+            Status-Warn "Speaker: no audio output device found — voice output requires speakers or headphones"
+        }
+    } catch {
+        Status-Warn "Speaker: could not query audio output devices — $_"
+    }
+}
+
+# ── WebView2 runtime ──────────────────────────────────────────────────────────
+# Tauri on Windows requires the WebView2 runtime (ships with Windows 11 and
+# Windows 10 20H2+; may need manual install on older builds).
+
+function Check-WebView2 {
+    $wv2Keys = @(
+        'HKLM:\SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}',
+        'HKCU:\SOFTWARE\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}'
+    )
+    $found = $false
+    foreach ($key in $wv2Keys) {
+        if (Test-Path $key) { $found = $true; break }
+    }
+    if ($found) {
+        Status-Pass "WebView2: runtime is installed (required by the desktop app)"
+    } else {
+        Status-Warn "WebView2: not detected — install from https://developer.microsoft.com/en-us/microsoft-edge/webview2/"
+    }
+}
+
+# ── Port availability ─────────────────────────────────────────────────────────
+
+function Check-Port([int]$Port, [string]$Label) {
+    $conn = Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction SilentlyContinue
+    if ($conn) {
+        $pid  = $conn.OwningProcess | Select-Object -First 1
+        $proc = Get-Process -Id $pid -ErrorAction SilentlyContinue
+        $name = if ($proc) { $proc.Name } else { 'unknown' }
+        Status-Warn "Port $Port ($Label): in use by PID $pid ($name) — stop it before starting services"
+    } else {
+        Status-Pass "Port $Port ($Label): free"
+    }
+}
+
+function Check-Ports {
+    Check-Port 7354 'convsim-ui'
+    Check-Port 7355 'convsim-core'
+    Check-Port 7356 'llm-runtime'
+    Check-Port 7357 'stt-runtime'
+    Check-Port 7358 'tts-runtime'
+}
+
+# ── Runtime health (developer path) ──────────────────────────────────────────
+
+function Check-Runtimes {
+    Status-Info "Runtime versions (developer path):"
+
+    # Python
+    $pythonCmd = Get-Command python -ErrorAction SilentlyContinue
+    if (-not $pythonCmd) {
+        $pythonCmd = Get-Command python3 -ErrorAction SilentlyContinue
+    }
+    if ($pythonCmd) {
+        $pyVer = & $pythonCmd.Source -c "import sys; print('%d.%d' % sys.version_info[:2])" 2>$null
+        $parts = ($pyVer -split '\.')
+        $pyMaj = [int]$parts[0]; $pyMin = [int]$parts[1]
+        if ($pyMaj -ge 3 -and $pyMin -ge 10) {
+            Status-Pass "Python $pyVer (convsim-core requires 3.10+)"
+        } else {
+            Status-Fail "Python $pyVer — 3.10+ required for convsim-core"
+        }
+    } else {
+        Status-Warn "Python: not found — required for the developer install path"
+    }
+
+    # Node.js
+    $nodeCmd = Get-Command node -ErrorAction SilentlyContinue
+    if ($nodeCmd) {
+        $nodeVer = (& node --version 2>$null) -replace '^v', ''
+        $nodeMaj = [int]($nodeVer -split '\.')[0]
+        if ($nodeMaj -ge 18) {
+            Status-Pass "Node.js $nodeVer (requires 18+)"
+        } else {
+            Status-Fail "Node.js $nodeVer — 18+ required"
+        }
+    } else {
+        Status-Warn "Node.js: not found — required for the developer install path"
+    }
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+Write-Host ""
+Write-Host "Conversation Simulator — first-run check"
+Write-Host "=========================================="
+Write-Host ""
+Write-Host "OS and CPU:"
+Check-OsArch
+Write-Host ""
+Write-Host "Memory:"
+Check-Ram
+Write-Host ""
+Write-Host "Disk space:"
+Check-Disk
+Write-Host ""
+Write-Host "Audio:"
+Check-Audio
+Write-Host ""
+Write-Host "WebView2 (desktop app):"
+Check-WebView2
+Write-Host ""
+Write-Host "Service ports:"
+Check-Ports
+Write-Host ""
+Check-Runtimes
+Write-Host ""
+Write-Host "────────────────────────────────────────────"
+if ($Errors -gt 0) {
+    Write-Host "FAIL  $Errors required check(s) failed — see FAIL lines above." -ForegroundColor Red
+    Write-Host ""
+    Write-Host "Fix the issues above, then run this script again."
+    Write-Host ""
+    exit 1
+} elseif ($Warnings -gt 0) {
+    Write-Host "WARN  All required checks passed. $Warnings warning(s) noted above." -ForegroundColor Yellow
+    Write-Host ""
+    Write-Host "The app will run, but some features may be degraded."
+    Write-Host "See docs\install.md for system requirements."
+    Write-Host ""
+} else {
+    Write-Host "PASS  All checks passed. System is ready to run Conversation Simulator." -ForegroundColor Green
+    Write-Host ""
+}

--- a/scripts/first-run-check.ps1
+++ b/scripts/first-run-check.ps1
@@ -88,9 +88,7 @@ function Check-Disk {
 function Check-Audio {
     # Microphone
     try {
-        $mics = Get-CimInstance -ClassName Win32_SoundDevice -ErrorAction Stop |
-                Where-Object { $_.StatusInfo -ne $null }
-        # Check for capture devices via WMI endpoint.
+        # Check for capture devices via the audio endpoint list.
         $micDevices = Get-PnpDevice -Class AudioEndpoint -ErrorAction SilentlyContinue |
                       Where-Object { $_.FriendlyName -match 'Microphone|Headset|Line In|Capture' }
         if ($micDevices) {

--- a/scripts/first-run-check.ps1
+++ b/scripts/first-run-check.ps1
@@ -141,10 +141,12 @@ function Check-WebView2 {
 function Check-Port([int]$Port, [string]$Label) {
     $conn = Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction SilentlyContinue
     if ($conn) {
-        $pid  = $conn.OwningProcess | Select-Object -First 1
-        $proc = Get-Process -Id $pid -ErrorAction SilentlyContinue
+        # NB: do not name this $pid — that is a read-only automatic variable
+        # in PowerShell, and assigning to it throws a terminating error.
+        $procId = $conn.OwningProcess | Select-Object -First 1
+        $proc = Get-Process -Id $procId -ErrorAction SilentlyContinue
         $name = if ($proc) { $proc.Name } else { 'unknown' }
-        Status-Warn "Port $Port ($Label): in use by PID $pid ($name) — stop it before starting services"
+        Status-Warn "Port $Port ($Label): in use by PID $procId ($name) — stop it before starting services"
     } else {
         Status-Pass "Port $Port ($Label): free"
     }

--- a/scripts/first-run-check.sh
+++ b/scripts/first-run-check.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# first-run-check.sh — Report system readiness for Conversation Simulator.
+#
+# Checks: OS version, CPU architecture, RAM, disk space, audio devices,
+#         and local port availability (7354-7358).
+#
+# Usage:   ./scripts/first-run-check.sh
+# Exit 0:  all required checks passed (warnings may be present)
+# Exit 1:  one or more required checks failed
+set -uo pipefail
+
+# ── Status helpers ────────────────────────────────────────────────────────────
+
+ERRORS=0
+WARNINGS=0
+
+status_pass() { printf "  PASS  %s\n" "$1"; }
+status_warn() { printf "  WARN  %s\n" "$1"; WARNINGS=$((WARNINGS + 1)); }
+status_fail() { printf "  FAIL  %s\n" "$1" >&2; ERRORS=$((ERRORS + 1)); }
+status_info() { printf "  INFO  %s\n" "$1"; }
+
+# ── OS and CPU architecture ───────────────────────────────────────────────────
+
+check_os_arch() {
+    local os arch
+    os="$(uname -s)"
+    arch="$(uname -m)"
+
+    case "$os" in
+        Darwin)
+            local ver
+            ver="$(sw_vers -productVersion 2>/dev/null || echo 'unknown')"
+            status_pass "OS: macOS $ver ($arch)"
+            # macOS 12 Monterey is the minimum supported version.
+            local major
+            major="$(echo "$ver" | cut -d. -f1)"
+            if [[ "$major" =~ ^[0-9]+$ ]] && [[ "$major" -lt 12 ]]; then
+                status_fail "macOS 12 Monterey or newer required (found $ver)"
+            fi
+            ;;
+        Linux)
+            local distro_name
+            distro_name="$(grep -oP '(?<=^PRETTY_NAME=").*(?=")' /etc/os-release 2>/dev/null || echo 'Linux')"
+            distro_name="${distro_name:-Linux}"
+            status_pass "OS: $distro_name ($arch)"
+            ;;
+        MINGW*|CYGWIN*|MSYS*)
+            status_warn "OS: Windows shell environment — run first-run-check.ps1 instead"
+            return
+            ;;
+        *)
+            status_fail "OS: $os — unsupported platform"
+            return
+            ;;
+    esac
+
+    case "$arch" in
+        x86_64|amd64)
+            status_pass "CPU: 64-bit x86 ($arch)"
+            ;;
+        arm64|aarch64)
+            status_pass "CPU: 64-bit ARM ($arch)"
+            ;;
+        *)
+            status_warn "CPU: $arch — may not have a pre-built llama-server binary; build from source if needed"
+            ;;
+    esac
+}
+
+# ── RAM ───────────────────────────────────────────────────────────────────────
+
+check_ram() {
+    local ram_gb=0
+    local os
+    os="$(uname -s)"
+
+    case "$os" in
+        Darwin)
+            local ram_bytes
+            ram_bytes="$(sysctl -n hw.memsize 2>/dev/null || echo 0)"
+            ram_bytes="${ram_bytes:-0}"
+            ram_gb=$(( ram_bytes / 1073741824 ))
+            ;;
+        Linux)
+            local ram_kb
+            ram_kb="$(awk '/MemTotal/ {print $2; exit}' /proc/meminfo 2>/dev/null || echo 0)"
+            ram_kb="${ram_kb:-0}"
+            ram_gb=$(( ram_kb / 1048576 ))
+            ;;
+    esac
+
+    if [[ "$ram_gb" -ge 16 ]]; then
+        status_pass "RAM: ${ram_gb} GB (sufficient for standard-tier models)"
+    elif [[ "$ram_gb" -ge 8 ]]; then
+        status_warn "RAM: ${ram_gb} GB — minimum met; 16 GB recommended for smooth inference"
+    elif [[ "$ram_gb" -gt 0 ]]; then
+        status_fail "RAM: ${ram_gb} GB — 8 GB minimum required"
+    else
+        status_warn "RAM: could not detect available memory"
+    fi
+}
+
+# ── Disk space ────────────────────────────────────────────────────────────────
+
+check_disk() {
+    local disk_avail_kb disk_avail_gb
+    disk_avail_kb="$(df -k "$HOME" 2>/dev/null | awk 'NR==2 {print $4; exit}' || echo 0)"
+    disk_avail_kb="${disk_avail_kb:-0}"
+    disk_avail_gb=$(( disk_avail_kb / 1048576 ))
+
+    if [[ "$disk_avail_gb" -ge 20 ]]; then
+        status_pass "Disk: ${disk_avail_gb} GB free in \$HOME (model weights need up to 15 GB)"
+    elif [[ "$disk_avail_gb" -ge 5 ]]; then
+        status_warn "Disk: ${disk_avail_gb} GB free — 20 GB recommended; starter model needs ~3 GB"
+    elif [[ "$disk_avail_gb" -gt 0 ]]; then
+        status_fail "Disk: ${disk_avail_gb} GB free — at least 5 GB required for the starter model"
+    else
+        status_warn "Disk: could not determine available space in \$HOME"
+    fi
+}
+
+# ── Audio devices — microphone and speaker ────────────────────────────────────
+
+check_audio_macos() {
+    local audio_info
+    audio_info="$(system_profiler SPAudioDataType 2>/dev/null || true)"
+
+    if echo "$audio_info" | grep -q "Input Channels"; then
+        status_pass "Microphone: audio input device detected"
+    else
+        status_warn "Microphone: no audio input device found — voice input requires a microphone"
+    fi
+
+    if echo "$audio_info" | grep -q "Output Channels"; then
+        status_pass "Speaker: audio output device detected"
+    else
+        status_warn "Speaker: no audio output device found — voice output requires speakers or headphones"
+    fi
+}
+
+check_audio_linux() {
+    # Microphone: look for ALSA capture (pcm *c*) entries.
+    if grep -q "c$" /proc/asound/pcm 2>/dev/null; then
+        status_pass "Microphone: ALSA capture device detected"
+    elif command -v arecord &>/dev/null && arecord -l 2>/dev/null | grep -q "card"; then
+        status_pass "Microphone: ALSA capture device detected"
+    else
+        status_warn "Microphone: could not detect audio input — voice input requires a microphone"
+    fi
+
+    # Speaker: look for ALSA playback (pcm *p*) entries.
+    if grep -q "p$" /proc/asound/pcm 2>/dev/null; then
+        status_pass "Speaker: ALSA playback device detected"
+    elif command -v aplay &>/dev/null && aplay -l 2>/dev/null | grep -q "card"; then
+        status_pass "Speaker: ALSA playback device detected"
+    else
+        status_warn "Speaker: could not detect audio output — voice output requires speakers or headphones"
+    fi
+}
+
+check_audio() {
+    local os
+    os="$(uname -s)"
+    case "$os" in
+        Darwin) check_audio_macos ;;
+        Linux)  check_audio_linux ;;
+        *)      status_info "Audio: skipped on $os" ;;
+    esac
+}
+
+# ── Port availability ─────────────────────────────────────────────────────────
+# Ports used by convsim services: 7354 (web UI), 7355 (core), 7356 (LLM),
+#   7357 (STT), 7358 (TTS).
+
+check_single_port() {
+    local port="$1"
+    local label="$2"
+
+    if command -v lsof &>/dev/null; then
+        if lsof -ti ":$port" >/dev/null 2>&1; then
+            local pid cmd
+            pid="$(lsof -ti ":$port" 2>/dev/null | head -1 || true)"
+            cmd="$(ps -p "$pid" -o comm= 2>/dev/null || echo 'unknown')"
+            status_warn "Port $port ($label): in use by PID $pid ($cmd) — stop it before starting services"
+            return
+        fi
+    elif command -v ss &>/dev/null; then
+        if ss -tlnp 2>/dev/null | grep -qE ":${port}[[:space:]]"; then
+            status_warn "Port $port ($label): in use — stop the blocking process before starting services"
+            return
+        fi
+    fi
+    status_pass "Port $port ($label): free"
+}
+
+check_ports() {
+    check_single_port 7354 "convsim-ui"
+    check_single_port 7355 "convsim-core"
+    check_single_port 7356 "llm-runtime"
+    check_single_port 7357 "stt-runtime"
+    check_single_port 7358 "tts-runtime"
+}
+
+# ── Runtime health (optional — developer path only) ───────────────────────────
+
+check_runtimes() {
+    status_info "Runtime versions (developer path):"
+
+    if command -v python3 &>/dev/null; then
+        local py_ver
+        py_ver="$(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])' 2>/dev/null || echo '?')"
+        local py_major py_minor
+        py_major="$(echo "$py_ver" | cut -d. -f1)"
+        py_minor="$(echo "$py_ver" | cut -d. -f2)"
+        if [[ "$py_major" -ge 3 ]] && [[ "$py_minor" -ge 10 ]] 2>/dev/null; then
+            status_pass "Python $py_ver (convsim-core requires 3.10+)"
+        else
+            status_fail "Python $py_ver — 3.10+ required for convsim-core"
+        fi
+    else
+        status_warn "Python: not found — required for the developer install path"
+    fi
+
+    if command -v node &>/dev/null; then
+        local node_ver node_major
+        node_ver="$(node --version 2>/dev/null | sed 's/^v//' || echo '?')"
+        node_major="$(echo "$node_ver" | cut -d. -f1)"
+        if [[ "$node_major" -ge 18 ]] 2>/dev/null; then
+            status_pass "Node.js $node_ver (requires 18+)"
+        else
+            status_fail "Node.js $node_ver — 18+ required"
+        fi
+    else
+        status_warn "Node.js: not found — required for the developer install path"
+    fi
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+echo ""
+echo "Conversation Simulator — first-run check"
+echo "=========================================="
+echo ""
+echo "OS and CPU:"
+check_os_arch
+echo ""
+echo "Memory:"
+check_ram
+echo ""
+echo "Disk space:"
+check_disk
+echo ""
+echo "Audio:"
+check_audio
+echo ""
+echo "Service ports:"
+check_ports
+echo ""
+check_runtimes
+echo ""
+echo "────────────────────────────────────────────"
+if [[ "$ERRORS" -gt 0 ]]; then
+    printf "FAIL  %d required check(s) failed — see FAIL lines above.\n" "$ERRORS" >&2
+    echo "" >&2
+    echo "Fix the issues above, then run this script again." >&2
+    echo ""
+    exit 1
+elif [[ "$WARNINGS" -gt 0 ]]; then
+    printf "WARN  All required checks passed. %d warning(s) noted above.\n" "$WARNINGS"
+    echo ""
+    echo "The app will run, but some features may be degraded."
+    echo "See docs/install.md for system requirements."
+    echo ""
+else
+    echo "PASS  All checks passed. System is ready to run Conversation Simulator."
+    echo ""
+fi

--- a/scripts/smoke-check.ps1
+++ b/scripts/smoke-check.ps1
@@ -105,6 +105,17 @@ Check-File "scripts\dev.ps1"
 Check-File "scripts\dev-desktop.sh"
 Check-File "scripts\dev-desktop.ps1"
 
+# First-run and release scripts
+Check-File "scripts\first-run-check.sh"
+Check-File "scripts\first-run-check.ps1"
+
+Write-Host ""
+
+# Release infrastructure
+Check-File ".github\workflows\release.yml"
+Check-File "docs\release-notes-template.md"
+Check-File "docs\platform-notes.md"
+
 Write-Host ""
 
 # Desktop Tauri wrapper

--- a/scripts/smoke-check.sh
+++ b/scripts/smoke-check.sh
@@ -103,6 +103,17 @@ check_file "scripts/dev.ps1"
 check_file "scripts/dev-desktop.sh"
 check_file "scripts/dev-desktop.ps1"
 
+# First-run and release scripts
+check_file "scripts/first-run-check.sh"
+check_file "scripts/first-run-check.ps1"
+
+echo ""
+
+# Release infrastructure
+check_file ".github/workflows/release.yml"
+check_file "docs/release-notes-template.md"
+check_file "docs/platform-notes.md"
+
 echo ""
 
 # Desktop Tauri wrapper


### PR DESCRIPTION
## Summary

Implements issue #78 — packaged alpha installer path and release infrastructure.

### What changed

**`.github/workflows/release.yml`** — New cross-platform release CI workflow triggered by `v*` tags or manual dispatch. Builds a Tauri desktop app on four runners (macOS aarch64, macOS x86_64, Linux x86_64, Windows x86_64), collects installers (`.dmg`, `.AppImage`, `.deb`, `.exe`, `.msi`), generates a `checksums-sha256.txt` manifest with bare filenames (matching published asset names), and creates a draft pre-release on GitHub. No model weights are included at any step.

**`scripts/first-run-check.sh` / `first-run-check.ps1`** — New platform-specific readiness scripts that check OS version, CPU architecture, RAM (≥8 GB required, ≥16 GB recommended), free disk space (≥20 GB recommended), microphone and speaker device detection, port availability for all five convsim services (7354–7358), and developer runtime versions (Python 3.10+, Node.js 18+). Exit 0 when all required checks pass; exit 1 on any required failure. Scripts pass `shellcheck` and are verified by the existing CI shellcheck job. The PowerShell variant uses read-only-safe locals and avoids dead queries.

**`docs/release-notes-template.md`** — Release notes template covering download verification, system requirements, macOS/Windows unsigned-build instructions (Gatekeeper / SmartScreen), privacy and safety caveats (local-only inference, no telemetry, microphone permission), known alpha limitations (no bundled sidecar yet, no code signing, no auto-update), backend startup requirements, and bug reporting instructions.

**`docs/platform-notes.md`** — Platform differences reference covering build prerequisites per OS, installer formats, code-signing and notarisation guidance, WebView engine differences, audio permission notes, llama.cpp binary notes for Windows, and a cross-platform summary table.

**`docs/install.md`** — Path A gains a first-run check step (step 0). Path B replaces the "future milestone" stub with complete alpha install instructions, including download/verify steps, platform-specific launch instructions, the backend startup caveat, and a link to `platform-notes.md`.

**`scripts/smoke-check.sh` / `smoke-check.ps1`** — Extended to verify all new files exist after a clean checkout (`first-run-check.sh`, `first-run-check.ps1`, `release.yml`, `release-notes-template.md`, `platform-notes.md`).

### Why

The alpha path previously had no automated way to build installers, no pre-flight system check, no documented Windows/macOS differences, and no release notes template. This change addresses all five acceptance criteria: a documented and automatable release path, no prohibited model weights in artifacts, actionable first-run checks, reproducible build scripts from a clean checkout, and release notes with safety and privacy caveats.

### Known limitation carried forward

The packaged desktop app does not yet bundle `convsim-core` (tracked separately as the sidecar milestone). The release notes template and install docs document this clearly: users must run the backend manually. The `dev.sh` / `dev.ps1` path remains fully functional as the primary alpha path.

### How it was tested

- `bash scripts/smoke-check.sh` passes with all new paths marked `OK`.
- `shellcheck scripts/first-run-check.sh scripts/smoke-check.sh` exits 0.
- `./scripts/first-run-check.sh` runs on macOS and reports PASS/WARN per check.
- Release workflow YAML is valid and follows the same patterns as the existing `ci.yml`.

Closes #78