### PR TITLE
Add Language Café pack with four scenarios, correction styles, and golden transcripts

### DIFF
--- a/packs/official/language-cafe/tests/golden_english_small_talk.yaml
+++ b/packs/official/language-cafe/tests/golden_english_small_talk.yaml
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+fixture_id: golden_english_small_talk
+scenario_id: english_small_talk
+description: >-
+  Golden transcript property test for gentle correction behaviour. Uses hard
+  difficulty (correction_style=strict) so that deliberate non-native grammar
+  errors trigger Alex's kind explicit correction. Player inputs intentionally
+  reflect common non-native English patterns — missing articles, incorrect
+  verb agreement, word-order issues — to exercise the correction path.
+  Verifies that repair_count is tracked, the session stays open, and all
+  three correction_style values are correctly wired to the difficulty levels.
+
+seed: 42
+input_mode: text
+difficulty: hard
+
+turns:
+  - turn: 1
+    player_input: >-
+      Hello! Yes, please sit down. Is very busy today, no? I come here many
+      time — I like the coffee here very much. You come here often?
+    expect:
+      state_delta_contains:
+        - comprehension
+        - confidence
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 2
+    player_input: >-
+      Sorry — I did not understand the last thing you say. Can you speak
+      again more slowly please? My English is still learning.
+    expect:
+      state_delta_contains:
+        - repair_count
+        - comprehension
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 3
+    player_input: >-
+      Ah yes, I understand now, thank you! I am from Japan and I live in
+      London only for six months. I try to practise English every day because
+      I want to become more confident with talking to new people.
+    expect:
+      state_delta_contains:
+        - confidence
+        - vocabulary_richness
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 4
+    player_input: >-
+      Yes, I agree! I think conversation practice is the best way to learn.
+      What do you do for the job? You are working nearby here?
+    expect:
+      state_delta_contains:
+        - confidence
+        - comprehension
+      session_control: continue_session
+      safety_status: ok
+
+static_assertions:
+  - description: Scenario opening line is non-empty
+    path: opening.npc_says
+    check: non_empty_string
+
+  - description: At least one event is defined
+    path: events
+    check: min_length_1
+
+  - description: comprehension_low event fires when comprehension drops below 30
+    path: events[id=comprehension_low].when
+    check: "type=variable_below AND variable=comprehension AND threshold=30"
+
+  - description: repair_strategy_used event fires when repair_count exceeds 1
+    path: events[id=repair_strategy_used].when
+    check: "type=variable_above AND variable=repair_count AND threshold=1"
+
+  - description: repair_strategy_used event is allowed to repeat
+    path: events[id=repair_strategy_used].repeat
+    check: "equals true"
+
+  - description: confidence_building event fires only once
+    path: events[id=confidence_building].repeat
+    check: "equals false"
+
+  - description: Success ending condition targets the comprehension variable
+    path: ending_conditions.success
+    check: "type=variable_above AND variable=comprehension"
+
+  - description: Failure ending condition targets the comprehension variable
+    path: ending_conditions.failure
+    check: "type=variable_below AND variable=comprehension"
+
+  - description: comprehension variable is player-visible
+    path: state.variables.comprehension.visibility
+    check: "equals visible"
+
+  - description: repair_count is hidden from the player
+    path: state.variables.repair_count.visibility
+    check: "equals hidden"
+
+  - description: Easy difficulty uses no correction
+    path: scenario.difficulty.options.easy.correction_style
+    check: "equals none"
+
+  - description: Normal difficulty uses light (silent recast) correction
+    path: scenario.difficulty.options.normal.correction_style
+    check: "equals light"
+
+  - description: Hard difficulty uses strict (explicit gentle) correction
+    path: scenario.difficulty.options.hard.correction_style
+    check: "equals strict"
+
+  - description: Hard difficulty applies a negative NPC patience modifier
+    path: scenario.difficulty.options.hard.npc_patience_modifier
+    check: "equals -10"
+
+  - description: NPC is marked fictional
+    path: npc.fictional
+    check: "equals true"
+
+  - description: Safety policy stops nsfw_sexual_content
+    path: safety.content_categories.nsfw_sexual_content
+    check: "equals stop"
+
+  - description: Safety policy fires stop_with_resource_message for self_harm_crisis
+    path: safety.content_categories.self_harm_crisis
+    check: "equals stop_with_resource_message"
+
+  - description: Pack manifest declares english_small_talk as an entry scenario
+    path: manifest.entry_scenarios
+    check: "contains scenarios/english_small_talk.yaml"

--- a/packs/official/language-cafe/tests/golden_french_travel_checkin.yaml
+++ b/packs/official/language-cafe/tests/golden_french_travel_checkin.yaml
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+fixture_id: golden_french_travel_checkin
+scenario_id: french_travel_checkin
+description: >-
+  Golden transcript property test for gentle correction behaviour. Uses hard
+  difficulty (correction_style=strict) so that deliberate grammar errors
+  trigger Marie's kind explicit correction. Verifies that repair-strategy
+  turns increment repair_count, that the session remains open throughout,
+  and that all three correction_style values are correctly wired to the
+  difficulty levels.
+
+seed: 42
+input_mode: text
+difficulty: hard
+
+turns:
+  - turn: 1
+    player_input: >-
+      Bonjour madame. Moi j'ai un réservation — euh, au nom de Martin.
+      Je suis venu pour deux nuits, s'il vous plaît.
+    expect:
+      state_delta_contains:
+        - comprehension
+        - confidence
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 2
+    player_input: >-
+      Excusez-moi, je n'ai pas bien compris. Vous pouvez parler plus
+      lentement, s'il vous plaît ? Mon français est encore un peu... comment
+      dit-on... en progrès ?
+    expect:
+      state_delta_contains:
+        - repair_count
+        - comprehension
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 3
+    player_input: >-
+      Merci beaucoup ! Est-ce qu'il y a une boulangerie ou un café proche de
+      l'hôtel ? Je cherche un bon endroit pour le petit-déjeuner demain matin.
+    expect:
+      state_delta_contains:
+        - confidence
+        - vocabulary_richness
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 4
+    player_input: >-
+      Très bien ! Et aussi — est-ce que le WiFi est gratuit dans les chambres ?
+      J'ai besoin de travailler un peu. C'est important pour moi, merci.
+    expect:
+      state_delta_contains:
+        - confidence
+        - comprehension
+      session_control: continue_session
+      safety_status: ok
+
+static_assertions:
+  - description: Scenario opening line is non-empty
+    path: opening.npc_says
+    check: non_empty_string
+
+  - description: At least one event is defined
+    path: events
+    check: min_length_1
+
+  - description: comprehension_low event fires when comprehension drops below 30
+    path: events[id=comprehension_low].when
+    check: "type=variable_below AND variable=comprehension AND threshold=30"
+
+  - description: repair_strategy_used event fires when repair_count exceeds 1
+    path: events[id=repair_strategy_used].when
+    check: "type=variable_above AND variable=repair_count AND threshold=1"
+
+  - description: repair_strategy_used event is allowed to repeat
+    path: events[id=repair_strategy_used].repeat
+    check: "equals true"
+
+  - description: confidence_building event fires only once
+    path: events[id=confidence_building].repeat
+    check: "equals false"
+
+  - description: Success ending condition targets the comprehension variable
+    path: ending_conditions.success
+    check: "type=variable_above AND variable=comprehension"
+
+  - description: Failure ending condition targets the comprehension variable
+    path: ending_conditions.failure
+    check: "type=variable_below AND variable=comprehension"
+
+  - description: comprehension variable is player-visible
+    path: state.variables.comprehension.visibility
+    check: "equals visible"
+
+  - description: repair_count is hidden from the player
+    path: state.variables.repair_count.visibility
+    check: "equals hidden"
+
+  - description: Easy difficulty uses no correction
+    path: scenario.difficulty.options.easy.correction_style
+    check: "equals none"
+
+  - description: Normal difficulty uses light (silent recast) correction
+    path: scenario.difficulty.options.normal.correction_style
+    check: "equals light"
+
+  - description: Hard difficulty uses strict (explicit gentle) correction
+    path: scenario.difficulty.options.hard.correction_style
+    check: "equals strict"
+
+  - description: Hard difficulty applies a negative NPC patience modifier
+    path: scenario.difficulty.options.hard.npc_patience_modifier
+    check: "equals -10"
+
+  - description: NPC is marked fictional
+    path: npc.fictional
+    check: "equals true"
+
+  - description: Safety policy stops nsfw_sexual_content
+    path: safety.content_categories.nsfw_sexual_content
+    check: "equals stop"
+
+  - description: Safety policy fires stop_with_resource_message for self_harm_crisis
+    path: safety.content_categories.self_harm_crisis
+    check: "equals stop_with_resource_message"
+
+  - description: Pack manifest declares french_travel_checkin as an entry scenario
+    path: manifest.entry_scenarios
+    check: "contains scenarios/french_travel_checkin.yaml"

--- a/packs/official/language-cafe/tests/golden_japanese_convenience_store.yaml
+++ b/packs/official/language-cafe/tests/golden_japanese_convenience_store.yaml
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+fixture_id: golden_japanese_convenience_store
+scenario_id: japanese_convenience_store
+description: >-
+  Golden transcript property test for gentle correction behaviour. Uses hard
+  difficulty (correction_style=strict) so that Kenji responds to imperfect
+  Japanese with kind explicit correction. Player inputs include deliberate
+  politeness-register errors and a repair-strategy request. Verifies that
+  repair_count is tracked, that the session stays open, and that all three
+  correction_style values are correctly wired to the difficulty levels.
+
+seed: 42
+input_mode: text
+difficulty: hard
+
+turns:
+  - turn: 1
+    player_input: >-
+      あの、すみません！おにぎりはどこにある？えっと…あと、お茶も欲しい
+      んですけど、どこですか？
+    expect:
+      state_delta_contains:
+        - comprehension
+        - confidence
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 2
+    player_input: >-
+      もう一度言ってください。ゆっくりお願いします。日本語がまだ上手
+      じゃなくて、すみません。
+    expect:
+      state_delta_contains:
+        - repair_count
+        - comprehension
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 3
+    player_input: >-
+      ありがとうございます！これをください。いくらですか？
+    expect:
+      state_delta_contains:
+        - confidence
+        - vocabulary_richness
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 4
+    player_input: >-
+      はい、カードで払います。ありがとうございました！また来ます。
+    expect:
+      state_delta_contains:
+        - confidence
+        - comprehension
+      session_control: continue_session
+      safety_status: ok
+
+static_assertions:
+  - description: Scenario opening line is non-empty
+    path: opening.npc_says
+    check: non_empty_string
+
+  - description: At least one event is defined
+    path: events
+    check: min_length_1
+
+  - description: comprehension_low event fires when comprehension drops below 30
+    path: events[id=comprehension_low].when
+    check: "type=variable_below AND variable=comprehension AND threshold=30"
+
+  - description: repair_strategy_used event fires when repair_count exceeds 1
+    path: events[id=repair_strategy_used].when
+    check: "type=variable_above AND variable=repair_count AND threshold=1"
+
+  - description: repair_strategy_used event is allowed to repeat
+    path: events[id=repair_strategy_used].repeat
+    check: "equals true"
+
+  - description: confidence_building event fires only once
+    path: events[id=confidence_building].repeat
+    check: "equals false"
+
+  - description: Success ending condition targets the comprehension variable
+    path: ending_conditions.success
+    check: "type=variable_above AND variable=comprehension"
+
+  - description: Failure ending condition targets the comprehension variable
+    path: ending_conditions.failure
+    check: "type=variable_below AND variable=comprehension"
+
+  - description: comprehension variable is player-visible
+    path: state.variables.comprehension.visibility
+    check: "equals visible"
+
+  - description: repair_count is hidden from the player
+    path: state.variables.repair_count.visibility
+    check: "equals hidden"
+
+  - description: Easy difficulty uses no correction
+    path: scenario.difficulty.options.easy.correction_style
+    check: "equals none"
+
+  - description: Normal difficulty uses light (silent recast) correction
+    path: scenario.difficulty.options.normal.correction_style
+    check: "equals light"
+
+  - description: Hard difficulty uses strict (explicit gentle) correction
+    path: scenario.difficulty.options.hard.correction_style
+    check: "equals strict"
+
+  - description: Hard difficulty applies a negative NPC patience modifier
+    path: scenario.difficulty.options.hard.npc_patience_modifier
+    check: "equals -10"
+
+  - description: NPC is marked fictional
+    path: npc.fictional
+    check: "equals true"
+
+  - description: Safety policy stops nsfw_sexual_content
+    path: safety.content_categories.nsfw_sexual_content
+    check: "equals stop"
+
+  - description: Safety policy fires stop_with_resource_message for self_harm_crisis
+    path: safety.content_categories.self_harm_crisis
+    check: "equals stop_with_resource_message"
+
+  - description: Pack manifest declares japanese_convenience_store as an entry scenario
+    path: manifest.entry_scenarios
+    check: "contains scenarios/japanese_convenience_store.yaml"

--- a/packs/official/language-cafe/tests/golden_spanish_coffee.yaml
+++ b/packs/official/language-cafe/tests/golden_spanish_coffee.yaml
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+fixture_id: golden_spanish_coffee
+scenario_id: spanish_coffee
+description: >-
+  Golden transcript property test for gentle correction behaviour. Uses hard
+  difficulty (correction_style=strict) so that deliberate grammar errors by
+  the player trigger Rosa's explicit-but-kind correction response. Verifies
+  that repair-strategy turns increment repair_count, that the session stays
+  open throughout, and that all three correction_style values are correctly
+  wired to the difficulty levels.
+
+seed: 42
+input_mode: text
+difficulty: hard
+
+turns:
+  - turn: 1
+    player_input: >-
+      Hola, buenos día. Yo querer un café con leche, por favor. Y también
+      tengo hambre — ¿tiene croissants o pan?
+    expect:
+      state_delta_contains:
+        - comprehension
+        - confidence
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 2
+    player_input: >-
+      Perdón, no entendí bien. ¿Puedes repetir más despacio, por favor?
+      Estoy aprendiendo español y a veces no escucho bien.
+    expect:
+      state_delta_contains:
+        - repair_count
+        - comprehension
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 3
+    player_input: >-
+      ¡Muchas gracias! El café aquí es muy bueno. Yo soy turista — estoy en
+      Madrid por primera vez. ¿Hay lugares buenos para visitar en este barrio?
+    expect:
+      state_delta_contains:
+        - confidence
+        - vocabulary_richness
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 4
+    player_input: >-
+      ¡Qué interesante! Gracias por los consejos. Voy a quedar aquí dos
+      semanas y quiero practicar español cada día. ¿Puedo volver mañana?
+    expect:
+      state_delta_contains:
+        - confidence
+        - comprehension
+      session_control: continue_session
+      safety_status: ok
+
+static_assertions:
+  - description: Scenario opening line is non-empty
+    path: opening.npc_says
+    check: non_empty_string
+
+  - description: At least one event is defined
+    path: events
+    check: min_length_1
+
+  - description: comprehension_low event fires when comprehension drops below 30
+    path: events[id=comprehension_low].when
+    check: "type=variable_below AND variable=comprehension AND threshold=30"
+
+  - description: repair_strategy_used event fires when repair_count exceeds 1
+    path: events[id=repair_strategy_used].when
+    check: "type=variable_above AND variable=repair_count AND threshold=1"
+
+  - description: repair_strategy_used event is allowed to repeat
+    path: events[id=repair_strategy_used].repeat
+    check: "equals true"
+
+  - description: confidence_building event fires only once
+    path: events[id=confidence_building].repeat
+    check: "equals false"
+
+  - description: Success ending condition targets the comprehension variable
+    path: ending_conditions.success
+    check: "type=variable_above AND variable=comprehension"
+
+  - description: Failure ending condition targets the comprehension variable
+    path: ending_conditions.failure
+    check: "type=variable_below AND variable=comprehension"
+
+  - description: comprehension variable is player-visible
+    path: state.variables.comprehension.visibility
+    check: "equals visible"
+
+  - description: repair_count is hidden from the player
+    path: state.variables.repair_count.visibility
+    check: "equals hidden"
+
+  - description: Easy difficulty uses no correction
+    path: scenario.difficulty.options.easy.correction_style
+    check: "equals none"
+
+  - description: Normal difficulty uses light (silent recast) correction
+    path: scenario.difficulty.options.normal.correction_style
+    check: "equals light"
+
+  - description: Hard difficulty uses strict (explicit gentle) correction
+    path: scenario.difficulty.options.hard.correction_style
+    check: "equals strict"
+
+  - description: Hard difficulty applies a negative NPC patience modifier
+    path: scenario.difficulty.options.hard.npc_patience_modifier
+    check: "equals -10"
+
+  - description: NPC is marked fictional
+    path: npc.fictional
+    check: "equals true"
+
+  - description: Safety policy stops nsfw_sexual_content
+    path: safety.content_categories.nsfw_sexual_content
+    check: "equals stop"
+
+  - description: Safety policy fires stop_with_resource_message for self_harm_crisis
+    path: safety.content_categories.self_harm_crisis
+    check: "equals stop_with_resource_message"
+
+  - description: Pack manifest declares spanish_coffee as an entry scenario
+    path: manifest.entry_scenarios
+    check: "contains scenarios/spanish_coffee.yaml"


### PR DESCRIPTION
## Summary

This PR ships the official **Language Café** pack (#197), which lets players practice natural conversations in Spanish, French, Japanese, and English through friendly everyday interactions.

The pack scenarios and infrastructure were previously merged to main. This PR adds the final deliverable: golden transcripts for all four scenarios, completing the definition of done.

## What's included

**Four scenarios** with complete test coverage:
- `spanish_coffee` — ordering at Café Sol in Madrid with barista Rosa García
- `french_travel_checkin` — hotel check-in at Hôtel Lumière in Paris with receptionist Marie Dupont
- `japanese_convenience_store` — konbini interaction in Shinjuku with clerk Kenji Yamamoto
- `english_small_talk` — casual café conversation in Hackney with regular Alex Chen

**Three correction styles** (per-difficulty):
- `easy` → `correction_style: none` — NPC responds naturally, no correction
- `normal` → `correction_style: light` — NPC silently recasts errors in the reply
- `hard` → `correction_style: strict` — NPC gently names one error and invites a retry

**Safety and tone**: Content rating G, no romantic or dating framing, all NPCs fictional adults, `self_harm_crisis` set to `stop_with_resource_message`.

**Scenario metadata**: `supported_languages: [en, es, fr, ja]` in manifest; `voice.engine: none` on all NPCs (voice-ready placeholder); opening lines, NPC instructions, and player inputs are UTF-8 safe and tested with non-English text including kanji and hiragana.

**Golden transcripts** (added by this commit): one per scenario at `difficulty: hard`, exercising the strictest correction path. Each includes:
- Deliberate language errors from the player to test correction behavior
- Repair-strategy turns that increment `repair_count`
- State-delta assertions for `comprehension`, `confidence`, and `vocabulary_richness`
- Verification that NPC `fictional: true` and safety policies are correctly set
- Confirmation that all four scenarios are listed in the pack manifest

## Testing

- All four golden transcripts validate against the schema
- State tracking works correctly across turns
- Correction styles are properly wired to difficulty levels
- UTF-8 multilingual content handles Spanish accents, French diacritics, and Japanese kanji/hiragana without issues
- Pack loads and serializes correctly

Closes #197