### PR TITLE
Implement llama.cpp sidecar download, detection, and launch

### DIFF
--- a/services/convsim-core/convsim_core/routers/sidecar.py
+++ b/services/convsim-core/convsim_core/routers/sidecar.py
@@ -4,18 +4,53 @@
 Endpoints allow the UI (or advanced users) to start/stop a local
 llama-server process managed by the app. Users who run their own
 llama-server externally can ignore these endpoints entirely.
+
+Also exposes:
+  GET  /api/runtime/capabilities  — capability flags of the active runtime
+  POST /api/sidecar/download-runtime — download/install llama-server binary
+  GET  /api/sidecar/download-runtime — poll download progress
+  DELETE /api/sidecar/download-runtime — cancel an in-progress download
 """
 from __future__ import annotations
 
+import asyncio
+from pathlib import Path
 from typing import Optional
 
 from fastapi import APIRouter, Request
 from pydantic import BaseModel
 
 from convsim_core.errors import ConvsimError
+from convsim_core.runtime.llama_cpp_download import (
+    DownloadProgress,
+    DownloadState,
+    detect_platform_string,
+    download_binary,
+)
 from convsim_core.runtime.sidecar import LlamaCppSidecar, SidecarState
 
 router = APIRouter()
+
+# ── Binary download state (one download at a time, module-level) ──────────────
+
+_download_progress: DownloadProgress = DownloadProgress()
+_download_task: Optional[asyncio.Task] = None  # type: ignore[type-arg]
+_download_cancel: asyncio.Event = asyncio.Event()
+
+# Strong reference so the task is not garbage-collected mid-download.
+_active_download_tasks: set[asyncio.Task] = set()  # type: ignore[type-arg]
+
+
+def _reset_download_state() -> None:
+    """Reset module-level download state (called by tests to avoid bleed)."""
+    global _download_progress, _download_task, _download_cancel
+    _download_progress = DownloadProgress()
+    _download_task = None
+    _download_cancel = asyncio.Event()
+    _active_download_tasks.clear()
+
+
+# ── Sidecar schemas ───────────────────────────────────────────────────────────
 
 
 class SidecarStartRequest(BaseModel):
@@ -53,6 +88,57 @@ class SidecarStatusResponse(BaseModel):
     host: str
     port: int
     started_at: Optional[str] = None
+
+
+# ── Download schemas ──────────────────────────────────────────────────────────
+
+
+class DownloadRuntimeRequest(BaseModel):
+    """Request body for POST /api/sidecar/download-runtime.
+
+    ``version`` is the exact llama.cpp release tag (e.g. ``"b5140"``).
+    Omit to auto-fetch the latest release.
+
+    ``dest_dir`` overrides the default install directory
+    (``~/.convsim/bin``). The binary is placed inside this directory as
+    ``llama-server`` (or ``llama-server.exe`` on Windows).
+    """
+
+    version: Optional[str] = None
+    dest_dir: Optional[str] = None
+
+
+class DownloadRuntimeStatusResponse(BaseModel):
+    """Current status of the binary download (or ``"idle"`` if never started)."""
+
+    state: str
+    bytes_downloaded: int = 0
+    total_bytes: Optional[int] = None
+    error: Optional[str] = None
+    binary_path: Optional[str] = None
+    release_tag: Optional[str] = None
+    platform: Optional[str] = None
+
+
+# ── Capabilities schema ───────────────────────────────────────────────────────
+
+
+class RuntimeCapabilitiesResponse(BaseModel):
+    """Feature flags advertised by the active runtime.
+
+    Clients can use this to decide which UI features to enable (e.g. hide the
+    structured-output toggle when ``json_schema`` is False).
+    """
+
+    runtime_id: str
+    streaming: bool
+    json_schema: bool
+    grammar: bool
+    tool_calling: bool
+    embeddings: bool
+
+
+# ── Sidecar lifecycle endpoints ───────────────────────────────────────────────
 
 
 @router.post("/api/sidecar/start", response_model=SidecarStartResponse)
@@ -123,3 +209,142 @@ async def sidecar_status(request: Request) -> SidecarStatusResponse:
     sidecar: LlamaCppSidecar = request.app.state.sidecar
     status = sidecar.get_status()
     return SidecarStatusResponse(**status)
+
+
+# ── Binary download endpoints ─────────────────────────────────────────────────
+
+
+@router.post("/api/sidecar/download-runtime", response_model=DownloadRuntimeStatusResponse)
+async def start_download_runtime(body: DownloadRuntimeRequest) -> DownloadRuntimeStatusResponse:
+    """Start a background download/install of the llama-server binary.
+
+    Only one download can run at a time. Returns 409 if a download is already
+    in progress. Poll ``GET /api/sidecar/download-runtime`` for progress.
+
+    On completion the binary is placed in ``dest_dir`` (default:
+    ``~/.convsim/bin``) and ``find_executable()`` will discover it via PATH
+    or the ``CONVSIM_BUNDLED_RUNTIME_DIR`` convention (see
+    docs/sidecar-bundling.md).
+    """
+    global _download_progress, _download_task, _download_cancel
+
+    if _download_task is not None and not _download_task.done():
+        raise ConvsimError(
+            code="DOWNLOAD_ALREADY_IN_PROGRESS",
+            message=(
+                "A binary download is already in progress. "
+                "Poll GET /api/sidecar/download-runtime for status, "
+                "or DELETE /api/sidecar/download-runtime to cancel."
+            ),
+            status_code=409,
+        )
+
+    try:
+        platform_str = detect_platform_string()
+    except RuntimeError as exc:
+        raise ConvsimError(
+            code="PLATFORM_NOT_SUPPORTED",
+            message=str(exc),
+            status_code=400,
+        ) from exc
+
+    dest = Path(body.dest_dir) if body.dest_dir else Path.home() / ".convsim" / "bin"
+
+    _download_cancel = asyncio.Event()
+    _download_progress = DownloadProgress(state=DownloadState.FETCHING_RELEASE)
+
+    def _on_progress(p: DownloadProgress) -> None:
+        global _download_progress
+        _download_progress = p
+
+    async def _run() -> None:
+        try:
+            await download_binary(
+                dest_dir=dest,
+                version=body.version,
+                platform_string=platform_str,
+                cancel_event=_download_cancel,
+                progress_cb=_on_progress,
+            )
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            pass  # error is captured in progress via progress_cb
+
+    task = asyncio.create_task(_run())
+    _active_download_tasks.add(task)
+    task.add_done_callback(_active_download_tasks.discard)
+    _download_task = task
+
+    return DownloadRuntimeStatusResponse(
+        state=_download_progress.state.value,
+        bytes_downloaded=_download_progress.bytes_downloaded,
+        total_bytes=_download_progress.total_bytes,
+        error=_download_progress.error,
+        binary_path=_download_progress.binary_path,
+        release_tag=_download_progress.release_tag,
+        platform=platform_str,
+    )
+
+
+@router.get("/api/sidecar/download-runtime", response_model=DownloadRuntimeStatusResponse)
+async def get_download_runtime_status() -> DownloadRuntimeStatusResponse:
+    """Return the current status of the binary download.
+
+    Returns ``state: "idle"`` when no download has been started this session.
+    """
+    try:
+        platform_str = detect_platform_string()
+    except RuntimeError:
+        platform_str = None
+
+    p = _download_progress
+    return DownloadRuntimeStatusResponse(
+        state=p.state.value,
+        bytes_downloaded=p.bytes_downloaded,
+        total_bytes=p.total_bytes,
+        error=p.error,
+        binary_path=p.binary_path,
+        release_tag=p.release_tag,
+        platform=platform_str,
+    )
+
+
+@router.delete("/api/sidecar/download-runtime", status_code=204)
+async def cancel_download_runtime() -> None:
+    """Cancel an in-progress binary download.
+
+    Returns 409 when no download is running.
+    """
+    global _download_task
+
+    if _download_task is None or _download_task.done():
+        raise ConvsimError(
+            code="NO_DOWNLOAD_IN_PROGRESS",
+            message="No binary download is currently in progress.",
+            status_code=409,
+        )
+    _download_cancel.set()
+
+
+# ── Runtime capabilities endpoint ─────────────────────────────────────────────
+
+
+@router.get("/api/runtime/capabilities", response_model=RuntimeCapabilitiesResponse)
+async def get_runtime_capabilities(request: Request) -> RuntimeCapabilitiesResponse:
+    """Return the feature flags of the currently active runtime.
+
+    Streaming and structured-output (json_schema) flags let the UI show or
+    hide features that depend on runtime support.  The flags are determined
+    by the runtime adapter selected at startup (llama_cpp, ollama, fake, …).
+    """
+    runtime = request.app.state.runtime
+    caps = runtime.capabilities
+    return RuntimeCapabilitiesResponse(
+        runtime_id=runtime.id,
+        streaming=caps.streaming,
+        json_schema=caps.json_schema,
+        grammar=caps.grammar,
+        tool_calling=caps.tool_calling,
+        embeddings=caps.embeddings,
+    )

--- a/services/convsim-core/convsim_core/runtime/llama_cpp_download.py
+++ b/services/convsim-core/convsim_core/runtime/llama_cpp_download.py
@@ -1,0 +1,329 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Platform-aware downloader for the llama-server binary.
+
+Downloads a pre-built llama-server from GitHub releases, verifies the
+SHA-256 checksum against the release's sha256sum.txt, extracts the binary
+from the ZIP archive, and installs it to a caller-specified directory.
+
+This module provides the programmatic equivalent of runtimes/llama_cpp/
+download-runtime.sh so the desktop app can trigger a binary install from
+Settings without the user leaving the app or running a shell script.
+
+Supported platforms
+-------------------
+  Linux  x86_64  → linux-x64
+  Linux  aarch64 → linux-arm64
+  macOS  arm64   → macos-arm64  (Apple Silicon)
+  macOS  x86_64  → macos-x64   (Intel Mac)
+
+Windows native binaries are not supported here; Windows users should use
+WSL2 (targeting the linux-x64 asset) or build from source.
+
+Usage
+-----
+::
+
+    from pathlib import Path
+    from convsim_core.runtime.llama_cpp_download import download_binary
+
+    binary_path = await download_binary(
+        dest_dir=Path.home() / ".convsim" / "bin",
+        version="b5140",          # omit for latest
+    )
+    # binary_path is the absolute path to the installed llama-server binary
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import io
+import platform as _platform
+import sys
+import zipfile
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Callable
+
+import httpx
+
+_GITHUB_REPO = "ggml-org/llama.cpp"
+_GITHUB_API = "https://api.github.com"
+_GITHUB_RELEASES = "https://github.com"
+_BINARY_NAME = "llama-server"
+_CHUNK_SIZE = 65_536  # 64 KB
+
+
+class DownloadState(str, Enum):
+    IDLE = "idle"
+    FETCHING_RELEASE = "fetching_release"
+    DOWNLOADING = "downloading"
+    VERIFYING = "verifying"
+    EXTRACTING = "extracting"
+    COMPLETE = "complete"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+@dataclass
+class DownloadProgress:
+    """Point-in-time snapshot of a binary download operation."""
+
+    state: DownloadState = DownloadState.IDLE
+    bytes_downloaded: int = 0
+    total_bytes: int | None = None
+    error: str | None = None
+    binary_path: str | None = None
+    release_tag: str | None = None
+
+
+def detect_platform_string() -> str:
+    """Return the llama.cpp release platform tag for this machine.
+
+    Matches the naming used by the GitHub release assets so the download URL
+    can be constructed deterministically.
+
+    Raises RuntimeError for unsupported OS/architecture combinations.
+    """
+    system = sys.platform
+    machine = _platform.machine().lower()
+
+    if system.startswith("linux"):
+        if machine in ("x86_64", "amd64"):
+            return "linux-x64"
+        if machine in ("aarch64", "arm64"):
+            return "linux-arm64"
+    elif system == "darwin":
+        if machine == "arm64":
+            return "macos-arm64"
+        if machine in ("x86_64", "amd64"):
+            return "macos-x64"
+    elif system == "win32":
+        raise RuntimeError(
+            "Native Windows binary download is not supported. "
+            "Use WSL2 with the Linux binary, or build from source: "
+            "https://github.com/ggml-org/llama.cpp#build"
+        )
+
+    raise RuntimeError(
+        f"Unsupported platform: {system}/{machine}. "
+        "Build from source: https://github.com/ggml-org/llama.cpp#build"
+    )
+
+
+def build_asset_name(release_tag: str, platform_string: str) -> str:
+    """Return the expected ZIP asset name for a llama.cpp release.
+
+    Convention: ``llama-{tag}-bin-{platform}-cpu.zip``
+    """
+    return f"llama-{release_tag}-bin-{platform_string}-cpu.zip"
+
+
+def build_asset_url(release_tag: str, asset_name: str) -> str:
+    """Return the GitHub download URL for *asset_name* in *release_tag*."""
+    return f"{_GITHUB_RELEASES}/{_GITHUB_REPO}/releases/download/{release_tag}/{asset_name}"
+
+
+def build_sha256sum_url(release_tag: str) -> str:
+    """Return the URL for the sha256sum.txt file published alongside a release."""
+    return f"{_GITHUB_RELEASES}/{_GITHUB_REPO}/releases/download/{release_tag}/sha256sum.txt"
+
+
+async def fetch_latest_release_tag(client: httpx.AsyncClient) -> str:
+    """Return the latest llama.cpp release tag from the GitHub API.
+
+    Raises httpx.HTTPStatusError on non-200 responses.
+    """
+    resp = await client.get(
+        f"{_GITHUB_API}/repos/{_GITHUB_REPO}/releases/latest",
+        headers={"Accept": "application/vnd.github.v3+json"},
+        follow_redirects=True,
+    )
+    resp.raise_for_status()
+    tag = resp.json().get("tag_name", "")
+    if not tag:
+        raise RuntimeError("GitHub API returned a release with no tag_name.")
+    return tag
+
+
+async def fetch_expected_sha256(
+    client: httpx.AsyncClient, sha256sum_url: str, asset_name: str
+) -> str | None:
+    """Return the expected hex digest for *asset_name* from sha256sum.txt.
+
+    Returns None when the file is absent (404) or the asset isn't listed.
+    The caller decides whether a missing checksum is acceptable.
+    """
+    try:
+        resp = await client.get(sha256sum_url, follow_redirects=True)
+        if resp.status_code == 404:
+            return None
+        resp.raise_for_status()
+    except (httpx.HTTPStatusError, httpx.TransportError):
+        return None
+
+    for line in resp.text.splitlines():
+        parts = line.strip().split(None, 1)
+        if len(parts) == 2:
+            digest, name = parts
+            if name.lstrip("*") == asset_name:
+                return digest.lower()
+    return None
+
+
+def _sha256_of_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest().lower()
+
+
+def _extract_binary_from_zip(data: bytes) -> bytes:
+    """Return the llama-server binary bytes from a ZIP archive.
+
+    Raises RuntimeError when the expected binary is not found.
+    """
+    target_names = {"llama-server", "llama-server.exe"}
+    with zipfile.ZipFile(io.BytesIO(data)) as zf:
+        for name in zf.namelist():
+            if Path(name).name.lower() in target_names:
+                return zf.read(name)
+    raise RuntimeError(
+        "llama-server binary not found in the downloaded archive. "
+        "The release asset format may have changed."
+    )
+
+
+async def download_binary(
+    *,
+    dest_dir: Path,
+    version: str | None = None,
+    platform_string: str | None = None,
+    cancel_event: asyncio.Event | None = None,
+    progress_cb: Callable[[DownloadProgress], None] | None = None,
+    _client: httpx.AsyncClient | None = None,
+    _timeout: float = 120.0,
+) -> str:
+    """Download, verify, and install the llama-server binary.
+
+    Args:
+        dest_dir: Directory where the binary will be placed.
+        version: Exact release tag to download (e.g. ``"b5140"``).  Omit to
+            auto-fetch the latest release.
+        platform_string: Override the auto-detected platform (useful in
+            tests).  Must match a llama.cpp release asset segment, e.g.
+            ``"linux-x64"``.
+        cancel_event: When set, the download stops cleanly and
+            ``asyncio.CancelledError`` is raised.  Checked between chunks.
+        progress_cb: Called after each significant state or byte-count change
+            with a ``DownloadProgress`` snapshot.
+        _client: Injected ``httpx.AsyncClient`` for tests.  Production code
+            leaves this None; a client is created and closed internally.
+        _timeout: HTTP request timeout in seconds.
+
+    Returns:
+        Absolute path string of the installed binary.
+
+    Raises:
+        RuntimeError: Platform not supported, download failed, checksum
+            mismatch, or binary missing from archive.
+        asyncio.CancelledError: *cancel_event* was set.
+    """
+    if platform_string is None:
+        platform_string = detect_platform_string()
+
+    progress = DownloadProgress(state=DownloadState.FETCHING_RELEASE)
+    if progress_cb:
+        progress_cb(progress)
+
+    def _check_cancel() -> None:
+        if cancel_event is not None and cancel_event.is_set():
+            raise asyncio.CancelledError("Binary download cancelled by user.")
+
+    own_client = _client is None
+    client = _client or httpx.AsyncClient(follow_redirects=True, timeout=_timeout)
+
+    try:
+        release_tag = version
+        if release_tag is None:
+            release_tag = await fetch_latest_release_tag(client)
+        progress.release_tag = release_tag
+
+        asset_name = build_asset_name(release_tag, platform_string)
+        asset_url = build_asset_url(release_tag, asset_name)
+        sha256sum_url = build_sha256sum_url(release_tag)
+
+        expected_sha256 = await fetch_expected_sha256(client, sha256sum_url, asset_name)
+
+        _check_cancel()
+        progress.state = DownloadState.DOWNLOADING
+        if progress_cb:
+            progress_cb(progress)
+
+        data = bytearray()
+        async with client.stream("GET", asset_url) as resp:
+            if resp.status_code != 200:
+                raise RuntimeError(
+                    f"Download failed: HTTP {resp.status_code} for {asset_url}. "
+                    f"Check that release {release_tag} has asset {asset_name}. "
+                    f"Browse releases: https://github.com/{_GITHUB_REPO}/releases"
+                )
+            content_length = resp.headers.get("content-length")
+            progress.total_bytes = int(content_length) if content_length else None
+            async for chunk in resp.aiter_bytes(_CHUNK_SIZE):
+                _check_cancel()
+                data.extend(chunk)
+                progress.bytes_downloaded = len(data)
+                if progress_cb:
+                    progress_cb(progress)
+
+        _check_cancel()
+        progress.state = DownloadState.VERIFYING
+        if progress_cb:
+            progress_cb(progress)
+
+        actual_sha256 = await asyncio.to_thread(_sha256_of_bytes, bytes(data))
+        if expected_sha256 is not None and actual_sha256 != expected_sha256:
+            raise RuntimeError(
+                f"SHA-256 checksum mismatch for {asset_name}. "
+                f"Expected {expected_sha256}, got {actual_sha256}. "
+                "The downloaded file may be corrupted. Try again."
+            )
+
+        _check_cancel()
+        progress.state = DownloadState.EXTRACTING
+        if progress_cb:
+            progress_cb(progress)
+
+        binary_data: bytes = await asyncio.to_thread(_extract_binary_from_zip, bytes(data))
+
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        suffix = ".exe" if sys.platform == "win32" else ""
+        dest_path = dest_dir / f"{_BINARY_NAME}{suffix}"
+
+        def _write() -> None:
+            dest_path.write_bytes(binary_data)
+            dest_path.chmod(0o755)
+
+        await asyncio.to_thread(_write)
+
+        progress.state = DownloadState.COMPLETE
+        progress.binary_path = str(dest_path)
+        if progress_cb:
+            progress_cb(progress)
+
+        return str(dest_path)
+
+    except asyncio.CancelledError:
+        progress.state = DownloadState.CANCELLED
+        if progress_cb:
+            progress_cb(progress)
+        raise
+
+    except Exception as exc:
+        progress.state = DownloadState.FAILED
+        progress.error = str(exc)
+        if progress_cb:
+            progress_cb(progress)
+        raise
+
+    finally:
+        if own_client:
+            await client.aclose()

--- a/services/convsim-core/tests/test_llama_cpp_download.py
+++ b/services/convsim-core/tests/test_llama_cpp_download.py
@@ -1,0 +1,719 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the llama.cpp binary downloader.
+
+All HTTP calls are intercepted by mock clients or in-process fake HTTP servers;
+no real network access or model weights are required.  This matches the mock-server
+pattern already established in test_sidecar.py for the sidecar integration tests.
+"""
+from __future__ import annotations
+
+import asyncio
+import io
+import sys
+import zipfile
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from convsim_core.runtime.llama_cpp_download import (
+    DownloadProgress,
+    DownloadState,
+    _extract_binary_from_zip,
+    _sha256_of_bytes,
+    build_asset_name,
+    build_asset_url,
+    build_sha256sum_url,
+    detect_platform_string,
+    download_binary,
+    fetch_expected_sha256,
+    fetch_latest_release_tag,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_zip(filename: str, content: bytes = b"fake-binary") -> bytes:
+    """Return a ZIP archive containing a single file *filename* with *content*."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr(filename, content)
+    return buf.getvalue()
+
+
+def _mock_async_client(
+    *,
+    latest_tag: str = "b5000",
+    sha256sum_text: str | None = None,
+    sha256sum_status: int = 200,
+    asset_data: bytes | None = None,
+    asset_status: int = 200,
+    api_error: Exception | None = None,
+    download_error: Exception | None = None,
+) -> Any:
+    """Build a mock httpx.AsyncClient for download_binary() tests.
+
+    Intercepts:
+      GET  <github_api>/releases/latest → ``{"tag_name": latest_tag}``
+      GET  .../sha256sum.txt            → sha256sum_text (or 404)
+      GET (stream)  .../asset.zip       → asset_data
+    """
+    import httpx
+
+    client = MagicMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    client.aclose = AsyncMock()
+
+    # API call → latest release tag
+    api_resp = MagicMock()
+    api_resp.status_code = 200
+    api_resp.json = MagicMock(return_value={"tag_name": latest_tag})
+    api_resp.raise_for_status = MagicMock()
+
+    # sha256sum.txt response
+    sha_resp = MagicMock()
+    sha_resp.status_code = sha256sum_status
+    sha_resp.text = sha256sum_text or ""
+    sha_resp.raise_for_status = MagicMock()
+    if sha256sum_status >= 400:
+        sha_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            message=f"HTTP {sha256sum_status}",
+            request=MagicMock(),
+            response=sha_resp,
+        )
+
+    async def _get(url, **_kw):
+        if api_error is not None:
+            raise api_error
+        if "api.github.com" in url:
+            return api_resp
+        return sha_resp
+
+    client.get = _get
+
+    # Streaming download context manager
+    stream_ctx = MagicMock()
+    stream_ctx.__aenter__ = AsyncMock(return_value=stream_ctx)
+    stream_ctx.__aexit__ = AsyncMock(return_value=None)
+
+    data = asset_data or _make_zip("llama-server", b"binary-content")
+    stream_ctx.status_code = asset_status
+    stream_ctx.headers = {"content-length": str(len(data))}
+
+    async def _aiter_bytes(chunk_size=65536):
+        if download_error is not None:
+            raise download_error
+        offset = 0
+        while offset < len(data):
+            yield data[offset : offset + chunk_size]
+            offset += chunk_size
+
+    stream_ctx.aiter_bytes = _aiter_bytes
+    client.stream = MagicMock(return_value=stream_ctx)
+
+    return client
+
+
+# ---------------------------------------------------------------------------
+# detect_platform_string — pure unit tests (monkeypatched sys.platform)
+# ---------------------------------------------------------------------------
+
+
+def test_detect_platform_linux_x86_64(monkeypatch):
+    monkeypatch.setattr("sys.platform", "linux")
+    monkeypatch.setattr("platform.machine", lambda: "x86_64")
+    assert detect_platform_string() == "linux-x64"
+
+
+def test_detect_platform_linux_amd64(monkeypatch):
+    monkeypatch.setattr("sys.platform", "linux")
+    monkeypatch.setattr("platform.machine", lambda: "amd64")
+    assert detect_platform_string() == "linux-x64"
+
+
+def test_detect_platform_linux_aarch64(monkeypatch):
+    monkeypatch.setattr("sys.platform", "linux")
+    monkeypatch.setattr("platform.machine", lambda: "aarch64")
+    assert detect_platform_string() == "linux-arm64"
+
+
+def test_detect_platform_linux_arm64(monkeypatch):
+    monkeypatch.setattr("sys.platform", "linux")
+    monkeypatch.setattr("platform.machine", lambda: "arm64")
+    assert detect_platform_string() == "linux-arm64"
+
+
+def test_detect_platform_macos_arm64(monkeypatch):
+    monkeypatch.setattr("sys.platform", "darwin")
+    monkeypatch.setattr("platform.machine", lambda: "arm64")
+    assert detect_platform_string() == "macos-arm64"
+
+
+def test_detect_platform_macos_x86_64(monkeypatch):
+    monkeypatch.setattr("sys.platform", "darwin")
+    monkeypatch.setattr("platform.machine", lambda: "x86_64")
+    assert detect_platform_string() == "macos-x64"
+
+
+def test_detect_platform_macos_amd64(monkeypatch):
+    monkeypatch.setattr("sys.platform", "darwin")
+    monkeypatch.setattr("platform.machine", lambda: "amd64")
+    assert detect_platform_string() == "macos-x64"
+
+
+def test_detect_platform_windows_raises(monkeypatch):
+    monkeypatch.setattr("sys.platform", "win32")
+    monkeypatch.setattr("platform.machine", lambda: "amd64")
+    with pytest.raises(RuntimeError, match="Windows"):
+        detect_platform_string()
+
+
+def test_detect_platform_unsupported_os_raises(monkeypatch):
+    monkeypatch.setattr("sys.platform", "freebsd14")
+    monkeypatch.setattr("platform.machine", lambda: "x86_64")
+    with pytest.raises(RuntimeError, match="Unsupported platform"):
+        detect_platform_string()
+
+
+def test_detect_platform_unsupported_arch_raises(monkeypatch):
+    monkeypatch.setattr("sys.platform", "linux")
+    monkeypatch.setattr("platform.machine", lambda: "riscv64")
+    with pytest.raises(RuntimeError, match="Unsupported platform"):
+        detect_platform_string()
+
+
+# ---------------------------------------------------------------------------
+# Asset name and URL construction
+# ---------------------------------------------------------------------------
+
+
+def test_build_asset_name():
+    name = build_asset_name("b5140", "linux-x64")
+    assert name == "llama-b5140-bin-linux-x64-cpu.zip"
+
+
+def test_build_asset_name_macos():
+    name = build_asset_name("b1234", "macos-arm64")
+    assert name == "llama-b1234-bin-macos-arm64-cpu.zip"
+
+
+def test_build_asset_url():
+    url = build_asset_url("b5140", "llama-b5140-bin-linux-x64-cpu.zip")
+    assert "ggml-org/llama.cpp" in url
+    assert "b5140" in url
+    assert "linux-x64" in url
+    assert url.startswith("https://")
+
+
+def test_build_sha256sum_url():
+    url = build_sha256sum_url("b5140")
+    assert "sha256sum.txt" in url
+    assert "b5140" in url
+
+
+# ---------------------------------------------------------------------------
+# fetch_latest_release_tag
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fetch_latest_release_tag_returns_tag():
+    import httpx
+
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json = MagicMock(return_value={"tag_name": "b9999"})
+    resp.raise_for_status = MagicMock()
+
+    client = MagicMock()
+    client.get = AsyncMock(return_value=resp)
+
+    tag = await fetch_latest_release_tag(client)
+    assert tag == "b9999"
+
+
+@pytest.mark.asyncio
+async def test_fetch_latest_release_tag_empty_raises():
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json = MagicMock(return_value={"tag_name": ""})
+    resp.raise_for_status = MagicMock()
+
+    client = MagicMock()
+    client.get = AsyncMock(return_value=resp)
+
+    with pytest.raises(RuntimeError, match="tag_name"):
+        await fetch_latest_release_tag(client)
+
+
+# ---------------------------------------------------------------------------
+# fetch_expected_sha256
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fetch_expected_sha256_found():
+    sha256sum_text = (
+        "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890  llama-b5140-bin-linux-x64-cpu.zip\n"
+        "0000000000000000000000000000000000000000000000000000000000000000  other.zip\n"
+    )
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.text = sha256sum_text
+    resp.raise_for_status = MagicMock()
+
+    client = MagicMock()
+    client.get = AsyncMock(return_value=resp)
+
+    result = await fetch_expected_sha256(
+        client,
+        "https://example.com/sha256sum.txt",
+        "llama-b5140-bin-linux-x64-cpu.zip",
+    )
+    assert result == "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+
+
+@pytest.mark.asyncio
+async def test_fetch_expected_sha256_star_prefix():
+    """GNU checksum format prepends '*' to filenames in binary mode."""
+    sha256sum_text = (
+        "deadbeef00000000000000000000000000000000000000000000000000000000 *llama-b1-bin-macos-arm64-cpu.zip\n"
+    )
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.text = sha256sum_text
+    resp.raise_for_status = MagicMock()
+
+    client = MagicMock()
+    client.get = AsyncMock(return_value=resp)
+
+    result = await fetch_expected_sha256(
+        client,
+        "https://example.com/sha256sum.txt",
+        "llama-b1-bin-macos-arm64-cpu.zip",
+    )
+    assert result == "deadbeef00000000000000000000000000000000000000000000000000000000"
+
+
+@pytest.mark.asyncio
+async def test_fetch_expected_sha256_not_in_file_returns_none():
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.text = "aabbcc  other-file.zip\n"
+    resp.raise_for_status = MagicMock()
+
+    client = MagicMock()
+    client.get = AsyncMock(return_value=resp)
+
+    result = await fetch_expected_sha256(
+        client,
+        "https://example.com/sha256sum.txt",
+        "llama-b9-bin-linux-x64-cpu.zip",
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_expected_sha256_404_returns_none():
+    import httpx
+
+    resp = MagicMock()
+    resp.status_code = 404
+    resp.raise_for_status = MagicMock(
+        side_effect=httpx.HTTPStatusError("404", request=MagicMock(), response=resp)
+    )
+
+    client = MagicMock()
+    client.get = AsyncMock(return_value=resp)
+
+    result = await fetch_expected_sha256(
+        client,
+        "https://example.com/sha256sum.txt",
+        "asset.zip",
+    )
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _extract_binary_from_zip
+# ---------------------------------------------------------------------------
+
+
+def test_extract_binary_from_zip_linux():
+    data = _make_zip("llama-server", b"binary-linux")
+    result = _extract_binary_from_zip(data)
+    assert result == b"binary-linux"
+
+
+def test_extract_binary_from_zip_windows():
+    data = _make_zip("llama-server.exe", b"binary-win")
+    result = _extract_binary_from_zip(data)
+    assert result == b"binary-win"
+
+
+def test_extract_binary_from_zip_in_subdirectory():
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("build/bin/llama-server", b"binary-in-subdir")
+    result = _extract_binary_from_zip(buf.getvalue())
+    assert result == b"binary-in-subdir"
+
+
+def test_extract_binary_from_zip_missing_raises():
+    data = _make_zip("some-other-file.txt", b"content")
+    with pytest.raises(RuntimeError, match="not found"):
+        _extract_binary_from_zip(data)
+
+
+# ---------------------------------------------------------------------------
+# download_binary — happy path (mock client)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_download_binary_success(tmp_path):
+    """download_binary() installs the binary and returns its path."""
+    binary_content = b"\x7fELFfakebinary"
+    zip_data = _make_zip("llama-server", binary_content)
+    actual_sha256 = _sha256_of_bytes(zip_data)
+
+    sha256sum_text = f"{actual_sha256}  llama-b5000-bin-linux-x64-cpu.zip\n"
+    client = _mock_async_client(
+        latest_tag="b5000",
+        sha256sum_text=sha256sum_text,
+        asset_data=zip_data,
+    )
+
+    with patch("convsim_core.runtime.llama_cpp_download.httpx.AsyncClient", return_value=client):
+        result = await download_binary(
+            dest_dir=tmp_path / "bin",
+            version="b5000",
+            platform_string="linux-x64",
+        )
+
+    assert result.endswith("llama-server") or result.endswith("llama-server.exe")
+    dest = Path(result)
+    assert dest.exists()
+    assert dest.read_bytes() == binary_content
+    assert dest.stat().st_mode & 0o111  # executable bit set
+
+
+@pytest.mark.asyncio
+async def test_download_binary_auto_fetches_latest_tag(tmp_path):
+    """When version=None, the latest release tag is fetched from the API."""
+    zip_data = _make_zip("llama-server", b"bin")
+    client = _mock_async_client(latest_tag="b9999", asset_data=zip_data)
+
+    progress_states: list[str] = []
+
+    def _cb(p: DownloadProgress) -> None:
+        progress_states.append(p.state.value)
+
+    with patch("convsim_core.runtime.llama_cpp_download.httpx.AsyncClient", return_value=client):
+        result = await download_binary(
+            dest_dir=tmp_path / "bin",
+            platform_string="linux-x64",
+            progress_cb=_cb,
+        )
+
+    assert Path(result).exists()
+    assert "fetching_release" in progress_states
+    assert "complete" in progress_states
+
+
+@pytest.mark.asyncio
+async def test_download_binary_no_sha256sum_file_still_succeeds(tmp_path):
+    """Missing sha256sum.txt does not abort the download."""
+    zip_data = _make_zip("llama-server", b"bin")
+    client = _mock_async_client(
+        latest_tag="b1",
+        sha256sum_status=404,
+        asset_data=zip_data,
+    )
+
+    with patch("convsim_core.runtime.llama_cpp_download.httpx.AsyncClient", return_value=client):
+        result = await download_binary(
+            dest_dir=tmp_path / "bin",
+            version="b1",
+            platform_string="linux-x64",
+        )
+
+    assert Path(result).exists()
+
+
+@pytest.mark.asyncio
+async def test_download_binary_checksum_mismatch_raises(tmp_path):
+    """A mismatched SHA-256 must raise RuntimeError and leave no binary."""
+    zip_data = _make_zip("llama-server", b"bin")
+    wrong_sha = "a" * 64
+    sha256sum_text = f"{wrong_sha}  llama-b1-bin-linux-x64-cpu.zip\n"
+    client = _mock_async_client(
+        latest_tag="b1",
+        sha256sum_text=sha256sum_text,
+        asset_data=zip_data,
+    )
+
+    dest = tmp_path / "bin"
+    with patch("convsim_core.runtime.llama_cpp_download.httpx.AsyncClient", return_value=client):
+        with pytest.raises(RuntimeError, match="checksum mismatch"):
+            await download_binary(
+                dest_dir=dest,
+                version="b1",
+                platform_string="linux-x64",
+            )
+
+    # Binary must not have been written
+    assert not (dest / "llama-server").exists()
+
+
+@pytest.mark.asyncio
+async def test_download_binary_asset_404_raises(tmp_path):
+    """HTTP 404 for the asset file must raise RuntimeError with a helpful message."""
+    client = _mock_async_client(latest_tag="b1", asset_status=404)
+
+    with patch("convsim_core.runtime.llama_cpp_download.httpx.AsyncClient", return_value=client):
+        with pytest.raises(RuntimeError, match="Download failed"):
+            await download_binary(
+                dest_dir=tmp_path / "bin",
+                version="b1",
+                platform_string="linux-x64",
+            )
+
+
+@pytest.mark.asyncio
+async def test_download_binary_binary_missing_from_zip_raises(tmp_path):
+    """If the ZIP doesn't contain llama-server, RuntimeError must be raised."""
+    zip_data = _make_zip("README.txt", b"nope")
+    client = _mock_async_client(latest_tag="b1", asset_data=zip_data)
+
+    with patch("convsim_core.runtime.llama_cpp_download.httpx.AsyncClient", return_value=client):
+        with pytest.raises(RuntimeError, match="not found in the downloaded archive"):
+            await download_binary(
+                dest_dir=tmp_path / "bin",
+                version="b1",
+                platform_string="linux-x64",
+            )
+
+
+@pytest.mark.asyncio
+async def test_download_binary_progress_states_in_order(tmp_path):
+    """progress_cb must be called with states in the expected sequence."""
+    zip_data = _make_zip("llama-server", b"bin")
+    client = _mock_async_client(latest_tag="b1", asset_data=zip_data)
+
+    states: list[str] = []
+
+    def _cb(p: DownloadProgress) -> None:
+        states.append(p.state.value)
+
+    with patch("convsim_core.runtime.llama_cpp_download.httpx.AsyncClient", return_value=client):
+        await download_binary(
+            dest_dir=tmp_path / "bin",
+            version="b1",
+            platform_string="linux-x64",
+            progress_cb=_cb,
+        )
+
+    # Must visit these states in order; deduplicate so repeated "downloading"
+    # progress callbacks (one per chunk) don't expand the sequence.
+    seen: set[str] = set()
+    ordered: list[str] = []
+    _key_states = {"fetching_release", "downloading", "verifying", "extracting", "complete"}
+    for s in states:
+        if s in _key_states and s not in seen:
+            ordered.append(s)
+            seen.add(s)
+    assert ordered == ["fetching_release", "downloading", "verifying", "extracting", "complete"]
+
+
+@pytest.mark.asyncio
+async def test_download_binary_cancelled_mid_download(tmp_path):
+    """Setting cancel_event during the download must raise CancelledError."""
+    zip_data = _make_zip("llama-server", b"bin")
+
+    cancel = asyncio.Event()
+    chunk_count = 0
+
+    client = _mock_async_client(latest_tag="b1", asset_data=zip_data)
+
+    orig_stream = client.stream
+
+    # Wrap the stream context manager so we set the cancel event after the first chunk
+    stream_ctx = client.stream.return_value
+
+    orig_aiter = stream_ctx.aiter_bytes
+
+    async def _aiter_with_cancel(chunk_size=65536):
+        nonlocal chunk_count
+        async for chunk in orig_aiter(chunk_size):
+            chunk_count += 1
+            if chunk_count == 1:
+                cancel.set()
+            yield chunk
+
+    stream_ctx.aiter_bytes = _aiter_with_cancel
+
+    with patch("convsim_core.runtime.llama_cpp_download.httpx.AsyncClient", return_value=client):
+        with pytest.raises(asyncio.CancelledError):
+            await download_binary(
+                dest_dir=tmp_path / "bin",
+                version="b1",
+                platform_string="linux-x64",
+                cancel_event=cancel,
+            )
+
+
+@pytest.mark.asyncio
+async def test_download_binary_creates_dest_dir(tmp_path):
+    """download_binary() must create dest_dir if it doesn't exist."""
+    zip_data = _make_zip("llama-server", b"bin")
+    client = _mock_async_client(latest_tag="b1", asset_data=zip_data)
+
+    nested = tmp_path / "a" / "b" / "c"
+    assert not nested.exists()
+
+    with patch("convsim_core.runtime.llama_cpp_download.httpx.AsyncClient", return_value=client):
+        await download_binary(
+            dest_dir=nested,
+            version="b1",
+            platform_string="linux-x64",
+        )
+
+    assert nested.is_dir()
+
+
+@pytest.mark.asyncio
+async def test_download_binary_progress_includes_release_tag(tmp_path):
+    """The progress snapshot must include the resolved release tag."""
+    zip_data = _make_zip("llama-server", b"bin")
+    client = _mock_async_client(latest_tag="b9876", asset_data=zip_data)
+
+    final_progress: list[DownloadProgress] = []
+
+    def _cb(p: DownloadProgress) -> None:
+        final_progress.append(p)
+
+    with patch("convsim_core.runtime.llama_cpp_download.httpx.AsyncClient", return_value=client):
+        await download_binary(
+            dest_dir=tmp_path / "bin",
+            version="b9876",
+            platform_string="linux-x64",
+            progress_cb=_cb,
+        )
+
+    complete = next(p for p in reversed(final_progress) if p.state == DownloadState.COMPLETE)
+    assert complete.release_tag == "b9876"
+    assert complete.binary_path is not None
+
+
+# ---------------------------------------------------------------------------
+# API endpoint tests via TestClient
+# ---------------------------------------------------------------------------
+
+
+def test_download_runtime_status_idle(client):
+    """GET /api/sidecar/download-runtime returns idle state when no download started."""
+    from convsim_core.routers import sidecar as sidecar_mod
+    sidecar_mod._reset_download_state()
+
+    resp = client.get("/api/sidecar/download-runtime")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["state"] == "idle"
+    assert data["bytes_downloaded"] == 0
+    assert data["binary_path"] is None
+
+
+def test_download_runtime_409_when_already_running(client):
+    """POST /api/sidecar/download-runtime returns 409 when a download is in progress."""
+    import convsim_core.routers.sidecar as sidecar_mod
+    from unittest.mock import MagicMock
+
+    sidecar_mod._reset_download_state()
+
+    # Plant a sentinel task object that reports done=False without actually
+    # running a coroutine, so we avoid the "coroutine never awaited" warning.
+    fake_task = MagicMock()
+    fake_task.done.return_value = False
+    sidecar_mod._download_task = fake_task
+    sidecar_mod._download_progress = DownloadProgress(state=DownloadState.DOWNLOADING)
+
+    try:
+        with patch(
+            "convsim_core.routers.sidecar.detect_platform_string",
+            return_value="linux-x64",
+        ):
+            resp = client.post(
+                "/api/sidecar/download-runtime",
+                json={"version": "b1"},
+            )
+
+        assert resp.status_code == 409
+        assert resp.json()["error"]["code"] == "DOWNLOAD_ALREADY_IN_PROGRESS"
+    finally:
+        sidecar_mod._reset_download_state()
+
+
+def test_download_runtime_cancel_no_download_returns_409(client):
+    """DELETE /api/sidecar/download-runtime when idle returns 409."""
+    import convsim_core.routers.sidecar as sidecar_mod
+    sidecar_mod._reset_download_state()
+
+    resp = client.delete("/api/sidecar/download-runtime")
+    assert resp.status_code == 409
+    assert resp.json()["error"]["code"] == "NO_DOWNLOAD_IN_PROGRESS"
+
+
+def test_download_runtime_unsupported_platform_returns_400(client, monkeypatch):
+    """POST /api/sidecar/download-runtime returns 400 on an unsupported platform."""
+    import convsim_core.routers.sidecar as sidecar_mod
+    sidecar_mod._reset_download_state()
+
+    with patch(
+        "convsim_core.routers.sidecar.detect_platform_string",
+        side_effect=RuntimeError("Unsupported platform: win32/amd64"),
+    ):
+        resp = client.post("/api/sidecar/download-runtime", json={})
+
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "PLATFORM_NOT_SUPPORTED"
+
+
+# ---------------------------------------------------------------------------
+# Runtime capabilities endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_runtime_capabilities_endpoint_llama_cpp(client, monkeypatch):
+    """GET /api/runtime/capabilities returns llama_cpp flags."""
+    monkeypatch.setenv("CONVSIM_RUNTIME", "llama_cpp")
+    resp = client.get("/api/runtime/capabilities")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "streaming" in data
+    assert "json_schema" in data
+    assert "grammar" in data
+    assert "tool_calling" in data
+    assert "embeddings" in data
+    assert "runtime_id" in data
+
+
+def test_runtime_capabilities_streaming_true_for_llama_cpp(client):
+    """llama_cpp runtime must advertise streaming=True."""
+    from convsim_core.runtime.llama_cpp import LlamaCppRuntime
+    if not isinstance(client.app.state.runtime, LlamaCppRuntime):
+        pytest.skip("Active runtime is not llama_cpp in this test config")
+    resp = client.get("/api/runtime/capabilities")
+    assert resp.json()["streaming"] is True
+
+
+def test_runtime_capabilities_runtime_id_matches_active(client):
+    """The runtime_id in the response must match the active runtime."""
+    runtime = client.app.state.runtime
+    resp = client.get("/api/runtime/capabilities")
+    assert resp.json()["runtime_id"] == runtime.id

--- a/services/convsim-core/tests/test_sidecar.py
+++ b/services/convsim-core/tests/test_sidecar.py
@@ -435,8 +435,15 @@ def test_sidecar_start_forwards_custom_host_and_port(client):
 
 _FAKE_LLAMA_SERVER = textwrap.dedent("""\
     #!/usr/bin/env python3
-    \"\"\"Minimal fake llama-server for sidecar integration testing.\"\"\"
+    \"\"\"Minimal fake llama-server for sidecar integration testing.
+
+    Handles:
+      GET  /health                    → 200 {"status":"ok"}
+      GET  /v1/models                 → 200 {"data":[{"id":"fake-model"}]}
+      POST /v1/chat/completions       → SSE stream with one token then [DONE]
+    \"\"\"
     import http.server
+    import json
     import sys
 
     port = 7356
@@ -446,16 +453,54 @@ _FAKE_LLAMA_SERVER = textwrap.dedent("""\
             port = int(args[i + 1])
             break
 
+    _SSE_CHUNK = json.dumps({
+        "choices": [{"delta": {"content": "hello"}, "finish_reason": None}],
+        "usage": None,
+    })
+    _SSE_FINAL = json.dumps({
+        "choices": [{"delta": {}, "finish_reason": "stop"}],
+        "usage": {"prompt_tokens": 3, "completion_tokens": 1},
+    })
+    _SSE_BODY = (
+        f"data: {_SSE_CHUNK}\\n\\n"
+        f"data: {_SSE_FINAL}\\n\\n"
+        "data: [DONE]\\n\\n"
+    ).encode()
+
     class _H(http.server.BaseHTTPRequestHandler):
         def do_GET(self):
             if self.path == "/health":
-                self.send_response(200)
-                self.send_header("Content-Type", "application/json")
-                self.end_headers()
-                self.wfile.write(b'{"status":"ok"}')
+                self._json(b'{"status":"ok"}')
+            elif self.path == "/v1/models":
+                self._json(b'{"data":[{"id":"fake-model"}]}')
             else:
                 self.send_response(404)
                 self.end_headers()
+
+        def do_POST(self):
+            # Consume request body so the connection can proceed
+            length = int(self.headers.get("Content-Length", 0))
+            if length:
+                self.rfile.read(length)
+            if self.path == "/v1/chat/completions":
+                self.send_response(200)
+                self.send_header("Content-Type", "text/event-stream")
+                self.send_header("Content-Length", str(len(_SSE_BODY)))
+                self.send_header("Connection", "close")
+                self.end_headers()
+                self.wfile.write(_SSE_BODY)
+                self.wfile.flush()
+            else:
+                self.send_response(404)
+                self.end_headers()
+
+        def _json(self, body: bytes):
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
         def log_message(self, *_a, **_kw):
             pass
 
@@ -763,3 +808,121 @@ async def test_wait_for_ready_timeout_message_includes_http_status(tmp_path):
     assert "503" in str(exc_info.value), (
         "Timeout message should include the last HTTP status (503), not 'Last error: None'"
     )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end integration: sidecar + runtime adapter + streaming chat
+#
+# These tests use the enhanced _FAKE_LLAMA_SERVER (which now handles
+# GET /health, GET /v1/models, and POST /v1/chat/completions) to verify the
+# full pipeline without a real model or GPU.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_streaming_chat_via_fake_server(tmp_path):
+    """LlamaCppRuntime.chat_stream() works end-to-end with the fake llama-server.
+
+    This is the CI-safe mock-server integration test: a real subprocess runs
+    the fake HTTP server, the sidecar manages its lifecycle, and the runtime
+    adapter communicates with it over localhost — no model weights needed.
+    """
+    from convsim_core.runtime.llama_cpp import LlamaCppConfig, LlamaCppRuntime
+    from convsim_core.runtime.types import ChatFinal, ChatMessage, ChatRequest, ChatToken
+
+    exe = _write_fake_server(tmp_path)
+    port = _free_port()
+    sidecar = LlamaCppSidecar(log_dir=str(tmp_path / "logs"))
+
+    await sidecar.start("fake-model.gguf", executable=exe, port=port, startup_timeout=15.0)
+    assert sidecar.state == SidecarState.RUNNING
+
+    try:
+        runtime = LlamaCppRuntime(
+            LlamaCppConfig(base_url=f"http://127.0.0.1:{port}", model_id="fake-model")
+        )
+
+        request = ChatRequest(messages=[ChatMessage(role="user", content="hello")])
+        tokens: list[str] = []
+        final: ChatFinal | None = None
+
+        async for chunk in runtime.chat_stream(request):
+            if isinstance(chunk, ChatToken):
+                tokens.append(chunk.text)
+            elif isinstance(chunk, ChatFinal):
+                final = chunk
+
+        assert final is not None, "chat_stream() must yield a ChatFinal"
+        assert final.text == "hello", f"Unexpected text: {final.text!r}"
+        assert len(tokens) >= 1
+
+        # Capability flags must be set correctly for the llama_cpp adapter
+        caps = runtime.capabilities
+        assert caps.streaming is True, "streaming must be True"
+        assert caps.json_schema is True, "json_schema must be True (enabled by default)"
+        assert caps.grammar is False
+        assert caps.tool_calling is False
+
+    finally:
+        await sidecar.stop()
+
+
+@pytest.mark.asyncio
+async def test_list_models_via_fake_server(tmp_path):
+    """LlamaCppRuntime.list_models() returns the models served by the fake server."""
+    from convsim_core.runtime.llama_cpp import LlamaCppConfig, LlamaCppRuntime
+
+    exe = _write_fake_server(tmp_path)
+    port = _free_port()
+    sidecar = LlamaCppSidecar(log_dir=str(tmp_path / "logs"))
+
+    await sidecar.start("fake-model.gguf", executable=exe, port=port, startup_timeout=15.0)
+    assert sidecar.state == SidecarState.RUNNING
+
+    try:
+        runtime = LlamaCppRuntime(
+            LlamaCppConfig(base_url=f"http://127.0.0.1:{port}")
+        )
+        models = await runtime.list_models()
+        assert len(models) == 1
+        assert models[0].id == "fake-model"
+    finally:
+        await sidecar.stop()
+
+
+@pytest.mark.asyncio
+async def test_structured_output_via_fake_server(tmp_path):
+    """Structured-output (json_schema) path works when json_schema is sent to fake server.
+
+    The fake server echoes a token "hello"; the runtime must attempt to parse
+    it as JSON and fall back gracefully (structured=None) without crashing.
+    """
+    from convsim_core.runtime.llama_cpp import LlamaCppConfig, LlamaCppRuntime
+    from convsim_core.runtime.types import ChatFinal, ChatMessage, ChatRequest
+
+    exe = _write_fake_server(tmp_path)
+    port = _free_port()
+    sidecar = LlamaCppSidecar(log_dir=str(tmp_path / "logs"))
+
+    await sidecar.start("fake-model.gguf", executable=exe, port=port, startup_timeout=15.0)
+
+    try:
+        runtime = LlamaCppRuntime(
+            LlamaCppConfig(base_url=f"http://127.0.0.1:{port}")
+        )
+        schema = {"type": "object", "properties": {"answer": {"type": "string"}}}
+        request = ChatRequest(
+            messages=[ChatMessage(role="user", content="go")],
+            json_schema=schema,
+        )
+        final: ChatFinal | None = None
+        async for chunk in runtime.chat_stream(request):
+            if isinstance(chunk, ChatFinal):
+                final = chunk
+
+        assert final is not None
+        # "hello" is not valid JSON → structured must be None (graceful fallback)
+        assert final.structured is None
+
+    finally:
+        await sidecar.stop()


### PR DESCRIPTION
## Summary

This PR implements the core infrastructure for user-initiated download and installation of the llama.cpp `llama-server` binary, plus new capabilities exposure and enhanced test infrastructure.

### New Binary Download Module

Added `convsim_core/runtime/llama_cpp_download.py`, a platform-aware downloader that:
- Fetches pre-built `llama-server` binaries from [ggml-org/llama.cpp](https://github.com/ggml-org/llama.cpp) GitHub releases
- Verifies SHA-256 checksums against the published `sha256sum.txt` in the release
- Extracts the binary from the ZIP archive and installs it to a caller-specified directory
- Supports four platforms: Linux x64, Linux ARM64, macOS ARM64 (Apple Silicon), macOS x64
- Reports download progress via `DownloadProgress` dataclass (`state`, `bytes_downloaded`, `total_bytes`, `release_tag`, `binary_path`)
- Respects an `asyncio.Event` cancellation signal for mid-download cancellation
- Handles auto-fetching of the latest release tag if no version is specified

### New API Endpoints (in `routers/sidecar.py`)

**Download lifecycle endpoints:**
- `POST /api/sidecar/download-runtime` — Start a background binary download/install. Returns 409 if a download is already in progress, 400 for unsupported platforms. Accepts optional `version` (exact release tag) and `dest_dir` (installation directory).
- `GET  /api/sidecar/download-runtime` — Poll download progress. Returns `state: "idle"` when no download has started.
- `DELETE /api/sidecar/download-runtime` — Cancel an in-progress download.

**Runtime capabilities endpoint:**
- `GET /api/runtime/capabilities` — Return feature flags of the currently active runtime (streaming, json_schema, grammar, tool_calling, embeddings). Lets the UI show or hide features that depend on runtime support.

### Enhanced Mock Server

Updated `_FAKE_LLAMA_SERVER` test subprocess to handle:
- `GET /health` — Returns `{"status":"ok"}`
- `GET /v1/models` — Returns `{"data":[{"id":"fake-model"}]}`
- `POST /v1/chat/completions` — Streams SSE-formatted tokens followed by `[DONE]` marker

### Test Coverage

**41 new tests** in `test_llama_cpp_download.py`:
- Platform detection (all supported platforms + unsupported combinations)
- Asset URL and filename construction
- SHA-256 checksum verification
- ZIP extraction and binary extraction
- Download state sequencing and progress callbacks
- Cancellation mid-download
- API endpoint behavior (409 on already-in-progress, 400 on unsupported platform, etc.)

**3 new end-to-end integration tests** in `test_sidecar.py`:
- `test_streaming_chat_via_fake_server` — Full pipeline: fake server subprocess, sidecar lifecycle, runtime adapter streaming chat, capability flag verification
- `test_list_models_via_fake_server` — Verify `/v1/models` endpoint integration
- `test_structured_output_via_fake_server` — Verify graceful fallback when streaming invalid JSON

All existing sidecar, supervisor, and llama_cpp_runtime tests continue to pass unchanged.

### Test Results

Full pytest suite: **1455 passed, 3 skipped, 0 failures**

Closes #189