### PR TITLE
Register Steam app, depots, packages, and free-to-play configuration

### DIFF
--- a/.github/workflows/steam-deploy.yml
+++ b/.github/workflows/steam-deploy.yml
@@ -1,0 +1,201 @@
+# SPDX-License-Identifier: Apache-2.0
+# Steam deploy workflow.
+#
+# Uploads a tagged GitHub release to Steam via SteamPipe (steamcmd).
+# This workflow is triggered manually — it does not run on every push.
+#
+# ── One-time setup required ──────────────────────────────────────────────────
+#
+# Repository variables (Settings → Secrets and variables → Actions → Variables):
+#   STEAM_APP_ID              Valve-assigned App ID (non-secret, assigned at registration)
+#   STEAM_DEPOT_WINDOWS_ID    Windows x86-64 depot ID
+#   STEAM_DEPOT_MACOS_ID      macOS depot ID
+#   STEAM_DEPOT_LINUX_ID      Linux / SteamOS depot ID
+#
+# Repository secrets (Settings → Secrets and variables → Actions → Secrets):
+#   STEAM_USERNAME            Steam username of the dedicated CI build account
+#   STEAM_CONFIG_VDF          Base64-encoded config.vdf from an authenticated Steam
+#                             session on the build account (bypasses SteamGuard in CI)
+#
+# See publishing/STEAM_APP_REGISTRATION.md for how to obtain and rotate these values.
+#
+# ── Release gate reminder ────────────────────────────────────────────────────
+#
+# Stage 3 (private beta): set_live_branch = "beta"
+#   All Stage 3 gate criteria in docs/steam-mvp-scope.md must pass first,
+#   including G3-01 (code signing and notarisation) and G3-02 (depot audit).
+#
+# Stage 4 (public release): set_live_branch = "default"
+#   All Stage 4 gate criteria must pass first, including G4-01 (Valve review
+#   approval) and G4-02 (Steam Deck Verified tier).
+#
+# When set_live_branch is empty, the build is staged in Steamworks but no
+# branch goes live — use this for dry runs or when manual sign-off is needed.
+name: Steam Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'GitHub release tag to upload (e.g. v0.1.0)'
+        required: true
+        type: string
+      build_description:
+        description: >
+          Human-readable build description shown in Steamworks partner portal.
+          Defaults to "Conversation Simulator <tag>" if left empty.
+        required: false
+        default: ''
+        type: string
+      set_live_branch:
+        description: >
+          Steam branch to set live after upload.
+          Leave empty to stage the build without making it live.
+          Use "beta" for Stage 3 private beta.
+          Use "default" only for a Stage 4 public release — all gate criteria
+          in docs/steam-mvp-scope.md must be met before selecting "default".
+        required: false
+        default: ''
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  steam-upload:
+    name: Upload to Steam (${{ inputs.release_tag }})
+    runs-on: ubuntu-latest
+
+    # The steam-release environment gates this job behind a manual approval step.
+    # Create it in GitHub → Settings → Environments → New environment.
+    # Add required reviewers so no Steam credential is exposed without sign-off.
+    environment: steam-release
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # ── Resolve build description ──────────────────────────────────────────
+      - name: Resolve build description
+        id: desc
+        run: |
+          if [ -n "${{ inputs.build_description }}" ]; then
+            printf 'value=%s\n' "${{ inputs.build_description }}" >> "$GITHUB_OUTPUT"
+          else
+            printf 'value=Conversation Simulator %s\n' "${{ inputs.release_tag }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      # ── Download GitHub release assets ─────────────────────────────────────
+      - name: Download release artifacts
+        run: |
+          gh release download "${{ inputs.release_tag }}" \
+            --dir release-artifacts \
+            --skip-errors
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: List downloaded artifacts
+        run: find release-artifacts -type f | sort
+
+      # ── Organise artifacts into per-platform depot content directories ──────
+      #
+      # Steam depots contain application files, not installer packages.
+      # The current release.yml produces installers (.exe, .msi, .dmg,
+      # .AppImage, .deb). Until a separate "raw binary" build step is added,
+      # these installer assets are placed in the depot directories as a
+      # placeholder. Update these patterns when the Tauri build produces
+      # a portable application directory alongside the installers.
+      - name: Organise depot content
+        run: |
+          mkdir -p steam-content/windows steam-content/macos steam-content/linux
+
+          find release-artifacts -name "*.exe" \
+            -exec cp -v {} steam-content/windows/ \;
+          find release-artifacts -name "*.msi" \
+            -exec cp -v {} steam-content/windows/ \;
+
+          find release-artifacts -name "*.dmg" \
+            -exec cp -v {} steam-content/macos/ \;
+
+          find release-artifacts -name "*.AppImage" \
+            -exec cp -v {} steam-content/linux/ \;
+          find release-artifacts -name "*.deb" \
+            -exec cp -v {} steam-content/linux/ \;
+
+          echo "--- Depot content summary ---"
+          find steam-content -type f | sort
+
+      # ── Verify no model weight files are staged ────────────────────────────
+      # Enforces depot content exclusion rule MD-04 from the compliance register.
+      - name: Audit depot content for model weight files
+        run: |
+          bad=$(find steam-content -type f \( \
+            -name "*.gguf" -o -name "*.safetensors" -o -name "*.bin" \
+          \))
+          if [ -n "$bad" ]; then
+            echo "ERROR: model weight files found in depot content — remove before uploading:"
+            echo "$bad"
+            exit 1
+          fi
+          echo "Depot audit passed: no model weight files detected."
+
+      # ── Generate SteamPipe build scripts from VDF templates ────────────────
+      - name: Generate SteamPipe VDF files
+        env:
+          STEAM_APP_ID:            ${{ vars.STEAM_APP_ID }}
+          STEAM_DEPOT_WINDOWS_ID:  ${{ vars.STEAM_DEPOT_WINDOWS_ID }}
+          STEAM_DEPOT_MACOS_ID:    ${{ vars.STEAM_DEPOT_MACOS_ID }}
+          STEAM_DEPOT_LINUX_ID:    ${{ vars.STEAM_DEPOT_LINUX_ID }}
+          STEAM_BUILD_DESCRIPTION: ${{ steps.desc.outputs.value }}
+          STEAM_SET_LIVE_BRANCH:   ${{ inputs.set_live_branch }}
+        run: |
+          mkdir -p steam-build/output
+          envsubst < steam/app_build.vdf.tpl     > steam-build/app_build.vdf
+          envsubst < steam/depot_windows.vdf.tpl > steam-build/depot_windows.vdf
+          envsubst < steam/depot_macos.vdf.tpl   > steam-build/depot_macos.vdf
+          envsubst < steam/depot_linux.vdf.tpl   > steam-build/depot_linux.vdf
+
+          # Log the generated app_build.vdf with numeric IDs redacted for safety.
+          echo "--- Generated app_build.vdf (IDs redacted) ---"
+          sed 's/[0-9]\{6,\}/[REDACTED]/g' steam-build/app_build.vdf
+
+      # ── Install steamcmd ───────────────────────────────────────────────────
+      - name: Install steamcmd
+        run: |
+          sudo add-apt-repository multiverse
+          sudo dpkg --add-architecture i386
+          sudo apt-get update -qq
+          echo steamcmd steam/question select "I AGREE" | sudo debconf-set-selections
+          sudo apt-get install -y steamcmd
+
+      # ── Restore SteamGuard config ──────────────────────────────────────────
+      # Decodes the base64-encoded config.vdf from the STEAM_CONFIG_VDF secret.
+      # This bypasses the interactive SteamGuard prompt in headless CI.
+      - name: Restore Steam config
+        env:
+          STEAM_CONFIG_VDF: ${{ secrets.STEAM_CONFIG_VDF }}
+        run: |
+          mkdir -p "$HOME/.steam/steam/config"
+          printf '%s' "$STEAM_CONFIG_VDF" | base64 --decode \
+            > "$HOME/.steam/steam/config/config.vdf"
+          chmod 600 "$HOME/.steam/steam/config/config.vdf"
+
+      # ── Upload to Steam ────────────────────────────────────────────────────
+      - name: Upload build to Steam
+        env:
+          STEAM_USERNAME: ${{ secrets.STEAM_USERNAME }}
+        run: |
+          steamcmd \
+            +login "$STEAM_USERNAME" \
+            +run_app_build "$(pwd)/steam-build/app_build.vdf" \
+            +quit
+
+      # ── Log build output ───────────────────────────────────────────────────
+      - name: Show steamcmd build output
+        if: always()
+        run: |
+          if [ -d steam-build/output ]; then
+            find steam-build/output -type f | sort
+            for f in steam-build/output/*.log; do
+              [ -f "$f" ] && { echo "--- $f ---"; cat "$f"; }
+            done
+          fi

--- a/.github/workflows/steam-deploy.yml
+++ b/.github/workflows/steam-deploy.yml
@@ -77,21 +77,27 @@ jobs:
       # ── Resolve build description ──────────────────────────────────────────
       - name: Resolve build description
         id: desc
+        # Inputs are passed through env vars — never interpolated directly into
+        # the shell — to avoid GitHub Actions expression injection (CWE-94).
+        env:
+          BUILD_DESCRIPTION: ${{ inputs.build_description }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
-          if [ -n "${{ inputs.build_description }}" ]; then
-            printf 'value=%s\n' "${{ inputs.build_description }}" >> "$GITHUB_OUTPUT"
+          if [ -n "$BUILD_DESCRIPTION" ]; then
+            printf 'value=%s\n' "$BUILD_DESCRIPTION" >> "$GITHUB_OUTPUT"
           else
-            printf 'value=Conversation Simulator %s\n' "${{ inputs.release_tag }}" >> "$GITHUB_OUTPUT"
+            printf 'value=Conversation Simulator %s\n' "$RELEASE_TAG" >> "$GITHUB_OUTPUT"
           fi
 
       # ── Download GitHub release assets ─────────────────────────────────────
       - name: Download release artifacts
-        run: |
-          gh release download "${{ inputs.release_tag }}" \
-            --dir release-artifacts \
-            --skip-errors
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          gh release download "$RELEASE_TAG" \
+            --dir release-artifacts \
+            --skip-errors
 
       - name: List downloaded artifacts
         run: find release-artifacts -type f | sort

--- a/docs/STEAM_ROADMAP.md
+++ b/docs/STEAM_ROADMAP.md
@@ -220,6 +220,7 @@ issue must not be started until the upstream issue is merged and closed.
 | [[Steam Roadmap] Create Steam compliance and risk register for local-AI distribution](https://github.com/outrightmental/ConversationSimulator/issues?q=is%3Aissue+steam-compliance-risk-register+in%3Atitle) | [publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md](../publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md) | Stage 3 prerequisite |
 | [[Steam Roadmap] Define Steam MVP scope and release gates](https://github.com/outrightmental/ConversationSimulator/issues?q=is%3Aissue+steam-mvp-scope+in%3Atitle) | [docs/steam-mvp-scope.md](steam-mvp-scope.md) | Stage 2 prerequisite |
 | [[Steam Roadmap] Add issue templates for Steam QA, platform bugs, and content-pack bugs](https://github.com/outrightmental/ConversationSimulator/issues/185) | [docs/steam-triage.md](steam-triage.md) | Stage 3 prerequisite |
+| [[Steamworks] Register Steam app, depots, packages, and free-to-play configuration](https://github.com/outrightmental/ConversationSimulator/issues/226) | [publishing/STEAM_APP_REGISTRATION.md](../publishing/STEAM_APP_REGISTRATION.md), [`steam/`](../steam/), [`.github/workflows/steam-deploy.yml`](../.github/workflows/steam-deploy.yml) | Stage 3 prerequisite (must be complete before first depot submission) |
 
 All open and closed issues in this work stream:
 [GitHub — issues with `[Steam Roadmap]` prefix](https://github.com/outrightmental/ConversationSimulator/issues?q=is%3Aissue+%5BSteam+Roadmap%5D+in%3Atitle)

--- a/docs/STEAM_ROADMAP.md
+++ b/docs/STEAM_ROADMAP.md
@@ -219,6 +219,7 @@ issue must not be started until the upstream issue is merged and closed.
 | [[Steam Roadmap] Add Steam edition roadmap addendum and release principles](https://github.com/outrightmental/ConversationSimulator/issues?q=is%3Aissue+steam-roadmap-addendum+in%3Atitle) | [docs/STEAM_ROADMAP.md](STEAM_ROADMAP.md) | Stage 1 prerequisite |
 | [[Steam Roadmap] Create Steam compliance and risk register for local-AI distribution](https://github.com/outrightmental/ConversationSimulator/issues?q=is%3Aissue+steam-compliance-risk-register+in%3Atitle) | [publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md](../publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md) | Stage 3 prerequisite |
 | [[Steam Roadmap] Define Steam MVP scope and release gates](https://github.com/outrightmental/ConversationSimulator/issues?q=is%3Aissue+steam-mvp-scope+in%3Atitle) | [docs/steam-mvp-scope.md](steam-mvp-scope.md) | Stage 2 prerequisite |
+| [[Steamworks] Register Steam app, depots, packages, and free-to-play configuration](https://github.com/outrightmental/ConversationSimulator/issues/226) | [publishing/STEAM_APP_REGISTRATION.md](../publishing/STEAM_APP_REGISTRATION.md), [`steam/`](../steam/), [`.github/workflows/steam-deploy.yml`](../.github/workflows/steam-deploy.yml) | Stage 3 prerequisite (must be complete before first depot submission) |
 
 All open and closed issues in this work stream:
 [GitHub — issues with `[Steam Roadmap]` prefix](https://github.com/outrightmental/ConversationSimulator/issues?q=is%3Aissue+%5BSteam+Roadmap%5D+in%3Atitle)

--- a/publishing/STEAM_APP_REGISTRATION.md
+++ b/publishing/STEAM_APP_REGISTRATION.md
@@ -1,0 +1,248 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+# Steam App Registration
+
+> **Purpose:** Record the Steamworks partner portal configuration for the free
+> Outright Mental-sponsored edition of Conversation Simulator. This document is
+> the authoritative reference for app identity, depot layout, package
+> configuration, branch strategy, and the location of CI credentials.
+>
+> **Audience:** Platform team members and Outright Mental staff with Steamworks
+> partner portal access.
+>
+> **Sensitive data:** No secret credentials appear in this document. App IDs and
+> depot IDs are non-secret identifiers assigned by Valve. Steam partner
+> credentials are stored as GitHub Actions secrets — see
+> [CI credentials](#ci-credentials).
+
+---
+
+## Publisher and developer identity
+
+| Field | Value |
+|-------|-------|
+| **Partner account** | Outright Mental |
+| **Publisher display name** | Outright Mental |
+| **Developer display name** | Outright Mental |
+| **Partner portal** | https://partner.steamgames.com/ |
+
+The app is registered under the Outright Mental partner account. All Steamworks
+permissions are managed through that account. Team members who need partner
+access must be granted it by the account holder — see
+[Partner permissions](#partner-permissions).
+
+---
+
+## App registration checklist
+
+Steps to complete in the Steamworks partner portal when registering the app.
+Mark each item when done and record the assigned identifiers in the
+[Identifiers](#identifiers) table below.
+
+### Basic setup
+
+- [ ] Register new app under the Outright Mental partner account.
+- [ ] Set **App type** to `Game`.
+- [ ] Set **Developer** to `Outright Mental`.
+- [ ] Set **Publisher** to `Outright Mental`.
+- [ ] Enter the store page title: `Conversation Simulator`.
+- [ ] Record the assigned **App ID** in the [Identifiers](#identifiers) table and set it as the `STEAM_APP_ID` repository variable.
+
+### Free-to-play configuration
+
+- [ ] Under **Pricing & Availability**, set the **Base price** to `Free to Play`.
+- [ ] Do **not** set a purchase price or create a paid package. The base package is always free.
+- [ ] Verify the app does **not** appear in the "Set up pricing" wizard with a price — it must be marked Free on Steam from the first configuration step.
+- [ ] Confirm no DLC or microtransaction package is created during initial setup.
+- [ ] Verify the free default package (automatically created by Valve for free-to-play apps) contains all three platform depots once they are created.
+
+The Steam release is and will remain free to download and play. There is no
+base purchase price, no subscription, and no pay-to-unlock core content.
+See [`docs/STEAM_ROADMAP.md`](../docs/STEAM_ROADMAP.md) — Free on Steam,
+sponsored by Outright Mental.
+
+### Depots
+
+Create exactly three depots — one per supported platform. Do not create a shared
+data depot for the MVP. See [Depot layout](#depot-layout) for rationale and
+content rules.
+
+- [ ] Create depot **Windows x86-64** — record its ID as `STEAM_DEPOT_WINDOWS_ID`.
+- [ ] Create depot **macOS (Universal)** — record its ID as `STEAM_DEPOT_MACOS_ID`.
+- [ ] Create depot **Linux x86-64 / SteamOS** — record its ID as `STEAM_DEPOT_LINUX_ID`.
+- [ ] Set repository variables `STEAM_DEPOT_WINDOWS_ID`, `STEAM_DEPOT_MACOS_ID`, and `STEAM_DEPOT_LINUX_ID` to the assigned depot IDs.
+
+### Packages
+
+A **package** in Steamworks bundles one or more depots and determines what a
+player owns. For a free-to-play title, Valve automatically creates a **free
+default package** containing all depots.
+
+- [ ] Verify the automatic free package exists and contains all three depots.
+- [ ] Do **not** create a paid package or a retail activation package.
+- [ ] Record the free package ID (assigned by Valve) in the [Identifiers](#identifiers) table.
+
+### Release state
+
+- [ ] Set the **Release State** to `Coming Soon` during initial setup.
+- [ ] Do **not** set the app live until Stage 3 (private beta) criteria are met. See [`docs/steam-mvp-scope.md`](../docs/steam-mvp-scope.md) Stage 3 gate.
+
+---
+
+## Identifiers
+
+These identifiers are assigned by Valve when the app is registered. They are
+not secret — they appear in Steam store URLs and are visible to anyone with
+access to the app. They are stored as GitHub repository **variables** (not
+secrets) so that CI workflows can reference them without hardcoding values in
+source files.
+
+| Identifier | GitHub repository variable | Description |
+|-----------|---------------------------|-------------|
+| App ID | `vars.STEAM_APP_ID` | Assigned by Valve at registration. Seven-digit format, e.g. `1234567`. |
+| Windows depot ID | `vars.STEAM_DEPOT_WINDOWS_ID` | First depot created; Windows x86-64 content. Valve assigns depot IDs sequentially after the App ID. |
+| macOS depot ID | `vars.STEAM_DEPOT_MACOS_ID` | Second depot created; macOS (Apple Silicon + Intel) content. |
+| Linux/SteamOS depot ID | `vars.STEAM_DEPOT_LINUX_ID` | Third depot created; Linux x86-64 and Steam Deck content. |
+| Free package ID | *(record here after registration)* | Automatically created by Valve for free-to-play apps. Not referenced in CI. |
+
+**To set a repository variable:** GitHub → repository Settings → Secrets and
+variables → Actions → Variables tab → New repository variable.
+
+---
+
+## Depot layout
+
+The MVP uses three depots — one per target platform. Each depot contains only
+the binaries and resources for that platform.
+
+| Depot variable | Platform | Content |
+|----------------|----------|---------|
+| `STEAM_DEPOT_WINDOWS_ID` | Windows 10 / 11 (x86-64) | Tauri application directory; no NSIS installer |
+| `STEAM_DEPOT_MACOS_ID` | macOS 13+ (Apple Silicon + Intel) | Tauri `.app` bundle |
+| `STEAM_DEPOT_LINUX_ID` | Linux x86-64 + SteamOS 3.x | Tauri binary and resources |
+
+**No shared data depot in v1.** Scenario packs and model weights are distributed
+separately:
+
+- **Official packs** are bundled with the application binary and included in
+  each platform depot.
+- **Model weights** are never placed in any depot — they are downloaded
+  explicitly through the Model Manager at the player's request. See risk MD-04
+  in [`publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md`](STEAM_COMPLIANCE_AND_RISK_REGISTER.md).
+
+### Depot content exclusions
+
+The following file types must **never** appear in any Steam depot:
+
+| Pattern | Reason |
+|---------|--------|
+| `*.gguf`, `*.bin`, `*.safetensors` | Model weight files — distribution via Steam would violate most model licenses and add gigabytes to the installer (see MD-04) |
+| `*.pdb` | Windows debug symbols — not useful to players and may expose internal symbol names |
+| `*.dSYM/` | macOS debug symbol bundles |
+| `~/.convsim/` | Player data directories — must never be included in a depot |
+
+These exclusions are enforced in the SteamPipe depot VDF templates:
+
+- [`steam/depot_windows.vdf.tpl`](../steam/depot_windows.vdf.tpl)
+- [`steam/depot_macos.vdf.tpl`](../steam/depot_macos.vdf.tpl)
+- [`steam/depot_linux.vdf.tpl`](../steam/depot_linux.vdf.tpl)
+
+A depot content audit is required before each Steam build submission — see
+checklist item SR-08 in
+[`publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md`](STEAM_COMPLIANCE_AND_RISK_REGISTER.md).
+
+---
+
+## Branch strategy
+
+Steam uses **branches** to control which build a player's Steam client
+downloads. The following branches are used for Conversation Simulator.
+
+| Branch | Audience | Set live by |
+|--------|----------|------------|
+| `default` | All public players | Platform team, only after Stage 4 gate passes |
+| `beta` | Private beta testers (Stage 3) | Platform team, after Stage 3 gate passes |
+
+**Do not create additional branches** without updating this document and the
+deploy workflow.
+
+### Setting a branch live
+
+1. Trigger the deploy workflow (`.github/workflows/steam-deploy.yml`) with the
+   target release tag and, optionally, the `set_live_branch` input set to
+   `beta` or `default`.
+2. If `set_live_branch` is left empty, the build is staged in Steamworks but no
+   branch is made live — use this for a dry run or when manual sign-off is
+   required before going live.
+3. For `default` (public release): the Stage 4 gate in
+   [`docs/steam-mvp-scope.md`](../docs/steam-mvp-scope.md) must be fully passed
+   before this branch is set live.
+
+---
+
+## Partner permissions
+
+Access to the Steamworks partner portal is managed through the Outright Mental
+partner account.
+
+| Role | Who | Permissions |
+|------|-----|------------|
+| **Account administrator** | Outright Mental account holder | Full access; manages partner permissions, financial settings, and legal agreements |
+| **Developer** | Platform team members | Upload builds, manage depots, edit store page draft |
+| **QA tester** | QA team, beta testers | Access private beta builds; no partner portal access |
+
+**To add a team member:** Steamworks partner portal → Users & Permissions →
+Manage Users → Add a user. Assign the Developer group. Do not assign the Admin
+role to individuals who do not own the partner account.
+
+**Beta tester access** is granted through a Steam key batch — not through
+partner portal roles. Keys for Stage 3 private testers are generated in
+Steamworks → Packages → [Free package] → Generate Steam Product Codes.
+
+---
+
+## CI credentials
+
+The Steam deploy workflow (`.github/workflows/steam-deploy.yml`) authenticates
+to Steam using a **dedicated build account**, not the main Outright Mental
+partner account. A separate account limits the blast radius of a compromised CI
+credential.
+
+### Required GitHub Actions secrets
+
+| Secret name | Description | How to obtain |
+|------------|-------------|---------------|
+| `STEAM_USERNAME` | Steam username of the dedicated CI build account | Create a new Steam account for CI use; grant it Developer access in the Steamworks partner portal under Users & Permissions |
+| `STEAM_CONFIG_VDF` | Base64-encoded `config.vdf` from an authenticated Steam session on the build account | Log in as the build account on a machine with Steam installed; complete the SteamGuard prompt; copy `~/.steam/steam/config/config.vdf`; encode it: `base64 -w0 ~/.steam/steam/config/config.vdf` |
+
+**Why `STEAM_CONFIG_VDF` instead of a password:** Steam requires two-factor
+authentication (SteamGuard). Storing a `config.vdf` from an already-authenticated
+session bypasses the interactive 2FA prompt in headless CI environments. Treat
+this file with the same confidentiality as a password — rotate it if the build
+account is ever compromised.
+
+**To set a GitHub Actions secret:** GitHub → repository Settings → Secrets and
+variables → Actions → Secrets tab → New repository secret.
+
+### Refreshing `STEAM_CONFIG_VDF`
+
+The SteamGuard config expires after approximately one year of inactivity on the
+build account. If the deploy workflow fails with a SteamGuard or authentication
+error:
+
+1. Log in as the build account on a local machine with Steam installed.
+2. Complete the SteamGuard prompt.
+3. Copy and re-encode the updated `config.vdf`.
+4. Update the `STEAM_CONFIG_VDF` secret in GitHub.
+
+---
+
+## Links
+
+- [`steam/app_build.vdf.tpl`](../steam/app_build.vdf.tpl) — SteamPipe app build VDF template
+- [`steam/depot_windows.vdf.tpl`](../steam/depot_windows.vdf.tpl) — Windows depot VDF template
+- [`steam/depot_macos.vdf.tpl`](../steam/depot_macos.vdf.tpl) — macOS depot VDF template
+- [`steam/depot_linux.vdf.tpl`](../steam/depot_linux.vdf.tpl) — Linux/SteamOS depot VDF template
+- [`.github/workflows/steam-deploy.yml`](../.github/workflows/steam-deploy.yml) — Steam deploy workflow
+- [`docs/STEAM_ROADMAP.md`](../docs/STEAM_ROADMAP.md) — Release train and release principles
+- [`docs/steam-mvp-scope.md`](../docs/steam-mvp-scope.md) — Stage gate criteria
+- [`publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md`](STEAM_COMPLIANCE_AND_RISK_REGISTER.md) — Risk register (MD-04, SR-08)

--- a/steam/app_build.vdf.tpl
+++ b/steam/app_build.vdf.tpl
@@ -1,0 +1,48 @@
+// SteamPipe app build configuration template.
+//
+// This is a template file — do not pass it to steamcmd directly.
+// The deploy workflow (.github/workflows/steam-deploy.yml) substitutes
+// the ${VAR} placeholders using envsubst before invoking steamcmd.
+//
+// Variables substituted at deploy time:
+//   STEAM_APP_ID             — from GitHub repository variable vars.STEAM_APP_ID
+//   STEAM_DEPOT_WINDOWS_ID   — from vars.STEAM_DEPOT_WINDOWS_ID
+//   STEAM_DEPOT_MACOS_ID     — from vars.STEAM_DEPOT_MACOS_ID
+//   STEAM_DEPOT_LINUX_ID     — from vars.STEAM_DEPOT_LINUX_ID
+//   STEAM_BUILD_DESCRIPTION  — set by the deploy workflow (tag + date)
+//   STEAM_SET_LIVE_BRANCH    — from workflow input; empty = stage only, do not set live
+//   GITHUB_WORKSPACE         — set automatically by GitHub Actions
+//
+// See publishing/STEAM_APP_REGISTRATION.md for depot layout and content rules.
+"AppBuild"
+{
+    "AppID"         "${STEAM_APP_ID}"
+    "Desc"          "${STEAM_BUILD_DESCRIPTION}"
+
+    // Preview mode: set to "1" to do a dry run without uploading to Steam.
+    // The deploy workflow always sets this to "0" for a real upload.
+    "Preview"       "0"
+
+    // Local: path to a local content server; leave empty for normal uploads.
+    "Local"         ""
+
+    // SetLive: branch to set live after upload. Empty string = stage only.
+    // Use "beta" for Stage 3 private beta; "default" for Stage 4 public release.
+    "SetLive"       "${STEAM_SET_LIVE_BRANCH}"
+
+    // ContentRoot is the base directory for relative paths in depot VDFs.
+    // Set to the workspace root so depot VDFs can use absolute paths.
+    "ContentRoot"   "${GITHUB_WORKSPACE}/"
+
+    // BuildOutput: where steamcmd writes build logs and manifests.
+    "BuildOutput"   "${GITHUB_WORKSPACE}/steam-build/output/"
+
+    "Depots"
+    {
+        // One depot per platform. Depot IDs are assigned by Valve at registration
+        // and stored as GitHub repository variables — see publishing/STEAM_APP_REGISTRATION.md.
+        "${STEAM_DEPOT_WINDOWS_ID}"  "depot_windows.vdf"
+        "${STEAM_DEPOT_MACOS_ID}"    "depot_macos.vdf"
+        "${STEAM_DEPOT_LINUX_ID}"    "depot_linux.vdf"
+    }
+}

--- a/steam/depot_linux.vdf.tpl
+++ b/steam/depot_linux.vdf.tpl
@@ -1,0 +1,33 @@
+// SteamPipe depot build configuration — Linux x86-64 / SteamOS.
+//
+// Template file. Substituted by the deploy workflow before steamcmd is invoked.
+// Variables: STEAM_DEPOT_LINUX_ID, GITHUB_WORKSPACE.
+//
+// Content: the Tauri application binary and resources for Linux x86-64.
+// This depot covers both standard Linux (glibc, tested on Ubuntu 22.04 and
+// Fedora 40) and Steam Deck (SteamOS 3.x, x86-64).
+//
+// Steam Deck Verified tier requires passing the verification checklist in
+// docs/STEAM_ROADMAP.md before the public release gate (Stage 4) opens.
+//
+// The deploy workflow places Linux content at:
+//   ${GITHUB_WORKSPACE}/steam-content/linux/
+"DepotBuild"
+{
+    "DepotID"       "${STEAM_DEPOT_LINUX_ID}"
+
+    "ContentRoot"   "${GITHUB_WORKSPACE}/steam-content/linux/"
+
+    "FileMapping"
+    {
+        "LocalPath"     "*"
+        "DepotPath"     "."
+        "Recursive"     "1"
+    }
+
+    // Exclude model weight files — see risk MD-04 in
+    // publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md.
+    "FileExclusion" "*.gguf"
+    "FileExclusion" "*.bin"
+    "FileExclusion" "*.safetensors"
+}

--- a/steam/depot_macos.vdf.tpl
+++ b/steam/depot_macos.vdf.tpl
@@ -1,0 +1,37 @@
+// SteamPipe depot build configuration — macOS (Apple Silicon + Intel).
+//
+// Template file. Substituted by the deploy workflow before steamcmd is invoked.
+// Variables: STEAM_DEPOT_MACOS_ID, GITHUB_WORKSPACE.
+//
+// Content: the Tauri .app bundle for macOS, targeting Apple Silicon (arm64)
+// and Intel (x86-64). A universal binary is preferred; separate slices are
+// acceptable if a universal build is not yet available.
+//
+// The build must be notarised with an Apple Developer ID certificate before
+// this depot is submitted for Stage 3 (private beta) or Stage 4 (public
+// release) — see gate G3-01 in docs/steam-mvp-scope.md.
+//
+// The deploy workflow places macOS content at:
+//   ${GITHUB_WORKSPACE}/steam-content/macos/
+"DepotBuild"
+{
+    "DepotID"       "${STEAM_DEPOT_MACOS_ID}"
+
+    "ContentRoot"   "${GITHUB_WORKSPACE}/steam-content/macos/"
+
+    "FileMapping"
+    {
+        "LocalPath"     "*"
+        "DepotPath"     "."
+        "Recursive"     "1"
+    }
+
+    // Exclude debug symbol bundles.
+    "FileExclusion" "*.dSYM"
+
+    // Exclude model weight files — see risk MD-04 in
+    // publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md.
+    "FileExclusion" "*.gguf"
+    "FileExclusion" "*.bin"
+    "FileExclusion" "*.safetensors"
+}

--- a/steam/depot_macos.vdf.tpl
+++ b/steam/depot_macos.vdf.tpl
@@ -26,8 +26,10 @@
         "Recursive"     "1"
     }
 
-    // Exclude debug symbol bundles.
-    "FileExclusion" "*.dSYM"
+    // Exclude debug symbol bundles. A .dSYM is a directory bundle, so the
+    // pattern must match the files inside it — SteamPipe FileExclusion is
+    // matched per file path, not against directory entries.
+    "FileExclusion" "*.dSYM/*"
 
     // Exclude model weight files — see risk MD-04 in
     // publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md.

--- a/steam/depot_windows.vdf.tpl
+++ b/steam/depot_windows.vdf.tpl
@@ -1,0 +1,35 @@
+// SteamPipe depot build configuration — Windows x86-64.
+//
+// Template file. Substituted by the deploy workflow before steamcmd is invoked.
+// Variables: STEAM_DEPOT_WINDOWS_ID, GITHUB_WORKSPACE.
+//
+// Content: the Tauri application directory for Windows x86-64.
+// Do NOT include the NSIS installer (.exe setup) here — Steam's own depot
+// mechanism handles installation. Upload the raw application binary and
+// its resources from the Tauri build output.
+//
+// The deploy workflow places Windows content at:
+//   ${GITHUB_WORKSPACE}/steam-content/windows/
+"DepotBuild"
+{
+    "DepotID"       "${STEAM_DEPOT_WINDOWS_ID}"
+
+    "ContentRoot"   "${GITHUB_WORKSPACE}/steam-content/windows/"
+
+    "FileMapping"
+    {
+        "LocalPath"     "*"
+        "DepotPath"     "."
+        "Recursive"     "1"
+    }
+
+    // Exclude debug symbols — not useful to players.
+    "FileExclusion" "*.pdb"
+
+    // Exclude model weight files. Model weights must never appear in any
+    // Steam depot — see risk MD-04 in
+    // publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md.
+    "FileExclusion" "*.gguf"
+    "FileExclusion" "*.bin"
+    "FileExclusion" "*.safetensors"
+}


### PR DESCRIPTION
## Summary

Delivers issue #226 — establishes the Steamworks infrastructure for the free Outright Mental-sponsored Steam edition of Conversation Simulator. This includes partner portal configuration, depot build specifications, CI/CD workflow automation, security hardening against expression injection, and a fix for macOS depot exclusion patterns.

## Changes

### Documentation and Configuration

- **`publishing/STEAM_APP_REGISTRATION.md`** — Authoritative reference for Steamworks partner portal setup: publisher/developer identity (Outright Mental), app registration checklist, free-to-play configuration, three-depot layout with platform-specific content rules, branch strategy (`default` for public, `beta` for Stage 3 private beta), partner permissions matrix, and CI credential setup instructions.

### SteamPipe Depot Templates

- **`steam/app_build.vdf.tpl`** — App build manifest template with `${VAR}` placeholders for App ID, depot IDs, build description, and target branch. Substituted by CI before `steamcmd` invocation.
- **`steam/depot_windows.vdf.tpl`** — Windows x86-64 depot with `FileExclusion` rules for `.pdb` debug symbols and model weight files (`*.gguf`, `*.bin`, `*.safetensors`).
- **`steam/depot_macos.vdf.tpl`** — macOS universal (Apple Silicon + Intel) depot with exclusions for `.dSYM` debug bundle contents and model weights.
- **`steam/depot_linux.vdf.tpl`** — Linux x86-64 / SteamOS depot covering both standard Linux and Steam Deck, with model weight exclusions.

### CI/CD Workflow

- **`.github/workflows/steam-deploy.yml`** — Manually-triggered upload workflow that downloads a tagged GitHub release, audits depot content for model weight files (enforcing compliance register risk MD-04), generates VDF files via `envsubst`, and submits to Steam via `steamcmd`. Protected by `steam-release` GitHub environment for approval-gated credential access.

### Roadmap Updates

- **`docs/STEAM_ROADMAP.md`** — Added issue #226 to the Steam roadmap issue set table, marking it as a Stage 3 prerequisite.

## Credentials and Secrets

No credentials are committed. Non-secret Valve-assigned identifiers (App ID, depot IDs) are stored as GitHub repository **variables** (`STEAM_APP_ID`, `STEAM_DEPOT_WINDOWS_ID`, `STEAM_DEPOT_MACOS_ID`, `STEAM_DEPOT_LINUX_ID`). The dedicated CI build account username and base64-encoded `config.vdf` (for headless SteamGuard bypass) are stored as repository **secrets** (`STEAM_USERNAME`, `STEAM_CONFIG_VDF`). Setup instructions are documented in `publishing/STEAM_APP_REGISTRATION.md`.

## Security Improvements

- **Hardened against Actions expression injection (CWE-94):** Workflow inputs (`build_description`, `release_tag`) are passed through `env:` rather than interpolated directly into shell blocks. This prevents crafted inputs like `$(...)` from executing arbitrary code in a job that holds Steam build credentials, defeating the approval gate's purpose.
- **Credential isolation:** Uses a dedicated CI build account with limited Steamworks permissions, not the main Outright Mental partner account, to limit the blast radius of a compromised credential.
- **Approval-gated deployment:** The workflow runs in the `steam-release` environment, requiring manual review before any Steam credential is exposed.

## Fixes

- **macOS depot exclusion:** Fixed `.dSYM` directory pattern matching. SteamPipe matches against file paths within directories, not directory entries themselves. Changed pattern from `*.dSYM` to `*.dSYM/*` so debug symbols inside `.dSYM` bundles are actually excluded from the depot.

## How It Was Tested

This PR establishes documentation and CI infrastructure. The workflow cannot execute until:
1. The Steamworks app is registered in the partner portal (manual action)
2. App ID and depot IDs are recorded as GitHub repository variables
3. A dedicated CI build account is created and granted Developer access
4. The build account's base64-encoded `config.vdf` is stored as a repository secret

VDF templates were reviewed against SteamPipe documentation to verify KeyValues format, `ContentRoot` resolution, `FileExclusion` syntax, and `SetLive` / `Preview` field semantics.

Closes #226