### PR TITLE
CI: drop deprecated macos-13 Intel runner from Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,12 +35,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Apple Silicon (arm64) — macos-latest is ARM since late 2024
+          # macOS is ARM64-only via GitHub-hosted runners: macos-13 (the last
+          # Intel/x86_64 runner) was deprecated by GitHub and is no longer
+          # available. macos-latest is Apple Silicon (ARM64) since late 2024.
           - name: macOS-aarch64
             runner: macos-latest
-          # Intel Mac — macos-13 is the last Intel runner
-          - name: macOS-x86_64
-            runner: macos-13
           # Linux x86_64 — AppImage + .deb
           - name: Linux-x86_64
             runner: ubuntu-22.04


### PR DESCRIPTION
## Summary

GitHub shut down the `macos-13` runner (the last Intel/x86_64 macOS runner). This left the `macOS-x86_64` leg of the **Release** workflow hung indefinitely, which in turn blocked the `Publish release` job (it `needs: build-desktop`). The `v0.1.0` tag push therefore never produced any release artifacts.

This PR incorporates the fix that was applied to the `v0.1.0` tag (via `git merge tag v0.1.0`) so it lands on `main` and going forward: **macOS builds are now ARM64-only** via `macos-latest`, matching the stance already documented in `release-smoke.yml`.

## Changes

- Remove the `macos-13` (Intel/x86_64) matrix entry from `.github/workflows/release.yml`.
- Update the matrix comment to document that macOS is ARM64-only via GitHub-hosted runners.

Remaining Release desktop matrix: `macos-latest` (ARM64), `ubuntu-22.04`, `windows-latest`.

## Verification

The `v0.1.0` tag was re-tagged onto this fix and force-pushed. The re-triggered [Release run](https://github.com/outrightmental/ConversationSimulator/actions/runs/29049689769) completed **green across all 5 jobs** (Validate, macOS-aarch64, Linux-x86_64, Windows-x86_64, Publish release), and the [v0.1.0 release](https://github.com/outrightmental/ConversationSimulator/releases/tag/v0.1.0) now has all installers + `checksums-sha256.txt` attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)