### PR TITLE
Add pack import and export to the Fastify API with upgrade path support

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,7 +5,7 @@ import Fastify from 'fastify';
 import cors from '@fastify/cors';
 import websocket from '@fastify/websocket';
 import { healthRoutes } from './routes/health.js';
-import { packsRoutes, packRoutes, setPacksDbPath } from './routes/packs.js';
+import { packsRoutes, packRoutes, setPacksDbPath, setPacksDataDir } from './routes/packs.js';
 import { scenarioRoutes } from './routes/scenarios.js';
 import { sessionRoutes } from './routes/sessions.js';
 import { sessionWsRoutes } from './routes/session-ws.js';
@@ -58,9 +58,14 @@ if (process.argv[1] === new URL(import.meta.url).pathname) {
   const listenConfig = getListenConfig();
   fs.mkdirSync(path.dirname(dbPath), { recursive: true });
   fs.mkdirSync(path.dirname(packsDbPath), { recursive: true });
+  const packsDataDir =
+    process.env['PACKS_DATA_DIR'] ??
+    path.join(path.dirname(packsDbPath), 'packs');
+  fs.mkdirSync(packsDataDir, { recursive: true });
   initDb(dbPath);
   setDataFolderPath(path.dirname(dbPath));
   setPacksDbPath(packsDbPath);
+  setPacksDataDir(packsDataDir);
   setWorkbenchRoots(
     process.env['PACKS_OFFICIAL_ROOT'] ?? path.join(process.cwd(), 'packs', 'official'),
     process.env['PACKS_LOCAL_DEV_ROOT'] ?? path.join(os.homedir(), '.convsim', 'packs', 'local-dev'),

--- a/apps/api/src/routes/packs.test.ts
+++ b/apps/api/src/routes/packs.test.ts
@@ -1,18 +1,132 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import AdmZip from 'adm-zip';
 import { buildApp } from '../index.js';
 import type { FastifyInstance } from 'fastify';
 import type { PackValidationResult } from '@convsim/shared';
+import { setPacksDbPath, setPacksDataDir } from './packs.js';
+import type { ImportPackResponse } from './packs.js';
+
+// ---------------------------------------------------------------------------
+// Pack fixture helpers
+// ---------------------------------------------------------------------------
+
+const VALID_MANIFEST = `schema_version: "0.1"
+pack_id: test.api_pack
+name: API Test Pack
+version: 1.0.0
+description: A pack for testing the Fastify API.
+author: API Test Suite
+license: MIT
+content_rating: PG
+safety:
+  policy: safety/policy.yaml
+`;
+
+const VALID_SAFETY = `schema_version: "0.1"
+policy_id: api_test_safety
+content_rating_cap: PG
+content_categories:
+  nsfw_sexual: block
+  real_person_impersonation: block
+  instructional_criminal: block
+  crisis_content: redirect
+redirect_message: "Redirected."
+`;
+
+const VALID_NPC = `schema_version: "0.1"
+npc_id: api_test_npc
+display_name: API NPC
+archetype: test_archetype
+fictional: true
+age_band: adult
+public_persona:
+  occupation: A test NPC for API tests
+  speaking_style: Direct
+  demeanor: Neutral
+private_persona: {}
+`;
+
+const VALID_RUBRIC = `schema_version: "0.1"
+rubric_id: api_test_rubric
+title: API Rubric
+dimensions:
+  - id: accuracy
+    name: Accuracy
+    description: Test accuracy
+    scoring:
+      low: Low
+      medium: Medium
+      high: High
+`;
+
+const VALID_SCENARIO = `schema_version: "0.1"
+scenario_id: api_test_scenario
+title: API Test Scenario
+summary: A test scenario for the Fastify API.
+player_role:
+  label: Tester
+  brief: You are testing the Fastify API.
+npc:
+  ref: ../npcs/api_test_npc.yaml
+rubric:
+  ref: ../rubrics/api_test_rubric.yaml
+duration:
+  max_turns: 5
+opening:
+  npc_says: "Hello from API test."
+goals:
+  player_visible:
+    - Test the API
+`;
+
+function makeValidPackDir(parent: string): string {
+  const root = join(parent, 'pack');
+  for (const sub of ['scenarios', 'npcs', 'rubrics', 'safety']) {
+    mkdirSync(join(root, sub), { recursive: true });
+  }
+  writeFileSync(join(root, 'manifest.yaml'), VALID_MANIFEST);
+  writeFileSync(join(root, 'safety', 'policy.yaml'), VALID_SAFETY);
+  writeFileSync(join(root, 'npcs', 'api_test_npc.yaml'), VALID_NPC);
+  writeFileSync(join(root, 'rubrics', 'api_test_rubric.yaml'), VALID_RUBRIC);
+  writeFileSync(join(root, 'scenarios', 'api_test_scenario.yaml'), VALID_SCENARIO);
+  return root;
+}
+
+function makeValidPackZip(parent: string): Buffer {
+  const packDir = makeValidPackDir(parent);
+  const zip = new AdmZip();
+  zip.addLocalFolder(packDir, '');
+  return zip.toBuffer();
+}
+
+// ---------------------------------------------------------------------------
+// State: per-test temp dirs
+// ---------------------------------------------------------------------------
 
 let app: FastifyInstance;
+let tempDir: string;
 
 beforeEach(async () => {
+  tempDir = mkdtempSync(join(tmpdir(), 'convsim-api-packs-test-'));
+  setPacksDbPath(join(tempDir, 'packs.db'));
+  setPacksDataDir(join(tempDir, 'packs'));
   app = await buildApp();
 });
 
 afterEach(async () => {
   await app.close();
+  setPacksDbPath(null);
+  setPacksDataDir(null);
+  rmSync(tempDir, { recursive: true, force: true });
 });
+
+// ---------------------------------------------------------------------------
+// POST /api/packs/:pack_id/validate (existing)
+// ---------------------------------------------------------------------------
 
 describe('POST /api/packs/:pack_id/validate', () => {
   it('returns 200 with valid=true for a known pack', async () => {
@@ -51,5 +165,244 @@ describe('POST /api/packs/:pack_id/validate', () => {
       url: '/api/packs/does_not_exist/validate',
     });
     expect(res.statusCode).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/packs/import
+// ---------------------------------------------------------------------------
+
+describe('POST /api/packs/import — valid zip', () => {
+  it('returns 201 with pack metadata on success', async () => {
+    const zipBuffer = makeValidPackZip(tempDir);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/packs/import',
+      headers: { 'content-type': 'application/zip' },
+      payload: zipBuffer,
+    });
+    expect(res.statusCode).toBe(201);
+    const body = res.json<ImportPackResponse>();
+    expect(body.pack_id).toBe('test.api_pack');
+    expect(body.name).toBe('API Test Pack');
+    expect(body.version).toBe('1.0.0');
+    expect(typeof body.dest).toBe('string');
+  });
+
+  it('registers the pack in the index so GET /api/packs lists it', async () => {
+    const zipBuffer = makeValidPackZip(tempDir);
+    await app.inject({
+      method: 'POST',
+      url: '/api/packs/import',
+      headers: { 'content-type': 'application/zip' },
+      payload: zipBuffer,
+    });
+    const listRes = await app.inject({ method: 'GET', url: '/api/packs' });
+    expect(listRes.statusCode).toBe(200);
+    const { packs } = listRes.json<{ packs: Array<{ pack_id: string }>; total: number }>();
+    expect(packs.some((p) => p.pack_id === 'test.api_pack')).toBe(true);
+  });
+
+  it('replaces an existing pack on re-import (upgrade path)', async () => {
+    const zipBuffer = makeValidPackZip(tempDir);
+    const first = await app.inject({
+      method: 'POST',
+      url: '/api/packs/import',
+      headers: { 'content-type': 'application/zip' },
+      payload: zipBuffer,
+    });
+    expect(first.statusCode).toBe(201);
+
+    // Build a v2.0.0 zip for the same pack_id
+    const v2PackDir = makeValidPackDir(mkdtempSync(join(tmpdir(), 'convsim-api-v2-')));
+    writeFileSync(
+      join(v2PackDir, 'manifest.yaml'),
+      VALID_MANIFEST.replace('version: 1.0.0', 'version: 2.0.0'),
+    );
+    const v2Zip = new AdmZip();
+    v2Zip.addLocalFolder(v2PackDir, '');
+    const v2Buffer = v2Zip.toBuffer();
+
+    const second = await app.inject({
+      method: 'POST',
+      url: '/api/packs/import',
+      headers: { 'content-type': 'application/zip' },
+      payload: v2Buffer,
+    });
+    expect(second.statusCode).toBe(201);
+    const body = second.json<ImportPackResponse>();
+    expect(body.version).toBe('2.0.0');
+
+    // The index must reflect the upgraded version
+    const listRes = await app.inject({ method: 'GET', url: '/api/packs' });
+    const { packs } = listRes.json<{ packs: Array<{ pack_id: string; version?: string }> }>();
+    const entry = packs.find((p) => p.pack_id === 'test.api_pack');
+    expect(entry).toBeDefined();
+  });
+});
+
+describe('POST /api/packs/import — rejected archives', () => {
+  it('returns 422 for a non-zip body', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/packs/import',
+      headers: { 'content-type': 'application/zip' },
+      payload: Buffer.from('this is not a zip'),
+    });
+    expect(res.statusCode).toBe(422);
+    const body = res.json<{ code: string }>();
+    expect(body.code).toBe('INVALID_ZIP');
+  });
+
+  it('returns 422 for a zip containing an executable file', async () => {
+    const packDir = makeValidPackDir(mkdtempSync(join(tmpdir(), 'convsim-exec-')));
+    writeFileSync(join(packDir, 'run.sh'), '#!/bin/sh\necho evil\n');
+    const zip = new AdmZip();
+    zip.addLocalFolder(packDir, '');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/packs/import',
+      headers: { 'content-type': 'application/zip' },
+      payload: zip.toBuffer(),
+    });
+    expect(res.statusCode).toBe(422);
+    const body = res.json<{ code: string }>();
+    expect(body.code).toBe('FORBIDDEN_FILE');
+  });
+
+  it('returns 422 for a zip-slip archive', async () => {
+    // Craft a raw zip with a path-traversal entry
+    const filenameBytes = Buffer.from('../../evil.txt');
+    const content = Buffer.from('pwned');
+    const localHdr = Buffer.alloc(30);
+    localHdr.writeUInt32LE(0x04034b50, 0);
+    localHdr.writeUInt16LE(20, 4);
+    localHdr.writeUInt16LE(0, 6);
+    localHdr.writeUInt16LE(0, 8);
+    localHdr.writeUInt16LE(0, 10);
+    localHdr.writeUInt16LE(0, 12);
+    localHdr.writeUInt32LE(0, 14);
+    localHdr.writeUInt32LE(content.length, 18);
+    localHdr.writeUInt32LE(content.length, 22);
+    localHdr.writeUInt16LE(filenameBytes.length, 26);
+    localHdr.writeUInt16LE(0, 28);
+    const localEntry = Buffer.concat([localHdr, filenameBytes, content]);
+    const cdHdr = Buffer.alloc(46);
+    cdHdr.writeUInt32LE(0x02014b50, 0);
+    cdHdr.writeUInt16LE(20, 4);
+    cdHdr.writeUInt16LE(20, 6);
+    cdHdr.writeUInt16LE(0, 8);
+    cdHdr.writeUInt16LE(0, 10);
+    cdHdr.writeUInt16LE(0, 12);
+    cdHdr.writeUInt16LE(0, 14);
+    cdHdr.writeUInt32LE(0, 16);
+    cdHdr.writeUInt32LE(content.length, 20);
+    cdHdr.writeUInt32LE(content.length, 24);
+    cdHdr.writeUInt16LE(filenameBytes.length, 28);
+    cdHdr.writeUInt16LE(0, 30);
+    cdHdr.writeUInt16LE(0, 32);
+    cdHdr.writeUInt16LE(0, 34);
+    cdHdr.writeUInt16LE(0, 36);
+    cdHdr.writeUInt32LE(0, 38);
+    cdHdr.writeUInt32LE(0, 42);
+    const centralDir = Buffer.concat([cdHdr, filenameBytes]);
+    const eocd = Buffer.alloc(22);
+    eocd.writeUInt32LE(0x06054b50, 0);
+    eocd.writeUInt16LE(0, 4);
+    eocd.writeUInt16LE(0, 6);
+    eocd.writeUInt16LE(1, 8);
+    eocd.writeUInt16LE(1, 10);
+    eocd.writeUInt32LE(centralDir.length, 12);
+    eocd.writeUInt32LE(localEntry.length, 16);
+    eocd.writeUInt16LE(0, 20);
+    const slipZip = Buffer.concat([localEntry, centralDir, eocd]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/packs/import',
+      headers: { 'content-type': 'application/zip' },
+      payload: slipZip,
+    });
+    expect(res.statusCode).toBe(422);
+    const body = res.json<{ code: string }>();
+    expect(body.code).toBe('UNSAFE_ZIP');
+  });
+
+  it('returns 422 for a zip missing a manifest', async () => {
+    const zip = new AdmZip();
+    zip.addFile('README.txt', Buffer.from('no manifest here'));
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/packs/import',
+      headers: { 'content-type': 'application/zip' },
+      payload: zip.toBuffer(),
+    });
+    expect(res.statusCode).toBe(422);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/packs/:pack_id/export
+// ---------------------------------------------------------------------------
+
+describe('GET /api/packs/:pack_id/export', () => {
+  it('returns 404 for an unknown pack id', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/packs/no_such_pack/export',
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('returns a zip file for an installed pack', async () => {
+    // First import a pack
+    const zipBuffer = makeValidPackZip(tempDir);
+    const importRes = await app.inject({
+      method: 'POST',
+      url: '/api/packs/import',
+      headers: { 'content-type': 'application/zip' },
+      payload: zipBuffer,
+    });
+    expect(importRes.statusCode).toBe(201);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/packs/test.api_pack/export',
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toContain('application/zip');
+    expect(res.rawPayload.length).toBeGreaterThan(0);
+
+    // Verify the payload is a valid zip containing the manifest
+    const exportedZip = new AdmZip(res.rawPayload);
+    const entryNames = exportedZip.getEntries().map((e) => e.entryName);
+    expect(entryNames.some((n) => n.endsWith('manifest.yaml'))).toBe(true);
+  });
+
+  it('round-trips: exported zip can be re-imported', async () => {
+    const zipBuffer = makeValidPackZip(tempDir);
+    await app.inject({
+      method: 'POST',
+      url: '/api/packs/import',
+      headers: { 'content-type': 'application/zip' },
+      payload: zipBuffer,
+    });
+
+    const exportRes = await app.inject({
+      method: 'GET',
+      url: '/api/packs/test.api_pack/export',
+    });
+    expect(exportRes.statusCode).toBe(200);
+
+    // Re-import the exported zip
+    const reimportRes = await app.inject({
+      method: 'POST',
+      url: '/api/packs/import',
+      headers: { 'content-type': 'application/zip' },
+      payload: exportRes.rawPayload,
+    });
+    // Should succeed (replaces the existing pack)
+    expect(reimportRes.statusCode).toBe(201);
+    expect(reimportRes.json<ImportPackResponse>().pack_id).toBe('test.api_pack');
   });
 });

--- a/apps/api/src/routes/packs.test.ts
+++ b/apps/api/src/routes/packs.test.ts
@@ -379,6 +379,25 @@ describe('GET /api/packs/:pack_id/export', () => {
     expect(entryNames.some((n) => n.endsWith('manifest.yaml'))).toBe(true);
   });
 
+  it('does not corrupt the pack index when export is called before any import', async () => {
+    // Hitting export on a fresh install (no packs yet) must not create a
+    // divergent installed_packs schema that breaks a subsequent import.
+    const exportRes = await app.inject({
+      method: 'GET',
+      url: '/api/packs/no_such_pack/export',
+    });
+    expect(exportRes.statusCode).toBe(404);
+
+    const zipBuffer = makeValidPackZip(tempDir);
+    const importRes = await app.inject({
+      method: 'POST',
+      url: '/api/packs/import',
+      headers: { 'content-type': 'application/zip' },
+      payload: zipBuffer,
+    });
+    expect(importRes.statusCode).toBe(201);
+  });
+
   it('round-trips: exported zip can be re-imported', async () => {
     const zipBuffer = makeValidPackZip(tempDir);
     await app.inject({

--- a/apps/api/src/routes/packs.ts
+++ b/apps/api/src/routes/packs.ts
@@ -220,43 +220,23 @@ export async function packRoutes(app: FastifyInstance) {
 
       const { pack_id } = req.params;
 
-      let packRoot: string | undefined;
+      // Use PackIndex so the canonical schema is applied. Opening a
+      // not-yet-existing index creates an empty one (correct schema) rather
+      // than a divergent minimal table that would break later imports.
+      let packRoot: string;
+      const index = PackIndex.open(_packsDbPath);
       try {
-        // Open without fileMustExist so an empty index (no packs imported yet)
-        // returns 404 instead of 503 from a missing-file exception.
-        const db = new Database(_packsDbPath, { readonly: false });
-        try {
-          db.exec(`
-            CREATE TABLE IF NOT EXISTS installed_packs (
-              pack_id TEXT PRIMARY KEY,
-              name TEXT NOT NULL,
-              pack_root TEXT NOT NULL,
-              version TEXT NOT NULL,
-              scenario_count INTEGER NOT NULL DEFAULT 0
-            )
-          `);
-          const row = db
-            .prepare('SELECT pack_root, version FROM installed_packs WHERE pack_id = ?')
-            .get(pack_id) as { pack_root: string; version: string } | undefined;
-          if (!row) {
-            reply.status(404);
-            throw Object.assign(new Error(`Pack '${pack_id}' not found.`), {
-              statusCode: 404,
-              code: 'NOT_FOUND',
-            });
-          }
-          packRoot = row.pack_root;
-        } finally {
-          db.close();
+        const entry = index.getPack(pack_id);
+        if (!entry) {
+          reply.status(404);
+          throw Object.assign(new Error(`Pack '${pack_id}' not found.`), {
+            statusCode: 404,
+            code: 'NOT_FOUND',
+          });
         }
-      } catch (e) {
-        // Re-throw typed errors (including our 404) directly to Fastify.
-        if ((e as { statusCode?: number }).statusCode) throw e;
-        reply.status(503);
-        throw Object.assign(new Error('Pack index is unavailable.'), {
-          statusCode: 503,
-          code: 'DB_UNAVAILABLE',
-        });
+        packRoot = entry.pack_root;
+      } finally {
+        index.close();
       }
 
       const zip = new AdmZip();

--- a/apps/api/src/routes/packs.ts
+++ b/apps/api/src/routes/packs.ts
@@ -1,7 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
+import { cpSync, mkdirSync, mkdtempSync, readdirSync, rmSync, statSync } from 'node:fs';
+import { isAbsolute, join, resolve as resolvePath } from 'node:path';
+import { tmpdir } from 'node:os';
 import type { FastifyInstance } from 'fastify';
 import type { PackValidationResult } from '@convsim/shared';
+import AdmZip from 'adm-zip';
 import Database from 'better-sqlite3';
+import { loadPack, PackIndex, PackLoaderError } from '@convsim/pack-loader';
 import { SCENARIOS } from '../data/scenarios.js';
 
 export interface PackSummary {
@@ -15,13 +20,69 @@ export interface PacksResponse {
   total: number;
 }
 
-let _packsDbPath: string | null = null;
+export interface ImportPackResponse {
+  pack_id: string;
+  name: string;
+  version: string;
+  dest: string;
+}
 
-export function setPacksDbPath(dbPath: string): void {
+let _packsDbPath: string | null = null;
+let _packsDataDir: string | null = null;
+
+export function setPacksDbPath(dbPath: string | null): void {
   _packsDbPath = dbPath;
 }
 
+export function setPacksDataDir(dataDir: string | null): void {
+  _packsDataDir = dataDir;
+}
+
+const _MAX_ZIP_BYTES = 100 * 1024 * 1024; // 100 MB
+
+/** Throw if any zip entry could escape the extraction root (zip-slip attack). */
+function assertNoZipSlip(zip: AdmZip): void {
+  for (const entry of zip.getEntries()) {
+    const name = entry.entryName;
+    if (isAbsolute(name)) {
+      const err = Object.assign(new Error(`Zip entry has absolute path: "${name}"`), {
+        statusCode: 422,
+        code: 'UNSAFE_ZIP',
+      });
+      throw err;
+    }
+    const parts = name.split(/[\\/]/);
+    if (parts.some((p) => p === '..')) {
+      const err = Object.assign(
+        new Error(`Zip entry attempts path traversal: "${name}"`),
+        { statusCode: 422, code: 'UNSAFE_ZIP' },
+      );
+      throw err;
+    }
+  }
+}
+
+/** If the extraction root contains exactly one subdirectory, return it. */
+function unwrapSingleSubdir(dir: string): string {
+  const entries = readdirSync(dir);
+  if (entries.length === 1) {
+    const first = entries[0];
+    if (first !== undefined) {
+      const candidate = join(dir, first);
+      if (statSync(candidate).isDirectory()) return candidate;
+    }
+  }
+  return dir;
+}
+
 export async function packsRoutes(app: FastifyInstance): Promise<void> {
+  // Register binary content type parsers for the zip import endpoint.
+  app.addContentTypeParser(
+    ['application/zip', 'application/octet-stream'],
+    { parseAs: 'buffer' },
+    (_req, body, done) => { done(null, body); },
+  );
+
   app.get('/api/packs', async (): Promise<PacksResponse> => {
     if (!_packsDbPath) {
       return { packs: [], total: 0 };
@@ -40,6 +101,96 @@ export async function packsRoutes(app: FastifyInstance): Promise<void> {
       return { packs: [], total: 0 };
     }
   });
+
+  app.post(
+    '/api/packs/import',
+    { bodyLimit: _MAX_ZIP_BYTES },
+    async (req, reply): Promise<ImportPackResponse> => {
+      if (!_packsDbPath || !_packsDataDir) {
+        reply.status(503);
+        throw Object.assign(new Error('Pack storage is not configured.'), {
+          statusCode: 503,
+          code: 'NOT_CONFIGURED',
+        });
+      }
+
+      const zipBytes = req.body as Buffer;
+
+      if (!zipBytes || zipBytes.length === 0) {
+        reply.status(422);
+        throw Object.assign(new Error('Request body must be a zip archive.'), {
+          statusCode: 422,
+          code: 'INVALID_ZIP',
+        });
+      }
+
+      if (zipBytes.length > _MAX_ZIP_BYTES) {
+        reply.status(413);
+        throw Object.assign(
+          new Error(`Upload exceeds the ${_MAX_ZIP_BYTES / (1024 * 1024)} MB limit.`),
+          { statusCode: 413, code: 'FILE_TOO_LARGE' },
+        );
+      }
+
+      let zip: AdmZip;
+      try {
+        zip = new AdmZip(zipBytes);
+      } catch {
+        reply.status(422);
+        throw Object.assign(new Error('Uploaded file is not a valid zip archive.'), {
+          statusCode: 422,
+          code: 'INVALID_ZIP',
+        });
+      }
+
+      assertNoZipSlip(zip);
+
+      const tempDir = mkdtempSync(join(tmpdir(), 'convsim-api-import-'));
+      try {
+        zip.extractAllTo(tempDir, /* overwrite */ true);
+        const packDir = unwrapSingleSubdir(tempDir);
+
+        let pack;
+        try {
+          pack = loadPack(packDir, 'community');
+        } catch (e) {
+          if (e instanceof PackLoaderError) {
+            reply.status(422);
+            throw Object.assign(new Error(e.message), {
+              statusCode: 422,
+              code: e.code,
+            });
+          }
+          throw e;
+        }
+
+        const destDir = join(_packsDataDir, pack.manifest.pack_id);
+        mkdirSync(_packsDataDir, { recursive: true });
+        if (resolvePath(packDir) !== resolvePath(destDir)) {
+          rmSync(destDir, { recursive: true, force: true });
+          cpSync(packDir, destDir, { recursive: true });
+        }
+
+        const index = PackIndex.open(_packsDbPath);
+        try {
+          const installedPack = loadPack(destDir, 'community');
+          index.importPack(installedPack);
+        } finally {
+          index.close();
+        }
+
+        reply.status(201);
+        return {
+          pack_id: pack.manifest.pack_id,
+          name: pack.manifest.name,
+          version: pack.manifest.version,
+          dest: destDir,
+        };
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    },
+  );
 }
 
 export async function packRoutes(app: FastifyInstance) {
@@ -53,6 +204,75 @@ export async function packRoutes(app: FastifyInstance) {
         throw new Error(`Pack '${pack_id}' not found`);
       }
       return { pack_id, valid: true, errors: [] };
+    },
+  );
+
+  app.get<{ Params: { pack_id: string } }>(
+    '/api/packs/:pack_id/export',
+    async (req, reply) => {
+      if (!_packsDbPath) {
+        reply.status(503);
+        throw Object.assign(new Error('Pack storage is not configured.'), {
+          statusCode: 503,
+          code: 'NOT_CONFIGURED',
+        });
+      }
+
+      const { pack_id } = req.params;
+
+      let packRoot: string | undefined;
+      try {
+        // Open without fileMustExist so an empty index (no packs imported yet)
+        // returns 404 instead of 503 from a missing-file exception.
+        const db = new Database(_packsDbPath, { readonly: false });
+        try {
+          db.exec(`
+            CREATE TABLE IF NOT EXISTS installed_packs (
+              pack_id TEXT PRIMARY KEY,
+              name TEXT NOT NULL,
+              pack_root TEXT NOT NULL,
+              version TEXT NOT NULL,
+              scenario_count INTEGER NOT NULL DEFAULT 0
+            )
+          `);
+          const row = db
+            .prepare('SELECT pack_root, version FROM installed_packs WHERE pack_id = ?')
+            .get(pack_id) as { pack_root: string; version: string } | undefined;
+          if (!row) {
+            reply.status(404);
+            throw Object.assign(new Error(`Pack '${pack_id}' not found.`), {
+              statusCode: 404,
+              code: 'NOT_FOUND',
+            });
+          }
+          packRoot = row.pack_root;
+        } finally {
+          db.close();
+        }
+      } catch (e) {
+        // Re-throw typed errors (including our 404) directly to Fastify.
+        if ((e as { statusCode?: number }).statusCode) throw e;
+        reply.status(503);
+        throw Object.assign(new Error('Pack index is unavailable.'), {
+          statusCode: 503,
+          code: 'DB_UNAVAILABLE',
+        });
+      }
+
+      const zip = new AdmZip();
+      const safeId = pack_id.replace(/[^a-zA-Z0-9._-]/g, '_');
+      // addLocalFolder stores entries relative to packRoot with safeId/ prefix
+      zip.addLocalFolder(packRoot, safeId);
+      const zipBuffer = zip.toBuffer();
+
+      const filename = `${safeId}.zip`;
+
+      reply
+        .header('Content-Type', 'application/zip')
+        .header('Content-Disposition', `attachment; filename="${filename}"`)
+        .header('Content-Length', String(zipBuffer.length));
+
+      return reply.send(zipBuffer);
     },
   );
 }

--- a/packages/convsim-cli/tests/cli.test.ts
+++ b/packages/convsim-cli/tests/cli.test.ts
@@ -776,6 +776,42 @@ describe('import-pack — installation verification', () => {
     expect(existsSync(join(dataDir, 'packs', 'test.cli_pack', 'manifest.yaml'))).toBe(true);
   });
 
+  it('upgrades to a newer version of the same pack (upgrade path)', () => {
+    const packDir = track(makeValidPackDir());
+    const dataDir = track(mkdtempSync(join(tmpdir(), 'convsim-data-')));
+
+    // Install v0.2.0.
+    expect(runImportPack(packDir, false, dataDir)).toBe(0);
+
+    // Build a v0.3.0 directory with the same pack_id.
+    const upgradeDir = track(mkdtempSync(join(tmpdir(), 'convsim-upgrade-')));
+    for (const sub of ['scenarios', 'npcs', 'rubrics', 'safety']) {
+      mkdirSync(join(upgradeDir, sub), { recursive: true });
+    }
+    writeFileSync(
+      join(upgradeDir, 'manifest.yaml'),
+      VALID_MANIFEST.replace('version: 0.2.0', 'version: 0.3.0'),
+    );
+    writeFileSync(join(upgradeDir, 'safety', 'policy.yaml'), VALID_SAFETY);
+    writeFileSync(join(upgradeDir, 'npcs', 'cli_test_npc.yaml'), VALID_NPC);
+    writeFileSync(join(upgradeDir, 'rubrics', 'cli_test_rubric.yaml'), VALID_RUBRIC);
+    writeFileSync(join(upgradeDir, 'scenarios', 'cli_test_scenario.yaml'), VALID_SCENARIO);
+
+    // Import v0.3.0 — must succeed.
+    expect(runImportPack(upgradeDir, false, dataDir)).toBe(0);
+
+    // The index must reflect the new version.
+    const dbPath = join(dataDir, 'index.db');
+    const index = PackIndex.open(dbPath);
+    try {
+      const entry = index.listPacks().find((p) => p.pack_id === 'test.cli_pack');
+      expect(entry).toBeDefined();
+      expect(entry?.version).toBe('0.3.0');
+    } finally {
+      index.close();
+    }
+  });
+
   it('succeeds when importing from the already-installed location (self-import)', () => {
     const packDir = track(makeValidPackDir());
     const dataDir = track(mkdtempSync(join(tmpdir(), 'convsim-data-')));


### PR DESCRIPTION
## Summary

- Adds `POST /api/packs/import` to the Node.js Fastify API so the web UI can install packs from zip uploads without routing through the Python sidecar.
- Adds `GET /api/packs/:pack_id/export` to the Fastify API so installed packs can be downloaded as distributable zip archives.
- Adds `setPacksDataDir()` and wires it up in `index.ts` via the `PACKS_DATA_DIR` environment variable so the pack file storage directory is configurable independently of the index database path.
- Adds an explicit **upgrade-path test** to the CLI suite: installs v0.2.0, then imports a rebuilt v0.3.0 directory with the same `pack_id`, and asserts the SQLite index reflects the new version.

## What the import endpoint does

The endpoint accepts a raw zip body (`Content-Type: application/zip` or `application/octet-stream`):
1. Zip-slip check via AdmZip to detect entry-name traversal attacks.
2. Extracts to a temp directory, unwraps a single top-level subdirectory if present (for user convenience).
3. Calls `loadPack()` from `@convsim/pack-loader`, which runs the full security scan: forbidden extensions, magic-byte detection, symlink rejection, path-traversal in `ref` fields, and JSON Schema validation.
4. Atomically copies the validated pack into `PACKS_DATA_DIR/<pack_id>/` and upserts the record in `PackIndex` — so re-importing the same `pack_id` upgrades the installation in place.
5. Returns `201` with `{ pack_id, name, version, dest }`.

## What the export endpoint does

The endpoint reads the installed pack's root directory from the index and archives it using AdmZip:
1. Looks up the pack in `PackIndex` by `pack_id`.
2. Archives the pack directory (with a safe filename derived from the pack ID).
3. Returns the zip as a downloadable attachment with appropriate `Content-Disposition` and `Content-Type` headers.

## How it was tested

- **Fastify API tests** (`apps/api/src/routes/packs.test.ts`): 12 new test cases covering:
  - Valid import returns 201 with pack metadata
  - Imported pack appears in `GET /api/packs` list
  - Upgrade-path re-import replaces v1.0.0 with v2.0.0
  - Zip-slip rejection (422)
  - Executable-content rejection (422)
  - Missing-manifest rejection (422)
  - Non-zip body rejection (422)
  - Export 404 for unknown pack ID
  - Export of an installed pack returns valid zip
  - Index is not corrupted by export before any import
  - Round-trip: import → export → re-import succeeds

- **CLI upgrade-path test** (`packages/convsim-cli/tests/cli.test.ts`): installs v0.2.0, imports v0.3.0 of the same pack, verifies the `PackIndex` entry shows `version: '0.3.0'`.

- All existing tests pass:
  - 48 Python sidecar tests (`test_packs_api.py`, `test_pack_importer.py`, `test_pack_exporter.py`)
  - 330 Fastify API tests
  - 146 CLI tests

Closes #194