### PR TITLE
Add golden transcript tests and integration coverage for the Difficult Conversations pack

### DIFF
--- a/packages/convsim-cli/tests/offline-smoke-test.test.ts
+++ b/packages/convsim-cli/tests/offline-smoke-test.test.ts
@@ -541,4 +541,34 @@ describe('offline-smoke-test — official packs', () => {
     runOfflineSmokeTest(jobInterviewPack, true);
     expect(Socket.prototype.connect).toBe(origConnect);
   });
+
+  const difficultConvPack = join(repoRoot, 'packs', 'official', 'difficult-conversations');
+
+  it('passes for the difficult-conversations pack', () => {
+    const code = runOfflineSmokeTest(difficultConvPack, false);
+    expect(code).toBe(0);
+  });
+
+  it('JSON output is ok for the difficult-conversations pack', () => {
+    let captured = '';
+    const spy = vi.spyOn(process.stdout, 'write').mockImplementation((d) => {
+      captured += String(d);
+      return true;
+    });
+    runOfflineSmokeTest(difficultConvPack, true);
+    spy.mockRestore();
+    const result = JSON.parse(captured) as Record<string, unknown>;
+    expect(result['status']).toBe('ok');
+    expect(result['pack_id']).toBe('official.difficult_conversations');
+    expect(typeof result['scenario_id']).toBe('string');
+    expect((result['turns_played'] as number)).toBeGreaterThan(0);
+    expect(result['debrief_generated']).toBe(true);
+    expect((result['network_violations'] as unknown[]).length).toBe(0);
+  });
+
+  it('Socket.prototype.connect is restored after the difficult-conversations pack run', () => {
+    const origConnect = Socket.prototype.connect;
+    runOfflineSmokeTest(difficultConvPack, true);
+    expect(Socket.prototype.connect).toBe(origConnect);
+  });
 });

--- a/packages/convsim-cli/tests/runner.test.ts
+++ b/packages/convsim-cli/tests/runner.test.ts
@@ -271,3 +271,117 @@ describe('golden — job-interview-basic smoke test', () => {
     expect(fixture?.mode).toBe('fake');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Golden snapshot: difficult-conversations — all eight fixtures (4 smoke + 4 golden)
+// ---------------------------------------------------------------------------
+
+describe('golden — difficult-conversations pack test', () => {
+  const repoRoot = fileURLToPath(new URL('../../../', import.meta.url));
+  const packDir = join(repoRoot, 'packs', 'official', 'difficult-conversations');
+
+  it('passes all fixtures with the fake runtime', () => {
+    const pack = loadPack(packDir, 'official');
+    const result = runPackTests(pack);
+
+    expect(result.failed).toBe(0);
+    expect(result.fixture_count).toBeGreaterThanOrEqual(8);
+  });
+
+  it('smoke_coworker_feedback fixture passes all static assertions', () => {
+    const pack = loadPack(packDir, 'official');
+    const result = runPackTests(pack);
+
+    const fixture = result.fixtures.find((f) => f.fixture_id === 'smoke_coworker_feedback');
+    expect(fixture).toBeDefined();
+    expect(fixture?.status).toBe('passed');
+    expect(fixture?.failures).toHaveLength(0);
+    expect(fixture?.static_assertion_count).toBeGreaterThan(0);
+  });
+
+  it('smoke_missed_deadline_apology fixture passes all static assertions', () => {
+    const pack = loadPack(packDir, 'official');
+    const result = runPackTests(pack);
+
+    const fixture = result.fixtures.find((f) => f.fixture_id === 'smoke_missed_deadline_apology');
+    expect(fixture).toBeDefined();
+    expect(fixture?.status).toBe('passed');
+    expect(fixture?.failures).toHaveLength(0);
+  });
+
+  it('smoke_boundary_with_friend fixture passes all static assertions', () => {
+    const pack = loadPack(packDir, 'official');
+    const result = runPackTests(pack);
+
+    const fixture = result.fixtures.find((f) => f.fixture_id === 'smoke_boundary_with_friend');
+    expect(fixture).toBeDefined();
+    expect(fixture?.status).toBe('passed');
+    expect(fixture?.failures).toHaveLength(0);
+  });
+
+  it('smoke_ask_for_raise fixture passes all static assertions', () => {
+    const pack = loadPack(packDir, 'official');
+    const result = runPackTests(pack);
+
+    const fixture = result.fixtures.find((f) => f.fixture_id === 'smoke_ask_for_raise');
+    expect(fixture).toBeDefined();
+    expect(fixture?.status).toBe('passed');
+    expect(fixture?.failures).toHaveLength(0);
+  });
+
+  it('golden_coworker_feedback fixture passes all static assertions', () => {
+    const pack = loadPack(packDir, 'official');
+    const result = runPackTests(pack);
+
+    const fixture = result.fixtures.find((f) => f.fixture_id === 'golden_coworker_feedback');
+    expect(fixture).toBeDefined();
+    expect(fixture?.status).toBe('passed');
+    expect(fixture?.failures).toHaveLength(0);
+    expect(fixture?.static_assertion_count).toBeGreaterThan(0);
+  });
+
+  it('golden_missed_deadline_apology fixture passes all static assertions', () => {
+    const pack = loadPack(packDir, 'official');
+    const result = runPackTests(pack);
+
+    const fixture = result.fixtures.find((f) => f.fixture_id === 'golden_missed_deadline_apology');
+    expect(fixture).toBeDefined();
+    expect(fixture?.status).toBe('passed');
+    expect(fixture?.failures).toHaveLength(0);
+    expect(fixture?.static_assertion_count).toBeGreaterThan(0);
+  });
+
+  it('golden_boundary_with_friend fixture passes all static assertions', () => {
+    const pack = loadPack(packDir, 'official');
+    const result = runPackTests(pack);
+
+    const fixture = result.fixtures.find((f) => f.fixture_id === 'golden_boundary_with_friend');
+    expect(fixture).toBeDefined();
+    expect(fixture?.status).toBe('passed');
+    expect(fixture?.failures).toHaveLength(0);
+    expect(fixture?.static_assertion_count).toBeGreaterThan(0);
+  });
+
+  it('golden_ask_for_raise fixture passes all static assertions', () => {
+    const pack = loadPack(packDir, 'official');
+    const result = runPackTests(pack);
+
+    const fixture = result.fixtures.find((f) => f.fixture_id === 'golden_ask_for_raise');
+    expect(fixture).toBeDefined();
+    expect(fixture?.status).toBe('passed');
+    expect(fixture?.failures).toHaveLength(0);
+    expect(fixture?.static_assertion_count).toBeGreaterThan(0);
+  });
+
+  it('reports correct turn counts for golden fixtures', () => {
+    const pack = loadPack(packDir, 'official');
+    const result = runPackTests(pack);
+
+    for (const id of ['golden_coworker_feedback', 'golden_missed_deadline_apology',
+                      'golden_boundary_with_friend', 'golden_ask_for_raise']) {
+      const fixture = result.fixtures.find((f) => f.fixture_id === id);
+      expect(fixture?.turn_count).toBe(4);
+      expect(fixture?.mode).toBe('fake');
+    }
+  });
+});

--- a/packs/official/difficult-conversations/tests/golden_ask_for_raise.yaml
+++ b/packs/official/difficult-conversations/tests/golden_ask_for_raise.yaml
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+fixture_id: golden_ask_for_raise
+scenario_id: ask_for_raise
+description: >-
+  Golden transcript property test: verifies that a player who opens with a
+  specific track record of impact before naming a number, anchors a concrete
+  salary range to market and scope evidence, responds to Diane's probing with
+  specific data rather than reassertion, and reframes the ask as a business
+  decision Diane can take upward causes case_clarity to exceed the success
+  threshold. Also verifies that vague_claim_probe fires when evidence is thin,
+  strong_case_acknowledged fires when evidence is strong, and that no_number_anchor
+  fires before a figure is on the table.
+
+seed: 42
+input_mode: text
+difficulty: normal
+
+turns:
+  - turn: 1
+    player_input: >-
+      Thank you for the time. I want to walk you through what has changed in my
+      role over the last six months and make the case for a compensation
+      adjustment. When I joined, my scope was individual delivery on the
+      payments team — three services, one stakeholder group. In the last two
+      quarters I led the cross-team API migration that involved six teams and
+      shipped three weeks early, I onboarded two new engineers who are now
+      independent contributors, and I picked up the Q3 regulatory reporting
+      project after the original owner left. That is a materially larger role
+      than my current compensation reflects.
+    expect:
+      state_delta_contains:
+        - impression
+        - evidence_strength
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 2
+    player_input: >-
+      Based on comparable senior individual contributor roles at similar-stage
+      B2B companies in this market — I looked at three current postings and
+      two recent offers from people in my network — the range sits between
+      ninety-five and one-ten. My current base is eighty-four. I am asking
+      for a move to ninety-eight, which is the lower end of that range and
+      reflects the scope I am already carrying. I am not asking for the top
+      of the band; I am asking for alignment with what this scope actually
+      costs on the open market.
+    expect:
+      state_delta_contains:
+        - case_clarity
+        - evidence_strength
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 3
+    player_input: >-
+      On the API migration specifically — I can send you the project retrospective,
+      which has the timeline, the teams involved, and the outcome metrics. The
+      original estimate was a twelve-week project; we shipped in nine. The
+      project lead role was not in my job description when I was hired. I took
+      it on at your request and I delivered. That is the scope change I am
+      pointing at, and I think it is specific enough to substantiate the ask.
+    expect:
+      state_delta_contains:
+        - evidence_strength
+        - impression
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 4
+    player_input: >-
+      I want to make this easy for you to take upward if you decide to. The
+      business case in one sentence: I am doing the work of a senior contributor
+      at a junior contributor's pay rate, and the cost of not correcting that
+      is either the adjustment eventually happens under worse circumstances,
+      or you start a backfill process. Neither of those is cheaper than a
+      fourteen-thousand-dollar correction now. I am not making a threat —
+      I am trying to frame this the way I would if I were in your position.
+    expect:
+      state_delta_contains:
+        - case_clarity
+        - impression
+      session_control: continue_session
+      safety_status: ok
+
+static_assertions:
+  - description: Scenario opening line is non-empty
+    path: opening.npc_says
+    check: non_empty_string
+
+  - description: At least one event is defined
+    path: events
+    check: min_length_1
+
+  - description: vague_claim_probe fires when evidence_strength is below 30
+    path: events[id=vague_claim_probe].when
+    check: "type=variable_below AND variable=evidence_strength AND threshold=30"
+
+  - description: vague_claim_probe can repeat
+    path: events[id=vague_claim_probe].repeat
+    check: "equals true"
+
+  - description: no_number_anchor fires when case_clarity is below 25
+    path: events[id=no_number_anchor].when
+    check: "type=variable_below AND variable=case_clarity AND threshold=25"
+
+  - description: no_number_anchor fires only once
+    path: events[id=no_number_anchor].repeat
+    check: "equals false"
+
+  - description: strong_case_acknowledged fires when evidence_strength exceeds 70
+    path: events[id=strong_case_acknowledged].when
+    check: "type=variable_above AND variable=evidence_strength AND threshold=70"
+
+  - description: strong_case_acknowledged fires only once
+    path: events[id=strong_case_acknowledged].repeat
+    check: "equals false"
+
+  - description: deflation_signal fires when impression falls below 25
+    path: events[id=deflation_signal].when
+    check: "type=variable_below AND variable=impression AND threshold=25"
+
+  - description: Success ending condition targets case_clarity above 65
+    path: ending_conditions.success
+    check: "type=variable_above AND variable=case_clarity AND threshold=65"
+
+  - description: Failure ending condition targets impression below 15
+    path: ending_conditions.failure
+    check: "type=variable_below AND variable=impression AND threshold=15"
+
+  - description: impression is player-visible
+    path: state.variables.impression.visibility
+    check: "equals visible"
+
+  - description: evidence_strength is hidden from player
+    path: state.variables.evidence_strength.visibility
+    check: "equals hidden"
+
+  - description: case_clarity is hidden from player
+    path: state.variables.case_clarity.visibility
+    check: "equals hidden"
+
+  - description: NPC is marked fictional
+    path: npc.fictional
+    check: "equals true"
+
+  - description: Safety policy stops nsfw_sexual_content
+    path: safety.content_categories.nsfw_sexual_content
+    check: "equals stop"
+
+  - description: Safety policy fires stop_with_resource_message for self_harm_crisis
+    path: safety.content_categories.self_harm_crisis
+    check: "equals stop_with_resource_message"
+
+  - description: Pack manifest declares ask_for_raise as an entry scenario
+    path: manifest.entry_scenarios
+    check: "contains scenarios/ask_for_raise.yaml"
+
+  - description: Hard difficulty applies a negative patience modifier
+    path: scenario.difficulty.options.hard.npc_patience_modifier
+    check: "equals -20"

--- a/packs/official/difficult-conversations/tests/golden_boundary_with_friend.yaml
+++ b/packs/official/difficult-conversations/tests/golden_boundary_with_friend.yaml
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+fixture_id: golden_boundary_with_friend
+scenario_id: boundary_with_friend
+description: >-
+  Golden transcript property test: verifies that a player who states the
+  boundary clearly and early while explicitly reaffirming the friendship,
+  holds it calmly through Jamie's reframe and guilt play without escalating
+  or over-explaining, and reaffirms care once Jamie accepts causes acceptance
+  to exceed the success threshold. Also verifies that first_pushback fires on
+  early pressure, guilt_play fires on high pressure, and reluctant_acceptance
+  fires when Jamie genuinely stands down.
+
+seed: 42
+input_mode: text
+difficulty: normal
+
+turns:
+  - turn: 1
+    player_input: >-
+      Everything is good between us — I want you to hear that right away,
+      because I did not want this to feel like a weird coffee. I care about
+      our friendship and nothing about what I am about to say changes that.
+      The birthday weekend — I am not going to be able to help coordinate it.
+      That is the thing I needed to tell you in person. It is not about wanting
+      you to have a great birthday, which I really do. It is just that I cannot
+      take on something that scale right now, and I needed to say that to you
+      directly rather than just let it become something I quietly resented.
+    expect:
+      state_delta_contains:
+        - rapport
+        - boundary_clarity
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 2
+    player_input: >-
+      I hear you, and I know you would not ask if you did not need it. Even
+      just the venue piece — I am still not going to be able to do it. I know
+      that is not what you were hoping for and I am genuinely sorry it lands
+      that way. But my answer is the same: I cannot take this on right now,
+      not even a piece of it.
+    expect:
+      state_delta_contains:
+        - boundary_clarity
+        - pressure
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 3
+    player_input: >-
+      I know you showed up for me when I moved. That was real, and I have not
+      forgotten it. What I am telling you is not that I am pulling back from
+      the friendship — it is that this particular thing is not something I
+      can do right now. Those are different things. You have always been someone
+      I can count on and I hope I am that for you too. This is not me changing
+      that. I just cannot do this one thing.
+    expect:
+      state_delta_contains:
+        - rapport
+        - acceptance
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 4
+    player_input: >-
+      I know it is a little disappointing and I appreciate that you heard me.
+      I really do want your birthday weekend to be amazing — I hope you find
+      the right person to help you pull it together, and I will absolutely
+      be there celebrating with you. You and I are fine. I just needed you
+      to know where I was at.
+    expect:
+      state_delta_contains:
+        - rapport
+        - acceptance
+      session_control: continue_session
+      safety_status: ok
+
+static_assertions:
+  - description: Scenario opening line is non-empty
+    path: opening.npc_says
+    check: non_empty_string
+
+  - description: At least one event is defined
+    path: events
+    check: min_length_1
+
+  - description: first_pushback fires when pressure exceeds 60
+    path: events[id=first_pushback].when
+    check: "type=variable_above AND variable=pressure AND threshold=60"
+
+  - description: first_pushback fires only once
+    path: events[id=first_pushback].repeat
+    check: "equals false"
+
+  - description: guilt_play fires when pressure exceeds 75
+    path: events[id=guilt_play].when
+    check: "type=variable_above AND variable=pressure AND threshold=75"
+
+  - description: guilt_play fires only once
+    path: events[id=guilt_play].repeat
+    check: "equals false"
+
+  - description: reluctant_acceptance fires when acceptance exceeds 65
+    path: events[id=reluctant_acceptance].when
+    check: "type=variable_above AND variable=acceptance AND threshold=65"
+
+  - description: reluctant_acceptance fires only once
+    path: events[id=reluctant_acceptance].repeat
+    check: "equals false"
+
+  - description: rapport_drop_warning fires when rapport falls below 35
+    path: events[id=rapport_drop_warning].when
+    check: "type=variable_below AND variable=rapport AND threshold=35"
+
+  - description: Success ending condition targets acceptance above 60
+    path: ending_conditions.success
+    check: "type=variable_above AND variable=acceptance AND threshold=60"
+
+  - description: Failure ending condition targets rapport below 20
+    path: ending_conditions.failure
+    check: "type=variable_below AND variable=rapport AND threshold=20"
+
+  - description: rapport is player-visible
+    path: state.variables.rapport.visibility
+    check: "equals visible"
+
+  - description: pressure is hidden from player
+    path: state.variables.pressure.visibility
+    check: "equals hidden"
+
+  - description: acceptance is hidden from player
+    path: state.variables.acceptance.visibility
+    check: "equals hidden"
+
+  - description: NPC is marked fictional
+    path: npc.fictional
+    check: "equals true"
+
+  - description: Safety policy stops nsfw_sexual_content
+    path: safety.content_categories.nsfw_sexual_content
+    check: "equals stop"
+
+  - description: Safety policy fires stop_with_resource_message for self_harm_crisis
+    path: safety.content_categories.self_harm_crisis
+    check: "equals stop_with_resource_message"
+
+  - description: Pack manifest declares boundary_with_friend as an entry scenario
+    path: manifest.entry_scenarios
+    check: "contains scenarios/boundary_with_friend.yaml"
+
+  - description: Hard difficulty applies a negative patience modifier
+    path: scenario.difficulty.options.hard.npc_patience_modifier
+    check: "equals -20"

--- a/packs/official/difficult-conversations/tests/golden_coworker_feedback.yaml
+++ b/packs/official/difficult-conversations/tests/golden_coworker_feedback.yaml
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+fixture_id: golden_coworker_feedback
+scenario_id: coworker_feedback
+description: >-
+  Golden transcript property test: verifies that a player who opens by
+  acknowledging Marcus's strengths, gives specific behavioural feedback,
+  asks about his experience before pressing for change, and proposes a
+  concrete collaborative next step causes resolution_progress to exceed
+  the success threshold. Also verifies that trust_breakthrough fires when
+  Marcus feels safe and that resolution_near fires when the resolution is
+  close.
+
+seed: 42
+input_mode: text
+difficulty: normal
+
+turns:
+  - turn: 1
+    player_input: >-
+      Hey, thanks for grabbing coffee with me. I want to start by saying —
+      your technical work has been solid. The auth refactor you shipped last
+      month was clean and the team noticed. That is not nothing. But there is
+      something that has been affecting me directly, and I wanted to come to
+      you before it got bigger. In the last three sprints, your handoff tasks
+      have come in late — a day, sometimes two — and I have been covering that
+      gap without us actually talking about it. I do not want to keep doing
+      that without saying something to you first.
+    expect:
+      state_delta_contains:
+        - trust
+        - defensiveness
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 2
+    player_input: >-
+      I hear you — I know it has been a rough quarter for everyone. I am not
+      trying to say you are the only person under pressure. What I am saying
+      is that from where I sit, the pattern has been consistent enough that
+      it is affecting my own deadlines. I am not here to assign blame; I wanted
+      to name it because I think we can actually fix it together. I would rather
+      do that than keep silently absorbing it.
+    expect:
+      state_delta_contains:
+        - trust
+        - clarity
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 3
+    player_input: >-
+      Actually, before I say anything else — what has it been like for you
+      this quarter? I have been on the receiving end of the delays and I have
+      been thinking about what to say to you, but I have not really stopped
+      to ask what is actually going on. Is there something happening that I
+      do not know about?
+    expect:
+      state_delta_contains:
+        - trust
+        - defensiveness
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 4
+    player_input: >-
+      That makes a lot of sense. I did not know about the situation at home
+      and I am glad you told me. Here is what I am thinking — what if we do
+      a quick sync at the start of each sprint, just the two of us, fifteen
+      minutes? That way if something is slipping, we catch it before it
+      becomes a handoff miss rather than after. Would that actually work for
+      you, or is there a better version of that from your side?
+    expect:
+      state_delta_contains:
+        - resolution_progress
+        - trust
+      session_control: continue_session
+      safety_status: ok
+
+static_assertions:
+  - description: Scenario opening line is non-empty
+    path: opening.npc_says
+    check: non_empty_string
+
+  - description: At least one event is defined
+    path: events
+    check: min_length_1
+
+  - description: deflection_redirect fires when defensiveness exceeds 75
+    path: events[id=deflection_redirect].when
+    check: "type=variable_above AND variable=defensiveness AND threshold=75"
+
+  - description: deflection_redirect can repeat
+    path: events[id=deflection_redirect].repeat
+    check: "equals true"
+
+  - description: trust_breakthrough fires once when trust exceeds 65
+    path: events[id=trust_breakthrough].when
+    check: "type=variable_above AND variable=trust AND threshold=65"
+
+  - description: trust_breakthrough fires only once
+    path: events[id=trust_breakthrough].repeat
+    check: "equals false"
+
+  - description: resolution_near fires when resolution_progress exceeds 70
+    path: events[id=resolution_near].when
+    check: "type=variable_above AND variable=resolution_progress AND threshold=70"
+
+  - description: resolution_near fires only once
+    path: events[id=resolution_near].repeat
+    check: "equals false"
+
+  - description: Success ending condition targets resolution_progress
+    path: ending_conditions.success
+    check: "type=variable_above AND variable=resolution_progress AND threshold=65"
+
+  - description: Failure ending condition triggers on high defensiveness
+    path: ending_conditions.failure
+    check: "type=variable_above AND variable=defensiveness AND threshold=90"
+
+  - description: trust is player-visible
+    path: state.variables.trust.visibility
+    check: "equals visible"
+
+  - description: defensiveness is hidden from player
+    path: state.variables.defensiveness.visibility
+    check: "equals hidden"
+
+  - description: resolution_progress is hidden from player
+    path: state.variables.resolution_progress.visibility
+    check: "equals hidden"
+
+  - description: NPC is marked fictional
+    path: npc.fictional
+    check: "equals true"
+
+  - description: Safety policy stops nsfw_sexual_content
+    path: safety.content_categories.nsfw_sexual_content
+    check: "equals stop"
+
+  - description: Safety policy fires stop_with_resource_message for self_harm_crisis
+    path: safety.content_categories.self_harm_crisis
+    check: "equals stop_with_resource_message"
+
+  - description: Pack manifest declares coworker_feedback as an entry scenario
+    path: manifest.entry_scenarios
+    check: "contains scenarios/coworker_feedback.yaml"
+
+  - description: Hard difficulty applies a negative patience modifier
+    path: scenario.difficulty.options.hard.npc_patience_modifier
+    check: "equals -20"

--- a/packs/official/difficult-conversations/tests/golden_missed_deadline_apology.yaml
+++ b/packs/official/difficult-conversations/tests/golden_missed_deadline_apology.yaml
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+fixture_id: golden_missed_deadline_apology
+scenario_id: missed_deadline_apology
+description: >-
+  Golden transcript property test: verifies that a player who takes clear,
+  specific ownership first, acknowledges the concrete downstream impact on
+  Priya and the client, provides a named and credible remedy, and stays
+  regulated through Priya's continued disappointment causes repair_confidence
+  to exceed the success threshold. Also verifies that trust_recovery fires
+  when real ownership is received and resolution_signal fires when the
+  conversation is ready to close.
+
+seed: 42
+input_mode: text
+difficulty: normal
+
+turns:
+  - turn: 1
+    player_input: >-
+      I missed the deadline, and that is on me. I saw the scope expanding on
+      Wednesday and I told myself I could still make it work without flagging
+      it. I was wrong about that. I should have come to you by Thursday at
+      the latest and asked for help prioritising. I did not, and the client
+      delivery slipped because of that call.
+    expect:
+      state_delta_contains:
+        - trust
+        - clarity
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 2
+    player_input: >-
+      I know this put you in a specific position — you had to go to Vikram
+      and explain something that should not have needed explaining, and that
+      is a cost I put on you by not flagging early. I do not want to minimise
+      that. The client delay is one thing; having to absorb the upward
+      conversation is another, and I understand that was not fair to you.
+    expect:
+      state_delta_contains:
+        - trust
+        - repair_confidence
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 3
+    player_input: >-
+      What I am putting in place starting now: any time I see scope shift
+      mid-sprint that looks like it could affect a deadline, I flag it to you
+      within twenty-four hours and give you a revised estimate — not a
+      reassurance. If I cannot hit the target with the available scope, I
+      surface that before it becomes a miss, not after. That is a specific
+      change I can hold myself to, and you can hold me to it.
+    expect:
+      state_delta_contains:
+        - repair_confidence
+        - clarity
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 4
+    player_input: >-
+      I do not have anything else to add. I think what happened is clear,
+      I think what I am changing is clear, and I am glad we talked about it
+      directly rather than letting it sit. Is there anything else you need
+      from me right now, or anything specific you want me to do with the
+      client relationship from here?
+    expect:
+      state_delta_contains:
+        - repair_confidence
+        - trust
+      session_control: continue_session
+      safety_status: ok
+
+static_assertions:
+  - description: Scenario opening line is non-empty
+    path: opening.npc_says
+    check: non_empty_string
+
+  - description: At least one event is defined
+    path: events
+    check: min_length_1
+
+  - description: excuse_detection fires when pressure exceeds 75
+    path: events[id=excuse_detection].when
+    check: "type=variable_above AND variable=pressure AND threshold=75"
+
+  - description: excuse_detection can repeat
+    path: events[id=excuse_detection].repeat
+    check: "equals true"
+
+  - description: trust_recovery fires once when trust exceeds 70
+    path: events[id=trust_recovery].when
+    check: "type=variable_above AND variable=trust AND threshold=70"
+
+  - description: trust_recovery fires only once
+    path: events[id=trust_recovery].repeat
+    check: "equals false"
+
+  - description: resolution_signal fires when repair_confidence exceeds 70
+    path: events[id=resolution_signal].when
+    check: "type=variable_above AND variable=repair_confidence AND threshold=70"
+
+  - description: resolution_signal fires only once
+    path: events[id=resolution_signal].repeat
+    check: "equals false"
+
+  - description: Success ending condition targets repair_confidence
+    path: ending_conditions.success
+    check: "type=variable_above AND variable=repair_confidence AND threshold=65"
+
+  - description: Failure ending condition targets trust below 15
+    path: ending_conditions.failure
+    check: "type=variable_below AND variable=trust AND threshold=15"
+
+  - description: trust is player-visible
+    path: state.variables.trust.visibility
+    check: "equals visible"
+
+  - description: pressure is hidden from player
+    path: state.variables.pressure.visibility
+    check: "equals hidden"
+
+  - description: repair_confidence is hidden from player
+    path: state.variables.repair_confidence.visibility
+    check: "equals hidden"
+
+  - description: NPC is marked fictional
+    path: npc.fictional
+    check: "equals true"
+
+  - description: Safety policy stops nsfw_sexual_content
+    path: safety.content_categories.nsfw_sexual_content
+    check: "equals stop"
+
+  - description: Safety policy fires stop_with_resource_message for self_harm_crisis
+    path: safety.content_categories.self_harm_crisis
+    check: "equals stop_with_resource_message"
+
+  - description: Pack manifest declares missed_deadline_apology as an entry scenario
+    path: manifest.entry_scenarios
+    check: "contains scenarios/missed_deadline_apology.yaml"
+
+  - description: Hard difficulty applies a negative patience modifier
+    path: scenario.difficulty.options.hard.npc_patience_modifier
+    check: "equals -25"


### PR DESCRIPTION
## What changed

The Difficult Conversations pack (`official.difficult_conversations`) shipped with four complete scenarios, NPCs, rubrics, scenes, a safety policy, and smoke tests, but was missing the golden transcript fixtures specified in issue #198's definition of done.

This PR adds:

- **4 golden transcript fixtures** (`packs/official/difficult-conversations/tests/golden_{coworker_feedback,missed_deadline_apology,boundary_with_friend,ask_for_raise}.yaml`) — one per scenario, each demonstrating an ideal conversation path with four player turns and 15–18 static assertions verifying key event conditions, ending thresholds, state variable visibility, safety policy enforcement, and manifest entry-scenario listing.

- **Runner test coverage** (`packages/convsim-cli/tests/runner.test.ts`) — a new `golden — difficult-conversations pack test` describe block with nine test cases that load the pack and assert all eight fixtures (four smoke + four golden) pass with the fake runtime, verifying fixture counts, static assertion counts, and per-turn execution.

- **Offline smoke test coverage** (`packages/convsim-cli/tests/offline-smoke-test.test.ts`) — the difficult-conversations pack is added to the official packs acceptance suite alongside job-interview-basic, confirming the pack validates cleanly, plays at least one turn, generates a debrief, and makes zero outbound network calls.

## Why

Issue #198 requires golden transcripts for each scenario to demonstrate emotionally useful practice at the quality bar defined in the official pack authoring guide. The golden fixtures serve two purposes: they document the ideal player path for each scenario in executable form, and they give the fake-runtime test suite something to run against so regressions in the pack structure are caught before they reach users.

## Testing

- `pnpm --filter @convsim/cli test` — 158 tests across 3 test files, all passed.
- `pnpm --filter @convsim/pack-loader test` — 76 tests across 3 test files, all passed.
- Pack validation confirmed the pack loads with 4 scenarios, 4 NPCs, 4 rubrics, and 4 scenes.

Closes #198