### PR TITLE
Add Steam edition issue templates and triage flow document

### DIFF
--- a/.github/ISSUE_TEMPLATE/steam_creator_workbench.yml
+++ b/.github/ISSUE_TEMPLATE/steam_creator_workbench.yml
@@ -1,0 +1,175 @@
+name: Steam — Creator Workbench bug
+description: >
+  Report a bug in the Creator Workbench when running under the Steam edition:
+  pack authoring, scenario editing, asset management, schema validation, or
+  workbench-specific UI issues.
+labels:
+  - steam
+  - creator-workbench
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template to report a bug in the Creator Workbench UI or pack
+        tooling when running under the Steam edition. This covers pack and
+        scenario authoring, NPC editing, asset management, schema validation
+        inside the Workbench, and Workbench-specific crashes or UI problems.
+
+        For pack content bugs that appear during *play* (not authoring), use
+        the **Steam — pack validation or content bug** template instead.
+
+        **Privacy note:** Do not paste conversation transcripts, NPC session
+        logs, or audio recordings in this issue. If describing a bug requires
+        showing pack content, use a minimal made-up example rather than a real
+        pack in progress. Do not include any personally identifying information.
+
+  - type: dropdown
+    id: workbench-area
+    attributes:
+      label: Which area of the Creator Workbench?
+      options:
+        - Pack creation / manifest editing
+        - Scenario editor
+        - NPC editor
+        - Asset manager (images, audio)
+        - Schema validation panel
+        - Pack preview / test-run
+        - Export / publish flow
+        - Workbench UI / layout / navigation
+        - Other (describe below)
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+      placeholder: >
+        Example: The schema validation panel shows "valid" for a scenario that
+        is missing a required `npc_id` field. Saving the pack and loading it
+        in the player then fails with a schema error.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+      placeholder: >
+        Example: The validation panel should highlight the missing `npc_id`
+        field and prevent saving until it is filled in.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps using a made-up pack if possible.
+      placeholder: |
+        1. Open Creator Workbench → New Pack
+        2. Add a scenario, leave `npc_id` blank
+        3. Click "Validate pack" — shows green "Valid"
+        4. Save pack and load it in the player — error: "npc_id is required"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - Windows 10
+        - Windows 11
+        - macOS 13 (Ventura)
+        - macOS 14 (Sonoma)
+        - macOS 15 (Sequoia)
+        - Linux (specify distro below)
+        - Steam Deck / SteamOS
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: steam-deck
+    attributes:
+      label: Steam Deck
+      options:
+        - label: This bug occurs on or is specific to Steam Deck / SteamOS.
+
+  - type: textarea
+    id: hardware
+    attributes:
+      label: Hardware (CPU / GPU / RAM)
+      placeholder: |
+        CPU: AMD Ryzen 7 7700X
+        GPU: AMD RX 6700 XT (driver 23.11)
+        RAM: 32 GB
+        OS: Fedora 40
+    validations:
+      required: true
+
+  - type: input
+    id: app-version
+    attributes:
+      label: App version
+      description: Shown in the app footer or About screen.
+      placeholder: "Example: 0.9.1-steam-beta.3"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: runtime
+    attributes:
+      label: Runtime backend in use (if relevant to the bug)
+      options:
+        - llama.cpp (built-in)
+        - ollama
+        - Not applicable / Workbench-only bug
+        - Other (describe below)
+    validations:
+      required: true
+
+  - type: input
+    id: model
+    attributes:
+      label: Model loaded at time of bug (if any)
+      placeholder: "Example: Qwen3 4B Instruct Q4_K_M"
+    validations:
+      required: false
+
+  - type: input
+    id: pack
+    attributes:
+      label: Pack being edited (if applicable)
+      description: Use a made-up name if the pack is not yet published.
+      placeholder: "Example: My Test Pack (in progress)"
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Sanitized logs or crash bundle path
+      description: >
+        Paste sanitized console output or the path to a crash bundle on your
+        machine. Redact any personal file-path prefixes (e.g. replace your
+        username with `<user>`). Do not include conversation transcripts or
+        session audio.
+      render: text
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and this has not been reported before.
+          required: true
+        - label: I am running the latest Steam build (check for updates in Steam).
+          required: false
+        - label: >
+            I have not pasted any conversation transcripts or session audio in
+            this issue.
+          required: true

--- a/.github/ISSUE_TEMPLATE/steam_model_install.yml
+++ b/.github/ISSUE_TEMPLATE/steam_model_install.yml
@@ -1,0 +1,156 @@
+name: Steam — local model install failure
+description: >
+  Report a failure to download, verify, or load a local AI model through the
+  Steam edition Model Manager.
+labels:
+  - steam
+  - model-install
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template when the Model Manager in the Steam edition fails to
+        download, verify (SHA-256 checksum), or load a local AI model.
+
+        **Privacy note:** Do not paste conversation transcripts, NPC session
+        logs, or audio recordings in this issue. Conversation Simulator keeps
+        all session data on your machine; please keep it there. Model install
+        failures should not involve any session content — if they do, describe
+        the content in general terms only.
+
+        See [docs/local-models.md](https://github.com/outrightmental/ConversationSimulator/blob/main/docs/local-models.md)
+        and [docs/troubleshooting.md](https://github.com/outrightmental/ConversationSimulator/blob/main/docs/troubleshooting.md)
+        before filing — common download and runtime issues are documented there.
+
+  - type: dropdown
+    id: failure-stage
+    attributes:
+      label: At which stage did the install fail?
+      options:
+        - Download did not start
+        - Download started but stalled or was incomplete
+        - Download completed but checksum verification failed
+        - Model downloaded successfully but failed to load / initialise
+        - Model loaded but produces no output or crashes on first inference
+        - Other (describe below)
+    validations:
+      required: true
+
+  - type: input
+    id: model-name
+    attributes:
+      label: Model name and variant
+      placeholder: "Example: Qwen3 4B Instruct Q4_K_M"
+    validations:
+      required: true
+
+  - type: input
+    id: model-source
+    attributes:
+      label: Model source shown in the Model Manager
+      placeholder: "Example: Hugging Face — Qwen/Qwen3-4B-GGUF"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: runtime
+    attributes:
+      label: Runtime backend
+      options:
+        - llama.cpp (built-in)
+        - ollama
+        - Other (describe below)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - Windows 10
+        - Windows 11
+        - macOS 13 (Ventura)
+        - macOS 14 (Sonoma)
+        - macOS 15 (Sequoia)
+        - Linux (specify distro below)
+        - Steam Deck / SteamOS
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: steam-deck
+    attributes:
+      label: Steam Deck
+      options:
+        - label: This failure occurs on or is specific to Steam Deck / SteamOS.
+
+  - type: textarea
+    id: hardware
+    attributes:
+      label: Hardware (CPU / GPU / RAM)
+      description: >
+        GPU details matter for inference failures — include the driver version
+        if you know it.
+      placeholder: |
+        CPU: AMD Ryzen 9 7950X
+        GPU: AMD RX 7900 XTX (ROCm 6.1)
+        RAM: 64 GB
+        OS: Ubuntu 24.04 LTS
+    validations:
+      required: true
+
+  - type: input
+    id: app-version
+    attributes:
+      label: App version
+      description: Shown in the app footer or About screen.
+      placeholder: "Example: 0.9.1-steam-beta.3"
+    validations:
+      required: true
+
+  - type: textarea
+    id: error-message
+    attributes:
+      label: Error message shown in the app
+      description: Copy the exact error text from the Model Manager UI.
+      placeholder: >
+        Example: "Checksum mismatch — expected a3b1c2… got f9e7d1…
+        Download has been removed. Please try again."
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Sanitized logs or crash bundle path
+      description: >
+        Paste sanitized console output or the path to a crash bundle on your
+        machine. Redact any personal file-path prefixes (e.g. replace your
+        username with `<user>`). Do not include conversation transcripts or
+        session audio.
+      render: text
+    validations:
+      required: false
+
+  - type: input
+    id: disk-space
+    attributes:
+      label: Free disk space at time of failure
+      placeholder: "Example: 12 GB free on C:\\"
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and this has not been reported before.
+          required: true
+        - label: I checked docs/troubleshooting.md for known model-install issues.
+          required: false
+        - label: >
+            I have not pasted any conversation transcripts or session audio in
+            this issue.
+          required: true

--- a/.github/ISSUE_TEMPLATE/steam_model_install.yml
+++ b/.github/ISSUE_TEMPLATE/steam_model_install.yml
@@ -52,6 +52,17 @@ body:
     validations:
       required: false
 
+  - type: input
+    id: pack
+    attributes:
+      label: Installed pack (if the install was prompted by a pack)
+      description: >
+        Some packs recommend a specific model — note the pack here if the
+        install was triggered while setting up or playing a pack.
+      placeholder: "Example: Job Interview Basics 1.2.0"
+    validations:
+      required: false
+
   - type: dropdown
     id: runtime
     attributes:

--- a/.github/ISSUE_TEMPLATE/steam_pack_bug.yml
+++ b/.github/ISSUE_TEMPLATE/steam_pack_bug.yml
@@ -1,0 +1,182 @@
+name: Steam — pack validation or content bug
+description: >
+  Report a bug in a scenario pack: validation failure, schema error, broken
+  scenario, incorrect scoring, or content that does not match the pack's
+  declared rating or safety policy.
+labels:
+  - steam
+  - pack-bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template to report a problem with a scenario pack —
+        validation errors, schema failures, broken scenarios, incorrect
+        scoring, or content that does not match the pack's declared rating
+        or safety policy in the Steam edition.
+
+        For bugs in the safety validation system itself (false positives /
+        false negatives), use the **Safety issue** template.
+
+        **Privacy note:** Do not paste conversation transcripts, NPC session
+        logs, or audio recordings in this issue. Conversation Simulator keeps
+        all session data on your machine; please keep it there. If describing a
+        content problem requires quoting NPC output, use the shortest excerpt
+        necessary and prefer paraphrasing over verbatim quotes. Do not include
+        any personally identifying information.
+
+  - type: dropdown
+    id: bug-type
+    attributes:
+      label: Type of pack bug
+      options:
+        - Pack fails to load / schema validation error
+        - Scenario fails to start or crashes mid-conversation
+        - NPC output is broken, repetitive, or off-character
+        - Scoring / debrief results are wrong or missing
+        - Content does not match the declared content rating
+        - Audio asset missing or fails to play
+        - Pack content violates stated safety policy (use Safety issue for egregious violations)
+        - Other (describe below)
+    validations:
+      required: true
+
+  - type: input
+    id: pack-name
+    attributes:
+      label: Pack name and version
+      placeholder: "Example: Job Interview Basics 1.2.0"
+    validations:
+      required: true
+
+  - type: input
+    id: scenario
+    attributes:
+      label: Scenario (if applicable)
+      placeholder: "Example: The Executive Gauntlet"
+    validations:
+      required: false
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: >
+        Describe the problem. For content bugs, use the shortest paraphrase
+        necessary — do not reproduce long passages of NPC output verbatim.
+      placeholder: >
+        Example: The debrief score for "The Executive Gauntlet" is always
+        shown as 0/100 regardless of conversation length or quality.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+      placeholder: >
+        Example: A score between 0 and 100 reflecting my conversation
+        performance, with feedback in the debrief panel.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Install Job Interview Basics from the Pack Browser
+        2. Start "The Executive Gauntlet"
+        3. Complete the conversation (any length)
+        4. Open the debrief — score shows 0
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - Windows 10
+        - Windows 11
+        - macOS 13 (Ventura)
+        - macOS 14 (Sonoma)
+        - macOS 15 (Sequoia)
+        - Linux (specify distro below)
+        - Steam Deck / SteamOS
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: steam-deck
+    attributes:
+      label: Steam Deck
+      options:
+        - label: This bug occurs on or is specific to Steam Deck / SteamOS.
+
+  - type: textarea
+    id: hardware
+    attributes:
+      label: Hardware (CPU / GPU / RAM)
+      placeholder: |
+        CPU: Apple M3 Pro
+        GPU: Apple Metal (integrated)
+        RAM: 36 GB
+        OS: macOS 14.5
+    validations:
+      required: true
+
+  - type: input
+    id: app-version
+    attributes:
+      label: App version
+      description: Shown in the app footer or About screen.
+      placeholder: "Example: 0.9.1-steam-beta.3"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: runtime
+    attributes:
+      label: Runtime backend in use
+      options:
+        - llama.cpp (built-in)
+        - ollama
+        - Not applicable
+        - Other (describe below)
+    validations:
+      required: true
+
+  - type: input
+    id: model
+    attributes:
+      label: Model loaded at time of bug (if any)
+      placeholder: "Example: Qwen3 4B Instruct Q4_K_M"
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Sanitized logs or crash bundle path
+      description: >
+        Paste sanitized console output or validation error text. Redact any
+        personal file-path prefixes (e.g. replace your username with `<user>`).
+        Do not include conversation transcripts or session audio.
+      render: text
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and this has not been reported before.
+          required: true
+        - label: I am running the latest version of both the app and the pack.
+          required: false
+        - label: >
+            I have not pasted verbatim conversation transcripts or session audio
+            in this issue.
+          required: true

--- a/.github/ISSUE_TEMPLATE/steam_platform_bug.yml
+++ b/.github/ISSUE_TEMPLATE/steam_platform_bug.yml
@@ -1,0 +1,154 @@
+name: Steam — platform bug
+description: >
+  Report a bug specific to the Steam edition: launcher, overlay, controller
+  input, Steam Deck, code signing, or platform-specific crash.
+labels:
+  - steam
+  - platform-bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for bugs that are specific to the Steam edition —
+        the Steam launcher, Steam overlay, controller navigation, Steam Deck
+        behaviour, code-signing errors, or platform-specific crashes that do
+        not reproduce in the open-source build.
+
+        For general app bugs unrelated to Steam, use the **Bug report** template.
+
+        **Privacy note:** Do not paste conversation transcripts, NPC session
+        logs, or audio recordings in this issue. Conversation Simulator keeps
+        all session data on your machine; please keep it there. If reproducing
+        the bug requires session content, use a made-up example or describe the
+        content in general terms.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+      placeholder: >
+        Example: The Steam overlay (Shift+Tab) causes the app window to go
+        black and never recover. Only a Steam restart clears it.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+      placeholder: >
+        Example: The Steam overlay should open and close without affecting the
+        app window.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Launch via Steam (not the standalone executable)
+        2. Start any scenario
+        3. Press Shift+Tab to open the Steam overlay
+        4. Close the overlay — app window is now black
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - Windows 10
+        - Windows 11
+        - macOS 13 (Ventura)
+        - macOS 14 (Sonoma)
+        - macOS 15 (Sequoia)
+        - Linux (specify distro below)
+        - Steam Deck / SteamOS
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: steam-deck
+    attributes:
+      label: Steam Deck
+      options:
+        - label: This bug occurs on or is specific to Steam Deck / SteamOS.
+
+  - type: textarea
+    id: hardware
+    attributes:
+      label: Hardware (CPU / GPU / RAM)
+      placeholder: |
+        CPU: Intel Core i7-12700K
+        GPU: NVIDIA RTX 3080 (driver 555.xx)
+        RAM: 32 GB
+        (Steam Deck: leave GPU as "Steam Deck integrated AMD RDNA 2")
+    validations:
+      required: true
+
+  - type: input
+    id: app-version
+    attributes:
+      label: App version
+      description: Shown in the app footer or About screen.
+      placeholder: "Example: 0.9.1-steam-beta.3"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: runtime
+    attributes:
+      label: Runtime backend in use
+      options:
+        - llama.cpp (built-in)
+        - ollama
+        - Not applicable / crash before model loads
+        - Other (describe below)
+    validations:
+      required: true
+
+  - type: input
+    id: model
+    attributes:
+      label: Model loaded at time of bug (if any)
+      placeholder: "Example: Qwen3 4B Instruct Q4_K_M"
+    validations:
+      required: false
+
+  - type: input
+    id: pack
+    attributes:
+      label: Installed pack (if relevant)
+      placeholder: "Example: Job Interview Basics 1.2.0"
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Sanitized logs or crash bundle path
+      description: >
+        Paste sanitized console output, Steam log snippets, or the path to a
+        crash bundle on your machine. Do not include conversation transcripts
+        or session audio. Redact any personal file-path prefixes (e.g. replace
+        your username with `<user>`).
+      render: text
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and this has not been reported before.
+          required: true
+        - label: I am running the latest Steam build (check for updates in Steam).
+          required: false
+        - label: >
+            I have not pasted any conversation transcripts or session audio in
+            this issue.
+          required: true

--- a/.github/ISSUE_TEMPLATE/steam_privacy_safety.yml
+++ b/.github/ISSUE_TEMPLATE/steam_privacy_safety.yml
@@ -1,0 +1,177 @@
+name: Steam — privacy or safety report
+description: >
+  Report a concern about local data handling, unexpected network activity, or
+  content safety in the Steam edition.
+labels:
+  - steam
+  - privacy
+  - safety
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template to report a concern about data privacy, unexpected
+        network activity, or content safety in the Steam edition of Conversation
+        Simulator.
+
+        **When to use private reporting instead:**
+        - If your report involves a **security vulnerability** (e.g. prompt
+          injection that escapes the sandbox, privilege escalation, data
+          exfiltration, or network traffic that should not occur), please use
+          [GitHub private vulnerability reporting](https://github.com/outrightmental/ConversationSimulator/security/advisories/new)
+          or follow the process in
+          [SECURITY.md](https://github.com/outrightmental/ConversationSimulator/blob/main/SECURITY.md).
+        - For concerns that require **confidential handling**, contact the
+          maintainers directly as described in
+          [CODE_OF_CONDUCT.md](https://github.com/outrightmental/ConversationSimulator/blob/main/CODE_OF_CONDUCT.md).
+
+        **Privacy note:** This is a public issue. Do not paste conversation
+        transcripts, NPC session logs, or audio recordings here unless you
+        intentionally choose to make that content public. The app stores all
+        session data on your machine — there is no need to share it to report a
+        privacy or safety concern. Describe the concern in general terms.
+
+        See [docs/privacy.md](https://github.com/outrightmental/ConversationSimulator/blob/main/docs/privacy.md)
+        and [docs/network-security.md](https://github.com/outrightmental/ConversationSimulator/blob/main/docs/network-security.md)
+        for the local-first data guarantees.
+
+  - type: dropdown
+    id: concern-type
+    attributes:
+      label: Type of concern
+      options:
+        - Unexpected network activity during a session (data should stay local)
+        - Session data (transcripts, audio, model output) written outside ~/.convsim/
+        - Model or pack downloaded without explicit player confirmation
+        - Content safety — NPC output crossed a content boundary
+        - Content safety — safety validator accepted something it should reject
+        - Content safety — safety validator rejected something that should be allowed
+        - Privacy — personal information collected or logged unexpectedly
+        - Other (describe below)
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: >
+        Describe the concern. Do not include verbatim transcripts or audio
+        unless you intentionally choose to make that content public — describe
+        content issues in general terms or with a made-up example.
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence (network trace, file path, log excerpt)
+      description: >
+        For network concerns: a sanitized packet-capture summary or proxy log
+        showing the unexpected traffic. For file-location concerns: the path
+        where data appeared (redact your username as `<user>`). For content
+        concerns: the shortest paraphrase necessary to describe the issue.
+      render: text
+    validations:
+      required: false
+
+  - type: input
+    id: pack-name
+    attributes:
+      label: Pack and scenario (if applicable)
+      placeholder: "Example: Job Interview Basics — The Executive Gauntlet, turn 7"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - Windows 10
+        - Windows 11
+        - macOS 13 (Ventura)
+        - macOS 14 (Sonoma)
+        - macOS 15 (Sequoia)
+        - Linux (specify distro below)
+        - Steam Deck / SteamOS
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: steam-deck
+    attributes:
+      label: Steam Deck
+      options:
+        - label: This concern occurs on or is specific to Steam Deck / SteamOS.
+
+  - type: textarea
+    id: hardware
+    attributes:
+      label: Hardware (CPU / GPU / RAM)
+      placeholder: |
+        CPU: Intel Core i9-14900K
+        GPU: NVIDIA RTX 4090 (driver 560.xx)
+        RAM: 64 GB
+        OS: Windows 11 23H2
+    validations:
+      required: true
+
+  - type: input
+    id: app-version
+    attributes:
+      label: App version
+      description: Shown in the app footer or About screen.
+      placeholder: "Example: 0.9.1-steam-beta.3"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: runtime
+    attributes:
+      label: Runtime backend in use
+      options:
+        - llama.cpp (built-in)
+        - ollama
+        - Not applicable
+        - Other (describe below)
+    validations:
+      required: false
+
+  - type: input
+    id: model
+    attributes:
+      label: Model in use (if applicable)
+      placeholder: "Example: Qwen3 4B Instruct Q4_K_M"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: disclosure-preference
+    attributes:
+      label: Disclosure preference
+      description: >
+        Public issues are visible to everyone. Select private if this concern
+        requires confidential handling — a maintainer will contact you.
+      options:
+        - Public — I am comfortable with this being visible on GitHub
+        - Private — please contact me directly for confidential handling
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Before submitting
+      options:
+        - label: >
+            This is not a security vulnerability requiring private disclosure.
+            (For security issues, use GitHub private vulnerability reporting or
+            SECURITY.md.)
+          required: true
+        - label: I have read docs/privacy.md and docs/network-security.md.
+          required: false
+        - label: >
+            I have not pasted conversation transcripts or session audio in this
+            issue unless I intentionally chose to make that content public.
+          required: true

--- a/docs/STEAM_ROADMAP.md
+++ b/docs/STEAM_ROADMAP.md
@@ -219,6 +219,7 @@ issue must not be started until the upstream issue is merged and closed.
 | [[Steam Roadmap] Add Steam edition roadmap addendum and release principles](https://github.com/outrightmental/ConversationSimulator/issues?q=is%3Aissue+steam-roadmap-addendum+in%3Atitle) | [docs/STEAM_ROADMAP.md](STEAM_ROADMAP.md) | Stage 1 prerequisite |
 | [[Steam Roadmap] Create Steam compliance and risk register for local-AI distribution](https://github.com/outrightmental/ConversationSimulator/issues?q=is%3Aissue+steam-compliance-risk-register+in%3Atitle) | [publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md](../publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md) | Stage 3 prerequisite |
 | [[Steam Roadmap] Define Steam MVP scope and release gates](https://github.com/outrightmental/ConversationSimulator/issues?q=is%3Aissue+steam-mvp-scope+in%3Atitle) | [docs/steam-mvp-scope.md](steam-mvp-scope.md) | Stage 2 prerequisite |
+| [[Steam Roadmap] Add issue templates for Steam QA, platform bugs, and content-pack bugs](https://github.com/outrightmental/ConversationSimulator/issues/185) | [docs/steam-triage.md](steam-triage.md) | Stage 3 prerequisite |
 
 All open and closed issues in this work stream:
 [GitHub — issues with `[Steam Roadmap]` prefix](https://github.com/outrightmental/ConversationSimulator/issues?q=is%3Aissue+%5BSteam+Roadmap%5D+in%3Atitle)
@@ -229,6 +230,7 @@ All open and closed issues in this work stream:
 
 - [ROADMAP.md](../ROADMAP.md) — base project roadmap (MVP acceptance criteria, build order, status)
 - [steam-mvp-scope.md](steam-mvp-scope.md) — minimum playable release features, optional targeted features, pass/fail gates, and post-launch deferrals
+- [steam-triage.md](steam-triage.md) — issue triage flow for private beta and public launch
 - [post-alpha-issues.md](post-alpha-issues.md) — triaged items deferred from the alpha
 - [privacy.md](privacy.md) — local-first promise and data handling details
 - [network-security.md](network-security.md) — runtime network enforcement

--- a/docs/steam-triage.md
+++ b/docs/steam-triage.md
@@ -1,0 +1,155 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+# Steam Edition Issue Triage Flow
+
+> **Purpose of this document:** Define how incoming issues filed against the
+> Steam edition are triaged and routed during private beta and after public
+> launch. Maintainers and beta coordinators should follow this document when
+> processing the issue queue.
+
+---
+
+## Issue templates and labels
+
+Five issue templates cover Steam-specific report categories. Each template
+auto-applies one or more labels via GitHub front matter.
+
+| Template | Auto-applied labels | Use when |
+|----------|---------------------|----------|
+| Steam — platform bug | `steam`, `platform-bug` | Launcher, Steam overlay, controller navigation, Steam Deck, code-signing, or platform-specific crash |
+| Steam — local model install failure | `steam`, `model-install` | Model Manager download, checksum verification, or model-load failures |
+| Steam — pack validation or content bug | `steam`, `pack-bug` | Schema error, broken scenario, incorrect scoring, or content rating mismatch |
+| Steam — privacy or safety report | `steam`, `privacy`, `safety` | Unexpected network activity, data written outside `~/.convsim/`, or content safety violations |
+| Steam — Creator Workbench bug | `steam`, `creator-workbench` | Pack authoring, scenario editing, asset management, or Workbench-specific crashes |
+
+General (non-Steam) templates remain available for bugs that reproduce in the
+open-source build.
+
+---
+
+## Private beta triage (Stage 3)
+
+During the Steam private beta the reporter pool is limited to invited testers:
+Outright Mental developers, staff, and selected community members. The issue
+volume is expected to be low and the signal-to-noise ratio high.
+
+### Triage cadence
+
+- **Daily:** A maintainer reviews all new `steam` issues filed in the past 24 hours.
+- **Weekly:** A triage sync reviews all open `steam` issues without a milestone or assignee.
+
+### Triage steps
+
+1. **Confirm the template was used.** Issues filed without a Steam template
+   and lacking the required fields (OS, hardware, app version) should be
+   labelled `needs-info` and a comment should request the missing data.
+
+2. **Classify severity.** Apply one of:
+
+   | Label | Meaning |
+   |-------|---------|
+   | `severity:critical` | Crash, data loss, or privacy violation — blocks beta continuation |
+   | `severity:high` | Core feature broken for a significant fraction of testers |
+   | `severity:medium` | Feature degraded but workaround exists |
+   | `severity:low` | Minor UI or cosmetic issue |
+
+3. **Route to the right milestone.** Steam private beta issues belong to
+   **Milestone 3**. Issues that are pre-existing open-source bugs should be
+   relabelled without Steam labels and moved to the appropriate open-source
+   milestone.
+
+4. **Assign an owner.** Every `severity:critical` or `severity:high` issue
+   must have a named assignee before the triage session closes.
+
+5. **Privacy and safety fast-path.** Issues labelled `privacy` or `safety`
+   skip the standard queue and are escalated immediately to the lead
+   maintainer regardless of the triage schedule. Issues where the reporter
+   selected "Private — please contact me directly" must be moved to a private
+   channel (GitHub private vulnerability reporting or direct email) before
+   any public response is posted.
+
+### Beta exit criteria
+
+The private beta may not advance to the public release gate (Stage 4) while
+any of the following are open:
+
+- Any issue labelled `severity:critical`
+- Any `privacy` or `safety` issue not yet resolved or explicitly accepted as
+  a known limitation with a documented mitigation
+- Any `platform-bug` on a required platform (Windows 10/11, macOS 13+, Linux
+  x86-64, Steam Deck) labelled `severity:high` or above
+
+See [steam-mvp-scope.md](steam-mvp-scope.md) for the full pass/fail release
+gate checklist.
+
+---
+
+## Public launch triage (Stage 4+)
+
+After the public free Steam release the reporter pool is the general public.
+Issue volume will be higher and the fraction of actionable reports lower.
+Apply the following adjustments to the private beta flow.
+
+### Triage cadence
+
+- **Every 48 hours:** A maintainer reviews new `steam` issues for severity
+  classification and `needs-info` requests.
+- **Weekly:** A triage sync reviews all open `steam` issues without a
+  milestone or assignee and closes stale `needs-info` issues that have
+  received no response in 14 days.
+
+### Additional routing rules
+
+| Condition | Action |
+|-----------|--------|
+| Duplicate of an existing open issue | Label `duplicate`, close with a link to the canonical issue. |
+| Reproducible only on a non-required platform | Label `platform:unsupported`, note in a comment, defer to post-launch milestone. |
+| `model-install` failure on a model not in the registry | Route to the model registry maintainer; label `triage:registry`. |
+| `pack-bug` in a community pack (not an official Outright Mental pack) | Confirm the pack source; if community-distributed, close with a pointer to the pack's own repository. |
+| `privacy` or `safety` escalation | Same fast-path as private beta — immediate escalation regardless of severity label. |
+| Reporter discloses session transcripts or audio in the issue | Add a maintainer comment reminding the reporter that session data is private, advise them to edit the issue or close and re-file without the content, and do not quote the disclosed content in any response. |
+
+### SLA targets (post-launch)
+
+| Severity | First-response target | Fix-or-defer target |
+|----------|-----------------------|---------------------|
+| `severity:critical` | 24 hours | 72 hours (hotfix or rollback) |
+| `severity:high` | 48 hours | Next point release |
+| `severity:medium` | 1 week | Next minor release |
+| `severity:low` | 2 weeks | Backlog — no hard target |
+
+SLA targets are aspirational during the volunteer-maintained phase and will be
+reviewed after 90 days of public release data.
+
+---
+
+## Privacy handling for all stages
+
+Conversation Simulator's local-first promise means session transcripts, audio,
+and model outputs are player-private by default. Triage must reinforce this:
+
+- **Never ask reporters to paste transcripts.** If reproducing a bug requires
+  session content, ask for a made-up example or a description in general terms.
+- **Never quote transcript content** in a maintainer comment, even if the
+  reporter included it.
+- **Flag accidental disclosure immediately.** If a reporter pastes transcripts
+  or audio, add a comment explaining the privacy concern and advise them to
+  edit the issue. Do not screenshot, copy, or reference the disclosed content.
+- **Private disclosure channel.** For issues labelled `privacy` or where the
+  reporter selected "Private" in the disclosure preference field, all
+  substantive discussion must move out of the public issue to GitHub private
+  vulnerability reporting or direct maintainer contact.
+
+See [privacy.md](privacy.md) for the full local-first data handling policy and
+[SECURITY.md](../SECURITY.md) for the security disclosure process.
+
+---
+
+## Links
+
+- [STEAM_ROADMAP.md](STEAM_ROADMAP.md) — release principles and release train
+- [steam-mvp-scope.md](steam-mvp-scope.md) — MVP feature requirements and pass/fail gates
+- [privacy.md](privacy.md) — local-first data handling details
+- [network-security.md](network-security.md) — runtime network enforcement
+- [safety-policy.md](safety-policy.md) — content safety policy
+- [SECURITY.md](../SECURITY.md) — security vulnerability disclosure
+- [GitHub issue templates](https://github.com/outrightmental/ConversationSimulator/tree/main/.github/ISSUE_TEMPLATE) — all available templates


### PR DESCRIPTION
## Summary

Implements [Steam Roadmap] issue #185: structured GitHub issue templates for Steam beta and post-launch support, plus a documented triage flow for maintainers.

### New issue templates (`.github/ISSUE_TEMPLATE/`)

| Template file | Auto-applied labels | Coverage |
|---|---|---|
| `steam_platform_bug.yml` | `steam`, `platform-bug` | Steam launcher, overlay, controller navigation, Steam Deck, code signing, platform crashes |
| `steam_model_install.yml` | `steam`, `model-install` | Model Manager download, checksum verification, and model-load failures |
| `steam_pack_bug.yml` | `steam`, `pack-bug` | Schema errors, broken scenarios, incorrect scoring, content rating mismatch |
| `steam_privacy_safety.yml` | `steam`, `privacy`, `safety` | Unexpected network activity, data written outside `~/.convsim/`, content safety violations |
| `steam_creator_workbench.yml` | `steam`, `creator-workbench` | Pack authoring, scenario editing, asset management, Workbench-specific crashes |

Every template collects: OS, CPU/GPU/RAM, Steam Deck status, app version, runtime/model, installed pack, and a sanitized logs/crash-bundle field. Every template includes a privacy note reminding reporters not to paste conversation transcripts or private audio unless they intentionally choose to share them. The privacy/safety template additionally includes a disclosure-preference field to route private reports out of the public issue queue and a mandatory checkbox confirming the report is not a security vulnerability requiring private disclosure.

### New document: `docs/steam-triage.md`

Documents the triage flow for both private beta (Stage 3) and public launch (Stage 4+):

- **Private beta triage:** Daily review cadence, severity classification (`severity:critical` through `severity:low`), assignment rules for high-severity issues, and privacy/safety fast-path (immediate escalation regardless of queue position)
- **Public launch triage:** 48-hour review cadence, additional routing rules for duplicates, unsupported platforms, community-pack bugs, and SLA targets per severity tier
- **Beta exit criteria:** No `severity:critical` open, no unresolved `privacy`/`safety` issues, no `severity:high` platform bugs on required platforms
- **Privacy handling:** Guidelines for triage across all stages, including rules about never requesting transcripts, never quoting disclosed content, and flagging accidental disclosure

### Updated: `docs/STEAM_ROADMAP.md`

Added the new issue templates and triage document to the roadmap issue table and links index.

## Verification

- Confirmed all five template YAML files contain valid GitHub issue-form syntax (field types, `validations`, `labels` front matter)
- Verified label names are consistent across all templates
- Cross-checked required fields against the issue definition of done (OS, CPU/GPU/RAM, Steam Deck status, app version, runtime/model, installed pack, logs path)
- Confirmed privacy note appears in every template with consistent wording
- Verified `steam_privacy_safety.yml` includes the mandatory checkbox and disclosure-preference dropdown

Closes #185