### PR TITLE
Validate Ollama model existence in Settings / Model Manager and add request-format tests

### DIFF
--- a/services/convsim-core/convsim_core/routers/models.py
+++ b/services/convsim-core/convsim_core/routers/models.py
@@ -302,9 +302,27 @@ async def use_model(request: Request, body: UseModelRequest) -> UseModelResponse
         )
 
     test_runtime = None
+    _ollama_model_error: ConvsimError | None = None
+
     try:
         test_runtime = build_runtime(body.runtime_id)
         health = await test_runtime.health()
+
+        # When an Ollama model is explicitly selected, verify it is installed locally.
+        # list_models() returns [] silently on connection failure, so this only fires
+        # when Ollama is reachable but the model tag is missing.
+        if body.runtime_id == "ollama" and body.model_id is not None:
+            available = {m.id for m in await test_runtime.list_models()}
+            if body.model_id not in available:
+                _ollama_model_error = ConvsimError(
+                    code="OLLAMA_MODEL_NOT_FOUND",
+                    message=(
+                        f"Model '{body.model_id}' is not installed in your local Ollama. "
+                        f"Run 'ollama pull {body.model_id}' to install it, "
+                        "or select a different model from the list."
+                    ),
+                    status_code=404,
+                )
     except Exception as exc:
         raise ConvsimError(
             code="RUNTIME_UNAVAILABLE",
@@ -325,6 +343,9 @@ async def use_model(request: Request, body: UseModelRequest) -> UseModelResponse
             message=health.message or f"Runtime '{body.runtime_id}' is not available.",
             status_code=503,
         )
+
+    if _ollama_model_error is not None:
+        raise _ollama_model_error
 
     set_active_config(db.connection(), runtime_id=body.runtime_id, model_id=body.model_id)
 

--- a/services/convsim-core/tests/test_model_manager.py
+++ b/services/convsim-core/tests/test_model_manager.py
@@ -544,6 +544,28 @@ def _make_unavailable_runtime():
     return rt
 
 
+def _make_ready_ollama_runtime(model_ids: list[str]):
+    """Return a fake Ollama runtime that reports READY and exposes a fixed model list."""
+    from convsim_core.runtime.types import ModelInfo
+
+    rt = MagicMock()
+    rt.id = "ollama"
+    rt.display_name = "Ollama (local)"
+    rt.health = AsyncMock(
+        return_value=RuntimeHealth(
+            runtime_id="ollama",
+            runtime_name="Ollama (local)",
+            status=RuntimeStatus.READY,
+            model_id=model_ids[0] if model_ids else None,
+            checked_at="2026-01-01T00:00:00+00:00",
+        )
+    )
+    rt.list_models = AsyncMock(
+        return_value=[ModelInfo(id=mid, name=mid) for mid in model_ids]
+    )
+    return rt
+
+
 def test_use_model_ollama_runtime_returns_error_when_unavailable(client, monkeypatch):
     """use_model must return 503 when the requested runtime is unreachable."""
     import convsim_core.routers.models as models_module
@@ -574,6 +596,116 @@ def test_use_model_llama_cpp_returns_error_when_unavailable(client, monkeypatch)
     resp = client.post("/api/models/use", json={"runtime_id": "llama_cpp"})
     assert resp.status_code == 503
     assert resp.json()["error"]["code"] == "RUNTIME_UNAVAILABLE"
+
+
+def test_use_model_ollama_accepts_installed_model(client, monkeypatch):
+    """use_model must succeed when the requested Ollama model is in the local model list."""
+    import convsim_core.routers.models as models_module
+
+    monkeypatch.setattr(
+        models_module,
+        "build_runtime",
+        lambda _id: _make_ready_ollama_runtime(["llama3.2:latest", "phi3:mini"]),
+    )
+    resp = client.post(
+        "/api/models/use", json={"runtime_id": "ollama", "model_id": "llama3.2:latest"}
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["runtime_id"] == "ollama"
+    assert body["model_id"] == "llama3.2:latest"
+
+
+def test_use_model_ollama_rejects_missing_model(client, monkeypatch):
+    """use_model must return 404 when the requested model is not installed in Ollama."""
+    import convsim_core.routers.models as models_module
+
+    monkeypatch.setattr(
+        models_module,
+        "build_runtime",
+        lambda _id: _make_ready_ollama_runtime(["llama3.2:latest"]),
+    )
+    resp = client.post(
+        "/api/models/use", json={"runtime_id": "ollama", "model_id": "deepseek-r1:7b"}
+    )
+    assert resp.status_code == 404
+    body = resp.json()
+    assert body["error"]["code"] == "OLLAMA_MODEL_NOT_FOUND"
+    assert "deepseek-r1:7b" in body["error"]["message"]
+    assert "ollama pull" in body["error"]["message"]
+
+
+def test_use_model_ollama_no_model_id_skips_model_check(client, monkeypatch):
+    """Selecting an Ollama runtime without specifying model_id must not trigger model validation."""
+    import convsim_core.routers.models as models_module
+
+    monkeypatch.setattr(
+        models_module,
+        "build_runtime",
+        lambda _id: _make_ready_ollama_runtime(["llama3.2:latest"]),
+    )
+    resp = client.post("/api/models/use", json={"runtime_id": "ollama"})
+    assert resp.status_code == 200
+    assert resp.json()["runtime_id"] == "ollama"
+
+
+def test_use_model_ollama_rejects_missing_model_when_no_models_installed(client, monkeypatch):
+    """use_model returns 404 when Ollama has no models and a model_id is requested."""
+    import convsim_core.routers.models as models_module
+
+    monkeypatch.setattr(
+        models_module,
+        "build_runtime",
+        lambda _id: _make_ready_ollama_runtime([]),
+    )
+    resp = client.post(
+        "/api/models/use", json={"runtime_id": "ollama", "model_id": "llama3.2:latest"}
+    )
+    assert resp.status_code == 404
+    assert resp.json()["error"]["code"] == "OLLAMA_MODEL_NOT_FOUND"
+
+
+def test_use_model_ollama_persists_config_after_successful_validation(client, monkeypatch):
+    """Active config must be saved when Ollama model validation passes."""
+    import convsim_core.routers.models as models_module
+
+    monkeypatch.setattr(
+        models_module,
+        "build_runtime",
+        lambda _id: _make_ready_ollama_runtime(["phi3:mini"]),
+    )
+    client.post("/api/models/use", json={"runtime_id": "ollama", "model_id": "phi3:mini"})
+    cfg = get_active_config(client.app.state.db.connection())
+    assert cfg["runtime_id"] == "ollama"
+    assert cfg["model_id"] == "phi3:mini"
+
+
+# ── GET /api/models — ollama_models detection ────────────────────────────────
+
+
+def test_get_models_returns_detected_ollama_models(client, monkeypatch):
+    """GET /api/models must include live-detected Ollama models when Ollama is reachable."""
+    import convsim_core.routers.models as models_module
+    from convsim_core.routers.models import DetectedOllamaModel
+
+    async def _fake_detect():
+        return [
+            DetectedOllamaModel(id="llama3.2:latest", name="llama3.2:latest", size_category="medium"),
+            DetectedOllamaModel(id="phi3:mini", name="phi3:mini", size_category="small"),
+        ]
+
+    monkeypatch.setattr(models_module, "_detect_ollama_models", _fake_detect)
+    body = client.get("/api/models").json()
+    assert len(body["ollama_models"]) == 2
+    ids = {m["id"] for m in body["ollama_models"]}
+    assert "llama3.2:latest" in ids
+    assert "phi3:mini" in ids
+
+
+def test_get_models_ollama_models_empty_when_unreachable(client):
+    """GET /api/models returns ollama_models=[] when Ollama is not running (default in tests)."""
+    body = client.get("/api/models").json()
+    assert body["ollama_models"] == []
 
 
 # ── POST /api/models/benchmark ───────────────────────────────────────────────

--- a/services/convsim-core/tests/test_ollama_runtime.py
+++ b/services/convsim-core/tests/test_ollama_runtime.py
@@ -446,6 +446,279 @@ async def test_health_degraded_when_no_models():
 
 
 # ---------------------------------------------------------------------------
+# Request-format tests — verify the payload sent to /api/chat
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_request_has_stream_true():
+    """The payload sent to /api/chat must always set stream=True."""
+    client = MagicMock()
+    client.stream = MagicMock(return_value=_StreamContext(_STREAM_LINES))
+    runtime = OllamaChatRuntime(client=client)
+    request = ChatRequest(
+        model_id="llama3.2:latest",
+        messages=[ChatMessage(role="user", content="hello")],
+    )
+    async for _ in runtime.chat_stream(request):
+        pass
+
+    payload = client.stream.call_args.kwargs["json"]
+    assert payload["stream"] is True
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_request_model_matches_request():
+    """The 'model' field in the payload must match the request's model_id."""
+    client = MagicMock()
+    client.stream = MagicMock(return_value=_StreamContext(_STREAM_LINES))
+    runtime = OllamaChatRuntime(client=client)
+    request = ChatRequest(
+        model_id="mistral:7b",
+        messages=[ChatMessage(role="user", content="hi")],
+    )
+    async for _ in runtime.chat_stream(request):
+        pass
+
+    payload = client.stream.call_args.kwargs["json"]
+    assert payload["model"] == "mistral:7b"
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_request_messages_formatted_as_role_content():
+    """Messages must be serialised as a list of {role, content} dicts."""
+    client = MagicMock()
+    client.stream = MagicMock(return_value=_StreamContext(_STREAM_LINES))
+    runtime = OllamaChatRuntime(client=client)
+    request = ChatRequest(
+        model_id="llama3.2:latest",
+        messages=[
+            ChatMessage(role="system", content="You are helpful."),
+            ChatMessage(role="user", content="hello"),
+        ],
+    )
+    async for _ in runtime.chat_stream(request):
+        pass
+
+    payload = client.stream.call_args.kwargs["json"]
+    assert payload["messages"] == [
+        {"role": "system", "content": "You are helpful."},
+        {"role": "user", "content": "hello"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_request_options_has_num_predict_and_temperature():
+    """The options dict must contain num_predict (from max_tokens) and temperature."""
+    client = MagicMock()
+    client.stream = MagicMock(return_value=_StreamContext(_STREAM_LINES))
+    runtime = OllamaChatRuntime(client=client)
+    request = ChatRequest(
+        model_id="llama3.2:latest",
+        messages=[ChatMessage(role="user", content="hello")],
+        max_tokens=128,
+        temperature=0.3,
+    )
+    async for _ in runtime.chat_stream(request):
+        pass
+
+    payload = client.stream.call_args.kwargs["json"]
+    assert "options" in payload
+    assert payload["options"]["num_predict"] == 128
+    assert payload["options"]["temperature"] == pytest.approx(0.3)
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_request_includes_format_when_schema_provided():
+    """When json_schema is set, the 'format' key must appear in the payload."""
+    schema = {"type": "object", "properties": {"npc_text": {"type": "string"}}}
+    structured_lines = [
+        json.dumps(
+            {
+                "model": "llama3.2",
+                "message": {"role": "assistant", "content": '{"npc_text": "Hello!"}'},
+                "done": False,
+            }
+        ),
+        json.dumps(
+            {
+                "model": "llama3.2",
+                "message": {"role": "assistant", "content": ""},
+                "done": True,
+                "prompt_eval_count": 3,
+                "eval_count": 5,
+            }
+        ),
+    ]
+    client = MagicMock()
+    client.stream = MagicMock(return_value=_StreamContext(structured_lines))
+    runtime = OllamaChatRuntime(client=client)
+    request = ChatRequest(
+        model_id="llama3.2:latest",
+        messages=[ChatMessage(role="user", content="go")],
+        json_schema=schema,
+    )
+    async for _ in runtime.chat_stream(request):
+        pass
+
+    payload = client.stream.call_args.kwargs["json"]
+    assert "format" in payload
+    assert payload["format"] == schema
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_request_excludes_format_when_no_schema():
+    """Without a json_schema, 'format' must not appear in the payload."""
+    client = MagicMock()
+    client.stream = MagicMock(return_value=_StreamContext(_STREAM_LINES))
+    runtime = OllamaChatRuntime(client=client)
+    request = ChatRequest(
+        model_id="llama3.2:latest",
+        messages=[ChatMessage(role="user", content="hello")],
+    )
+    async for _ in runtime.chat_stream(request):
+        pass
+
+    payload = client.stream.call_args.kwargs["json"]
+    assert "format" not in payload
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_request_targets_api_chat_endpoint():
+    """The streaming request must be POSTed to /api/chat."""
+    client = MagicMock()
+    client.stream = MagicMock(return_value=_StreamContext(_STREAM_LINES))
+    runtime = OllamaChatRuntime(client=client)
+    request = ChatRequest(
+        model_id="llama3.2:latest",
+        messages=[ChatMessage(role="user", content="hello")],
+    )
+    async for _ in runtime.chat_stream(request):
+        pass
+
+    call_args = client.stream.call_args
+    assert call_args.args[0] == "POST"
+    assert call_args.args[1] == "/api/chat"
+
+
+# ---------------------------------------------------------------------------
+# Structured-output response tests — verify ChatFinal.structured population
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_structured_output_parses_valid_json_from_stream():
+    """When json_schema is set and the model returns valid JSON, structured must be populated."""
+    payload = {"npc_utterance": "Greetings!", "safety": {"status": "ok"}}
+    lines = [
+        json.dumps(
+            {
+                "model": "llama3.2",
+                "message": {"role": "assistant", "content": json.dumps(payload)},
+                "done": False,
+            }
+        ),
+        json.dumps(
+            {
+                "model": "llama3.2",
+                "message": {"role": "assistant", "content": ""},
+                "done": True,
+                "prompt_eval_count": 4,
+                "eval_count": 8,
+            }
+        ),
+    ]
+    runtime = _make_runtime(stream_lines=lines)
+    request = ChatRequest(
+        model_id="llama3.2:latest",
+        messages=[ChatMessage(role="user", content="go")],
+        json_schema={"type": "object"},
+    )
+    final = None
+    async for chunk in runtime.chat_stream(request):
+        if isinstance(chunk, ChatFinal):
+            final = chunk
+
+    assert final is not None
+    assert final.structured is not None
+    assert final.structured["npc_utterance"] == "Greetings!"
+    assert final.structured["safety"]["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_structured_output_none_when_model_returns_malformed_json():
+    """If the stream content cannot be parsed as JSON, structured must be None (not an error)."""
+    lines = [
+        json.dumps(
+            {
+                "model": "llama3.2",
+                "message": {"role": "assistant", "content": "not valid json {{{"},
+                "done": False,
+            }
+        ),
+        json.dumps(
+            {
+                "model": "llama3.2",
+                "message": {"role": "assistant", "content": ""},
+                "done": True,
+                "prompt_eval_count": 2,
+                "eval_count": 4,
+            }
+        ),
+    ]
+    runtime = _make_runtime(stream_lines=lines)
+    request = ChatRequest(
+        model_id="llama3.2:latest",
+        messages=[ChatMessage(role="user", content="go")],
+        json_schema={"type": "object"},
+    )
+    final = None
+    async for chunk in runtime.chat_stream(request):
+        if isinstance(chunk, ChatFinal):
+            final = chunk
+
+    assert final is not None
+    assert final.structured is None
+
+
+@pytest.mark.asyncio
+async def test_structured_output_none_without_schema_even_if_content_is_json():
+    """structured must be None when no json_schema is provided, even if the content is JSON."""
+    json_content = json.dumps({"some": "data"})
+    lines = [
+        json.dumps(
+            {
+                "model": "llama3.2",
+                "message": {"role": "assistant", "content": json_content},
+                "done": False,
+            }
+        ),
+        json.dumps(
+            {
+                "model": "llama3.2",
+                "message": {"role": "assistant", "content": ""},
+                "done": True,
+                "prompt_eval_count": 2,
+                "eval_count": 3,
+            }
+        ),
+    ]
+    runtime = _make_runtime(stream_lines=lines)
+    request = ChatRequest(
+        model_id="llama3.2:latest",
+        messages=[ChatMessage(role="user", content="go")],
+        # No json_schema
+    )
+    final = None
+    async for chunk in runtime.chat_stream(request):
+        if isinstance(chunk, ChatFinal):
+            final = chunk
+
+    assert final is not None
+    assert final.structured is None
+
+
+# ---------------------------------------------------------------------------
 # Adapter identity and capability tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- **Model validation in `POST /api/models/use`**: When a user selects `runtime_id="ollama"` and provides a `model_id`, the endpoint now calls `list_models()` to verify the model is actually installed in the local Ollama server. If the model is missing, it returns `OLLAMA_MODEL_NOT_FOUND` (404) with an actionable message that includes the `ollama pull <model>` command. When no `model_id` is specified, the check is skipped, preserving the existing any-available-model fallback.

- **Request-format tests**: Seven new assertions in `test_ollama_runtime.py` verify the exact structure of the JSON payload sent to `/api/chat` — `stream=True`, correct `model` field, `messages` as `[{role, content}]` dicts, `options.num_predict` / `options.temperature`, the `/api/chat` endpoint being targeted, and `format` present if and only if `json_schema` is provided.

- **Structured-output response tests**: Three new tests confirm that `ChatFinal.structured` is populated when the model returns valid JSON, remains `None` when the response content is malformed JSON, and remains `None` when no schema was requested.

- **Model-manager integration tests**: Seven new tests in `test_model_manager.py` cover the Ollama model validation paths in `use_model` — accepting installed models, rejecting missing models, skipping the check when no `model_id` is provided, handling empty model lists, persisting config after successful validation, and verifying that `GET /api/models` surfaces live-detected Ollama models via the `_detect_ollama_models` helper.

## What was already in place

Ollama detection (`_detect_ollama_models`), liveness probing (`OllamaChatRuntime.health()`), model listing (`list_models()`), and the `ollama-select` wizard step in the frontend were already implemented. The gap closed by this PR is the missing guard in `use_model` that lets a user persist a non-existent Ollama model tag as the active config, leading to a confusing 404 at inference time rather than a clear upfront error.

## Testing

- All new tests run without a real Ollama server; HTTP calls are mocked via injected `httpx.AsyncClient` or `monkeypatch`.
- Full test suite passes with no regressions.

Closes #190