### PR TITLE
Define runtime sidecar contract, process supervisor, and user-facing health diagnostics

### DIFF
--- a/docs/sidecar-bundling.md
+++ b/docs/sidecar-bundling.md
@@ -96,10 +96,14 @@ import os
 import sys
 from pathlib import Path
 
-def find_sidecar_executable(name: str) -> str | None:
-    """Resolve a sidecar binary using the Steam bundling convention."""
+def find_sidecar_executable(env_key: str, binary_name: str) -> str | None:
+    """Resolve a sidecar binary using the Steam bundling convention.
+
+    ``env_key`` is the override variable keyed on the sidecar id, e.g.
+    ``CONVSIM_LLAMA_CPP_EXECUTABLE`` for the ``llama_cpp`` sidecar.
+    ``binary_name`` is the on-disk filename, e.g. ``llama-server``.
+    """
     # 1. Explicit env-var override always wins.
-    env_key = f"CONVSIM_{name.upper().replace('-', '_')}_EXECUTABLE"
     if override := os.environ.get(env_key):
         return override
 
@@ -107,18 +111,19 @@ def find_sidecar_executable(name: str) -> str | None:
     bundled_dir = os.environ.get("CONVSIM_BUNDLED_RUNTIME_DIR")
     if bundled_dir:
         suffix = ".exe" if sys.platform == "win32" else ""
-        candidate = Path(bundled_dir) / f"{name}{suffix}"
+        candidate = Path(bundled_dir) / f"{binary_name}{suffix}"
         if candidate.is_file() and os.access(candidate, os.X_OK):
             return str(candidate)
 
     # 3. PATH (developer builds).
     import shutil
-    return shutil.which(name)
+    return shutil.which(binary_name)
 ```
 
 The actual implementation lives in each sidecar's module
-(`convsim_core/runtime/sidecar.py` for llama.cpp) and uses `find_executable()`
-from that module.
+(`find_executable()` in `convsim_core/runtime/sidecar.py` for llama.cpp, which
+resolves `CONVSIM_LLAMA_CPP_EXECUTABLE` → `CONVSIM_BUNDLED_RUNTIME_DIR/llama-server`
+→ PATH).
 
 ---
 
@@ -140,9 +145,9 @@ When implementing a new sidecar (e.g. `WhisperCppSidecar`):
 2. Implement `sidecar_id`, `display_name`, `stop()`, and `get_status()`.
 3. Add a typed `start()` method that calls `assert_localhost(host)` before
    spawning the child process.
-4. Implement executable resolution using the three-step order described above,
-   checking `CONVSIM_<NAME>_BUNDLED_PATH` when `CONVSIM_BUNDLED_RUNTIME_DIR`
-   is set.
+4. Implement executable resolution using the three-step order described above:
+   `CONVSIM_<SIDECAR_ID>_EXECUTABLE` override → the bundled binary under
+   `CONVSIM_BUNDLED_RUNTIME_DIR` → PATH.
 5. Register the sidecar with `ProcessSupervisor` in `app.py`'s `lifespan`.
 6. Add tests covering: missing binary, port conflict, crash, restart, and
    graceful shutdown. See `tests/test_sidecar.py` for the llama.cpp reference

--- a/docs/sidecar-bundling.md
+++ b/docs/sidecar-bundling.md
@@ -1,0 +1,169 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+# Sidecar bundling: Steam vs developer builds
+
+ConversationSimulator runs four managed subprocess sidecars alongside the core
+Python service. This document explains how each sidecar locates its executable
+in developer builds and in packaged Steam builds.
+
+| Sidecar | Service name | Default port | Runtime id |
+|---------|-------------|-------------|------------|
+| llama.cpp | `convsim-llm` | 7356 | `llama_cpp` |
+| Whisper.cpp (STT) | `convsim-stt` | 7357 | `whisper_cpp` |
+| Kokoro / sherpa-onnx (TTS) | `convsim-tts` | 7358 | `kokoro` |
+| Silero VAD | _(in-process)_ | — | `silero_vad` |
+
+All sidecars must bind only to `127.0.0.1` (IPv4 loopback) or `::1` (IPv6
+loopback). The `assert_localhost()` guard in
+`convsim_core/runtime/supervisor.py` enforces this at every `start()` call.
+See [network-security.md](network-security.md) for the localhost-only policy.
+
+---
+
+## Executable resolution order
+
+Each sidecar resolves its binary in this order, stopping at the first hit:
+
+1. **Explicit override** — the environment variable `CONVSIM_<SIDECAR>_EXECUTABLE`
+   (e.g. `CONVSIM_LLAMA_CPP_EXECUTABLE`), or the `executable` field in the
+   `POST /api/sidecar/start` request body.
+2. **Bundled path** — a platform-specific directory adjacent to the application
+   binary (Steam builds only; see below).
+3. **PATH lookup** — `shutil.which("llama-server")` or the equivalent name for
+   each sidecar (developer builds only).
+
+If none of the above resolves, `start()` raises `RuntimeError` with an
+actionable message directing the user to install the missing binary.
+
+---
+
+## Developer builds
+
+In a developer build the application is started directly from the repository
+(`uvicorn convsim_core.app:app` or `python -m convsim_core`). Sidecar
+binaries are expected to be on the developer's `PATH`.
+
+**Install sidecars for development:**
+
+```sh
+# llama.cpp (llama-server)
+./runtimes/llama_cpp/download-runtime.sh
+# → binary at ~/.convsim/bin/llama-server; add to PATH
+
+# Whisper.cpp
+./runtimes/whisper_cpp/download-runtime.sh
+# → binary at ~/.convsim/bin/whisper-cli; add to PATH
+
+# Kokoro / sherpa-onnx
+./runtimes/kokoro/download-runtime.sh
+# → binary at ~/.convsim/bin/sherpa-onnx-offline-tts; add to PATH
+```
+
+You can also set the explicit override variable to point to any binary:
+
+```sh
+export CONVSIM_LLAMA_CPP_EXECUTABLE=/path/to/llama-server
+```
+
+---
+
+## Steam (packaged) builds
+
+In a Steam build the application executable and all sidecars are bundled inside
+the Steam depot under a known relative layout. The Tauri/Electron wrapper
+sets the environment variable `CONVSIM_BUNDLED_RUNTIME_DIR` to the absolute
+path of the `runtimes/` directory inside the installed depot before launching
+`convsim-core`.
+
+### Bundled directory layout
+
+```
+<steam-install-dir>/
+├── convsim               # main application executable (Tauri shell)
+└── runtimes/
+    ├── llama-server      # llama.cpp inference server
+    ├── whisper-cli       # Whisper.cpp transcription binary
+    └── sherpa-onnx-offline-tts   # Kokoro TTS binary
+```
+
+On Windows the binaries include the `.exe` suffix. On macOS and Linux there is
+no suffix. The bundled path resolver appends the correct suffix for the current
+platform automatically.
+
+### Bundled path lookup (Python pseudocode)
+
+```python
+import os
+import sys
+from pathlib import Path
+
+def find_sidecar_executable(name: str) -> str | None:
+    """Resolve a sidecar binary using the Steam bundling convention."""
+    # 1. Explicit env-var override always wins.
+    env_key = f"CONVSIM_{name.upper().replace('-', '_')}_EXECUTABLE"
+    if override := os.environ.get(env_key):
+        return override
+
+    # 2. Bundled path (Steam builds).
+    bundled_dir = os.environ.get("CONVSIM_BUNDLED_RUNTIME_DIR")
+    if bundled_dir:
+        suffix = ".exe" if sys.platform == "win32" else ""
+        candidate = Path(bundled_dir) / f"{name}{suffix}"
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return str(candidate)
+
+    # 3. PATH (developer builds).
+    import shutil
+    return shutil.which(name)
+```
+
+The actual implementation lives in each sidecar's module
+(`convsim_core/runtime/sidecar.py` for llama.cpp) and uses `find_executable()`
+from that module.
+
+---
+
+## Localhost enforcement in packaged builds
+
+`assert_localhost(host)` in `convsim_core/runtime/supervisor.py` is called at
+the top of every sidecar `start()` method. It raises `RuntimeError` if the
+requested bind host is not `127.0.0.1`, `::1`, or `localhost`. This check
+cannot be disabled at runtime — there is no environment variable or config
+flag to bypass it. Network binding is always localhost-only.
+
+---
+
+## Adding a new sidecar
+
+When implementing a new sidecar (e.g. `WhisperCppSidecar`):
+
+1. Inherit from `SidecarProcess` in `convsim_core/runtime/supervisor.py`.
+2. Implement `sidecar_id`, `display_name`, `stop()`, and `get_status()`.
+3. Add a typed `start()` method that calls `assert_localhost(host)` before
+   spawning the child process.
+4. Implement executable resolution using the three-step order described above,
+   checking `CONVSIM_<NAME>_BUNDLED_PATH` when `CONVSIM_BUNDLED_RUNTIME_DIR`
+   is set.
+5. Register the sidecar with `ProcessSupervisor` in `app.py`'s `lifespan`.
+6. Add tests covering: missing binary, port conflict, crash, restart, and
+   graceful shutdown. See `tests/test_sidecar.py` for the llama.cpp reference
+   implementation.
+
+---
+
+## Environment variable reference
+
+| Variable | Purpose |
+|---|---|
+| `CONVSIM_BUNDLED_RUNTIME_DIR` | Absolute path to the bundled `runtimes/` directory (set by the Tauri/Electron wrapper in Steam builds) |
+| `CONVSIM_LLAMA_CPP_EXECUTABLE` | Override path to `llama-server` |
+| `CONVSIM_WHISPER_CPP_BINARY_PATH` | Override path to `whisper-cli` |
+| `CONVSIM_KOKORO_EXECUTABLE` | Override path to `sherpa-onnx-offline-tts` |
+
+---
+
+## Related documents
+
+- [network-security.md](network-security.md) — localhost-only binding policy
+- [runtime-adapters.md](runtime-adapters.md) — ChatRuntime interface and built-in adapters
+- [architecture.md](architecture.md) — service topology and port assignments
+- [runtimes/llama_cpp/README.md](../runtimes/llama_cpp/README.md) — llama.cpp setup

--- a/services/convsim-core/convsim_core/app.py
+++ b/services/convsim-core/convsim_core/app.py
@@ -15,6 +15,7 @@ from convsim_core.logging_setup import configure_logging
 from convsim_core.routers import diag as diag_router, health, models as models_router, packs as packs_router, scenarios as scenarios_router, sessions as sessions_router, settings as settings_router, sidecar as sidecar_router, stt as stt_router, tts as tts_router, vad as vad_router, workbench as workbench_router
 from convsim_core.runtime import build_runtime
 from convsim_core.runtime.sidecar import LlamaCppSidecar
+from convsim_core.runtime.supervisor import ProcessSupervisor
 from convsim_core.storage.database import Database
 from convsim_core.storage.repositories.settings_repo import load_settings
 from convsim_core.stt import build_stt_worker
@@ -40,9 +41,13 @@ def create_app(config: ServiceConfig | None = None) -> FastAPI:
         app.state.stt_worker = build_stt_worker(config.stt_worker_id)
         app.state.tts_worker = build_tts_worker(config.tts_worker_id)
         app.state.vad_worker = build_vad_worker(config.vad_worker_id)
-        app.state.sidecar = LlamaCppSidecar(log_dir=config.log_dir)
+        sidecar = LlamaCppSidecar(log_dir=config.log_dir)
+        supervisor = ProcessSupervisor()
+        supervisor.register(sidecar)
+        app.state.sidecar = sidecar
+        app.state.supervisor = supervisor
         yield
-        await app.state.sidecar.stop()
+        await supervisor.stop_all()
         db.close()
 
     app = FastAPI(title="convsim-core", version="0.1.0", lifespan=lifespan)

--- a/services/convsim-core/convsim_core/app.py
+++ b/services/convsim-core/convsim_core/app.py
@@ -42,7 +42,11 @@ def create_app(config: ServiceConfig | None = None) -> FastAPI:
         app.state.stt_worker = build_stt_worker(config.stt_worker_id)
         app.state.tts_worker = build_tts_worker(config.tts_worker_id)
         app.state.vad_worker = build_vad_worker(config.vad_worker_id)
-        app.state.sidecar = LlamaCppSidecar(log_dir=config.log_dir)
+        sidecar = LlamaCppSidecar(log_dir=config.log_dir)
+        app.state.sidecar = sidecar
+        supervisor = ProcessSupervisor()
+        supervisor.register(sidecar)
+        app.state.supervisor = supervisor
         seed_official_packs(config, db.connection())
         yield
         await supervisor.stop_all()

--- a/services/convsim-core/convsim_core/routers/health.py
+++ b/services/convsim-core/convsim_core/routers/health.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 import os
-from typing import Optional
+from typing import Any, Optional
 
 from fastapi import APIRouter, Request
 from pydantic import BaseModel
@@ -12,6 +12,87 @@ from convsim_core.stt.types import SttHealth
 from convsim_core.tts.types import TtsHealth
 
 router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Sidecar diagnostics helpers
+# ---------------------------------------------------------------------------
+
+
+def _user_message_for_sidecar(state: str, error: Optional[str]) -> str:
+    """Return an actionable one-sentence message for non-technical users."""
+    if state == "running":
+        return "Running."
+    if state == "starting":
+        return "Starting — this may take a minute while the model loads."
+    if state == "stopped":
+        return "Not started. Select a model in Settings to enable AI responses."
+    if state == "crashed":
+        hint = f": {error}" if error else "."
+        return f"Crashed unexpectedly{hint} Try restarting from Settings."
+    if state == "port_conflict":
+        return (
+            "Cannot start: another application is using the required port. "
+            "Close competing applications and try again from Settings."
+        )
+    return f"Unknown state ({state})."
+
+
+def _build_sidecar_diagnostics(
+    supervisor: Any,
+) -> "_SidecarDiagnostics":
+    """Build a SidecarDiagnostics object from the ProcessSupervisor."""
+    if supervisor is None:
+        return _SidecarDiagnostics(all_ready=False, user_message="Supervisor not available.", sidecars=[])
+
+    entries: list[_SidecarEntry] = []
+    for item in supervisor.health_summary():
+        state = item.get("state", "stopped")
+        error = item.get("error")
+        entries.append(
+            _SidecarEntry(
+                sidecar_id=item["sidecar_id"],
+                display_name=item["display_name"],
+                state=state,
+                pid=item.get("pid"),
+                error=error,
+                user_message=_user_message_for_sidecar(state, error),
+            )
+        )
+
+    all_ready = all(e.state == "running" for e in entries) if entries else True
+    if all_ready:
+        user_message = "All sidecars are running." if entries else "No sidecars registered."
+    else:
+        not_ready = [e for e in entries if e.state != "running"]
+        if len(not_ready) == 1:
+            user_message = not_ready[0].user_message
+        else:
+            user_message = f"{len(not_ready)} sidecars are not ready. Check Settings for details."
+
+    return _SidecarDiagnostics(all_ready=all_ready, user_message=user_message, sidecars=entries)
+
+
+class _SidecarEntry(BaseModel):
+    sidecar_id: str
+    display_name: str
+    state: str
+    pid: Optional[int] = None
+    error: Optional[str] = None
+    user_message: str
+
+
+class _SidecarDiagnostics(BaseModel):
+    """Aggregate health view of all registered sidecar processes.
+
+    ``all_ready`` is True when every sidecar is in the ``running`` state (or
+    when no sidecars are registered). ``user_message`` is a single sentence
+    suitable for display in the non-technical health panel.
+    """
+
+    all_ready: bool
+    user_message: str
+    sidecars: list[_SidecarEntry]
 
 
 class _DatabaseStatus(BaseModel):
@@ -56,6 +137,7 @@ class HealthResponse(BaseModel):
     privacy: _PrivacyPosture
     stt: SttHealth
     tts: TtsHealth
+    sidecar_diagnostics: _SidecarDiagnostics
     last_benchmark: Optional[_BenchmarkSummary] = None
 
 
@@ -80,6 +162,8 @@ async def health(request: Request) -> HealthResponse:
             benchmarked_at=bm_row["benchmarked_at"],
         )
 
+    supervisor = getattr(request.app.state, "supervisor", None)
+
     return HealthResponse(
         status="ok",
         version=__version__,
@@ -100,5 +184,6 @@ async def health(request: Request) -> HealthResponse:
         ),
         stt=await request.app.state.stt_worker.health(),
         tts=await request.app.state.tts_worker.health(),
+        sidecar_diagnostics=_build_sidecar_diagnostics(supervisor),
         last_benchmark=last_benchmark,
     )

--- a/services/convsim-core/convsim_core/runtime/sidecar.py
+++ b/services/convsim-core/convsim_core/runtime/sidecar.py
@@ -16,6 +16,8 @@ from enum import Enum
 from pathlib import Path
 from typing import IO
 
+from convsim_core.runtime.supervisor import SidecarProcess, assert_localhost
+
 
 class SidecarState(str, Enum):
     STOPPED = "stopped"
@@ -121,13 +123,24 @@ async def _wait_for_ready(
     )
 
 
-class LlamaCppSidecar:
+class LlamaCppSidecar(SidecarProcess):
     """Owns the lifecycle of a single managed llama-server child process.
+
+    Implements SidecarProcess so the ProcessSupervisor can stop it at exit
+    alongside any future sidecars (whisper.cpp, kokoro, …).
 
     One instance lives on ``app.state.sidecar`` for the duration of the
     server process. External llama.cpp users never call start(); the
     LlamaCppRuntime HTTP adapter connects directly to their server.
     """
+
+    @property
+    def sidecar_id(self) -> str:
+        return "llama_cpp"
+
+    @property
+    def display_name(self) -> str:
+        return "llama.cpp (llama-server)"
 
     def __init__(self, log_dir: str) -> None:
         self._log_dir = Path(log_dir)
@@ -161,6 +174,8 @@ class LlamaCppSidecar:
         """
         if self.state in (SidecarState.RUNNING, SidecarState.STARTING):
             return
+
+        assert_localhost(host)
 
         exe = executable or find_executable()
         if exe is None:

--- a/services/convsim-core/convsim_core/runtime/sidecar.py
+++ b/services/convsim-core/convsim_core/runtime/sidecar.py
@@ -8,9 +8,11 @@ the LlamaCppRuntime HTTP adapter works against any reachable llama-server.
 from __future__ import annotations
 
 import asyncio
+import os
 import shutil
 import socket
 import subprocess
+import sys
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
@@ -64,8 +66,38 @@ def build_command(
     return cmd
 
 
+_EXECUTABLE_ENV_VAR = "CONVSIM_LLAMA_CPP_EXECUTABLE"
+_BUNDLED_RUNTIME_DIR_ENV_VAR = "CONVSIM_BUNDLED_RUNTIME_DIR"
+_BUNDLED_BINARY_NAME = "llama-server"
+
+
 def find_executable() -> str | None:
-    """Return the path to llama-server if found in PATH, else None."""
+    """Resolve the llama-server binary using the Steam bundling convention.
+
+    Resolution order (first hit wins), matching docs/sidecar-bundling.md:
+
+    1. Explicit override — the ``CONVSIM_LLAMA_CPP_EXECUTABLE`` environment
+       variable. Used by developer builds and tests to point at any binary.
+       The value is returned verbatim (existence is validated when the process
+       is spawned) so an explicit override always wins.
+    2. Bundled path — ``<CONVSIM_BUNDLED_RUNTIME_DIR>/llama-server`` (Steam
+       depot builds). The ``.exe`` suffix is appended on Windows. Only used
+       when the file exists and is executable.
+    3. PATH lookup — ``shutil.which("llama-server")`` (developer builds).
+
+    Returns None when no candidate resolves.
+    """
+    override = os.environ.get(_EXECUTABLE_ENV_VAR)
+    if override:
+        return override
+
+    bundled_dir = os.environ.get(_BUNDLED_RUNTIME_DIR_ENV_VAR)
+    if bundled_dir:
+        suffix = ".exe" if sys.platform == "win32" else ""
+        candidate = Path(bundled_dir) / f"{_BUNDLED_BINARY_NAME}{suffix}"
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return str(candidate)
+
     return shutil.which("llama-server") or shutil.which("llama_server")
 
 

--- a/services/convsim-core/convsim_core/runtime/supervisor.py
+++ b/services/convsim-core/convsim_core/runtime/supervisor.py
@@ -1,0 +1,205 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Common sidecar contract and process supervisor for local runtime sidecars.
+
+Every managed subprocess (llama.cpp, whisper.cpp, kokoro, silero-vad) must
+implement SidecarProcess so the application can stop them through a consistent
+interface, gather health snapshots in one place, and guarantee localhost-only
+binding in packaged (Steam) builds.
+
+The ProcessSupervisor is the single authority over all sidecar lifetimes. It
+is created once in app.py and stored on app.state.supervisor.
+
+See docs/sidecar-bundling.md for how Steam packages and developer builds each
+locate the correct sidecar executable.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any
+
+_LOCALHOST_ADDRS: frozenset[str] = frozenset({"127.0.0.1", "::1", "localhost"})
+_LOG_TAIL_DEFAULT = 50
+
+logger = logging.getLogger(__name__)
+
+
+def assert_localhost(host: str) -> None:
+    """Raise RuntimeError if *host* is not a loopback address.
+
+    All managed sidecars must bind only to a loopback interface so they remain
+    unreachable from the local network. Concrete sidecar start() methods must
+    call this before spawning any child process.
+
+    Allowed values: ``"127.0.0.1"``, ``"::1"``, ``"localhost"``.
+
+    See docs/network-security.md for the localhost-only policy and
+    docs/sidecar-bundling.md for deployment context.
+    """
+    if host not in _LOCALHOST_ADDRS:
+        raise RuntimeError(
+            f"Sidecar host {host!r} is not a loopback address. "
+            "Managed sidecars must bind to 127.0.0.1 or ::1 to stay "
+            "unreachable from the local network. "
+            "See docs/network-security.md for the localhost-only policy."
+        )
+
+
+class SidecarProcess(ABC):
+    """Contract that every managed sidecar subprocess must satisfy.
+
+    Concrete implementations (LlamaCppSidecar, future WhisperCppSidecar, …)
+    inherit from this base. The rest of the application depends only on this
+    interface; it never imports concrete sidecar classes directly.
+
+    Design note: start() is excluded from the abstract interface deliberately.
+    Each sidecar type needs a different set of typed launch arguments (model
+    path, port, grammar file, sample rate, …). Concrete classes expose their
+    own typed start() method and must call assert_localhost(host) before
+    spawning any child process.
+    """
+
+    @property
+    @abstractmethod
+    def sidecar_id(self) -> str:
+        """Stable machine-readable identifier, e.g. ``"llama_cpp"``."""
+
+    @property
+    @abstractmethod
+    def display_name(self) -> str:
+        """Human-readable label shown in the runtime health panel."""
+
+    @abstractmethod
+    async def stop(self) -> None:
+        """Terminate the managed process and release file handles.
+
+        Must be idempotent: safe to call when already stopped or crashed.
+        Must clear all mutable state (pid, model_path, error) so that a
+        subsequent get_status() call returns a clean stopped snapshot.
+        """
+
+    @abstractmethod
+    def get_status(self) -> dict[str, Any]:
+        """Return a serialisable snapshot of the current sidecar state.
+
+        Required keys
+        -------------
+        state : str
+            Current lifecycle state: ``"stopped"``, ``"starting"``,
+            ``"running"``, ``"crashed"``, or ``"port_conflict"``.
+        pid : int | None
+            OS process id when running, else None.
+        error : str | None
+            Last error message, else None.
+        log_path : str
+            Absolute path to the sidecar log file. The file may not exist yet
+            if the sidecar has never been started.
+
+        Concrete sidecars may include additional keys such as model_path, host,
+        port, and started_at.
+        """
+
+    def tail_log(self, lines: int = _LOG_TAIL_DEFAULT) -> list[str]:
+        """Return the last *lines* lines from the sidecar log file.
+
+        Returns an empty list when the log file does not exist or cannot be
+        read (e.g. the sidecar has never been started or the log directory has
+        not been created yet).
+        """
+        log_path = Path(self.get_status().get("log_path", ""))
+        if not log_path.is_file():
+            return []
+        try:
+            text = log_path.read_text(errors="replace")
+        except OSError:
+            return []
+        all_lines = text.splitlines()
+        return all_lines[-lines:] if lines > 0 else all_lines
+
+
+class ProcessSupervisor:
+    """Manages the lifetimes of all locally-bound sidecar processes.
+
+    One instance lives on ``app.state.supervisor`` for the duration of the
+    server process. All managed sidecars are registered with the supervisor so
+    that they are stopped in one place when the application exits.
+
+    Usage::
+
+        supervisor = ProcessSupervisor()
+        supervisor.register(llama_sidecar)    # LlamaCppSidecar
+        supervisor.register(whisper_sidecar)  # future WhisperCppSidecar
+        …
+
+        # At application shutdown:
+        await supervisor.stop_all()
+
+    The supervisor does not own the start() call for each sidecar — each
+    concrete sidecar type has its own typed start() method that the router
+    calls directly. The supervisor's responsibilities are:
+
+    1. Guarantee that stop() is called on every sidecar at application exit.
+    2. Provide a central health_summary() view for the /api/health endpoint.
+    3. Document that all sidecars must be localhost-bound (see assert_localhost).
+    """
+
+    def __init__(self) -> None:
+        self._sidecars: dict[str, SidecarProcess] = {}
+
+    def register(self, sidecar: SidecarProcess) -> None:
+        """Add *sidecar* to the supervisor registry.
+
+        Raises ValueError if a sidecar with the same sidecar_id is already
+        registered. Duplicate registrations are always a programming error.
+        """
+        if sidecar.sidecar_id in self._sidecars:
+            raise ValueError(
+                f"A sidecar with id {sidecar.sidecar_id!r} is already registered. "
+                "Duplicate registrations are not allowed."
+            )
+        self._sidecars[sidecar.sidecar_id] = sidecar
+
+    def get(self, sidecar_id: str) -> SidecarProcess | None:
+        """Return the registered SidecarProcess with *sidecar_id*, or None."""
+        return self._sidecars.get(sidecar_id)
+
+    async def stop_all(self) -> None:
+        """Stop every registered sidecar concurrently.
+
+        Errors from individual sidecars are suppressed so that a crash in one
+        sidecar does not prevent the others from shutting down cleanly.
+        All errors are logged at WARNING level so they appear in the server log.
+        """
+        if not self._sidecars:
+            return
+        results = await asyncio.gather(
+            *(s.stop() for s in self._sidecars.values()),
+            return_exceptions=True,
+        )
+        for sidecar, result in zip(self._sidecars.values(), results):
+            if isinstance(result, Exception):
+                logger.warning(
+                    "Error stopping sidecar %r during shutdown: %s",
+                    sidecar.sidecar_id,
+                    result,
+                )
+
+    def health_summary(self) -> list[dict[str, Any]]:
+        """Return a status snapshot for every registered sidecar.
+
+        Each entry contains ``sidecar_id``, ``display_name``, and all keys
+        returned by the sidecar's get_status(). Callers must not depend on
+        the order of entries.
+        """
+        out: list[dict[str, Any]] = []
+        for sidecar in self._sidecars.values():
+            out.append(
+                {
+                    "sidecar_id": sidecar.sidecar_id,
+                    "display_name": sidecar.display_name,
+                    **sidecar.get_status(),
+                }
+            )
+        return out

--- a/services/convsim-core/tests/test_sidecar.py
+++ b/services/convsim-core/tests/test_sidecar.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import os
 import socket
+import sys
 import textwrap
 from pathlib import Path
 
@@ -246,6 +247,33 @@ async def test_stop_when_not_running_is_noop(tmp_path):
 def test_find_executable_returns_none_or_str():
     result = find_executable()
     assert result is None or isinstance(result, str)
+
+
+def test_find_executable_env_override_wins(monkeypatch):
+    """CONVSIM_LLAMA_CPP_EXECUTABLE takes precedence over PATH and bundled dir."""
+    monkeypatch.setenv("CONVSIM_LLAMA_CPP_EXECUTABLE", "/custom/llama-server")
+    monkeypatch.setenv("CONVSIM_BUNDLED_RUNTIME_DIR", "/somewhere/runtimes")
+    assert find_executable() == "/custom/llama-server"
+
+
+def test_find_executable_uses_bundled_dir(monkeypatch, tmp_path):
+    """When no override is set, an executable bundled binary is resolved."""
+    monkeypatch.delenv("CONVSIM_LLAMA_CPP_EXECUTABLE", raising=False)
+    binary_name = "llama-server.exe" if sys.platform == "win32" else "llama-server"
+    binary = tmp_path / binary_name
+    binary.write_text("#!/bin/sh\n")
+    binary.chmod(0o755)
+    monkeypatch.setenv("CONVSIM_BUNDLED_RUNTIME_DIR", str(tmp_path))
+    assert find_executable() == str(binary)
+
+
+def test_find_executable_bundled_dir_missing_binary_falls_through(monkeypatch, tmp_path):
+    """A bundled dir without the binary must not short-circuit to a bad path."""
+    monkeypatch.delenv("CONVSIM_LLAMA_CPP_EXECUTABLE", raising=False)
+    monkeypatch.setenv("CONVSIM_BUNDLED_RUNTIME_DIR", str(tmp_path))  # empty dir
+    from unittest.mock import patch
+    with patch("convsim_core.runtime.sidecar.shutil.which", return_value=None):
+        assert find_executable() is None
 
 
 # ---------------------------------------------------------------------------

--- a/services/convsim-core/tests/test_sidecar.py
+++ b/services/convsim-core/tests/test_sidecar.py
@@ -41,8 +41,8 @@ def test_build_command_minimal():
 
 
 def test_build_command_custom_host_port():
-    cmd = build_command("/bin/llama-server", "model.gguf", host="0.0.0.0", port=9999)
-    assert "0.0.0.0" in cmd
+    cmd = build_command("/bin/llama-server", "model.gguf", host="127.0.0.1", port=9999)
+    assert "127.0.0.1" in cmd
     assert "9999" in cmd
 
 
@@ -371,6 +371,7 @@ def test_sidecar_start_forwards_custom_host_and_port(client):
 
     The port-conflict error message tells users to "configure a different port",
     so the API must actually accept host/port fields and forward them.
+    Only localhost addresses are accepted; non-localhost is rejected by start().
     """
     from unittest.mock import AsyncMock, patch
 
@@ -385,18 +386,18 @@ def test_sidecar_start_forwards_custom_host_and_port(client):
             client.app.state.sidecar, "get_status",
             return_value={
                 "state": "running", "pid": 42, "model_path": "/m.gguf",
-                "log_path": "/tmp/runtime.log", "host": "0.0.0.0", "port": 9000,
+                "log_path": "/tmp/runtime.log", "host": "127.0.0.1", "port": 9001,
                 "error": None, "started_at": "2026-01-01T00:00:00+00:00",
             },
         ):
             resp = client.post(
                 "/api/sidecar/start",
-                json={"model_path": "/m.gguf", "host": "0.0.0.0", "port": 9000},
+                json={"model_path": "/m.gguf", "host": "127.0.0.1", "port": 9001},
             )
 
     assert resp.status_code == 200
-    assert captured["host"] == "0.0.0.0"
-    assert captured["port"] == 9000
+    assert captured["host"] == "127.0.0.1"
+    assert captured["port"] == 9001
 
 
 # ---------------------------------------------------------------------------

--- a/services/convsim-core/tests/test_supervisor.py
+++ b/services/convsim-core/tests/test_supervisor.py
@@ -1,0 +1,390 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the ProcessSupervisor and SidecarProcess contract.
+
+Covers:
+- assert_localhost enforcement
+- ProcessSupervisor registration, deduplication, stop_all, health_summary
+- SidecarProcess.tail_log default implementation
+- LlamaCppSidecar localhost enforcement via assert_localhost
+- Integration: missing binary, port conflict, crash, restart, graceful shutdown
+  (full integration tests are in test_sidecar.py; this file focuses on the
+   supervisor layer and the new contract behaviour)
+"""
+from __future__ import annotations
+
+import asyncio
+import socket
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from convsim_core.runtime.supervisor import (
+    ProcessSupervisor,
+    SidecarProcess,
+    assert_localhost,
+)
+
+
+# ---------------------------------------------------------------------------
+# assert_localhost
+# ---------------------------------------------------------------------------
+
+
+def test_assert_localhost_accepts_ipv4_loopback():
+    assert_localhost("127.0.0.1")  # must not raise
+
+
+def test_assert_localhost_accepts_ipv6_loopback():
+    assert_localhost("::1")  # must not raise
+
+
+def test_assert_localhost_accepts_localhost_name():
+    assert_localhost("localhost")  # must not raise
+
+
+def test_assert_localhost_rejects_wildcard_ipv4():
+    with pytest.raises(RuntimeError, match="not a loopback address"):
+        assert_localhost("0.0.0.0")
+
+
+def test_assert_localhost_rejects_wildcard_ipv6():
+    with pytest.raises(RuntimeError, match="not a loopback address"):
+        assert_localhost("::")
+
+
+def test_assert_localhost_rejects_lan_ip():
+    with pytest.raises(RuntimeError, match="not a loopback address"):
+        assert_localhost("192.168.1.100")
+
+
+def test_assert_localhost_message_includes_host():
+    try:
+        assert_localhost("10.0.0.1")
+    except RuntimeError as exc:
+        assert "10.0.0.1" in str(exc)
+
+
+# ---------------------------------------------------------------------------
+# Minimal concrete SidecarProcess for testing (not LlamaCppSidecar)
+# ---------------------------------------------------------------------------
+
+
+class _FakeSidecar(SidecarProcess):
+    """Minimal concrete SidecarProcess for testing supervisor behaviour."""
+
+    def __init__(self, sidecar_id: str = "fake_sidecar", stop_raises: bool = False) -> None:
+        self._id = sidecar_id
+        self._stop_raises = stop_raises
+        self.stop_called = 0
+        self._log_path = ""
+
+    @property
+    def sidecar_id(self) -> str:
+        return self._id
+
+    @property
+    def display_name(self) -> str:
+        return f"Fake ({self._id})"
+
+    async def stop(self) -> None:
+        self.stop_called += 1
+        if self._stop_raises:
+            raise RuntimeError("stop failed")
+
+    def get_status(self) -> dict[str, Any]:
+        return {
+            "state": "stopped",
+            "pid": None,
+            "error": None,
+            "log_path": self._log_path,
+        }
+
+
+# ---------------------------------------------------------------------------
+# ProcessSupervisor.register
+# ---------------------------------------------------------------------------
+
+
+def test_register_single_sidecar():
+    sup = ProcessSupervisor()
+    sidecar = _FakeSidecar("a")
+    sup.register(sidecar)
+    assert sup.get("a") is sidecar
+
+
+def test_register_duplicate_raises():
+    sup = ProcessSupervisor()
+    sup.register(_FakeSidecar("a"))
+    with pytest.raises(ValueError, match="already registered"):
+        sup.register(_FakeSidecar("a"))
+
+
+def test_register_different_ids_allowed():
+    sup = ProcessSupervisor()
+    sup.register(_FakeSidecar("a"))
+    sup.register(_FakeSidecar("b"))
+    assert sup.get("a") is not None
+    assert sup.get("b") is not None
+
+
+def test_get_unknown_id_returns_none():
+    sup = ProcessSupervisor()
+    assert sup.get("nonexistent") is None
+
+
+# ---------------------------------------------------------------------------
+# ProcessSupervisor.stop_all
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stop_all_calls_stop_on_every_sidecar():
+    sup = ProcessSupervisor()
+    a = _FakeSidecar("a")
+    b = _FakeSidecar("b")
+    sup.register(a)
+    sup.register(b)
+
+    await sup.stop_all()
+
+    assert a.stop_called == 1
+    assert b.stop_called == 1
+
+
+@pytest.mark.asyncio
+async def test_stop_all_with_no_sidecars_is_noop():
+    sup = ProcessSupervisor()
+    await sup.stop_all()  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_stop_all_suppresses_individual_errors():
+    """A failing stop() on one sidecar must not prevent others from stopping."""
+    sup = ProcessSupervisor()
+    bad = _FakeSidecar("bad", stop_raises=True)
+    good = _FakeSidecar("good")
+    sup.register(bad)
+    sup.register(good)
+
+    await sup.stop_all()  # must not raise even though bad.stop() raises
+
+    assert good.stop_called == 1
+
+
+@pytest.mark.asyncio
+async def test_stop_all_is_concurrent(monkeypatch):
+    """stop_all() runs all stops concurrently, not sequentially."""
+    order: list[str] = []
+
+    class _SlowSidecar(_FakeSidecar):
+        async def stop(self) -> None:
+            await asyncio.sleep(0.05)
+            order.append(self._id)
+
+    sup = ProcessSupervisor()
+    sup.register(_SlowSidecar("a"))
+    sup.register(_SlowSidecar("b"))
+
+    import time
+    t0 = time.monotonic()
+    await sup.stop_all()
+    elapsed = time.monotonic() - t0
+
+    # Both run concurrently so total time is ~0.05s, not ~0.10s.
+    assert elapsed < 0.09, f"stop_all took {elapsed:.3f}s — expected concurrent execution"
+    assert set(order) == {"a", "b"}
+
+
+# ---------------------------------------------------------------------------
+# ProcessSupervisor.health_summary
+# ---------------------------------------------------------------------------
+
+
+def test_health_summary_empty_when_no_sidecars():
+    sup = ProcessSupervisor()
+    assert sup.health_summary() == []
+
+
+def test_health_summary_includes_sidecar_id_and_display_name():
+    sup = ProcessSupervisor()
+    sup.register(_FakeSidecar("llm"))
+    summary = sup.health_summary()
+    assert len(summary) == 1
+    assert summary[0]["sidecar_id"] == "llm"
+    assert "display_name" in summary[0]
+
+
+def test_health_summary_merges_get_status_keys():
+    sup = ProcessSupervisor()
+    sup.register(_FakeSidecar("llm"))
+    summary = sup.health_summary()
+    entry = summary[0]
+    assert entry["state"] == "stopped"
+    assert entry["pid"] is None
+    assert entry["error"] is None
+    assert "log_path" in entry
+
+
+def test_health_summary_multiple_sidecars():
+    sup = ProcessSupervisor()
+    sup.register(_FakeSidecar("a"))
+    sup.register(_FakeSidecar("b"))
+    ids = {e["sidecar_id"] for e in sup.health_summary()}
+    assert ids == {"a", "b"}
+
+
+# ---------------------------------------------------------------------------
+# SidecarProcess.tail_log default implementation
+# ---------------------------------------------------------------------------
+
+
+def test_tail_log_returns_empty_when_log_missing(tmp_path):
+    sidecar = _FakeSidecar()
+    sidecar._log_path = str(tmp_path / "no-such.log")
+    assert sidecar.tail_log() == []
+
+
+def test_tail_log_returns_last_n_lines(tmp_path):
+    log = tmp_path / "runtime.log"
+    log.write_text("\n".join(f"line {i}" for i in range(100)))
+    sidecar = _FakeSidecar()
+    sidecar._log_path = str(log)
+    result = sidecar.tail_log(lines=10)
+    assert len(result) == 10
+    assert result[-1] == "line 99"
+
+
+def test_tail_log_zero_lines_returns_all(tmp_path):
+    log = tmp_path / "runtime.log"
+    log.write_text("a\nb\nc")
+    sidecar = _FakeSidecar()
+    sidecar._log_path = str(log)
+    assert sidecar.tail_log(lines=0) == ["a", "b", "c"]
+
+
+def test_tail_log_fewer_lines_than_requested(tmp_path):
+    log = tmp_path / "runtime.log"
+    log.write_text("only\ntwo")
+    sidecar = _FakeSidecar()
+    sidecar._log_path = str(log)
+    result = sidecar.tail_log(lines=50)
+    assert result == ["only", "two"]
+
+
+# ---------------------------------------------------------------------------
+# LlamaCppSidecar implements SidecarProcess
+# ---------------------------------------------------------------------------
+
+
+def test_llama_cpp_sidecar_is_sidecar_process(tmp_path):
+    from convsim_core.runtime.sidecar import LlamaCppSidecar
+    sidecar = LlamaCppSidecar(log_dir=str(tmp_path / "logs"))
+    assert isinstance(sidecar, SidecarProcess)
+
+
+def test_llama_cpp_sidecar_id(tmp_path):
+    from convsim_core.runtime.sidecar import LlamaCppSidecar
+    sidecar = LlamaCppSidecar(log_dir=str(tmp_path / "logs"))
+    assert sidecar.sidecar_id == "llama_cpp"
+
+
+def test_llama_cpp_display_name(tmp_path):
+    from convsim_core.runtime.sidecar import LlamaCppSidecar
+    sidecar = LlamaCppSidecar(log_dir=str(tmp_path / "logs"))
+    assert "llama" in sidecar.display_name.lower()
+
+
+@pytest.mark.asyncio
+async def test_llama_cpp_start_rejects_non_localhost_host(tmp_path):
+    """start() must raise RuntimeError for any non-loopback host."""
+    from convsim_core.runtime.sidecar import LlamaCppSidecar
+    sidecar = LlamaCppSidecar(log_dir=str(tmp_path / "logs"))
+    with pytest.raises(RuntimeError, match="not a loopback address"):
+        await sidecar.start("fake.gguf", host="0.0.0.0", port=_free_port())
+
+
+@pytest.mark.asyncio
+async def test_llama_cpp_start_rejects_lan_ip(tmp_path):
+    from convsim_core.runtime.sidecar import LlamaCppSidecar
+    sidecar = LlamaCppSidecar(log_dir=str(tmp_path / "logs"))
+    with pytest.raises(RuntimeError, match="not a loopback address"):
+        await sidecar.start("fake.gguf", host="192.168.1.1", port=_free_port())
+
+
+@pytest.mark.asyncio
+async def test_llama_cpp_non_localhost_does_not_change_state(tmp_path):
+    """State must remain STOPPED when start() is rejected before port check."""
+    from convsim_core.runtime.sidecar import LlamaCppSidecar, SidecarState
+    sidecar = LlamaCppSidecar(log_dir=str(tmp_path / "logs"))
+    try:
+        await sidecar.start("fake.gguf", host="0.0.0.0", port=_free_port())
+    except RuntimeError:
+        pass
+    assert sidecar.state == SidecarState.STOPPED
+
+
+# ---------------------------------------------------------------------------
+# Supervisor integration: app.state wiring
+# ---------------------------------------------------------------------------
+
+
+def test_app_state_has_supervisor(client):
+    """create_app must register a ProcessSupervisor on app.state.supervisor."""
+    assert hasattr(client.app.state, "supervisor")
+    assert isinstance(client.app.state.supervisor, ProcessSupervisor)
+
+
+def test_app_state_supervisor_has_llama_cpp_sidecar(client):
+    """The llama_cpp sidecar must be registered with the supervisor at startup."""
+    sup: ProcessSupervisor = client.app.state.supervisor
+    sidecar = sup.get("llama_cpp")
+    assert sidecar is not None
+    assert sidecar is client.app.state.sidecar
+
+
+def test_health_endpoint_includes_sidecar_diagnostics(client):
+    """GET /api/health must include the sidecar_diagnostics field."""
+    resp = client.get("/api/health")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "sidecar_diagnostics" in body
+    diag = body["sidecar_diagnostics"]
+    assert "all_ready" in diag
+    assert "user_message" in diag
+    assert "sidecars" in diag
+
+
+def test_health_sidecar_diagnostics_has_llama_cpp_entry(client):
+    """The sidecar_diagnostics sidecars list must contain the llama_cpp entry."""
+    body = client.get("/api/health").json()
+    sidecars = body["sidecar_diagnostics"]["sidecars"]
+    ids = [s["sidecar_id"] for s in sidecars]
+    assert "llama_cpp" in ids
+
+
+def test_health_sidecar_not_ready_when_stopped(client):
+    """all_ready must be False when the llama_cpp sidecar is stopped."""
+    body = client.get("/api/health").json()
+    diag = body["sidecar_diagnostics"]
+    assert diag["all_ready"] is False
+
+
+def test_health_sidecar_user_message_for_stopped(client):
+    """user_message must be an actionable non-empty string when sidecar is stopped."""
+    body = client.get("/api/health").json()
+    diag = body["sidecar_diagnostics"]
+    assert isinstance(diag["user_message"], str)
+    assert len(diag["user_message"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]


### PR DESCRIPTION
## Summary

This PR establishes a unified runtime sidecar lifecycle management system and adds user-facing health diagnostics:

**Sidecar contract & supervision:**
- Introduces `SidecarProcess` abstract base class defining a common contract (`sidecar_id`, `display_name`, `stop()`, `get_status()`, `tail_log()`) that all managed subprocesses must implement
- Adds `ProcessSupervisor` to coordinate sidecar lifetimes and guarantee shutdown at application exit through a single `stop_all()` call
- Enforces localhost-only binding with `assert_localhost()` guard — a hard runtime check that raises if any sidecar attempts to bind outside loopback addresses

**Integration:**
- `LlamaCppSidecar` now implements `SidecarProcess`, exposing `sidecar_id` (`"llama_cpp"`) and `display_name`
- `app.py` creates a `ProcessSupervisor` at startup and registers `LlamaCppSidecar`; shutdown invokes `supervisor.stop_all()` so future sidecars (whisper.cpp, kokoro) are cleaned up automatically once registered
- `LlamaCppSidecar.start()` calls `assert_localhost(host)` before spawning llama-server, converting the localhost-only promise from a convention into a runtime invariant

**User-facing health diagnostics:**
- `GET /api/health` gains a `sidecar_diagnostics` field with:
  - `all_ready` boolean for quick readiness checks
  - `user_message` — plain-English, non-technical summary for Steam users (e.g., "Running.", "Starting — this may take a minute…", "Not started. Select a model in Settings…")
  - `sidecars` array with per-sidecar entries covering states: `stopped`, `starting`, `running`, `crashed`, `port_conflict`

**Documentation & executable resolution:**
- `docs/sidecar-bundling.md` documents the three-step executable resolution order (env-var override → bundled `runtimes/` directory → PATH) and how Steam depot builds and developer checkouts each locate sidecar binaries
- `find_executable()` now implements the documented precedence order, fixing a gap where Steam depot builds could not find bundled sidecars

**Test coverage:**
- 35 new tests in `test_supervisor.py` cover:
  - `assert_localhost()` enforcement and rejection of non-loopback addresses
  - Supervisor registration, deduplication, and concurrent `stop_all()` semantics
  - Error suppression and tail log retrieval
  - `LlamaCppSidecar` contract compliance and health state transitions
  - `/api/health` `sidecar_diagnostics` field structure and messages

## Test plan

- [x] `pytest tests/test_supervisor.py` — 35 new tests all pass
- [x] `pytest tests/test_sidecar.py` — existing sidecar tests all pass
- [x] `pytest tests/test_health.py` — existing health tests all pass
- [x] Full suite passes (1401+ tests)

Closes #188