### PR TITLE
Fix cancel_events test isolation in model registry install flow

### DIFF
--- a/services/convsim-core/convsim_core/app.py
+++ b/services/convsim-core/convsim_core/app.py
@@ -37,6 +37,7 @@ def create_app(config: ServiceConfig | None = None) -> FastAPI:
         app.state.service_config = config
         app.state.db = db
         app.state.models_dir = config.models_dir
+        app.state.cancel_events = {}   # install_id → asyncio.Event (per-app)
         app.state.app_settings = load_settings(db.connection(), config.data_dir, config.log_dir)
         app.state.runtime = build_runtime(config.runtime_id)
         app.state.stt_worker = build_stt_worker(config.stt_worker_id)

--- a/services/convsim-core/convsim_core/routers/models.py
+++ b/services/convsim-core/convsim_core/routers/models.py
@@ -38,14 +38,18 @@ from convsim_core.services.model_registry_service import list_registry_models
 
 router = APIRouter()
 
-# Maps install_id → asyncio.Event; setting the event signals cancel to the download task.
-_cancel_events: dict[int, asyncio.Event] = {}
-
 # Strong references to in-flight download tasks. asyncio only keeps a weak
 # reference to tasks created via create_task, so without this the download task
 # can be garbage-collected mid-download and silently cancelled, leaving the
 # install record stuck in 'downloading'. Tasks remove themselves when done.
 _download_tasks: set[asyncio.Task[None]] = set()
+
+# Per-install-id cancel events are stored on app.state.cancel_events (a dict
+# initialised to {} in the lifespan) rather than as a module-level dict so that
+# each FastAPI app instance (and therefore each test) has its own isolated map.
+# Module-level state would leak between tests that suppress the download task,
+# leaving stale events under install_id=1 that would silently absorb a
+# subsequent cancel call and leave the record in 'pending' instead of 'cancelled'.
 
 
 def _spawn_download_task(coro: Any) -> "asyncio.Task[None]":
@@ -425,8 +429,11 @@ async def install_model(request: Request, body: InstallModelRequest) -> InstallM
     )
 
     # Register a cancel event before launching the task so DELETE can signal it.
+    # cancel_events lives on app.state (initialised in lifespan) so it is fresh
+    # per app instance and does not leak between tests.
+    cancel_events: dict[int, asyncio.Event] = request.app.state.cancel_events
     cancel_event = asyncio.Event()
-    _cancel_events[install_id] = cancel_event
+    cancel_events[install_id] = cancel_event
 
     async def _run_download() -> None:
         try:
@@ -440,7 +447,7 @@ async def install_model(request: Request, body: InstallModelRequest) -> InstallM
                 cancel_event=cancel_event,
             )
         finally:
-            _cancel_events.pop(install_id, None)
+            cancel_events.pop(install_id, None)
 
     _spawn_download_task(_run_download())
 
@@ -487,7 +494,8 @@ async def cancel_install(request: Request, install_id: int) -> None:
         )
 
     # Signal the background download task if one is running.
-    event = _cancel_events.get(install_id)
+    cancel_events: dict[int, asyncio.Event] = request.app.state.cancel_events
+    event = cancel_events.get(install_id)
     if event is not None:
         event.set()
     else:


### PR DESCRIPTION
## Summary

Fixes a test isolation bug in the model registry install flow where a module-level `_cancel_events` dict persisted across all FastAPI app instances created within a single pytest session.

### The Problem

- `_cancel_events: dict[int, asyncio.Event]` was declared at module level in `convsim_core/routers/models.py`
- Tests that suppress the background download task (via patching `_spawn_download_task`) register a cancel event for `install_id=1` but never clean it up, because the coroutine closes before the `finally` block runs
- When later tests create a fresh install record (same auto-incremented `install_id=1` from a new in-memory database), calling `DELETE /api/models/install/1` hits the stale event
- `event.set()` is called on the wrong event, leaving the record in `'pending'` instead of `'cancelled'`

### The Fix

Move `cancel_events` from module level to `app.state` (initialized to `{}` in the FastAPI lifespan). This ensures each app instance—and therefore each test—has its own isolated map. The `install_model` and `cancel_install` endpoints now access `request.app.state.cancel_events`.

## Test Coverage

- All 1,472 non-hardware-dependent tests pass (3 skipped)
- Model manager tests: 75 passed
- Includes explicit-download consent, checksum failure, cancelled download, external GGUF path validation, Ollama model existence check, and benchmark persistence

Closes #191