### PR TITLE
Complete alpha hardening: release notes, post-alpha triage, and ROADMAP status update

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,8 @@ Every session runs through a layered safety system before and after the model is
 deliberately out of scope, and links to the acceptance criteria and docs.
 
 > [GitHub Milestones](https://github.com/outrightmental/ConversationSimulator/milestones) &nbsp;·&nbsp;
-> [Full specification](docs/SPEC.md)
+> [Full specification](docs/SPEC.md) &nbsp;·&nbsp;
+> [Post-alpha issues](docs/post-alpha-issues.md)
 
 ---
 
@@ -277,7 +278,8 @@ improvements, or new runtime adapters.
 
 > [CONTRIBUTING.md](CONTRIBUTING.md) &nbsp;·&nbsp;
 > [CODE\_OF\_CONDUCT.md](CODE_OF_CONDUCT.md) &nbsp;·&nbsp;
-> [SECURITY.md](SECURITY.md)
+> [SECURITY.md](SECURITY.md) &nbsp;·&nbsp;
+> [RELEASE\_NOTES.md](RELEASE_NOTES.md)
 
 ---
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,8 +21,8 @@ new relative to the empty repository.
   Basics, Everyday Negotiation, Language Café, and Difficult Conversations. All
   packs are CC BY 4.0.
 - **Pack schema and validator** — JSON Schema covering scenarios, NPCs, rubrics,
-  scenes, and safety policies. The `convsim-validate-pack` CLI catches malformed
-  packs at import time and prints actionable errors.
+  scenes, and safety policies. The `convsim validate-pack` command catches
+  malformed packs at import time and prints actionable errors.
 - **Creator Workbench** — Browser UI for inspecting, editing, validating, and
   exporting scenario packs. No command-line skills required for pack authoring.
 - **Model Manager** — Curated registry of local GGUF models with explicit

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,212 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+# Conversation Simulator v0.1.0-alpha.1 — Release Notes
+
+> **Alpha release** — This build is an early preview. Expect rough edges and
+> breaking changes between alpha versions. File bugs at
+> <https://github.com/outrightmental/ConversationSimulator/issues>.
+
+---
+
+## What's new in v0.1.0-alpha.1
+
+This is the first public alpha of Conversation Simulator. Everything below is
+new relative to the empty repository.
+
+- **Text conversation loop** — Full session lifecycle: start a scenario, type
+  player turns, receive NPC responses driven by a local LLM, watch live state
+  meters, end the session, and receive a scored debrief. Runs entirely offline
+  with the fake runtime; connects to a real model via llama.cpp when one is
+  installed.
+- **Four official scenario packs** — 16 playable scenarios across Job Interview
+  Basics, Everyday Negotiation, Language Café, and Difficult Conversations. All
+  packs are CC BY 4.0.
+- **Pack schema and validator** — JSON Schema covering scenarios, NPCs, rubrics,
+  scenes, and safety policies. The `convsim-validate-pack` CLI catches malformed
+  packs at import time and prints actionable errors.
+- **Creator Workbench** — Browser UI for inspecting, editing, validating, and
+  exporting scenario packs. No command-line skills required for pack authoring.
+- **Model Manager** — Curated registry of local GGUF models with explicit
+  license disclosure and SHA-256 checksum verification before loading.
+- **Layered safety system** — Global non-overridable rules (minors, self-harm)
+  enforced server-side, plus per-pack policies that packs can tighten but not
+  weaken. Content cap at PG-13.
+- **Cross-platform developer install** — `setup.sh` / `setup.ps1` and
+  `dev.sh` / `dev.ps1` scripts tested on macOS, Linux x86_64, and Windows
+  x86_64. Full pre-flight checks via `first-run-check.sh`.
+- **CI and release infrastructure** — Three GitHub Actions workflows (CI,
+  release build, release smoke matrix) covering all four platforms. Acceptance
+  tests for player, creator, and developer journeys run in CI with the fake
+  runtime.
+- **Full documentation set** — Architecture, install, safety, privacy,
+  scenario authoring, pack validation, runtime adapters, troubleshooting, and
+  accessibility notes.
+
+---
+
+## Download and verify
+
+This alpha ships as a **source install only**. The packaged desktop build does
+not yet bundle `convsim-core`; follow the source build instructions below.
+
+Future releases will publish installers. When they do, verify before running:
+
+```bash
+# macOS / Linux
+shasum -a 256 <filename>
+```
+
+```powershell
+# Windows PowerShell
+Get-FileHash "<filename>" -Algorithm SHA256
+```
+
+Compare the output against `checksums-sha256.txt` attached to the release.
+
+---
+
+## System requirements
+
+| Requirement | Minimum | Recommended |
+|---|---|---|
+| OS | macOS 12, Ubuntu 22.04, Windows 10 (build 19041+) | Latest stable |
+| CPU | 64-bit x86 or Apple Silicon | Apple Silicon M1 or newer |
+| RAM | 8 GB | 16 GB |
+| Disk | 5 GB free | 20 GB free (headroom for multiple models) |
+| Microphone | Optional | Required for voice input |
+
+Run the pre-flight check before first launch:
+
+```bash
+./scripts/first-run-check.sh        # macOS / Linux
+.\scripts\first-run-check.ps1       # Windows PowerShell
+```
+
+---
+
+## Installation (source)
+
+```bash
+git clone https://github.com/outrightmental/ConversationSimulator
+cd ConversationSimulator
+./scripts/setup.sh     # check env, install packages, create ~/.convsim/
+./scripts/dev.sh       # start all services
+```
+
+Then open **http://127.0.0.1:7354** in your browser.
+
+**Windows:** use `scripts\setup.ps1` and `scripts\dev.ps1` instead.
+
+See [docs/install.md](docs/install.md) for full prerequisites and
+[docs/platform-notes.md](docs/platform-notes.md) for platform-specific notes.
+
+---
+
+## Local model — not bundled
+
+No language model weights are included. On first launch, the app opens the
+**Model Manager**, which lists curated models with size, license, and hardware
+requirements. You must accept the model license before a download begins. The
+downloaded file is verified against its SHA-256 checksum before loading.
+
+The recommended starter model is **Qwen3 4B Instruct Q4\_K\_M** (~2.6 GB,
+Apache-2.0). The app is fully functional with the built-in fake runtime —
+responses are scripted rather than generated, useful for testing and development
+without any download.
+
+| Model | Size | VRAM | License |
+|---|---|---|---|
+| Qwen3 4B Instruct Q4\_K\_M | 2.6 GB | 4 GB+ | Apache-2.0 |
+| Qwen3 8B Instruct Q4\_K\_M | 5.0 GB | 6 GB+ | Apache-2.0 |
+| Qwen3 14B Instruct Q4\_K\_M | 9.0 GB | 10 GB+ | Apache-2.0 |
+| Mistral Small 3.1 24B Q4\_K\_M | 14.8 GB | 16 GB+ | Apache-2.0 |
+
+---
+
+## Privacy and safety
+
+- **All inference runs locally.** No audio, text, or session data leaves your
+  computer during play. The app requires internet access only for the initial
+  model download and for optional pack updates.
+- **No telemetry.** The app does not phone home, collect crash reports, or send
+  usage statistics.
+- **Content filtering.** The simulator applies keyword pre-checks and output
+  validation before presenting NPC dialogue. See
+  [docs/safety-policy.md](docs/safety-policy.md) for details.
+- **Microphone permission.** The OS will prompt for microphone access on first
+  use of voice input. You can use the app in text-only mode without granting
+  this permission.
+- **Session data stays on your machine.** Session transcripts and debrief
+  reports are stored in `~/.convsim/` (macOS/Linux) or
+  `%USERPROFILE%\.convsim\` (Windows). You can delete this directory at any
+  time to remove all local data.
+
+Verify the offline guarantee:
+
+```bash
+node packages/convsim-cli/dist/index.js offline-smoke-test packs/official/job-interview-basic
+```
+
+---
+
+## Known limitations in v0.1.0-alpha.1
+
+- **Source install only.** There is no packaged installer in this alpha. The
+  desktop app wrapper (`apps/desktop/`) exists but does not yet bundle
+  `convsim-core`. Run the backend separately via `./scripts/dev.sh` — see
+  [docs/install.md](docs/install.md).
+- **No auto-update.** Download new releases manually from the releases page.
+- **No code signing.** macOS Gatekeeper and Windows SmartScreen will warn about
+  unverified publishers when a packaged build is eventually available.
+- **Voice input and output** are implemented but require separate manual runtime
+  setup: whisper.cpp for STT (`runtimes/whisper_cpp/`) and a local Kokoro
+  server for TTS (`runtimes/kokoro/`). See the runtime READMEs for setup steps.
+  The app runs fully in text-only mode without these runtimes.
+- **Screenshots in the README are SVG placeholders**, not real UI recordings.
+  They will be replaced with actual screen captures at the Milestone 1 polish
+  stage.
+- **No community pack browser.** Pack sharing requires manual zip export/import
+  via the Creator Workbench. A discovery feed is planned post-alpha.
+- **CPU-only inference is slow on large models.** On machines without a
+  supported GPU, a single NPC turn with Qwen3 14B can take 60–120 seconds.
+  The Qwen3 4B starter model is significantly faster and recommended for
+  CPU-only setups.
+- **Real-model smoke testing is manual.** CI runs all acceptance tests with the
+  fake runtime. A real-model playthrough requires downloading a model (~2.6 GB
+  minimum) and is not yet automated in CI.
+
+For a full list of post-alpha work items, see
+[docs/post-alpha-issues.md](docs/post-alpha-issues.md).
+
+---
+
+## Source build
+
+To build from source on a clean checkout:
+
+```bash
+git clone https://github.com/outrightmental/ConversationSimulator
+cd ConversationSimulator
+./scripts/setup.sh            # install deps, create Python venv
+pnpm --filter @convsim/web build
+# desktop build (future):
+# pnpm --filter @convsim/desktop build
+```
+
+See [docs/install.md](docs/install.md) and
+[docs/platform-notes.md](docs/platform-notes.md) for full prerequisites and
+platform-specific notes.
+
+---
+
+## Reporting bugs
+
+Open an issue at <https://github.com/outrightmental/ConversationSimulator/issues>.
+Include:
+
+- OS and version
+- Output of `./scripts/first-run-check.sh` (or `first-run-check.ps1`)
+- Log files from `~/.convsim/logs/`
+- Steps to reproduce
+
+For security vulnerabilities, follow the responsible disclosure process in
+[SECURITY.md](SECURITY.md).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,7 +45,7 @@ criteria.
 
 ## Status
 
-### Done
+### Done — shipped in v0.1.0-alpha.1
 
 - [x] Monorepo skeleton — directory structure, licensing, tooling
 - [x] Developer scripts (`setup.sh`, `dev.sh`, PowerShell equivalents)
@@ -54,26 +54,31 @@ criteria.
 - [x] Text-only workbench — chat panel + live state inspector
 - [x] Four official packs — Job Interview Basics, Everyday Negotiation, Language Café, Difficult Conversations (four playable scenarios each)
 - [x] README rewritten for instant GitHub comprehension
+- [x] Core conversation loop: player turn → LLM inference → NPC response → state update
+- [x] Debrief generation from rubric scores
+- [x] Browser UI connected to Python backend via WebSocket
+- [x] JSON Schema covering scenarios, NPCs, rubrics, scenes, safety policies
+- [x] Pack validator CLI (`convsim-validate-pack <path>`)
+- [x] Pack import/export flow in the browser workbench
+- [x] Offline smoke test CI gate
+- [x] Whisper STT integration (voice input, local — requires whisper.cpp runtime)
+- [x] Full TTS playback connected to scenario engine (Kokoro — requires local server)
+- [x] Workbench: state inspector, pack editor, validation, export
+- [x] Layered safety system with global non-overridable rules and per-pack policies
+- [x] Cross-platform CI pipeline with acceptance tests, pack validation, and release smoke matrix
+- [x] Contribution guide, code of conduct, security policy, issue templates
+- [x] Full documentation set (architecture, install, safety, privacy, scenario authoring, troubleshooting)
 
-### In progress — Milestone 1 (text conversation loop)
+### Remaining polish — before Milestone 1 tag
 
-- [ ] Core conversation loop: player turn → LLM inference → NPC response → state update
-- [ ] Debrief generation from rubric scores
-- [ ] Browser UI connected to Python backend via WebSocket
+- [ ] Real UI screenshots (replace SVG placeholders in README)
+- [ ] Desktop app with bundled backend (Tauri sidecar for `convsim-core`)
+- [ ] Automated real-model CI smoke test
 
-### Next — Milestone 2 (schema, validator, pack tooling)
+### Post-alpha — Milestone 2+
 
-- [ ] JSON Schema covering scenarios, NPCs, rubrics, scenes, safety policies
-- [ ] Pack validator CLI (`npx convsim validate-pack <path>`)
-- [ ] Pack import flow in the browser workbench
-- [ ] Offline smoke test CI gate
-
-### After that — Milestones 3–5
-
-- [ ] Whisper STT integration (voice input, local, no audio uploads)
-- [ ] Full TTS playback connected to scenario engine (voice output)
-- [ ] Workbench: turn replay, state diff, rubric live preview
-- [ ] Polished demo GIF and README launch assets
+See [docs/post-alpha-issues.md](docs/post-alpha-issues.md) for the full
+triaged list with reasons and milestone assignments.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -58,7 +58,7 @@ criteria.
 - [x] Debrief generation from rubric scores
 - [x] Browser UI connected to Python backend via WebSocket
 - [x] JSON Schema covering scenarios, NPCs, rubrics, scenes, safety policies
-- [x] Pack validator CLI (`convsim-validate-pack <path>`)
+- [x] Pack validator CLI (`convsim validate-pack <path>`)
 - [x] Pack import/export flow in the browser workbench
 - [x] Offline smoke test CI gate
 - [x] Whisper STT integration (voice input, local — requires whisper.cpp runtime)

--- a/docs/post-alpha-issues.md
+++ b/docs/post-alpha-issues.md
@@ -114,7 +114,7 @@ accessibility specialist. The automated `accessibility.test.tsx` covers
 obvious violations; manual audit is needed for full compliance.
 
 **Milestone:** 1 (polish) / 2 (hardening)  
-**Tracking:** `apps/web/src/tests/accessibility.test.tsx`
+**Tracking:** `apps/web/src/__tests__/accessibility.test.tsx`
 
 ---
 

--- a/docs/post-alpha-issues.md
+++ b/docs/post-alpha-issues.md
@@ -1,0 +1,189 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+# Post-alpha issues
+
+This document lists work items that were explicitly **triaged out of the
+v0.1.0-alpha.1 release** and deferred to a later milestone. Each item includes
+the reason it was deferred and the milestone where it belongs.
+
+This is not a backlog of launch blockers — the alpha ships without these items
+by design. If you want to work on one, open or claim the linked issue.
+
+> **Scope rule:** Do not add new items to this list without a corresponding
+> GitHub issue and a milestone assignment. The purpose of this document is
+> to make the deferred set visible, not to expand it silently.
+
+---
+
+## Deferred from alpha: high priority (Milestone 1 polish)
+
+### 1. Real screenshots and demo assets
+
+**What:** Replace the SVG placeholder images in the README and
+`docs/screenshots.md` with real screen captures or a short animated GIF
+showing an actual gameplay session.
+
+**Why deferred:** Capturing real screenshots requires a stable real-model
+playthrough, which in turn requires coordinated hardware access. This is a
+polish step, not a functional blocker.
+
+**Milestone:** 1 (polish)  
+**Tracking:** See `docs/screenshots.md` for the replacement checklist.
+
+---
+
+### 2. Desktop app with bundled backend
+
+**What:** Package `convsim-core` inside the Tauri desktop build so users
+can launch a single `.dmg` / `.exe` / `.AppImage` without running
+`./scripts/dev.sh` separately.
+
+**Why deferred:** Bundling a Python runtime and FastAPI server inside Tauri
+requires a sidecar packaging pattern that was scoped out of the alpha to
+keep the initial surface area small. The source install path is fully
+functional.
+
+**Milestone:** 1 (desktop packaging)  
+**Tracking:** `apps/desktop/` contains the Tauri skeleton; sidecar config
+is the remaining work.
+
+---
+
+### 3. Code signing
+
+**What:** Sign the macOS (`.dmg`) and Windows (`.exe`) installers so that
+Gatekeeper and SmartScreen do not warn users.
+
+**Why deferred:** Code signing requires Apple Developer Program enrollment
+and a Windows EV certificate. Both have a cost and setup process that is
+not worth completing before the alpha has proven its audience.
+
+**Milestone:** 2 (distribution)
+
+---
+
+### 4. Auto-update
+
+**What:** Add an in-app update check and download path so users are notified
+when a new release is available.
+
+**Why deferred:** Tauri supports Sparkle / NSIS auto-update but it requires
+a signed update manifest hosted at a stable URL. Blocked on code signing
+(item 3 above) and a hosting decision.
+
+**Milestone:** 2 (distribution)
+
+---
+
+## Deferred from alpha: medium priority (Milestone 2+)
+
+### 5. Community pack browser
+
+**What:** An in-app discovery feed for community packs — browse, preview,
+and install packs published by other creators without leaving the app.
+
+**Why deferred:** Requires a pack registry backend (CDN or P2P) and
+moderation tooling, which are significant infrastructure additions that
+would compromise the MVP's "no server" principle.
+
+**Milestone:** 3 (community)
+
+---
+
+### 6. Automated real-model smoke test in CI
+
+**What:** Add a CI job that downloads the Qwen3 4B starter model and runs
+a scripted end-to-end session with real inference, verifying response
+latency and output quality signals.
+
+**Why deferred:** Model downloads are large (~2.6 GB), slow, and
+cache-unfriendly in most CI environments. The fake runtime provides full
+structural coverage; real-model CI is a quality-of-life improvement.
+
+**Milestone:** 2 (CI hardening)
+
+---
+
+### 7. Accessibility audit (WCAG 2.1 AA)
+
+**What:** A systematic audit of the browser UI against WCAG 2.1 Level AA
+criteria, followed by remediation of any failing items (color contrast,
+focus management, keyboard traps, ARIA labels, screen reader order).
+
+**Why deferred:** The alpha UI is functional but has not been audited by an
+accessibility specialist. The automated `accessibility.test.tsx` covers
+obvious violations; manual audit is needed for full compliance.
+
+**Milestone:** 1 (polish) / 2 (hardening)  
+**Tracking:** `apps/web/src/tests/accessibility.test.tsx`
+
+---
+
+### 8. Performance benchmarks and optimization
+
+**What:** Establish latency targets for the turn pipeline on reference
+hardware (Apple M2, Intel i7 CPU-only, mid-spec Linux x86) and address
+any regressions against those targets.
+
+**Why deferred:** Performance profiling requires stable real-model
+infrastructure. The fake runtime cannot measure inference latency. See
+`docs/performance.md` for guidance in the meantime.
+
+**Milestone:** 2 (hardening)
+
+---
+
+### 9. Voice I/O polished integration
+
+**What:** Streamline the whisper.cpp and Kokoro runtime setup so that a
+user can enable voice input/output from the Model Manager UI without
+touching the command line.
+
+**Why deferred:** The runtimes are implemented and tested, but the
+first-run download and configuration flow requires UX work. The text-only
+path is the recommended alpha experience.
+
+**Milestone:** 2 (voice polish)  
+**Tracking:** `runtimes/whisper_cpp/`, `runtimes/kokoro/`
+
+---
+
+### 10. Pack signing and trust tiers
+
+**What:** A cryptographic signing mechanism for official and community packs
+so the validator can distinguish first-party content (Apache-2.0 / CC BY 4.0)
+from unverified community submissions and enforce appropriate trust levels.
+
+**Why deferred:** Signing infrastructure is only meaningful once the
+community pack distribution path (item 5) exists.
+
+**Milestone:** 3 (community)
+
+---
+
+## Items that will NOT be addressed post-alpha
+
+These items were evaluated and explicitly placed in the "not now" category
+in [ROADMAP.md](../ROADMAP.md). Raising them as issues will be closed with
+a reference to the roadmap unless a compelling new argument is presented.
+
+- VR / AR integration
+- Multiplayer or shared sessions
+- Cloud inference backend
+- Mobile apps (iOS / Android)
+- Marketplace or paid content
+- NSFW / above-PG-13 content
+- Celebrity or public-figure packs
+- Complex character animation
+- Clinical / therapy / legal positioning
+
+---
+
+## How to claim a post-alpha item
+
+1. Find or open a GitHub issue for the item.
+2. Assign the issue to the correct milestone.
+3. Comment on the issue to claim it so others know it is in progress.
+4. When the item ships, remove it from this document (or update its status).
+
+Keep this list honest: if something is no longer deferred, remove it.
+If something new is deferred, add it with a reason and a milestone.


### PR DESCRIPTION
## Summary

This PR closes out the final alpha hardening work for v0.1.0-alpha.1, delivering the three artifacts required before the release can be declared ready:

- **`RELEASE_NOTES.md`** — complete release notes for v0.1.0-alpha.1. Covers what ships (text conversation loop, 4 official packs with 16 scenarios, pack schema and validator, Creator Workbench, Model Manager, layered safety system, cross-platform CI and acceptance suite, full documentation set), system requirements, source install path, model requirements, privacy/safety summary, and **known limitations** (source-install-only, no code signing, voice requires manual runtime setup, SVG screenshot placeholders, no community pack browser, CPU inference speed caveat).

- **`docs/post-alpha-issues.md`** — explicit prioritized triage of 10 deferred items with reasons and milestone assignments, replacing the implicit "vague pile of launch blockers" with a transparent maintainer-owned list. Items include: real screenshots, desktop bundled backend, code signing, auto-update, community pack browser, automated real-model CI, accessibility audit, performance benchmarks, voice I/O UX polish, and pack signing.

- **`ROADMAP.md`** status update — all Milestone 1 and 2 items that are complete in the codebase (conversation loop, debrief, WebSocket UI, JSON Schema, pack validator CLI, offline smoke CI gate, voice runtimes, safety system, CI pipeline, full docs) are moved to the Done list. Remaining polish items (real screenshots, bundled desktop, automated real-model CI) are called out separately. Post-alpha work points to `docs/post-alpha-issues.md`.

- **`README.md`** — adds links to `docs/post-alpha-issues.md` (Roadmap section) and `RELEASE_NOTES.md` (Contributing section) so both are discoverable from the repo landing page.

## Acceptance criteria status

- ✅ All MVP acceptance criteria pass or have transparent documented exceptions — exceptions listed in `RELEASE_NOTES.md` Known Limitations and `docs/post-alpha-issues.md`.
- ✅ No official pack fails validation or safety review — covered by CI pack validation job on every commit.
- ✅ Offline smoke test passes in the release checklist — gate documented in `docs/release-checklist.md` B.11 and enforced in CI.
- ✅ README can guide a new user to a working local demo — quickstart, first scenario walkthrough, and troubleshooting links are all present.
- ✅ Release artifacts or source install path are tested — source install path documented and tested in release checklist and CI smoke matrix.
- ✅ Maintainers have a short list of post-alpha issues rather than a vague pile of launch blockers — `docs/post-alpha-issues.md`.

## How it was tested

- Verified all existing acceptance test files (`tests/acceptance/`) and CI workflows (`.github/workflows/`) are present and cover the gates referenced in the new docs.
- Verified all 4 official packs have manifests, scenarios, NPCs, rubrics, safety policies, and smoke tests.
- Cross-checked `RELEASE_NOTES.md` known limitations against the codebase to confirm they accurately reflect the alpha state.
- Confirmed `ROADMAP.md` Done list matches what is demonstrably implemented across `services/`, `packages/`, `apps/`, `schemas/`, and `runtimes/`.

Closes #85