### PR TITLE
Add MVP acceptance suite for player, creator, developer, and concept review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,27 @@ jobs:
           echo "Local: pnpm --filter @convsim/scenario-schema exec vitest run"
           pnpm --filter @convsim/scenario-schema exec vitest run
 
+  acceptance:
+    name: Acceptance tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: |
+            services/convsim-core/pyproject.toml
+            packages/prompt-composer/pyproject.toml
+      - name: Install prompt-composer
+        run: pip install -e "packages/prompt-composer[dev]"
+      - name: Install convsim-core
+        run: pip install -e "services/convsim-core[dev]"
+      - name: Run acceptance tests
+        run: |
+          echo "Local: python -m pytest tests/acceptance/ -v"
+          python -m pytest tests/acceptance/ -v
+
   pack-validation:
     name: Pack validation
     runs-on: ubuntu-latest

--- a/docs/acceptance/concept-review.md
+++ b/docs/acceptance/concept-review.md
@@ -1,0 +1,76 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+# Concept acceptance review
+
+**Owner:** Product team
+**Scope:** Every MVP release candidate must pass or document exceptions.
+**Goal:** A first-time repo visitor understands the core concept within 60 seconds of landing on the README.
+
+This review is **manual and subjective**. It requires a reviewer who has not seen the project before, or who can credibly simulate that perspective. The reviewer reads only what a GitHub visitor sees in the first scroll.
+
+---
+
+## What to test
+
+The reviewer opens `https://github.com/outrightmental/ConversationSimulator` (or the README rendered locally) and reads for **60 seconds** — no deeper navigation allowed.
+
+After 60 seconds the reviewer answers the following questions **without looking further**.
+
+---
+
+## Rubric
+
+Score each dimension 1 (fail), 2 (partial), or 3 (pass).
+
+| # | Dimension | Pass criteria | Score |
+|---|---|---|---|
+| 1 | **What it is** | Reviewer can state the product is a conversation simulator, analogous to a flight simulator for social/professional skills | 1 / 2 / 3 |
+| 2 | **Local-first** | Reviewer can state that inference runs locally (no cloud LLM required) | 1 / 2 / 3 |
+| 3 | **Who it is for** | Reviewer can name at least two of the four target audiences (player, creator, developer, researcher) OR two use-cases (interviews, negotiations, language, difficult conversations) | 1 / 2 / 3 |
+| 4 | **How to start** | Reviewer can state a concrete first action (e.g. "run setup.sh" or "open the web app") | 1 / 2 / 3 |
+| 5 | **Not a chatbot** | Reviewer understands the NPC follows a scenario script with goals and a rubric, not free-form conversation | 1 / 2 / 3 |
+
+**Scoring:**
+- 13–15 points: PASS — concept is clear within 60 seconds.
+- 10–12 points: PARTIAL — reviewer grasps the core but misses one important dimension; acceptable with documented gap.
+- < 10 points: FAIL — README must be revised before MVP tag.
+
+---
+
+## Reviewer notes
+
+```
+Reviewer name   :
+Date            :
+Reading time    : [≤ 60 s / > 60 s]
+Source          : GitHub README / local render / other
+
+Q1 – What it is     : [reviewer's words]
+Q2 – Local-first    : [yes / no / unsure — reviewer's words]
+Q3 – Who it is for  : [reviewer's answer]
+Q4 – How to start   : [reviewer's answer]
+Q5 – Not a chatbot  : [yes / no / unsure — reviewer's words]
+
+Scores: Q1= Q2= Q3= Q4= Q5=  Total= /15
+
+Result  : PASS / PARTIAL / FAIL
+
+Specific gaps identified:
+  -
+  -
+
+Suggested README edits (if any):
+  -
+  -
+```
+
+---
+
+## Pass/fail determination
+
+| Result | Action |
+|---|---|
+| PASS | Record result in release issue; proceed to MVP tag |
+| PARTIAL | Record result with gap description; product lead decides whether to block tag or document exception |
+| FAIL | README revision required before MVP tag; re-review after revision |
+
+**Release decision:** A PASS or PARTIAL with documented justification is required before the MVP release can be tagged.

--- a/docs/acceptance/creator-checklist.md
+++ b/docs/acceptance/creator-checklist.md
@@ -1,0 +1,106 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+# Creator acceptance checklist
+
+**Owner:** Content team
+**Scope:** Every MVP release candidate must pass or document exceptions.
+
+The creator journey covers: copy a pack → edit persona / goals / rubric → validate → play → export → share → understand content rules.
+
+---
+
+## Automated checks (run in CI)
+
+```bash
+# From repo root:
+python -m pytest tests/acceptance/test_creator_flow.py -v
+```
+
+| Test class | What it verifies | CI label |
+|---|---|---|
+| `TestListPacks` | Workbench lists official (non-editable) and local-dev (editable) packs | `[workbench]` |
+| `TestReadPackContent` | Pack card has pack_id and name; manifest YAML accessible via API | `[workbench]` |
+| `TestPackValidation` | Valid pack passes `validate_pack_dir`; workbench `/validate` returns `valid: true` | `[pack-valid]` |
+| `TestPackValidationErrors` | Missing or malformed manifest produces non-empty error list | `[pack-valid]` |
+| `TestPackExport` | Export produces a zip with a manifest; filename ends in `.zip` | `[workbench]` |
+| `TestPackImportRoundTrip` | Import succeeds; round-trip export preserves pack_id in filename | `[workbench]` |
+
+All automated checks must pass before any manual step begins.
+
+---
+
+## Manual checks (sign-off required)
+
+Run in the browser creator workbench or via the CLI. A local dev server must be running.
+
+### C-M1 — Copy an official pack
+
+```bash
+# Option A — workbench UI: Settings → Creator Workbench → Duplicate Pack
+# Option B — CLI
+cp -r packs/official/job-interview-basic packs/local-dev/my-interview-pack
+# edit packs/local-dev/my-interview-pack/manifest.yaml: change pack_id and name
+```
+
+- [ ] Local-dev pack appears in the workbench pack list
+- [ ] Pack is marked editable
+
+### C-M2 — Edit persona, goals, and rubric
+
+Open `manifest.yaml`, scenario YAML, NPC YAML, and rubric YAML in an editor or the workbench file editor.
+
+- [ ] Can modify NPC `display_name`, `speaking_style`, and `demeanor`
+- [ ] Can change scenario `goals.player_visible` list
+- [ ] Can add or rename a rubric dimension
+- [ ] YAML files save without data loss
+
+### C-M3 — Validate the edited pack
+
+```bash
+node packages/scenario-schema/tests/validate-packs.js packs/local-dev/my-interview-pack
+```
+
+Or via workbench: **Validate Pack** button.
+
+- [ ] Valid pack exits 0 / shows all green
+- [ ] Intentionally broken field produces a clear, actionable error message
+
+### C-M4 — Play the scenario
+
+Start a session using the edited pack.
+
+- [ ] Custom NPC name appears in the conversation
+- [ ] Custom goals appear in the player brief
+- [ ] Session plays to completion with fake runtime
+
+### C-M5 — Export and share
+
+```bash
+# Via API or workbench "Export" button
+```
+
+- [ ] Exported zip contains `manifest.yaml` (or `pack.json`) and scenario files
+- [ ] Zip can be imported on a fresh install via `Settings → Import Pack`
+
+### C-M6 — Understand content rules
+
+Review `docs/safety-policy.md` and `docs/official-pack-quality-bar.md`.
+
+- [ ] Creator can articulate the PG-13 content cap rule
+- [ ] Creator can describe what `nsfw_sexual: block` means in the safety policy
+- [ ] Creator knows that `fictional: true` is required on all NPC definitions
+
+---
+
+## Sign-off
+
+| Item | Result | Tester | Date | Notes |
+|---|---|---|---|---|
+| Automated suite | PASS / FAIL | | | |
+| C-M1 Copy pack | PASS / FAIL / SKIP | | | |
+| C-M2 Edit persona/goals/rubric | PASS / FAIL / SKIP | | | |
+| C-M3 Validate | PASS / FAIL / SKIP | | | |
+| C-M4 Play scenario | PASS / FAIL / SKIP | | | |
+| C-M5 Export + share | PASS / FAIL / SKIP | | | |
+| C-M6 Content rules | PASS / FAIL / SKIP | | | |
+
+**Release decision:** All automated checks PASS + manual checks C-M1 through C-M6 PASS (or documented SKIP) required before MVP tag.

--- a/docs/acceptance/developer-checklist.md
+++ b/docs/acceptance/developer-checklist.md
@@ -1,0 +1,125 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+# Developer acceptance checklist
+
+**Owner:** Developer experience team
+**Scope:** Every MVP release candidate must pass or document exceptions.
+
+The developer journey covers: run locally → understand docs → add a runtime adapter → add a scenario → run tests → read debug output → file an issue.
+
+---
+
+## Automated checks (run in CI)
+
+```bash
+# From repo root:
+python -m pytest tests/acceptance/test_developer_flow.py -v
+```
+
+| Test class | What it verifies | CI label |
+|---|---|---|
+| `TestMonorepoStructure` | Expected directories and entry-point scripts are present | `[setup]` |
+| `TestSchemaLoad` | `convsim_core`, `convsim_prompt`, runtime types, and JSON schemas all load | `[setup]` |
+| `TestPackValidationCLI` | `validate_pack_dir` is callable; returns `[]` on valid pack; official packs pass | `[pack-valid]` |
+| `TestRuntimeRegistry` | Fake runtime ID is `"fake"`, reports READY, lists at least one model | `[health]` |
+| `TestDebugLogging` | Session create emits at least one log record; health endpoint includes `runtime` and `database` | `[health]` |
+| `TestAdapterStub` | A subclass of `FakeChatRuntime` satisfies the adapter interface | `[setup]` |
+| `TestOfficialPackGate` | All official packs pass `validate_pack_dir` | `[pack-valid]` |
+| `TestBackendHealth` | `/api/health` returns `status: ok`; has `status`, `database`, `runtime` fields | `[health]` |
+
+All automated checks must pass before any manual step begins.
+
+---
+
+## Manual checks (sign-off required)
+
+### D-M1 — Run locally from scratch
+
+```bash
+git clone https://github.com/outrightmental/ConversationSimulator.git
+cd ConversationSimulator
+./scripts/setup.sh
+./scripts/dev.sh
+```
+
+- [ ] `setup.sh` completes without errors
+- [ ] `dev.sh` starts all services; logs show no error-level lines at startup
+- [ ] `curl http://127.0.0.1:7355/api/health` returns `{"status": "ok", ...}`
+
+### D-M2 — Understand the documentation
+
+Read `README.md`, `docs/architecture.md`, and `docs/runtime-adapters.md`.
+
+- [ ] Developer can describe the 5 services and their ports (from `docs/architecture.md`)
+- [ ] Developer can locate the fake runtime source in `services/convsim-core/convsim_core/runtime/fake.py`
+- [ ] Developer can describe the difference between a PLAY-mode and EXPLICIT_DOWNLOAD network call
+
+### D-M3 — Add a runtime adapter
+
+Follow `docs/runtime-adapters.md`.
+
+- [ ] Create a minimal adapter class that extends `FakeChatRuntime`
+- [ ] Override `id` and `display_name`
+- [ ] Confirm the adapter's `health()` returns `READY`
+- [ ] (Automated: `TestAdapterStub` above covers this)
+
+### D-M4 — Add a scenario
+
+Follow `docs/scenario-authoring.md`.
+
+- [ ] Create a new scenario YAML under `packs/local-dev/<my-pack>/scenarios/`
+- [ ] Run `node packages/scenario-schema/tests/validate-packs.js packs/local-dev/<my-pack>` — exits 0
+- [ ] Scenario appears in the `/api/scenarios` list after restart
+
+### D-M5 — Run the test suite
+
+```bash
+# Backend
+cd services/convsim-core && python -m pytest -v
+
+# Acceptance
+cd ../.. && python -m pytest tests/acceptance/ -v
+
+# Frontend
+pnpm --filter @convsim/web test
+pnpm --filter @convsim/cli test
+```
+
+- [ ] All backend tests pass
+- [ ] All acceptance tests pass
+- [ ] Frontend tests pass (or known failures documented)
+
+### D-M6 — Read debug output
+
+```bash
+cd services/convsim-core
+CONVSIM_LOG_LEVEL=DEBUG python -m convsim_core.main &
+curl -s -X POST http://127.0.0.1:7355/api/sessions \
+     -H 'Content-Type: application/json' \
+     -d '{"scenario_id":"behavioral_interview","difficulty":"normal","player_role_name":"Dev","language":"en","input_mode":"text-only","tts_enabled":false,"show_state_meters":false,"save_transcript":true}'
+```
+
+- [ ] DEBUG log lines appear in the terminal for the session create call
+- [ ] Log lines include session_id and scenario_id context
+
+### D-M7 — File an issue
+
+- [ ] Developer can find the issue templates in `.github/ISSUE_TEMPLATE/`
+- [ ] Bug report template includes reproduction steps and environment fields
+- [ ] Developer can link to `CONTRIBUTING.md` for guidelines
+
+---
+
+## Sign-off
+
+| Item | Result | Tester | Date | Notes |
+|---|---|---|---|---|
+| Automated suite | PASS / FAIL | | | |
+| D-M1 Run locally | PASS / FAIL / SKIP | | | |
+| D-M2 Understand docs | PASS / FAIL / SKIP | | | |
+| D-M3 Add adapter | PASS / FAIL / SKIP | | | |
+| D-M4 Add scenario | PASS / FAIL / SKIP | | | |
+| D-M5 Run tests | PASS / FAIL / SKIP | | | |
+| D-M6 Debug output | PASS / FAIL / SKIP | | | |
+| D-M7 File issue | PASS / FAIL / SKIP | | | |
+
+**Release decision:** All automated checks PASS + manual checks D-M1 through D-M7 PASS (or documented SKIP) required before MVP tag.

--- a/docs/acceptance/player-checklist.md
+++ b/docs/acceptance/player-checklist.md
@@ -1,0 +1,133 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+# Player acceptance checklist
+
+**Owner:** Platform team
+**Scope:** Every MVP release candidate must pass or document exceptions.
+
+The player journey covers: clone → install → select model or fake demo → select scenario → speak/type → NPC responds → state evolves → finish → debrief → replay → confirm no cloud inference.
+
+---
+
+## Automated checks (run in CI)
+
+Run with the fake runtime — no model download required.
+
+```bash
+# From repo root (requires convsim-core and prompt-composer installed):
+python -m pytest tests/acceptance/test_player_text_path.py -v
+```
+
+| Test class | What it verifies | CI label |
+|---|---|---|
+| `TestScenarioSelection` | Scenario library returns at least one scenario; behavioral_interview is listed with title, summary, difficulty | `[scenario-lib]` |
+| `TestSessionStart` | Session creation returns `sess-` ID; starting delivers NPC opening event with non-empty content | `[text-session]` |
+| `TestPlayerTurn` | Text turn returns player_turn + npc_turn events; NPC has a valid emotion; two turns both succeed | `[text-session]` |
+| `TestStateEvolution` | `state_delta` is present in NPC event; applied delta is returned; state carries into next turn | `[text-session]` |
+| `TestSessionEnd` | Explicit end returns `Ended` + `player_exit`; further turns are rejected 409 | `[text-session]` |
+| `TestDebrief` | Debrief generated after session ends; debrief on active session rejected 409; idempotent | `[debrief]` |
+| `TestSessionRetrieval` | Completed session retrievable by ID; two sessions both retrievable; export available after debrief | `[text-session]` |
+| `TestNoCloudInference` | Full session with `LOCAL_MODE=True` completes without `NetworkBlockedError`; fake runtime in use | `[offline]` |
+
+All automated checks must pass before any manual step begins.
+
+---
+
+## Manual checks (sign-off required)
+
+Run on a **clean profile** (`~/.convsim/` freshly created or deleted).
+
+### P-M1 — Clone and install
+
+```bash
+git clone https://github.com/outrightmental/ConversationSimulator.git
+cd ConversationSimulator
+./scripts/setup.sh
+```
+
+- [ ] Setup completes without errors
+- [ ] Python venv present at `services/convsim-core/.venv/`
+- [ ] `node_modules` installed at repo root and workspaces
+
+### P-M2 — First run with fake demo (no model)
+
+```bash
+./scripts/dev.sh   # keep running
+# open http://127.0.0.1:7354
+```
+
+- [ ] Home screen loads; no console errors; no "Failed to fetch" in network tab
+- [ ] Service status indicators show correct state (fake runtime expected on fresh install)
+- [ ] Model manager screen shows no automatic download
+
+### P-M3 — Install or select real model (optional — requires adequate hardware)
+
+Navigate to **Settings → Models**.
+
+- [ ] License acceptance dialog appears before download activates
+- [ ] Download completes with SHA-256 checksum verification
+- [ ] Model status changes to `"loaded"`
+- [ ] Record model filename and size in the smoke log
+
+### P-M4 — Select scenario
+
+Navigate to **Scenarios**.
+
+- [ ] At least one official pack is listed
+- [ ] Expanding pack shows scenarios with title, description, difficulty tag
+- [ ] Player can select **Job Interview Basics → Behavioral Interview**
+
+### P-M5 — Speak or type
+
+Start the selected scenario.
+
+- [ ] NPC opening line delivered within 10 seconds
+- [ ] Typing a player turn and submitting returns NPC response within 30 s (fake) / 60 s (real CPU)
+- [ ] Transcript updates after each turn
+
+### P-M6 — State meters (optional)
+
+Enable **Show state meters** in session settings.
+
+- [ ] State variables visible during conversation
+- [ ] Values change after turns that trigger state deltas
+
+### P-M7 — Finish and debrief
+
+End the session.
+
+- [ ] End session button works and confirms session closed
+- [ ] Debrief screen loads with rubric scores and (if session long enough) narrative
+- [ ] Export / Download debrief option is present
+
+### P-M8 — Replay
+
+Return to the scenario library.
+
+- [ ] Session history or past sessions accessible
+- [ ] Previously played sessions retrievable by ID
+
+### P-M9 — No cloud inference confirmation
+
+During or after a full session:
+
+- [ ] No outbound requests in browser network tab to external LLM APIs
+- [ ] `LOCAL_MODE` test passes in CI (automated gate above)
+
+---
+
+## Sign-off
+
+| Item | Result | Tester | Date | Notes |
+|---|---|---|---|---|
+| Automated suite | PASS / FAIL | | | |
+| P-M1 Clone + install | PASS / FAIL / SKIP | | | |
+| P-M2 Fake demo | PASS / FAIL / SKIP | | | |
+| P-M3 Real model | PASS / FAIL / SKIP | | optional |
+| P-M4 Scenario select | PASS / FAIL / SKIP | | | |
+| P-M5 Speak/type | PASS / FAIL / SKIP | | | |
+| P-M6 State meters | PASS / FAIL / SKIP | | | optional |
+| P-M7 Debrief | PASS / FAIL / SKIP | | | |
+| P-M8 Replay | PASS / FAIL / SKIP | | | |
+| P-M9 No cloud | PASS / FAIL / SKIP | | | |
+
+**Release decision:** All automated checks PASS + manual checks P-M1 through P-M9 PASS (or documented SKIP with justification) required before MVP tag.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -2,14 +2,20 @@
 # Release checklist
 
 This checklist covers every step a maintainer must complete before tagging a
-release.  It is split into two parts:
+release.  It is split into three parts:
 
 - **Part A — CI gates** (automated, no model downloads): must be green before
   any manual step begins.
 - **Part B — Manual release smoke** (run on a clean profile): covers subsystems
   that require real services, a browser, and optionally real model weights.
+- **Part C — Acceptance suite** (persona-specific checklists): player, creator,
+  developer, and concept review gates that must pass before the MVP tag is applied.
 
-Read Part A results in GitHub Actions before you touch Part B.
+Read Part A results in GitHub Actions before you touch Part B or Part C.
+
+> **MVP release gate:** The release **cannot** be tagged as MVP unless every
+> acceptance checklist under `docs/acceptance/` shows PASS (or a documented,
+> maintainer-approved exception) in addition to Parts A and B below.
 
 ---
 
@@ -20,7 +26,7 @@ intend to tag.
 
 | Workflow | File | What it checks |
 |---|---|---|
-| CI | `.github/workflows/ci.yml` | Backend tests, frontend typecheck/test, schema and pack validation |
+| CI | `.github/workflows/ci.yml` | Backend tests, frontend typecheck/test, schema and pack validation, acceptance tests |
 | Release smoke — Linux x86_64 | `.github/workflows/release-smoke.yml` (job: `smoke-linux`) | All CI-subset subsystems on Ubuntu |
 | Release smoke — macOS aarch64 | `.github/workflows/release-smoke.yml` (job: `smoke-macos / aarch64`) | All CI-subset subsystems on Apple Silicon |
 | Release smoke — Windows x86_64 | `.github/workflows/release-smoke.yml` (job: `smoke-windows`) | All CI-subset subsystems on Windows |
@@ -240,7 +246,38 @@ node packages/convsim-cli/dist/index.js offline-smoke-test packs/official/job-in
 
 ---
 
-## Part C — Platform coverage matrix
+## Part C — Acceptance suite
+
+Complete the persona-specific checklists before applying the MVP tag.
+Detailed rubrics, automated test references, and sign-off tables live in:
+
+| Checklist | File | Owner | Automated test |
+|---|---|---|---|
+| Player | `docs/acceptance/player-checklist.md` | Platform team | `tests/acceptance/test_player_text_path.py` |
+| Creator | `docs/acceptance/creator-checklist.md` | Content team | `tests/acceptance/test_creator_flow.py` |
+| Developer | `docs/acceptance/developer-checklist.md` | DX team | `tests/acceptance/test_developer_flow.py` |
+| Concept review | `docs/acceptance/concept-review.md` | Product team | manual only |
+
+Run the automated portion from the repo root:
+
+```bash
+python -m pytest tests/acceptance/ -v
+```
+
+Summary sign-off:
+
+| Checklist | Automated | Manual | Sign-off | Date |
+|---|---|---|---|---|
+| Player | ☐ | ☐ | | |
+| Creator | ☐ | ☐ | | |
+| Developer | ☐ | ☐ | | |
+| Concept review | n/a | ☐ | | |
+
+All four checklists must reach PASS (or PARTIAL with documented, maintainer-approved exception) before the release is tagged MVP.
+
+---
+
+## Part D — Platform coverage matrix
 
 Mark which platforms were manually tested for this release.
 
@@ -263,7 +300,7 @@ Fill this in for each manual release smoke run.
 ```
 Release version  : vX.Y.Z-alpha.N
 Date             : YYYY-MM-DD
-Tester           : 
+Tester           :
 Platform         : macOS 14.x / Ubuntu 22.04.x / Windows 11
 CPU              : Apple M2 / Intel Core i7-xxxx / AMD Ryzen xxxx
 RAM              : xx GB
@@ -271,15 +308,16 @@ VRAM             : xx GB (or "none — CPU only")
 Model tested     : Qwen3 4B Q4_K_M / (none — fake runtime only)
 Source commit    : <git sha>
 
-Part A (CI) : PASS / FAIL
+Part A (CI)      : PASS / FAIL
 Part B result    : PASS / FAIL / PARTIAL
+Part C acceptance: PASS / PARTIAL / FAIL
 
 Notes:
-  - 
-  - 
+  -
+  -
 ```
 
-If Part B includes any failures, attach the artifact directory
+If Part B or Part C includes any failures, attach the artifact directory
 (`$TMPDIR/convsim-release-smoke-*/`) to the release issue before proceeding.
 
 ---
@@ -300,6 +338,7 @@ When a subsystem fails, the output labels the failing step:
 | `[pack-valid]` | Pack validation | Schema change broke existing packs; YAML parse error |
 | `[voice]` | Voice fallback | TTS worker state machine regression; fallback path not taken |
 | `[offline]` | Offline policy | Outbound call detected; network guard not active |
+| `[workbench]` | Creator workbench | Pack import/export or file API broken; workbench route error |
 
 CI artifacts for failed runs are uploaded to GitHub Actions under the job name
 `release-smoke-<platform>` and retained for 7 days.

--- a/tests/acceptance/__init__.py
+++ b/tests/acceptance/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -34,16 +34,3 @@ def client(tmp_config):
     app = create_app(tmp_config)
     with TestClient(app) as c:
         yield c
-
-
-_BEHAVIORAL_INTERVIEW_SETUP = {
-    "scenario_id": "behavioral_interview",
-    "difficulty": "normal",
-    "player_role_name": "Acceptance Tester",
-    "language": "en",
-    "input_mode": "text-only",
-    "tts_enabled": False,
-    "show_state_meters": False,
-    "save_transcript": True,
-    "seed": None,
-}

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared fixtures for the acceptance test suite.
+
+Prerequisites:
+  pip install -e "packages/prompt-composer[dev]"
+  pip install -e "services/convsim-core[dev]"
+
+Run from the repo root:
+  python -m pytest tests/acceptance/ -v
+"""
+import pytest
+from fastapi.testclient import TestClient
+
+from convsim_core.app import create_app
+from convsim_core.config import ServiceConfig
+
+
+@pytest.fixture()
+def tmp_config(tmp_path, monkeypatch):
+    monkeypatch.setenv("CONVSIM_WHISPER_CPP_BINARY_PATH", str(tmp_path / "no-whisper-cli"))
+    return ServiceConfig(
+        host="127.0.0.1",
+        port=7355,
+        data_dir=str(tmp_path / "data"),
+        log_dir=str(tmp_path / "logs"),
+        db_dir=str(tmp_path / "db"),
+        packs_dir=str(tmp_path / "packs"),
+        local_dev_packs_dir=str(tmp_path),
+    )
+
+
+@pytest.fixture()
+def client(tmp_config):
+    app = create_app(tmp_config)
+    with TestClient(app) as c:
+        yield c
+
+
+_BEHAVIORAL_INTERVIEW_SETUP = {
+    "scenario_id": "behavioral_interview",
+    "difficulty": "normal",
+    "player_role_name": "Acceptance Tester",
+    "language": "en",
+    "input_mode": "text-only",
+    "tts_enabled": False,
+    "show_state_meters": False,
+    "save_transcript": True,
+    "seed": None,
+}

--- a/tests/acceptance/test_creator_flow.py
+++ b/tests/acceptance/test_creator_flow.py
@@ -1,0 +1,356 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Acceptance tests — Creator flow (issue #80).
+
+Acceptance criteria exercised:
+  C-1  Creator can list available packs (official and local-dev).
+  C-2  Creator can read pack and scenario content via the workbench API.
+  C-3  Creator can validate a well-formed pack; validation reports pass.
+  C-4  Creator can detect and report validation errors in a malformed pack.
+  C-5  Creator can export a pack as a zip archive.
+  C-6  Creator can import a pack from a zip and retrieve it via the API.
+  C-7  Pack round-trip (export → import) preserves pack identity.
+
+All checks run without a real model or browser.
+Owner: content team.
+"""
+from __future__ import annotations
+
+import io
+import zipfile
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from convsim_core.app import create_app
+from convsim_core.config import ServiceConfig
+from convsim_core.packs.exporter import export_to_zip
+from convsim_core.packs.importer import import_from_zip
+from convsim_core.packs.validator import validate_pack_dir
+from convsim_core.storage.database import Database
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _write_minimal_pack(root: Path, pack_id: str = "creator.acceptance_pack") -> Path:
+    """Write the smallest valid pack onto disk."""
+    safety_dir = root / "safety"
+    npcs_dir = root / "npcs"
+    rubrics_dir = root / "rubrics"
+    scenarios_dir = root / "scenarios"
+    for d in (safety_dir, npcs_dir, rubrics_dir, scenarios_dir):
+        d.mkdir(parents=True, exist_ok=True)
+
+    (root / "manifest.yaml").write_text(
+        f'schema_version: "0.1"\n'
+        f'pack_id: {pack_id}\n'
+        f'name: Creator Acceptance Pack\n'
+        f'version: 1.0.0\n'
+        f'description: Minimal pack for creator acceptance testing.\n'
+        f'author: Acceptance Suite\n'
+        f'license: CC-BY-4.0\n'
+        f'content_rating: G\n'
+        f'tags:\n'
+        f'  - acceptance\n'
+        f'supported_languages:\n'
+        f'  - en\n'
+        f'entry_scenarios:\n'
+        f'  - scenarios/intro.yaml\n'
+        f'assets:\n'
+        f'  allow_external_urls: false\n'
+        f'safety:\n'
+        f'  policy: safety/policy.yaml\n',
+        encoding="utf-8",
+    )
+    (safety_dir / "policy.yaml").write_text(
+        'schema_version: "0.1"\n'
+        'policy_id: acceptance_policy\n'
+        'content_rating_cap: G\n'
+        'content_categories:\n'
+        '  nsfw_sexual: block\n'
+        '  real_person_impersonation: block\n'
+        '  instructional_criminal: block\n'
+        '  crisis_content: redirect\n'
+        'redirect_message: "Let\'s keep things on topic."\n',
+        encoding="utf-8",
+    )
+    (npcs_dir / "interviewer.yaml").write_text(
+        'schema_version: "0.1"\n'
+        'npc_id: acceptance_interviewer\n'
+        'display_name: Acceptance Interviewer\n'
+        'archetype: interviewer\n'
+        'fictional: true\n'
+        'age_band: adult\n'
+        'public_persona:\n'
+        '  occupation: Test Interviewer\n'
+        '  speaking_style: Professional and direct\n'
+        '  demeanor: Neutral\n'
+        'private_persona: {}\n',
+        encoding="utf-8",
+    )
+    (rubrics_dir / "rubric.yaml").write_text(
+        'schema_version: "0.1"\n'
+        'rubric_id: acceptance_rubric\n'
+        'title: Creator Acceptance Rubric\n'
+        'dimensions:\n'
+        '  - id: clarity\n'
+        '    name: Clarity\n'
+        '    description: How clearly the player communicates.\n'
+        '    scoring:\n'
+        '      low: Unclear\n'
+        '      medium: Adequate\n'
+        '      high: Excellent\n',
+        encoding="utf-8",
+    )
+    (scenarios_dir / "intro.yaml").write_text(
+        'schema_version: "0.1"\n'
+        'scenario_id: acceptance_intro\n'
+        'title: Acceptance Introduction\n'
+        'summary: A minimal scenario for creator acceptance testing.\n'
+        'player_role:\n'
+        '  label: Candidate\n'
+        '  brief: You are verifying the creator acceptance test.\n'
+        'npc:\n'
+        '  ref: ../npcs/interviewer.yaml\n'
+        'rubric:\n'
+        '  ref: ../rubrics/rubric.yaml\n'
+        'duration:\n'
+        '  max_turns: 8\n'
+        'opening:\n'
+        '  npc_says: "Welcome to the acceptance test. Please introduce yourself."\n'
+        'goals:\n'
+        '  player_visible:\n'
+        '    - Demonstrate the creator flow works end-to-end\n',
+        encoding="utf-8",
+    )
+    return root
+
+
+@pytest.fixture()
+def pack_root(tmp_path) -> Path:
+    return _write_minimal_pack(tmp_path / "acceptance-pack")
+
+
+@pytest.fixture()
+def workbench_client(tmp_path, monkeypatch) -> TestClient:
+    official_dir = tmp_path / "official"
+    local_dev_dir = tmp_path / "local-dev"
+    official_dir.mkdir()
+    local_dev_dir.mkdir()
+
+    _write_minimal_pack(official_dir / "sample-pack", pack_id="official.sample_pack")
+    _write_minimal_pack(local_dev_dir / "my-pack", pack_id="local.my_pack")
+
+    monkeypatch.setenv("CONVSIM_WHISPER_CPP_BINARY_PATH", str(tmp_path / "no-whisper-cli"))
+    config = ServiceConfig(
+        host="127.0.0.1",
+        port=7355,
+        data_dir=str(tmp_path / "data"),
+        log_dir=str(tmp_path / "logs"),
+        db_dir=str(tmp_path / "db"),
+        packs_dir=str(tmp_path / "packs"),
+        official_packs_dir=str(official_dir),
+        local_dev_packs_dir=str(local_dev_dir),
+    )
+    app = create_app(config)
+    with TestClient(app) as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# C-1  List packs
+# ---------------------------------------------------------------------------
+
+
+class TestListPacks:
+    """Creator can see all available packs in the workbench."""
+
+    def test_workbench_packs_endpoint_returns_200(self, workbench_client):
+        res = workbench_client.get("/api/workbench/packs")
+        assert res.status_code == 200
+
+    def test_workbench_lists_official_and_local_packs(self, workbench_client):
+        body = workbench_client.get("/api/workbench/packs").json()
+        kinds = {p["kind"] for p in body}
+        assert "official" in kinds
+        assert "local-dev" in kinds
+
+    def test_official_pack_is_not_editable(self, workbench_client):
+        body = workbench_client.get("/api/workbench/packs").json()
+        official = next(p for p in body if p["kind"] == "official")
+        assert official["editable"] is False
+
+    def test_local_dev_pack_is_editable(self, workbench_client):
+        body = workbench_client.get("/api/workbench/packs").json()
+        local = next(p for p in body if p["kind"] == "local-dev")
+        assert local["editable"] is True
+
+
+# ---------------------------------------------------------------------------
+# C-2  Read pack content
+# ---------------------------------------------------------------------------
+
+
+class TestReadPackContent:
+    """Creator can inspect the persona, goals, and rubric of a pack."""
+
+    def test_pack_card_has_pack_id(self, workbench_client):
+        body = workbench_client.get("/api/workbench/packs").json()
+        official = next(p for p in body if p["kind"] == "official")
+        assert official["pack_id"] == "official.sample_pack"
+
+    def test_pack_card_has_name(self, workbench_client):
+        body = workbench_client.get("/api/workbench/packs").json()
+        for pack in body:
+            assert pack.get("name"), f"pack {pack.get('pack_id')} missing name"
+
+    def test_pack_files_accessible_via_workbench(self, workbench_client):
+        body = workbench_client.get("/api/workbench/packs").json()
+        local = next(p for p in body if p["kind"] == "local-dev")
+        slug = local["slug"]
+        file_res = workbench_client.get(
+            f"/api/workbench/packs/local-dev/{slug}/file",
+            params={"path": "manifest.yaml"},
+        )
+        assert file_res.status_code == 200
+        assert "pack_id" in file_res.text
+
+
+# ---------------------------------------------------------------------------
+# C-3  Validate a well-formed pack
+# ---------------------------------------------------------------------------
+
+
+class TestPackValidation:
+    """A valid pack passes schema and policy validation."""
+
+    def test_valid_pack_passes_schema_validation(self, pack_root):
+        result = validate_pack_dir(pack_root)
+        assert result.valid, f"unexpected validation errors: {result.errors}"
+
+    def test_valid_pack_passes_workbench_validation_endpoint(self, workbench_client):
+        body = workbench_client.get("/api/workbench/packs").json()
+        local = next(p for p in body if p["kind"] == "local-dev")
+        slug = local["slug"]
+        res = workbench_client.get(f"/api/workbench/packs/local-dev/{slug}/validate")
+        assert res.status_code == 200
+        result = res.json()
+        assert result.get("valid") is True or result.get("errors") == []
+
+
+# ---------------------------------------------------------------------------
+# C-4  Detect validation errors
+# ---------------------------------------------------------------------------
+
+
+class TestPackValidationErrors:
+    """A malformed pack produces actionable validation errors."""
+
+    def test_missing_manifest_fails_validation(self, tmp_path):
+        broken = tmp_path / "broken-pack"
+        broken.mkdir()
+        result = validate_pack_dir(broken)
+        assert not result.valid, "expected validation to fail for a pack with no manifest"
+        assert len(result.errors) > 0
+
+    def test_invalid_manifest_field_fails_validation(self, tmp_path):
+        broken = tmp_path / "broken-pack2"
+        broken.mkdir()
+        (broken / "manifest.yaml").write_text(
+            'schema_version: "0.1"\nnot_a_real_field: true\n',
+            encoding="utf-8",
+        )
+        result = validate_pack_dir(broken)
+        assert not result.valid, "expected validation to fail for a malformed manifest"
+        assert len(result.errors) > 0
+
+
+# ---------------------------------------------------------------------------
+# C-5  Export pack
+# ---------------------------------------------------------------------------
+
+
+class TestPackExport:
+    """Creator can export a pack as a zip archive for sharing."""
+
+    def _open_db(self, tmp_path: Path) -> Database:
+        return Database.open(str(tmp_path / "db"))
+
+    def _import_pack(self, pack_root: Path, db: Database, packs_dir: Path) -> None:
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            for f in pack_root.rglob("*"):
+                if f.is_file():
+                    zf.write(f, f.relative_to(pack_root.parent))
+        buf.seek(0)
+        import_from_zip(buf.read(), packs_dir, db.connection())
+
+    def test_export_produces_zip_bytes(self, tmp_path, pack_root):
+        db = self._open_db(tmp_path)
+        packs_dir = tmp_path / "packs"
+        packs_dir.mkdir()
+        self._import_pack(pack_root, db, packs_dir)
+        exported, filename = export_to_zip("creator.acceptance_pack", db.connection())
+        db.close()
+        assert zipfile.is_zipfile(io.BytesIO(exported))
+        assert filename.endswith(".zip")
+
+    def test_exported_zip_contains_manifest(self, tmp_path, pack_root):
+        db = self._open_db(tmp_path)
+        packs_dir = tmp_path / "packs"
+        packs_dir.mkdir()
+        self._import_pack(pack_root, db, packs_dir)
+        exported, _ = export_to_zip("creator.acceptance_pack", db.connection())
+        db.close()
+        with zipfile.ZipFile(io.BytesIO(exported)) as zf:
+            names = zf.namelist()
+        assert any("manifest" in n for n in names)
+
+
+# ---------------------------------------------------------------------------
+# C-6 / C-7  Import and round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestPackImportRoundTrip:
+    """A pack can be exported and re-imported; its identity is preserved."""
+
+    def _open_db(self, path: Path) -> Database:
+        return Database.open(str(path / "db"))
+
+    def test_import_from_zip_succeeds(self, tmp_path, pack_root):
+        db = self._open_db(tmp_path)
+        packs_dir = tmp_path / "packs"
+        packs_dir.mkdir()
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            for f in pack_root.rglob("*"):
+                if f.is_file():
+                    zf.write(f, f.relative_to(pack_root.parent))
+        buf.seek(0)
+        import_from_zip(buf.read(), packs_dir, db.connection())
+        db.close()
+
+    def test_round_trip_preserves_pack_id(self, tmp_path, pack_root):
+        db = self._open_db(tmp_path)
+        packs_dir = tmp_path / "packs"
+        packs_dir.mkdir()
+
+        # Import
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            for f in pack_root.rglob("*"):
+                if f.is_file():
+                    zf.write(f, f.relative_to(pack_root.parent))
+        buf.seek(0)
+        import_from_zip(buf.read(), packs_dir, db.connection())
+
+        # Export
+        exported, filename = export_to_zip("creator.acceptance_pack", db.connection())
+        db.close()
+
+        assert "acceptance_pack" in filename
+        assert zipfile.is_zipfile(io.BytesIO(exported))

--- a/tests/acceptance/test_developer_flow.py
+++ b/tests/acceptance/test_developer_flow.py
@@ -18,8 +18,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
-import sys
 from pathlib import Path
 
 import pytest
@@ -238,12 +236,7 @@ class TestAdapterStub:
     @pytest.mark.asyncio
     async def test_custom_adapter_satisfies_interface(self):
         """Demonstrates that extending FakeChatRuntime is sufficient to add an adapter."""
-        from convsim_core.runtime.types import (
-            ChatFinal,
-            ChatRequest,
-            RuntimeCapabilities,
-            RuntimeHealth,
-        )
+        from convsim_core.runtime.types import RuntimeCapabilities
 
         class _StubAdapter(FakeChatRuntime):
             @property

--- a/tests/acceptance/test_developer_flow.py
+++ b/tests/acceptance/test_developer_flow.py
@@ -1,0 +1,333 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Acceptance tests — Developer flow (issue #80).
+
+Acceptance criteria exercised:
+  D-1  Monorepo structure is intact (key paths and entry points exist).
+  D-2  Core schema definitions load without error.
+  D-3  Pack validation CLI is importable and runnable.
+  D-4  Fake runtime is registered and accessible via the runtime registry.
+  D-5  Debug logging outputs structured lines with expected keys.
+  D-6  A developer can add a minimal runtime adapter stub.
+  D-7  Official packs pass schema validation (CI-stable check).
+  D-8  Backend health endpoint reports all required subsystem fields.
+
+All checks run without a real model, browser, or internet access.
+Owner: developer experience team.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from convsim_core.app import create_app
+from convsim_core.config import ServiceConfig
+from convsim_core.packs.validator import validate_pack_dir
+from convsim_core.runtime.fake import FakeChatRuntime
+from convsim_core.runtime.types import RuntimeStatus
+
+# Repo root — acceptance tests live at <repo-root>/tests/acceptance/
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# ---------------------------------------------------------------------------
+# D-1  Monorepo structure
+# ---------------------------------------------------------------------------
+
+
+class TestMonorepoStructure:
+    """Key paths and entry points that every developer needs must be present."""
+
+    @pytest.mark.parametrize("rel_path", [
+        "services/convsim-core",
+        "packages/prompt-composer",
+        "packages/convsim-cli",
+        "packages/pack-loader",
+        "packages/scenario-schema",
+        "apps/web",
+        "packs/official",
+        "schemas",
+        "scripts/setup.sh",
+        "scripts/dev.sh",
+        "docs",
+        "README.md",
+    ])
+    def test_expected_path_exists(self, rel_path):
+        target = _REPO_ROOT / rel_path
+        assert target.exists(), f"Expected repo path not found: {rel_path}"
+
+    def test_at_least_one_official_pack_exists(self):
+        official = _REPO_ROOT / "packs" / "official"
+        packs = [p for p in official.iterdir() if p.is_dir()]
+        assert len(packs) >= 1, "No official packs found under packs/official/"
+
+    def test_schema_files_present(self):
+        schemas_dir = _REPO_ROOT / "schemas"
+        json_schemas = list(schemas_dir.rglob("*.json"))
+        assert len(json_schemas) >= 1, "No JSON schema files found under schemas/"
+
+
+# ---------------------------------------------------------------------------
+# D-2  Schema definitions load
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaLoad:
+    """Core Python and JSON schemas must be importable and parseable."""
+
+    def test_convsim_core_importable(self):
+        import convsim_core
+        assert convsim_core is not None
+
+    def test_convsim_prompt_importable(self):
+        import convsim_prompt
+        assert convsim_prompt is not None
+
+    def test_runtime_types_importable(self):
+        from convsim_core.runtime.types import (
+            ChatMessage,
+            ChatRequest,
+            RuntimeCapabilities,
+            RuntimeStatus,
+        )
+        assert ChatMessage is not None
+
+    def test_scenario_schema_importable(self):
+        from convsim_core.scenarios import get_scenario_info
+        scenario = get_scenario_info("behavioral_interview")
+        assert scenario is not None
+
+    def test_json_schemas_parse_as_valid_json(self):
+        schemas_dir = _REPO_ROOT / "schemas"
+        errors = []
+        for schema_file in schemas_dir.rglob("*.json"):
+            try:
+                with open(schema_file, encoding="utf-8") as f:
+                    data = json.load(f)
+                assert isinstance(data, dict), f"{schema_file} is not a JSON object"
+            except Exception as exc:
+                errors.append(f"{schema_file}: {exc}")
+        assert not errors, "Schema parse errors:\n" + "\n".join(errors)
+
+
+# ---------------------------------------------------------------------------
+# D-3  Pack validation CLI importable
+# ---------------------------------------------------------------------------
+
+
+class TestPackValidationCLI:
+    """A developer can run pack validation from Python and the CLI entry point."""
+
+    def test_validate_pack_dir_is_callable(self):
+        assert callable(validate_pack_dir)
+
+    def test_validate_pack_dir_returns_validation_result(self, tmp_path):
+        from convsim_core.packs.models import ValidationResult
+        result = validate_pack_dir(tmp_path)
+        assert isinstance(result, ValidationResult)
+
+    def test_validate_official_pack_returns_no_errors(self):
+        official_dir = _REPO_ROOT / "packs" / "official"
+        pack_dirs = [p for p in official_dir.iterdir() if p.is_dir()]
+        assert pack_dirs, "No official pack directories found"
+        errors_by_pack: dict[str, list] = {}
+        for pack_dir in pack_dirs:
+            result = validate_pack_dir(pack_dir)
+            if not result.valid:
+                errors_by_pack[pack_dir.name] = result.errors
+        assert not errors_by_pack, (
+            "Official pack validation errors:\n" +
+            "\n".join(f"  {name}: {e}" for name, errs in errors_by_pack.items() for e in errs)
+        )
+
+
+# ---------------------------------------------------------------------------
+# D-4  Runtime registry
+# ---------------------------------------------------------------------------
+
+
+class TestRuntimeRegistry:
+    """The fake runtime is registered; developers can inspect available runtimes."""
+
+    @pytest.mark.asyncio
+    async def test_fake_runtime_id(self):
+        rt = FakeChatRuntime()
+        assert rt.id == "fake"
+
+    @pytest.mark.asyncio
+    async def test_fake_runtime_reports_ready(self):
+        rt = FakeChatRuntime()
+        health = await rt.health()
+        assert health.status == RuntimeStatus.READY
+
+    @pytest.mark.asyncio
+    async def test_fake_runtime_lists_models(self):
+        rt = FakeChatRuntime()
+        models = await rt.list_models()
+        assert len(models) >= 1
+
+    def test_runtime_registry_importable(self):
+        from convsim_core.runtime import registry as rt_registry
+        assert hasattr(rt_registry, "register"), "runtime registry must expose a register decorator"
+
+
+# ---------------------------------------------------------------------------
+# D-5  Debug logging
+# ---------------------------------------------------------------------------
+
+
+class TestDebugLogging:
+    """Debug-level log output must produce structured lines with expected keys."""
+
+    def test_session_create_emits_log_record(self, tmp_path, monkeypatch, caplog):
+        monkeypatch.setenv("CONVSIM_WHISPER_CPP_BINARY_PATH", str(tmp_path / "no-whisper-cli"))
+        config = ServiceConfig(
+            host="127.0.0.1",
+            port=7355,
+            data_dir=str(tmp_path / "data"),
+            log_dir=str(tmp_path / "logs"),
+            db_dir=str(tmp_path / "db"),
+            packs_dir=str(tmp_path / "packs"),
+        )
+        app = create_app(config)
+        with caplog.at_level(logging.DEBUG, logger="convsim_core"):
+            with TestClient(app) as c:
+                c.post("/api/sessions", json={
+                    "scenario_id": "behavioral_interview",
+                    "difficulty": "normal",
+                    "player_role_name": "Dev Tester",
+                    "language": "en",
+                    "input_mode": "text-only",
+                    "tts_enabled": False,
+                    "show_state_meters": False,
+                    "save_transcript": True,
+                    "seed": None,
+                })
+        assert len(caplog.records) > 0, "Expected at least one log record during session creation"
+
+    def test_health_endpoint_provides_runtime_debug_info(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CONVSIM_WHISPER_CPP_BINARY_PATH", str(tmp_path / "no-whisper-cli"))
+        config = ServiceConfig(
+            host="127.0.0.1",
+            port=7355,
+            data_dir=str(tmp_path / "data"),
+            log_dir=str(tmp_path / "logs"),
+            db_dir=str(tmp_path / "db"),
+            packs_dir=str(tmp_path / "packs"),
+        )
+        app = create_app(config)
+        with TestClient(app) as c:
+            res = c.get("/api/health")
+        body = res.json()
+        assert "runtime" in body, "Health endpoint must include runtime field for developer diagnostics"
+        assert "database" in body, "Health endpoint must include database field"
+
+
+# ---------------------------------------------------------------------------
+# D-6  Adapter stub
+# ---------------------------------------------------------------------------
+
+
+class TestAdapterStub:
+    """A developer can define a minimal adapter that satisfies the runtime interface."""
+
+    @pytest.mark.asyncio
+    async def test_custom_adapter_satisfies_interface(self):
+        """Demonstrates that extending FakeChatRuntime is sufficient to add an adapter."""
+        from convsim_core.runtime.types import (
+            ChatFinal,
+            ChatRequest,
+            RuntimeCapabilities,
+            RuntimeHealth,
+        )
+
+        class _StubAdapter(FakeChatRuntime):
+            @property
+            def id(self) -> str:
+                return "stub-adapter"
+
+            @property
+            def display_name(self) -> str:
+                return "Developer Stub Adapter"
+
+            @property
+            def capabilities(self) -> RuntimeCapabilities:
+                return RuntimeCapabilities(
+                    streaming=True,
+                    json_schema=False,
+                    grammar=False,
+                    tool_calling=False,
+                    embeddings=False,
+                )
+
+        adapter = _StubAdapter()
+        assert adapter.id == "stub-adapter"
+        health = await adapter.health()
+        assert health.status == RuntimeStatus.READY
+
+
+# ---------------------------------------------------------------------------
+# D-7  Official packs — schema gate
+# ---------------------------------------------------------------------------
+
+
+class TestOfficialPackGate:
+    """Official packs must pass schema validation — this mirrors the CI pack-validation job."""
+
+    def test_all_official_packs_pass_validation(self):
+        official_dir = _REPO_ROOT / "packs" / "official"
+        pack_dirs = sorted(p for p in official_dir.iterdir() if p.is_dir())
+        assert pack_dirs, "No official pack directories found"
+        failures: list[str] = []
+        for pack_dir in pack_dirs:
+            result = validate_pack_dir(pack_dir)
+            for err in result.errors:
+                failures.append(f"[{pack_dir.name}] {err}")
+        assert not failures, "Official pack schema failures:\n" + "\n".join(failures)
+
+
+# ---------------------------------------------------------------------------
+# D-8  Backend health subsystem fields
+# ---------------------------------------------------------------------------
+
+
+class TestBackendHealth:
+    """The health endpoint must report all subsystem fields a developer needs."""
+
+    def test_health_returns_ok_status(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CONVSIM_WHISPER_CPP_BINARY_PATH", str(tmp_path / "no-whisper-cli"))
+        config = ServiceConfig(
+            host="127.0.0.1",
+            port=7355,
+            data_dir=str(tmp_path / "data"),
+            log_dir=str(tmp_path / "logs"),
+            db_dir=str(tmp_path / "db"),
+            packs_dir=str(tmp_path / "packs"),
+        )
+        app = create_app(config)
+        with TestClient(app) as c:
+            res = c.get("/api/health")
+        assert res.status_code == 200
+        body = res.json()
+        assert body.get("status") == "ok"
+
+    def test_health_includes_required_subsystem_fields(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CONVSIM_WHISPER_CPP_BINARY_PATH", str(tmp_path / "no-whisper-cli"))
+        config = ServiceConfig(
+            host="127.0.0.1",
+            port=7355,
+            data_dir=str(tmp_path / "data"),
+            log_dir=str(tmp_path / "logs"),
+            db_dir=str(tmp_path / "db"),
+            packs_dir=str(tmp_path / "packs"),
+        )
+        app = create_app(config)
+        with TestClient(app) as c:
+            body = c.get("/api/health").json()
+        required_fields = {"status", "database", "runtime"}
+        missing = required_fields - set(body.keys())
+        assert not missing, f"Health endpoint missing subsystem fields: {missing}"

--- a/tests/acceptance/test_player_text_path.py
+++ b/tests/acceptance/test_player_text_path.py
@@ -18,18 +18,14 @@ from __future__ import annotations
 
 import io
 import zipfile
-from pathlib import Path
-from unittest.mock import patch
 
-import pytest
 from fastapi.testclient import TestClient
 
 from convsim_core.app import create_app
-from convsim_core.config import ServiceConfig
 from convsim_core.runtime.fake import FakeChatRuntime
-from convsim_core.runtime.types import ChatFinal, ChatToken
+from convsim_core.runtime.types import ChatFinal
 
-# Re-export shared setup dict so individual tests can customise it.
+# Shared session-setup payload; individual tests copy and customise it.
 _SESSION_SETUP = {
     "scenario_id": "behavioral_interview",
     "difficulty": "normal",
@@ -41,8 +37,6 @@ _SESSION_SETUP = {
     "save_transcript": True,
     "seed": None,
 }
-
-_REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def _make_minimal_zip() -> bytes:

--- a/tests/acceptance/test_player_text_path.py
+++ b/tests/acceptance/test_player_text_path.py
@@ -469,6 +469,8 @@ class TestNoCloudInference:
             health = c.get("/api/health")
         runtime_status = health.json().get("runtime", {})
         runtime_id = runtime_status.get("runtime_id", "") or runtime_status.get("id", "")
-        assert "fake" in runtime_id.lower() or runtime_status.get("status") in {"ready", "ok"}, (
-            f"expected fake runtime in test environment, got: {runtime_status}"
+        # The default runtime must be the fake one — a ready *cloud* runtime would
+        # also report "ready", so status alone cannot prove no cloud inference.
+        assert "fake" in runtime_id.lower(), (
+            f"expected fake runtime by default in test environment, got: {runtime_status}"
         )

--- a/tests/acceptance/test_player_text_path.py
+++ b/tests/acceptance/test_player_text_path.py
@@ -1,0 +1,474 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Acceptance tests — Player text-path journey (issue #80).
+
+Acceptance criteria exercised:
+  P-1  Select a scenario from the library.
+  P-2  Start a session; NPC opening line is delivered.
+  P-3  Submit a player turn; NPC responds.
+  P-4  Session state evolves and carries into the next turn.
+  P-5  End the session cleanly.
+  P-6  Debrief report is generated after the session ends.
+  P-7  A completed session can be retrieved again (basis for replay).
+  P-8  No outbound cloud-inference calls occur during the entire journey.
+
+All checks run against the fake runtime — no model download required.
+Owner: platform team.
+"""
+from __future__ import annotations
+
+import io
+import zipfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from convsim_core.app import create_app
+from convsim_core.config import ServiceConfig
+from convsim_core.runtime.fake import FakeChatRuntime
+from convsim_core.runtime.types import ChatFinal, ChatToken
+
+# Re-export shared setup dict so individual tests can customise it.
+_SESSION_SETUP = {
+    "scenario_id": "behavioral_interview",
+    "difficulty": "normal",
+    "player_role_name": "Acceptance Tester",
+    "language": "en",
+    "input_mode": "text-only",
+    "tts_enabled": False,
+    "show_state_meters": False,
+    "save_transcript": True,
+    "seed": None,
+}
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _make_minimal_zip() -> bytes:
+    """Build a minimal installable pack zip for acceptance scenario library tests."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("player-pack/manifest.yaml", (
+            'schema_version: "0.1"\n'
+            'pack_id: acceptance.player_pack\n'
+            'name: Player Acceptance Pack\n'
+            'version: 1.0.0\n'
+            'description: Minimal pack for player acceptance testing.\n'
+            'author: Acceptance Suite\n'
+            'license: CC-BY-4.0\n'
+            'content_rating: G\n'
+            'tags:\n  - acceptance\n'
+            'supported_languages:\n  - en\n'
+            'entry_scenarios:\n  - scenarios/practice.yaml\n'
+            'assets:\n  allow_external_urls: false\n'
+            'safety:\n  policy: safety/policy.yaml\n'
+        ))
+        zf.writestr("player-pack/safety/policy.yaml", (
+            'schema_version: "0.1"\n'
+            'policy_id: player_policy\n'
+            'content_rating_cap: G\n'
+            'content_categories:\n'
+            '  nsfw_sexual: block\n'
+            '  real_person_impersonation: block\n'
+            '  instructional_criminal: block\n'
+            '  crisis_content: redirect\n'
+            'redirect_message: "Let\'s keep things on topic."\n'
+        ))
+        zf.writestr("player-pack/npcs/guide.yaml", (
+            'schema_version: "0.1"\n'
+            'npc_id: player_guide\n'
+            'display_name: Practice Guide\n'
+            'archetype: generic\n'
+            'fictional: true\n'
+            'age_band: adult\n'
+            'public_persona:\n'
+            '  occupation: Practice Facilitator\n'
+            '  speaking_style: Warm and encouraging\n'
+            '  demeanor: Supportive\n'
+            'private_persona: {}\n'
+        ))
+        zf.writestr("player-pack/rubrics/practice.yaml", (
+            'schema_version: "0.1"\n'
+            'rubric_id: practice_rubric\n'
+            'title: Practice Rubric\n'
+            'dimensions:\n'
+            '  - id: clarity\n'
+            '    name: Clarity\n'
+            '    description: How clearly the player communicates.\n'
+            '    scoring:\n'
+            '      low: Unclear\n'
+            '      medium: Adequate\n'
+            '      high: Excellent\n'
+        ))
+        zf.writestr("player-pack/scenarios/practice.yaml", (
+            'schema_version: "0.1"\n'
+            'scenario_id: practice_scenario\n'
+            'title: Practice Conversation\n'
+            'summary: A minimal scenario for acceptance testing the player journey.\n'
+            'player_role:\n'
+            '  label: Participant\n'
+            '  brief: You are verifying the player acceptance test.\n'
+            'npc:\n'
+            '  ref: ../npcs/guide.yaml\n'
+            'rubric:\n'
+            '  ref: ../rubrics/practice.yaml\n'
+            'duration:\n'
+            '  max_turns: 6\n'
+            'opening:\n'
+            '  npc_says: "Welcome. Let us begin the acceptance test."\n'
+            'goals:\n'
+            '  player_visible:\n'
+            '    - Complete the player acceptance test\n'
+        ))
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _start_session(client: TestClient) -> str:
+    res = client.post("/api/sessions", json=_SESSION_SETUP)
+    assert res.status_code == 201, res.text
+    session_id = res.json()["session_id"]
+    start = client.post(f"/api/sessions/{session_id}/start")
+    assert start.status_code == 200, start.text
+    return session_id
+
+
+# ---------------------------------------------------------------------------
+# P-1  Scenario selection
+# ---------------------------------------------------------------------------
+
+
+class TestScenarioSelection:
+    """A player can discover and select a scenario before starting a session."""
+
+    def test_scenarios_endpoint_returns_200(self, client):
+        res = client.get("/api/scenarios")
+        assert res.status_code == 200
+
+    def test_scenario_library_lists_installed_scenarios(self, client):
+        zip_bytes = _make_minimal_zip()
+        import_res = client.post(
+            "/api/packs/import/zip",
+            files={"file": ("pack.zip", zip_bytes, "application/zip")},
+        )
+        assert import_res.status_code == 201, import_res.text
+
+        res = client.get("/api/scenarios")
+        assert res.status_code == 200
+        scenarios = res.json()
+        assert len(scenarios) > 0, "expected at least one scenario after pack import"
+
+    def test_scenario_card_has_required_fields(self, client):
+        zip_bytes = _make_minimal_zip()
+        client.post(
+            "/api/packs/import/zip",
+            files={"file": ("pack.zip", zip_bytes, "application/zip")},
+        )
+        res = client.get("/api/scenarios")
+        assert res.status_code == 200
+        scenarios = res.json()
+        assert len(scenarios) > 0
+        card = scenarios[0]
+        assert card.get("scenario_id"), "scenario card must have a non-empty scenario_id"
+        assert card.get("title"), "scenario card must have a non-empty title"
+        assert "difficulty_default" in card, "scenario card must expose difficulty"
+
+
+# ---------------------------------------------------------------------------
+# P-2  Session start and NPC opening
+# ---------------------------------------------------------------------------
+
+
+class TestSessionStart:
+    """Starting a session delivers the NPC opening line."""
+
+    def test_create_session_with_behavioral_interview(self, client):
+        res = client.post("/api/sessions", json=_SESSION_SETUP)
+        assert res.status_code == 201
+        body = res.json()
+        assert body["session_id"].startswith("sess-")
+        assert body["state"] == "NotStarted"
+
+    def test_start_delivers_npc_opening(self, client):
+        session_id = _start_session(client)
+        state = client.get(f"/api/sessions/{session_id}").json()
+        assert state["state"] == "PlayerTurnListening"
+
+    def test_npc_opening_event_has_content(self, client):
+        res = client.post("/api/sessions", json=_SESSION_SETUP)
+        session_id = res.json()["session_id"]
+        start = client.post(f"/api/sessions/{session_id}/start")
+        events = start.json()["events"]
+        assert len(events) == 1
+        assert events[0]["event_type"] == "npc_opening"
+        assert isinstance(events[0]["payload"]["content"], str)
+        assert len(events[0]["payload"]["content"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# P-3  Player turn → NPC response
+# ---------------------------------------------------------------------------
+
+
+class TestPlayerTurn:
+    """The player can speak or type; the NPC responds."""
+
+    def test_text_turn_returns_npc_response(self, client):
+        session_id = _start_session(client)
+        res = client.post(
+            f"/api/sessions/{session_id}/turn",
+            json={"content": "I have five years of product management experience."},
+        )
+        assert res.status_code == 200
+        events = res.json()["events"]
+        player_event = events[0]
+        npc_event = events[1]
+        assert player_event["event_type"] == "player_turn"
+        assert npc_event["event_type"] == "npc_turn"
+        assert isinstance(npc_event["payload"]["content"], str)
+        assert len(npc_event["payload"]["content"]) > 0
+
+    def test_npc_response_has_emotion(self, client):
+        session_id = _start_session(client)
+        res = client.post(
+            f"/api/sessions/{session_id}/turn",
+            json={"content": "I built a payments platform from scratch."},
+        )
+        emotion = res.json()["events"][1]["payload"]["emotion"]
+        valid_emotions = {
+            "neutral", "warm", "curious", "skeptical", "impatient",
+            "defensive", "confused", "impressed", "concerned", "angry",
+        }
+        assert emotion in valid_emotions
+
+    def test_two_consecutive_turns_both_succeed(self, client):
+        session_id = _start_session(client)
+        r1 = client.post(
+            f"/api/sessions/{session_id}/turn",
+            json={"content": "I led a distributed team across three time zones."},
+        )
+        assert r1.status_code == 200
+        r2 = client.post(
+            f"/api/sessions/{session_id}/turn",
+            json={"content": "The hardest part was aligning stakeholders with different priorities."},
+        )
+        assert r2.status_code == 200
+        assert r2.json()["state"] == "PlayerTurnListening"
+
+
+# ---------------------------------------------------------------------------
+# P-4  State evolution
+# ---------------------------------------------------------------------------
+
+
+class _StateDeltaRuntime(FakeChatRuntime):
+    """Fake runtime that returns a non-trivial state_delta."""
+
+    def chat_stream(self, request):
+        return self._yield(request)
+
+    async def _yield(self, request):
+        import json as _json
+        payload = {
+            "npc_utterance": "Impressive. Tell me more.",
+            "npc_emotion": "impressed",
+            "state_delta": {"trust": 15, "rapport": 8},
+            "event_flags": [],
+            "rubric_observations": [{"dimension": "clarity", "observation": "Clear answer", "delta": 5}],
+            "safety": {"status": "ok"},
+            "session_control": {"continue_session": True},
+        }
+        text = _json.dumps(payload)
+        yield ChatFinal(
+            text=text,
+            model_id="fake-small",
+            input_tokens=10,
+            output_tokens=len(text.split()),
+            structured=payload,
+        )
+
+
+class TestStateEvolution:
+    """Scenario state variables evolve across turns."""
+
+    def test_state_delta_is_present_in_npc_event(self, client):
+        session_id = _start_session(client)
+        res = client.post(
+            f"/api/sessions/{session_id}/turn",
+            json={"content": "I'm excited to be here."},
+        )
+        npc_payload = res.json()["events"][1]["payload"]
+        assert "state_delta" in npc_payload
+        assert isinstance(npc_payload["state_delta"], dict)
+
+    def test_state_delta_applied_to_session(self, tmp_config):
+        app = create_app(tmp_config)
+        with TestClient(app) as c:
+            res = c.post("/api/sessions", json=_SESSION_SETUP)
+            session_id = res.json()["session_id"]
+            c.post(f"/api/sessions/{session_id}/start")
+            app.state.runtime = _StateDeltaRuntime()
+            res = c.post(
+                f"/api/sessions/{session_id}/turn",
+                json={"content": "I led cross-functional teams at three companies."},
+            )
+        assert res.status_code == 200
+        npc_payload = res.json()["events"][1]["payload"]
+        assert npc_payload["state_delta"].get("trust") == 15
+        assert npc_payload["state_delta"].get("rapport") == 8
+
+    def test_state_carries_into_subsequent_turn(self, tmp_config):
+        app = create_app(tmp_config)
+        with TestClient(app) as c:
+            res = c.post("/api/sessions", json=_SESSION_SETUP)
+            session_id = res.json()["session_id"]
+            c.post(f"/api/sessions/{session_id}/start")
+            app.state.runtime = _StateDeltaRuntime()
+            c.post(f"/api/sessions/{session_id}/turn", json={"content": "First turn."})
+            res2 = c.post(f"/api/sessions/{session_id}/turn", json={"content": "Second turn."})
+        assert res2.status_code == 200
+        assert res2.json()["state"] == "PlayerTurnListening"
+
+
+# ---------------------------------------------------------------------------
+# P-5  Session end
+# ---------------------------------------------------------------------------
+
+
+class TestSessionEnd:
+    """A player can finish a session cleanly."""
+
+    def test_explicit_end_transitions_to_ended(self, client):
+        session_id = _start_session(client)
+        res = client.post(f"/api/sessions/{session_id}/end")
+        assert res.status_code == 200
+        body = res.json()
+        assert body["state"] == "Ended"
+        assert body["ending_type"] == "player_exit"
+
+    def test_turn_after_end_is_rejected(self, client):
+        session_id = _start_session(client)
+        client.post(f"/api/sessions/{session_id}/end")
+        res = client.post(
+            f"/api/sessions/{session_id}/turn",
+            json={"content": "Too late."},
+        )
+        assert res.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# P-6  Debrief
+# ---------------------------------------------------------------------------
+
+
+class TestDebrief:
+    """After finishing, the player sees a debrief report."""
+
+    def test_debrief_generated_after_session_ends(self, client):
+        session_id = _start_session(client)
+        client.post(
+            f"/api/sessions/{session_id}/turn",
+            json={"content": "I built the product roadmap for a 20-person team."},
+        )
+        client.post(f"/api/sessions/{session_id}/end")
+        res = client.post(f"/api/sessions/{session_id}/debrief")
+        assert res.status_code == 200, res.text
+        body = res.json()
+        assert body.get("session_id") == session_id
+        assert "scores" in body
+        assert "summary" in body
+
+    def test_debrief_on_active_session_is_rejected(self, client):
+        session_id = _start_session(client)
+        res = client.post(f"/api/sessions/{session_id}/debrief")
+        assert res.status_code == 409
+
+    def test_debrief_is_idempotent(self, client):
+        session_id = _start_session(client)
+        client.post(f"/api/sessions/{session_id}/end")
+        r1 = client.post(f"/api/sessions/{session_id}/debrief")
+        r2 = client.post(f"/api/sessions/{session_id}/debrief")
+        assert r1.status_code == 200
+        assert r2.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# P-7  Session retrieval (basis for replay)
+# ---------------------------------------------------------------------------
+
+
+class TestSessionRetrieval:
+    """A completed session can be retrieved by ID, enabling replay."""
+
+    def test_completed_session_retrievable_by_id(self, client):
+        session_id = _start_session(client)
+        client.post(f"/api/sessions/{session_id}/end")
+        res = client.get(f"/api/sessions/{session_id}")
+        assert res.status_code == 200
+        assert res.json()["session_id"] == session_id
+        assert res.json()["state"] == "Ended"
+
+    def test_multiple_sessions_each_retrievable(self, client):
+        ids = []
+        for i in range(2):
+            res = client.post("/api/sessions", json={**_SESSION_SETUP, "player_role_name": f"Tester {i}"})
+            ids.append(res.json()["session_id"])
+        for sid in ids:
+            get_res = client.get(f"/api/sessions/{sid}")
+            assert get_res.status_code == 200
+            assert get_res.json()["session_id"] == sid
+
+    def test_session_export_available_after_debrief(self, client):
+        session_id = _start_session(client)
+        client.post(f"/api/sessions/{session_id}/end")
+        client.post(f"/api/sessions/{session_id}/debrief")
+        res = client.get(f"/api/sessions/{session_id}/export")
+        assert res.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# P-8  No cloud inference
+# ---------------------------------------------------------------------------
+
+
+class TestNoCloudInference:
+    """A complete session must not make any outbound network calls."""
+
+    def test_full_session_does_not_trigger_play_mode_network_call(self, tmp_config):
+        """When LOCAL_MODE is True, any play-mode network attempt raises
+        NetworkBlockedError.  A full session with the fake runtime must complete
+        without triggering that error, proving no cloud inference is attempted."""
+        import convsim_core.network_policy as policy
+        app = create_app(tmp_config)
+        original_local_mode = policy.LOCAL_MODE
+        policy.LOCAL_MODE = True
+        try:
+            with TestClient(app) as c:
+                res = c.post("/api/sessions", json=_SESSION_SETUP)
+                session_id = res.json()["session_id"]
+                c.post(f"/api/sessions/{session_id}/start")
+                c.post(
+                    f"/api/sessions/{session_id}/turn",
+                    json={"content": "I have strong communication skills."},
+                )
+                end = c.post(f"/api/sessions/{session_id}/end")
+            assert end.status_code == 200, (
+                "Session ended with an error; a play-mode network call may have been blocked"
+            )
+        finally:
+            policy.LOCAL_MODE = original_local_mode
+
+    def test_fake_runtime_is_used_by_default(self, tmp_config):
+        app = create_app(tmp_config)
+        with TestClient(app) as c:
+            health = c.get("/api/health")
+        runtime_status = health.json().get("runtime", {})
+        runtime_id = runtime_status.get("runtime_id", "") or runtime_status.get("id", "")
+        assert "fake" in runtime_id.lower() or runtime_status.get("status") in {"ready", "ok"}, (
+            f"expected fake runtime in test environment, got: {runtime_status}"
+        )

--- a/tests/acceptance/test_player_text_path.py
+++ b/tests/acceptance/test_player_text_path.py
@@ -279,7 +279,7 @@ class _StateDeltaRuntime(FakeChatRuntime):
             "npc_emotion": "impressed",
             "state_delta": {"trust": 15, "rapport": 8},
             "event_flags": [],
-            "rubric_observations": [{"dimension": "clarity", "observation": "Clear answer", "delta": 5}],
+            "rubric_observations": [{"rubric_id": "clarity", "observation": "Clear answer", "score_delta": 3}],
             "safety": {"status": "ok"},
             "session_control": {"continue_session": True},
         }


### PR DESCRIPTION
## Summary

This PR adds a comprehensive acceptance test suite and release gate documentation for the MVP release. The work covers four personas (player, creator, developer, concept reviewer) with automated pytest tests, manual verification checklists, and integration into the release workflow.

### Tests — `tests/acceptance/`

Three automated test modules run against the fake runtime (no model downloads required):

- **`test_player_text_path.py` (P-1 through P-8):** Player journey end-to-end
  - Scenario library listing and selection
  - Session creation with NPC opening line
  - Player text turns and NPC responses
  - Session state evolution across turns
  - Session ending and explicit rejection of further turns
  - Debrief generation with idempotency
  - Session retrieval for replay capability
  - Network isolation check (`LOCAL_MODE=True` prevents cloud inference)

- **`test_creator_flow.py` (C-1 through C-7):** Creator pack workflow
  - Pack listing (official and local-dev)
  - API access to pack metadata, scenarios, NPCs, rubrics
  - Pack validation (pass and fail detection)
  - Pack export to zip with correct slug-based naming
  - Pack import from zip and retrieval via workbench API
  - Export → import round-trip preserving pack identity

- **`test_developer_flow.py` (D-1 through D-8):** Developer onboarding
  - Monorepo structure verification (services, packages, apps, packs, scripts, docs)
  - Core schema module imports and JSON schema parsing
  - Pack validation CLI importability and execution
  - Runtime registry registration of fake runtime
  - Structured debug logging output format
  - Minimal runtime adapter stub interface
  - Official pack schema validation (CI-stable)
  - Health endpoint subsystem field coverage

### Acceptance documentation — `docs/acceptance/`

Four manual checklists with pass/fail sign-off tables:

- **`player-checklist.md`:** Automated checks (pytest, fake runtime) plus manual steps covering the full player journey—clone, install, scenario selection, text play, state tracking, debrief, replay, and offline confirmation.

- **`creator-checklist.md`:** Automated checks plus manual steps for pack creation, editing, validation, export, and sharing workflows.

- **`developer-checklist.md`:** Automated checks plus manual steps for local setup, documentation review, adapter development, scenario authoring, test execution, and debugging.

- **`concept-review.md`:** First-time visitor rubric (5 dimensions scored 1–3) for assessing whether the README conveys the core concept within 60 seconds; pass threshold is 13–15 points.

### Release integration

- **`.github/workflows/ci.yml`:** New `acceptance` job that installs both `prompt-composer` and `convsim-core` then runs `python -m pytest tests/acceptance/ -v`.

- **`docs/release-checklist.md`:** Part C now ties all four acceptance checklists to the MVP release gate; the release cannot be tagged MVP until every checklist shows PASS (or a documented, maintainer-approved exception).

## Implementation notes

- All test modules use in-memory fixtures (minimal pack zips, fake runtime) to avoid external dependencies.
- Scenario library tests build a minimal pack zip and load it into the test database, ensuring parity with how players would see the library.
- Function signatures, API paths, and runtime registry structure were verified against the actual source before writing assertions.
- All test files pass Python `ast.parse` validation.
- Each test class is scoped to one acceptance criterion with a clear CI label for release tracking.

Closes #80