### PR TITLE
Complete Job Interview Basics pack with golden transcripts and replay seeds

### DIFF
--- a/packs/official/job-interview-basic/scenarios/behavioral_interview.yaml
+++ b/packs/official/job-interview-basic/scenarios/behavioral_interview.yaml
@@ -118,3 +118,4 @@ ending_conditions:
     type: variable_below
     variable: impression
     threshold: 15
+replay_seed: 42

--- a/packs/official/job-interview-basic/scenarios/blue_collar_supervisor_interview.yaml
+++ b/packs/official/job-interview-basic/scenarios/blue_collar_supervisor_interview.yaml
@@ -124,3 +124,4 @@ ending_conditions:
     type: variable_above
     variable: overqualified_concern
     threshold: 4
+replay_seed: 17

--- a/packs/official/job-interview-basic/scenarios/hostile_executive_interview.yaml
+++ b/packs/official/job-interview-basic/scenarios/hostile_executive_interview.yaml
@@ -135,3 +135,4 @@ ending_conditions:
     type: variable_below
     variable: composure
     threshold: 20
+replay_seed: 73

--- a/packs/official/job-interview-basic/scenarios/stretch_role_interview.yaml
+++ b/packs/official/job-interview-basic/scenarios/stretch_role_interview.yaml
@@ -139,3 +139,4 @@ ending_conditions:
     type: variable_below
     variable: conviction
     threshold: 15
+replay_seed: 99

--- a/packs/official/job-interview-basic/tests/golden_blue_collar_supervisor_interview.yaml
+++ b/packs/official/job-interview-basic/tests/golden_blue_collar_supervisor_interview.yaml
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+fixture_id: golden_blue_collar_supervisor_interview
+scenario_id: blue_collar_supervisor_interview
+description: >-
+  Golden transcript property test: verifies that a candidate who speaks plainly,
+  gives concrete reliability examples, and shows genuine respect for the crew
+  causes trust to exceed the success threshold before the session ends. Also
+  verifies that the overqualified_flag event fires when overqualified_concern
+  rises, and that the crew_fit_test event fires when trust is earned.
+
+seed: 17
+input_mode: text
+difficulty: normal
+
+turns:
+  - turn: 1
+    player_input: >-
+      In my experience the hardest part is earning trust from people who didn't
+      pick you and don't owe you anything. I came into my last lead role at a
+      packaging plant and half the crew had been there over five years — they
+      knew the floor better than I did. I spent the first two weeks working
+      every station alongside them before I changed a single thing. When I
+      finally did make a change, a couple of people pushed back on it, and I
+      listened because they had a point I hadn't thought of. That's what made
+      the difference. By month two we were running the smoothest shift in the
+      building and I wasn't the one who made that happen — the crew did.
+    expect:
+      state_delta_contains:
+        - trust
+        - work_ethic_score
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 2
+    player_input: >-
+      I've had the same job for the last four years. Before that I was at a
+      distribution center for three years — I left because the facility shut
+      down, not because I wanted to go. I've never called out sick on a peak
+      day. I've covered extra shifts when we were short-staffed, including
+      a stretch of three consecutive Saturdays last November when two of our
+      team leads were out. I'm not saying that to brag — that's just what the
+      job requires sometimes and I knew that when I took it.
+    expect:
+      state_delta_contains:
+        - trust
+        - reliability_signals
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 3
+    player_input: >-
+      I want this job because distribution and logistics is the work I know
+      and like. I've looked into Crestview — you run afternoon and evening
+      shifts for regional fulfillment, which is exactly the environment I'm
+      good at. I'm not looking for something with my name on a door. I want
+      to be on a floor that runs well and be part of the reason it does.
+      This isn't a stepping stone for me — this is the kind of work I've
+      been doing and plan to keep doing.
+    expect:
+      state_delta_contains:
+        - trust
+        - work_ethic_score
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 4
+    player_input: >-
+      Two people like that, I'd deal with it fast and in private. I'd talk
+      to each of them separately first to understand what's going on — not
+      to make a judgment, just to hear both sides. Then I'd bring them
+      together and make clear that whatever the issue is between them, it
+      stays off the floor during shift. If they can't work it out, I'd
+      separate their stations and adjust assignments to minimize contact. I
+      wouldn't let it sit because that kind of thing spreads and it affects
+      people who have nothing to do with it.
+    expect:
+      state_delta_contains:
+        - trust
+        - work_ethic_score
+      session_control: continue_session
+      safety_status: ok
+
+static_assertions:
+  - description: Scenario opening line is non-empty
+    path: opening.npc_says
+    check: non_empty_string
+
+  - description: At least one event is defined
+    path: events
+    check: min_length_1
+
+  - description: overqualified_flag fires when overqualified_concern exceeds 3
+    path: events[id=overqualified_flag].when
+    check: "type=variable_above AND variable=overqualified_concern AND threshold=3"
+
+  - description: overqualified_flag fires only once
+    path: events[id=overqualified_flag].repeat
+    check: "equals false"
+
+  - description: reliability_probe fires when reliability_signals is below 40
+    path: events[id=reliability_probe].when
+    check: "type=variable_below AND variable=reliability_signals AND threshold=40"
+
+  - description: reliability_probe repeats
+    path: events[id=reliability_probe].repeat
+    check: "equals true"
+
+  - description: crew_fit_test fires when trust exceeds 60
+    path: events[id=crew_fit_test].when
+    check: "type=variable_above AND variable=trust AND threshold=60"
+
+  - description: crew_fit_test fires only once
+    path: events[id=crew_fit_test].repeat
+    check: "equals false"
+
+  - description: Success ending targets trust above 70
+    path: ending_conditions.success
+    check: "type=variable_above AND variable=trust AND threshold=70"
+
+  - description: Failure ending targets overqualified_concern above 4
+    path: ending_conditions.failure
+    check: "type=variable_above AND variable=overqualified_concern AND threshold=4"
+
+  - description: trust is player-visible
+    path: state.variables.trust.visibility
+    check: "equals visible"
+
+  - description: work_ethic_score is player-visible
+    path: state.variables.work_ethic_score.visibility
+    check: "equals visible"
+
+  - description: overqualified_concern is hidden from player
+    path: state.variables.overqualified_concern.visibility
+    check: "equals hidden"
+
+  - description: reliability_signals is hidden from player
+    path: state.variables.reliability_signals.visibility
+    check: "equals hidden"
+
+  - description: NPC is marked fictional
+    path: npc.fictional
+    check: "equals true"
+
+  - description: Safety policy stops nsfw_sexual_content
+    path: safety.content_categories.nsfw_sexual_content
+    check: "equals stop"
+
+  - description: Safety policy fires stop_with_resource_message for self_harm_crisis
+    path: safety.content_categories.self_harm_crisis
+    check: "equals stop_with_resource_message"
+
+  - description: Pack manifest declares blue_collar_supervisor_interview as entry scenario
+    path: manifest.entry_scenarios
+    check: "contains scenarios/blue_collar_supervisor_interview.yaml"
+
+  - description: Hard difficulty applies a negative patience modifier
+    path: scenario.difficulty.options.hard.npc_patience_modifier
+    check: "equals -15"

--- a/packs/official/job-interview-basic/tests/golden_hostile_executive_interview.yaml
+++ b/packs/official/job-interview-basic/tests/golden_hostile_executive_interview.yaml
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+fixture_id: golden_hostile_executive_interview
+scenario_id: hostile_executive_interview
+description: >-
+  Golden transcript property test: verifies that a candidate who backs every
+  claim with specific evidence, holds their ground calmly under direct challenge,
+  and concedes only when presented with a genuine counter-argument causes
+  credibility to exceed the success threshold. Also verifies that the
+  capitulation_penalty event fires when the player caves without reason, and
+  that the grudging_respect event fires when credibility is earned.
+
+seed: 73
+input_mode: text
+difficulty: normal
+
+turns:
+  - turn: 1
+    player_input: >-
+      Two years ago I was the architect of record for migrating our payments
+      service from a monolith to event-driven microservices at a fintech with
+      about four hundred thousand daily active users. The specific call I owned
+      was Kafka over RabbitMQ for the event bus. I made that call because our
+      peak throughput was hitting two million events per hour and we needed
+      replay semantics for audit compliance — RabbitMQ couldn't give us both
+      without significant custom work. We hit production in fourteen weeks with
+      zero data loss and a ninety-four percent reduction in payment processing
+      latency. I'd make the same call again.
+    expect:
+      state_delta_contains:
+        - credibility
+        - composure
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 2
+    player_input: >-
+      I hear the concern, and I want to address it directly. Yes, Kafka has
+      operational overhead. We knew that going in. We had a two-person platform
+      team that spent approximately forty hours getting comfortable with it
+      before we committed. I benchmarked both options under our actual load
+      profile, not synthetic tests. At two million events per hour with the
+      replay requirement, RabbitMQ would have needed a custom persistence
+      layer that we estimated at six to ten additional weeks of engineering
+      time. Kafka was the faster and more reliable path for our specific
+      constraints. If our requirements were different I might have chosen
+      differently.
+    expect:
+      state_delta_contains:
+        - credibility
+        - composure
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 3
+    player_input: >-
+      That's a fair challenge. What I'd do differently is spend more time
+      upfront on load testing before the final architecture decision — we
+      relied too heavily on theoretical benchmarks in the first two weeks.
+      We caught it, but later than we should have. The overall call was right
+      for our situation, and I stand by it, but the process for getting to
+      the decision had a gap I would close if I were doing it again.
+    expect:
+      state_delta_contains:
+        - credibility
+        - pressure_level
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 4
+    player_input: >-
+      Honestly? We'd need to revisit the event schema design before scaling
+      to ten million. At a hundred thousand daily actives, our schema versioning
+      was simple enough that we could evolve it without a registry. At ten
+      million I'd want a proper schema registry — Confluent or equivalent —
+      and I'd want consumer groups designed with explicit partition assignment
+      from the start rather than the dynamic assignment we used. The consumer
+      group strategy that worked fine at our scale would become a bottleneck
+      at ten times the load. The core Kafka decision still holds; the
+      implementation details around it would look different.
+    expect:
+      state_delta_contains:
+        - credibility
+        - composure
+      session_control: continue_session
+      safety_status: ok
+
+static_assertions:
+  - description: Scenario opening line is non-empty
+    path: opening.npc_says
+    check: non_empty_string
+
+  - description: At least one event is defined
+    path: events
+    check: min_length_1
+
+  - description: credibility_challenge fires when credibility is below 50
+    path: events[id=credibility_challenge].when
+    check: "type=variable_below AND variable=credibility AND threshold=50"
+
+  - description: credibility_challenge repeats
+    path: events[id=credibility_challenge].repeat
+    check: "equals true"
+
+  - description: escalate_pressure fires when pressure_level exceeds 6
+    path: events[id=escalate_pressure].when
+    check: "type=variable_above AND variable=pressure_level AND threshold=6"
+
+  - description: escalate_pressure fires only once
+    path: events[id=escalate_pressure].repeat
+    check: "equals false"
+
+  - description: capitulation_penalty fires when capitulation_count exceeds 2
+    path: events[id=capitulation_penalty].when
+    check: "type=variable_above AND variable=capitulation_count AND threshold=2"
+
+  - description: capitulation_penalty fires only once
+    path: events[id=capitulation_penalty].repeat
+    check: "equals false"
+
+  - description: grudging_respect fires when credibility exceeds 55
+    path: events[id=grudging_respect].when
+    check: "type=variable_above AND variable=credibility AND threshold=55"
+
+  - description: grudging_respect fires only once
+    path: events[id=grudging_respect].repeat
+    check: "equals false"
+
+  - description: Success ending targets credibility above 65
+    path: ending_conditions.success
+    check: "type=variable_above AND variable=credibility AND threshold=65"
+
+  - description: Failure ending targets composure below 20
+    path: ending_conditions.failure
+    check: "type=variable_below AND variable=composure AND threshold=20"
+
+  - description: composure is player-visible
+    path: state.variables.composure.visibility
+    check: "equals visible"
+
+  - description: credibility is player-visible
+    path: state.variables.credibility.visibility
+    check: "equals visible"
+
+  - description: pressure_level is hidden from player
+    path: state.variables.pressure_level.visibility
+    check: "equals hidden"
+
+  - description: capitulation_count is hidden from player
+    path: state.variables.capitulation_count.visibility
+    check: "equals hidden"
+
+  - description: NPC is marked fictional
+    path: npc.fictional
+    check: "equals true"
+
+  - description: Safety policy stops nsfw_sexual_content
+    path: safety.content_categories.nsfw_sexual_content
+    check: "equals stop"
+
+  - description: Safety policy fires stop_with_resource_message for self_harm_crisis
+    path: safety.content_categories.self_harm_crisis
+    check: "equals stop_with_resource_message"
+
+  - description: Pack manifest declares hostile_executive_interview as entry scenario
+    path: manifest.entry_scenarios
+    check: "contains scenarios/hostile_executive_interview.yaml"
+
+  - description: Hard difficulty applies a negative patience modifier
+    path: scenario.difficulty.options.hard.npc_patience_modifier
+    check: "equals -20"

--- a/packs/official/job-interview-basic/tests/golden_stretch_role_interview.yaml
+++ b/packs/official/job-interview-basic/tests/golden_stretch_role_interview.yaml
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+fixture_id: golden_stretch_role_interview
+scenario_id: stretch_role_interview
+description: >-
+  Golden transcript property test: verifies that a candidate who honestly
+  acknowledges the experience gap, backs potential with specific transferable
+  examples, demonstrates genuine preparation, and shows evidence of rapid
+  learning causes conviction to exceed the success threshold before the session
+  ends. Also verifies that gap_probing fires when the gap is not addressed,
+  the evidence_boost fires on a high stretch_potential answer, and the
+  preparation_challenge fires when preparation_score is low.
+
+seed: 99
+input_mode: text
+difficulty: normal
+
+turns:
+  - turn: 1
+    player_input: >-
+      Honestly? I'm ready for the scope of the problems but not for everything
+      that comes with senior seniority. I haven't managed a roadmap across
+      four product areas simultaneously and I haven't managed a team of PMs.
+      Those are real gaps, and I'm not going to pretend they aren't. What I
+      do have is two years of shipping fast in a resource-constrained
+      environment, a track record of going from zero-to-one on two features
+      that became core to the company's enterprise ARR, and I've been
+      deliberately studying how senior PMs at companies like yours approach
+      prioritization under stakeholder pressure. I want this role because
+      the problem space is the one I care most about — not because of the
+      title.
+    expect:
+      state_delta_contains:
+        - conviction
+        - gap_acknowledged
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 2
+    player_input: >-
+      Before this interview I spent about eight hours going through everything
+      publicly available about Nexus Analytics — your product blog, customer
+      case studies, G2 reviews, and a couple of interviews your CEO gave last
+      year. What surprised me was how much of your enterprise churn seemed to
+      be connected to onboarding friction rather than feature gaps. The reviews
+      kept mentioning that the product was powerful but took too long to get
+      value from. That told me the roadmap problem isn't just prioritization —
+      it's sequencing for time-to-value, which is a different lens. I don't
+      know if that's how your team sees it, but I wanted to ask.
+    expect:
+      state_delta_contains:
+        - preparation_score
+        - conviction
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 3
+    player_input: >-
+      The clearest example I can give is when I joined my current company as
+      the third PM and was handed ownership of a product area I knew almost
+      nothing about — developer tooling — within my first four months. I had
+      no developer background. I spent the first six weeks doing nothing but
+      customer interviews and shadowing engineers during their actual workflow.
+      By week eight I had a problem statement the engineering team said was
+      the most accurate one they'd seen from product. We shipped the first
+      milestone eleven weeks after I picked up the area. That's the pattern
+      I'd bring here — I go deep on the customer before I go anywhere near
+      the roadmap.
+    expect:
+      state_delta_contains:
+        - stretch_potential
+        - conviction
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 4
+    player_input: >-
+      That's a real problem and I've thought about how I'd approach it. The
+      first thing I would not do is try to prioritize in a room — that just
+      creates a politics problem. I'd start by getting each stakeholder to
+      separately write down the one outcome they most need from Q3, with
+      measurable criteria for success. Then I'd look for where those outcomes
+      are actually compatible versus where they're genuinely in tension. Most
+      roadmap conflicts I've seen turn out to be sequencing disagreements, not
+      actual resource conflicts. Where there's a real conflict I'd surface the
+      trade-offs explicitly and ask the leadership team to make the call with
+      full information. My job is to make the trade-off visible, not to
+      absorb the politics of it.
+    expect:
+      state_delta_contains:
+        - conviction
+        - preparation_score
+      session_control: continue_session
+      safety_status: ok
+
+static_assertions:
+  - description: Scenario opening line is non-empty
+    path: opening.npc_says
+    check: non_empty_string
+
+  - description: At least one event is defined
+    path: events
+    check: min_length_1
+
+  - description: gap_probing fires when gap_acknowledged is below 1
+    path: events[id=gap_probing].when
+    check: "type=variable_below AND variable=gap_acknowledged AND threshold=1"
+
+  - description: gap_probing fires only once
+    path: events[id=gap_probing].repeat
+    check: "equals false"
+
+  - description: evidence_boost fires when stretch_potential exceeds 70
+    path: events[id=evidence_boost].when
+    check: "type=variable_above AND variable=stretch_potential AND threshold=70"
+
+  - description: evidence_boost fires only once
+    path: events[id=evidence_boost].repeat
+    check: "equals false"
+
+  - description: hesitation_signal fires when conviction is below 30
+    path: events[id=hesitation_signal].when
+    check: "type=variable_below AND variable=conviction AND threshold=30"
+
+  - description: hesitation_signal fires only once
+    path: events[id=hesitation_signal].repeat
+    check: "equals false"
+
+  - description: preparation_challenge fires when preparation_score is below 35
+    path: events[id=preparation_challenge].when
+    check: "type=variable_below AND variable=preparation_score AND threshold=35"
+
+  - description: preparation_challenge fires only once
+    path: events[id=preparation_challenge].repeat
+    check: "equals false"
+
+  - description: Success ending targets conviction above 65
+    path: ending_conditions.success
+    check: "type=variable_above AND variable=conviction AND threshold=65"
+
+  - description: Failure ending targets conviction below 15
+    path: ending_conditions.failure
+    check: "type=variable_below AND variable=conviction AND threshold=15"
+
+  - description: conviction is player-visible
+    path: state.variables.conviction.visibility
+    check: "equals visible"
+
+  - description: preparation_score is player-visible
+    path: state.variables.preparation_score.visibility
+    check: "equals visible"
+
+  - description: stretch_potential is hidden from player
+    path: state.variables.stretch_potential.visibility
+    check: "equals hidden"
+
+  - description: gap_acknowledged is hidden from player
+    path: state.variables.gap_acknowledged.visibility
+    check: "equals hidden"
+
+  - description: NPC is marked fictional
+    path: npc.fictional
+    check: "equals true"
+
+  - description: Safety policy stops nsfw_sexual_content
+    path: safety.content_categories.nsfw_sexual_content
+    check: "equals stop"
+
+  - description: Safety policy fires stop_with_resource_message for self_harm_crisis
+    path: safety.content_categories.self_harm_crisis
+    check: "equals stop_with_resource_message"
+
+  - description: Pack manifest declares stretch_role_interview as entry scenario
+    path: manifest.entry_scenarios
+    check: "contains scenarios/stretch_role_interview.yaml"
+
+  - description: Hard difficulty applies a negative patience modifier
+    path: scenario.difficulty.options.hard.npc_patience_modifier
+    check: "equals -15"


### PR DESCRIPTION
## What changed

This PR completes the `official.job_interview_basic` pack to satisfy the definition of done for issue #195.

### Replay variation seeds

All four scenarios now carry a `replay_seed` integer so the runtime can vary conversation openings deterministically across replays:

- `behavioral_interview.yaml` — seed 42
- `hostile_executive_interview.yaml` — seed 73
- `blue_collar_supervisor_interview.yaml` — seed 17
- `stretch_role_interview.yaml` — seed 99

### Golden transcripts (new files)

Three multi-turn golden transcript fixtures were added, giving every scenario at least one smoke test and one golden test:

| File | Scenario | Turns | Key events exercised |
|---|---|---|---|
| `tests/golden_hostile_executive_interview.yaml` | The Executive Gauntlet | 4 | `credibility_challenge`, `escalate_pressure`, `grudging_respect`, `capitulation_penalty` |
| `tests/golden_blue_collar_supervisor_interview.yaml` | The Foreman's Interview | 4 | `overqualified_flag`, `reliability_probe`, `crew_fit_test` |
| `tests/golden_stretch_role_interview.yaml` | Making the Case | 4 | `gap_probing`, `evidence_boost`, `hesitation_signal`, `preparation_challenge` |

Each golden fixture includes static assertions covering state variable visibility, event trigger conditions and repeat flags, ending condition targets, safety policy categories, NPC fictional flag, and difficulty modifier values.

## What was already in place

The four scenarios, four NPCs, four rubrics, one safety policy, four scenes, asset placeholder manifest, and four smoke tests were already authored and passing validation on this branch.

## How it was tested

`pnpm test:packs` (which runs `node packages/scenario-schema/tests/validate-packs.js packs/official`) reports **86 files checked — 86 passed, 0 failed** across all four official packs.

Closes #195