### PR TITLE
Wire prompt-composer fully into the scenario engine turn pipeline

### DIFF
--- a/services/convsim-core/convsim_core/services/turn_pipeline.py
+++ b/services/convsim-core/convsim_core/services/turn_pipeline.py
@@ -14,6 +14,8 @@ Processing steps (SPEC §6):
 """
 from __future__ import annotations
 
+import asyncio
+import concurrent.futures
 import json
 import logging
 import sqlite3
@@ -28,11 +30,13 @@ from convsim_prompt import (
     SafetyPolicy,
     SessionState as PromptSessionState,
     TranscriptEntry,
+    TurnEvent,
     compose_turn_prompt,
     parse_turn_output,
 )
 from convsim_prompt.types import ScenarioData
 
+from convsim_core.input_router import SafetyPolicyConfig
 from convsim_core.runtime.base import ChatRuntime
 from convsim_core.runtime.types import ChatFinal, ChatMessage, ChatRequest, ChatToken
 from convsim_core.scenario_state import (
@@ -64,6 +68,53 @@ _DEFAULT_SAFETY_POLICY = SafetyPolicy(
         "illegal": "That's not something I can discuss. Let me steer us back on track.",
     },
 )
+
+
+def _safety_policy_config_to_prompt_policy(config: SafetyPolicyConfig) -> SafetyPolicy:
+    """Convert a SafetyPolicyConfig (input-router) to SafetyPolicy (prompt-composer).
+
+    The prompt-composer SafetyPolicy.prohibited list is shown to the LLM as NPC
+    behavior constraints in the SAFETY_POLICY layer.  Category names from
+    SafetyPolicyConfig are used directly — they are descriptive enough for the model.
+    """
+    prohibited = list(config.categories.keys())
+    redirects: Dict[str, str] = dict(config.per_category_messages)
+    if config.global_redirect_message and "default" not in redirects:
+        redirects["default"] = config.global_redirect_message
+    return SafetyPolicy(
+        policy_id=config.policy_id,
+        content_rating=config.content_rating,
+        prohibited=prohibited,
+        redirects=redirects,
+    )
+
+
+class _SyncRuntimeBridge:
+    """Synchronous RuntimeProtocol bridge over ChatRuntime for repair calls.
+
+    parse_turn_output expects a synchronous RuntimeProtocol.call_llm() to request
+    structural-repair or content-safety-retry responses from the model.  ChatRuntime
+    exposes only an async chat_stream() interface, so this bridge runs each repair
+    call in a dedicated thread with its own event loop, isolating it from the
+    caller's running asyncio loop.
+
+    If the runtime is event-loop-bound (e.g. uses a per-loop aiohttp session) the
+    call will raise from the foreign loop — that exception propagates to
+    parse_turn_output's except clause, which logs it and falls back gracefully.
+    """
+
+    def __init__(self, runtime: ChatRuntime) -> None:
+        self._runtime = runtime
+
+    def call_llm(self, prompt: str) -> str:
+        async def _call() -> str:
+            request = ChatRequest(
+                messages=[ChatMessage(role="user", content=prompt)],
+            )
+            return await _collect_runtime_output(self._runtime, request)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            return pool.submit(asyncio.run, _call()).result(timeout=60)
 
 
 class TurnInputError(ValueError):
@@ -144,6 +195,7 @@ async def process_turn(
     *,
     save_transcript: bool = True,
     source_mode: str = "text-only",
+    safety_policy_config: Optional[SafetyPolicyConfig] = None,
 ) -> TurnPipelineResult:
     """Execute the full player-turn pipeline and persist results.
 
@@ -182,13 +234,18 @@ async def process_turn(
     recent_transcript = _load_recent_turns(session_id, conn)
 
     # 5. Build prompt.
+    prompt_safety_policy = (
+        _safety_policy_config_to_prompt_policy(safety_policy_config)
+        if safety_policy_config is not None
+        else _DEFAULT_SAFETY_POLICY
+    )
     prompt = compose_turn_prompt(PromptComposerInput(
         scenario=scenario_data,
         session_state=PromptSessionState(
             variables=state_vars,
             turn_number=turn_number,
         ),
-        safety_policy=_DEFAULT_SAFETY_POLICY,
+        safety_policy=prompt_safety_policy,
         player_utterance=normalized,
         recent_transcript=recent_transcript,
     ))
@@ -203,13 +260,22 @@ async def process_turn(
         json_schema=NPC_TURN_OUTPUT_SCHEMA,
     )
     logger.debug(
-        "Calling runtime %s for session %s turn %d (estimated %d tokens)",
-        runtime.id, session_id, turn_number, prompt.estimated_token_count,
+        "Calling runtime %s for session %s turn %d (estimated %d tokens, truncated=%s)",
+        runtime.id, session_id, turn_number, prompt.estimated_token_count, prompt.was_truncated,
     )
     raw_text = await _collect_runtime_output(runtime, request)
 
     # 7. Validate / repair / fallback.
-    turn_output = parse_turn_output(raw_text)
+    # Wrap the runtime so parse_turn_output can make synchronous repair calls.
+    # Hidden agenda is forwarded for verbatim-leak detection in the output validator.
+    runtime_bridge = _SyncRuntimeBridge(runtime)
+    turn_parse_events: List[TurnEvent] = []
+    turn_output = parse_turn_output(
+        raw_text,
+        runtime=runtime_bridge,
+        hidden_agenda=scenario_data.npc.private_persona.hidden_agenda,
+        turn_events=turn_parse_events,
+    )
     used_fallback = (turn_output.npc_utterance == SAFE_FALLBACK_UTTERANCE)
     if used_fallback:
         logger.warning("Turn output fell back to safe utterance for session %s turn %d", session_id, turn_number)
@@ -254,6 +320,15 @@ async def process_turn(
     now = datetime.now(timezone.utc).isoformat()
     player_turn_number = turn_number * 2 - 1
     npc_turn_number = turn_number * 2
+
+    # Prompt metadata stored for debugging. Only non-private fields are kept:
+    # token count, truncation flag, and which layers were present. The raw
+    # prompt text and NPC private persona content are never written to the log.
+    prompt_metadata_payload = json.dumps({
+        "estimated_token_count": prompt.estimated_token_count,
+        "was_truncated": prompt.was_truncated,
+        "layers_present": list(prompt.layer_map.keys()),
+    })
 
     with conn:
         player_cursor = conn.execute(
@@ -321,8 +396,21 @@ async def process_turn(
                 now,
             ))
         events_to_insert.append((
+            session_id, turn_number, "prompt_metadata", prompt_metadata_payload, now,
+        ))
+        events_to_insert.append((
             session_id, turn_number, "debug",
-            json.dumps({"used_fallback": used_fallback}), now,
+            json.dumps({
+                "used_fallback": used_fallback,
+                "parse_events": [
+                    {
+                        "event_type": e.event_type,
+                        "category": e.category,
+                        "reason": e.reason,
+                    }
+                    for e in turn_parse_events
+                ],
+            }), now,
         ))
         conn.executemany(
             "INSERT INTO turn_session_events "

--- a/services/convsim-core/convsim_core/services/turn_pipeline.py
+++ b/services/convsim-core/convsim_core/services/turn_pipeline.py
@@ -113,8 +113,15 @@ class _SyncRuntimeBridge:
             )
             return await _collect_runtime_output(self._runtime, request)
 
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        try:
             return pool.submit(asyncio.run, _call()).result(timeout=60)
+        finally:
+            # Never wait on a hung repair call — the 60s timeout above must be
+            # the real ceiling. A context manager would call shutdown(wait=True)
+            # on exit and block indefinitely if the runtime never returns, so we
+            # shut down without waiting and let a stuck thread die on its own.
+            pool.shutdown(wait=False)
 
 
 class TurnInputError(ValueError):

--- a/services/convsim-core/convsim_core/services/turn_pipeline.py
+++ b/services/convsim-core/convsim_core/services/turn_pipeline.py
@@ -413,7 +413,15 @@ async def process_turn(
                     {
                         "event_type": e.event_type,
                         "category": e.category,
-                        "reason": e.reason,
+                        # A hidden_agenda_leak reason embeds verbatim keywords
+                        # copied from the NPC's private hidden agenda. Redact it
+                        # so private content is never written to the debug log
+                        # (issue #199: no hidden/private content in logs by
+                        # default). event_type + category still identify the leak.
+                        "reason": (
+                            None if e.category == "hidden_agenda_leak" else e.reason
+                        ),
+                        "is_recoverable": e.is_recoverable,
                     }
                     for e in turn_parse_events
                 ],

--- a/services/convsim-core/tests/test_turn_pipeline.py
+++ b/services/convsim-core/tests/test_turn_pipeline.py
@@ -12,6 +12,11 @@ Test plan:
   - Unit: safety.status='stop' ends the session with safety_stop.
   - Unit: safety.status='redirect' keeps session alive.
   - Idempotency guard: state machine rejects a turn in a non-listening state.
+  - Unit (issue #199): prompt layer ordering respected end-to-end.
+  - Unit (issue #199): safety-policy config is converted and forwarded to compose_turn_prompt.
+  - Unit (issue #199): hidden agenda is forwarded to parse_turn_output for leak detection.
+  - Unit (issue #199): prompt metadata persisted without private content.
+  - Unit (issue #199): transcript truncation flag stored in prompt_metadata event.
 """
 from __future__ import annotations
 
@@ -26,6 +31,7 @@ from fastapi.testclient import TestClient
 
 from convsim_core.app import create_app
 from convsim_core.config import ServiceConfig
+from convsim_core.input_router import RouteAction, SafetyPolicyConfig
 from convsim_core.runtime.fake import FakeChatRuntime
 from convsim_core.runtime.types import (
     ChatFinal,
@@ -37,12 +43,15 @@ from convsim_core.runtime.types import (
     RuntimeStatus,
 )
 from convsim_core.scenario_state import build_variable_defs, initialize_state
-from convsim_core.scenarios import get_scenario_info
+from convsim_core.scenarios import get_scenario_data, get_scenario_info
 from convsim_core.services.turn_pipeline import (
     MAX_TURN_CONTENT_CHARS,
     TurnInputError,
     process_turn,
 )
+from convsim_core.storage.migrations import run_migrations
+from convsim_prompt import LAYER_ORDER, SafetyPolicy, TurnEvent
+from convsim_prompt.turn_output import SafetyStatus, SessionControl, TurnOutput
 
 
 # ---------------------------------------------------------------------------
@@ -606,3 +615,369 @@ class TestStatePersistence:
             )
         assert res2.status_code == 200
         assert res2.json()["state"] == "PlayerTurnListening"
+
+
+# ---------------------------------------------------------------------------
+# Helpers for direct process_turn unit tests (issue #199)
+# ---------------------------------------------------------------------------
+
+def _make_unit_db() -> sqlite3.Connection:
+    """Return an in-memory SQLite connection with all migrations applied."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    run_migrations(conn)
+    return conn
+
+
+def _insert_unit_session(
+    conn: sqlite3.Connection,
+    session_id: str = "sess-unit",
+) -> sqlite3.Row:
+    conn.execute(
+        "INSERT INTO turn_sessions "
+        "(session_id, scenario_id, flow_state, state_vars_json, fired_events_json, "
+        "turn_count, setup_json) "
+        "VALUES (?, 'behavioral_interview', 'PlayerTurnListening', '{}', '[]', 0, '{}')",
+        (session_id,),
+    )
+    conn.commit()
+    return conn.execute(
+        "SELECT * FROM turn_sessions WHERE session_id = ?", (session_id,)
+    ).fetchone()
+
+
+def _get_event_payloads(
+    conn: sqlite3.Connection,
+    session_id: str,
+    event_type: str,
+) -> list:
+    rows = conn.execute(
+        "SELECT payload_json FROM turn_session_events "
+        "WHERE session_id = ? AND event_type = ?",
+        (session_id, event_type),
+    ).fetchall()
+    return [json.loads(r["payload_json"]) for r in rows]
+
+
+def _valid_turn_output() -> TurnOutput:
+    return TurnOutput(
+        npc_utterance="That's a great point, thank you.",
+        npc_emotion="neutral",
+        state_delta={},
+        event_flags=[],
+        rubric_observations=[],
+        safety=SafetyStatus(status="ok"),
+        session_control=SessionControl(continue_session=True),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Issue #199: prompt-composer wiring unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestPromptComposerWiring:
+    """Unit tests for prompt-composer wiring: layer ordering, safety policy,
+    hidden agenda handling, prompt metadata persistence, and transcript truncation.
+    """
+
+    @pytest.mark.asyncio
+    async def test_prompt_metadata_event_persisted_after_turn(self):
+        """A 'prompt_metadata' event is written to turn_session_events each turn."""
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        await process_turn(
+            session_row=row,
+            player_text="I have five years of experience.",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=10,
+            runtime=FakeChatRuntime(),
+            conn=conn,
+        )
+
+        events = _get_event_payloads(conn, "sess-unit", "prompt_metadata")
+        assert len(events) == 1
+        meta = events[0]
+        assert "estimated_token_count" in meta
+        assert meta["estimated_token_count"] > 0
+        assert "was_truncated" in meta
+        assert isinstance(meta["was_truncated"], bool)
+        assert "layers_present" in meta
+        assert isinstance(meta["layers_present"], list)
+        assert len(meta["layers_present"]) > 0
+
+    @pytest.mark.asyncio
+    async def test_prompt_metadata_lists_all_expected_layers(self):
+        """layers_present in the prompt_metadata event covers the full layer set."""
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        await process_turn(
+            session_row=row,
+            player_text="Tell me about the role.",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=10,
+            runtime=FakeChatRuntime(),
+            conn=conn,
+        )
+
+        meta = _get_event_payloads(conn, "sess-unit", "prompt_metadata")[0]
+        for layer in LAYER_ORDER:
+            assert layer in meta["layers_present"], (
+                f"Expected layer {layer!r} in layers_present"
+            )
+
+    @pytest.mark.asyncio
+    async def test_prompt_metadata_excludes_private_persona_text(self):
+        """Hidden agenda text and raw prompt content are not stored in prompt_metadata."""
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        await process_turn(
+            session_row=row,
+            player_text="What does success look like in this role?",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=10,
+            runtime=FakeChatRuntime(),
+            conn=conn,
+        )
+
+        rows = conn.execute(
+            "SELECT payload_json FROM turn_session_events "
+            "WHERE session_id = 'sess-unit' AND event_type = 'prompt_metadata'",
+        ).fetchall()
+        assert len(rows) == 1
+        raw_payload = rows[0]["payload_json"]
+
+        # Hidden agenda bullets from the behavioral_interview NPC must not appear.
+        assert "Assess candidate" not in raw_payload
+        assert "Probe for specific" not in raw_payload
+        # Raw prompt structure markers must not appear.
+        assert "LAYER:SAFETY_POLICY" not in raw_payload
+        assert "LAYER:NPC_PRIVATE_PERSONA" not in raw_payload
+
+    @pytest.mark.asyncio
+    async def test_truncation_flag_stored_when_compose_returns_truncated(self):
+        """When compose_turn_prompt signals was_truncated=True, it appears in the event."""
+        from convsim_prompt.types import PromptBundle
+
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        fake_bundle = PromptBundle(
+            system_prompt="s",
+            user_prompt="u",
+            layer_map={name: "..." for name in LAYER_ORDER},
+            estimated_token_count=5000,
+            was_truncated=True,
+        )
+
+        with patch(
+            "convsim_core.services.turn_pipeline.compose_turn_prompt",
+            return_value=fake_bundle,
+        ):
+            await process_turn(
+                session_row=row,
+                player_text="Hello.",
+                scenario_data=get_scenario_data("behavioral_interview", "normal"),
+                max_turns=10,
+                runtime=FakeChatRuntime(),
+                conn=conn,
+            )
+
+        meta = _get_event_payloads(conn, "sess-unit", "prompt_metadata")
+        assert len(meta) == 1
+        assert meta[0]["was_truncated"] is True
+        assert meta[0]["estimated_token_count"] == 5000
+
+    @pytest.mark.asyncio
+    async def test_custom_safety_policy_config_forwarded_to_compose_turn_prompt(self):
+        """Providing safety_policy_config converts and passes the policy to compose_turn_prompt."""
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        custom_config = SafetyPolicyConfig(
+            policy_id="pack_pg13",
+            content_rating="PG-13",
+            categories={
+                "nsfw_sexual_content": RouteAction.STOP,
+                "criminal_instruction": RouteAction.REFUSE,
+            },
+        )
+        captured: list = []
+
+        import convsim_core.services.turn_pipeline as _tp
+        _orig = _tp.compose_turn_prompt
+
+        def _spy(inp):
+            captured.append(inp.safety_policy)
+            return _orig(inp)
+
+        with patch("convsim_core.services.turn_pipeline.compose_turn_prompt", side_effect=_spy):
+            await process_turn(
+                session_row=row,
+                player_text="Hello.",
+                scenario_data=get_scenario_data("behavioral_interview", "normal"),
+                max_turns=10,
+                runtime=FakeChatRuntime(),
+                conn=conn,
+                safety_policy_config=custom_config,
+            )
+
+        assert len(captured) == 1
+        used = captured[0]
+        assert isinstance(used, SafetyPolicy)
+        assert used.policy_id == "pack_pg13"
+        assert used.content_rating == "PG-13"
+        assert "nsfw_sexual_content" in used.prohibited
+        assert "criminal_instruction" in used.prohibited
+
+    @pytest.mark.asyncio
+    async def test_default_safety_policy_applied_when_no_config_provided(self):
+        """When safety_policy_config is None the built-in default PG policy is used."""
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        captured: list = []
+        import convsim_core.services.turn_pipeline as _tp
+        _orig = _tp.compose_turn_prompt
+
+        def _spy(inp):
+            captured.append(inp.safety_policy)
+            return _orig(inp)
+
+        with patch("convsim_core.services.turn_pipeline.compose_turn_prompt", side_effect=_spy):
+            await process_turn(
+                session_row=row,
+                player_text="Hello.",
+                scenario_data=get_scenario_data("behavioral_interview", "normal"),
+                max_turns=10,
+                runtime=FakeChatRuntime(),
+                conn=conn,
+            )
+
+        assert len(captured) == 1
+        used = captured[0]
+        assert isinstance(used, SafetyPolicy)
+        assert used.policy_id == "default_pg"
+        assert used.content_rating == "PG"
+
+    @pytest.mark.asyncio
+    async def test_hidden_agenda_forwarded_to_parse_turn_output(self):
+        """parse_turn_output receives the NPC's hidden_agenda for leak detection."""
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+        scenario_data = get_scenario_data("behavioral_interview", "normal")
+        expected_agenda = scenario_data.npc.private_persona.hidden_agenda
+
+        captured: dict = {}
+
+        def _spy_parse(raw, runtime=None, hidden_agenda=None, turn_events=None):
+            captured["hidden_agenda"] = hidden_agenda
+            return _valid_turn_output()
+
+        with patch(
+            "convsim_core.services.turn_pipeline.parse_turn_output",
+            side_effect=_spy_parse,
+        ):
+            await process_turn(
+                session_row=row,
+                player_text="I have relevant experience.",
+                scenario_data=scenario_data,
+                max_turns=10,
+                runtime=FakeChatRuntime(),
+                conn=conn,
+            )
+
+        assert captured.get("hidden_agenda") == expected_agenda
+
+    @pytest.mark.asyncio
+    async def test_runtime_bridge_forwarded_to_parse_turn_output(self):
+        """A non-None runtime bridge is passed to parse_turn_output for repair calls."""
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        captured: dict = {}
+
+        def _spy_parse(raw, runtime=None, hidden_agenda=None, turn_events=None):
+            captured["runtime"] = runtime
+            return _valid_turn_output()
+
+        with patch(
+            "convsim_core.services.turn_pipeline.parse_turn_output",
+            side_effect=_spy_parse,
+        ):
+            await process_turn(
+                session_row=row,
+                player_text="What are the next steps?",
+                scenario_data=get_scenario_data("behavioral_interview", "normal"),
+                max_turns=10,
+                runtime=FakeChatRuntime(),
+                conn=conn,
+            )
+
+        assert captured.get("runtime") is not None
+
+    @pytest.mark.asyncio
+    async def test_parse_turn_events_included_in_debug_event(self):
+        """TurnEvents emitted by parse_turn_output are stored in the debug event payload."""
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        def _spy_parse(raw, runtime=None, hidden_agenda=None, turn_events=None):
+            if turn_events is not None:
+                turn_events.append(TurnEvent(
+                    event_type="structural_validation_failure",
+                    reason="injected test event",
+                ))
+            return _valid_turn_output()
+
+        with patch(
+            "convsim_core.services.turn_pipeline.parse_turn_output",
+            side_effect=_spy_parse,
+        ):
+            await process_turn(
+                session_row=row,
+                player_text="Interesting.",
+                scenario_data=get_scenario_data("behavioral_interview", "normal"),
+                max_turns=10,
+                runtime=FakeChatRuntime(),
+                conn=conn,
+            )
+
+        debug = _get_event_payloads(conn, "sess-unit", "debug")
+        assert len(debug) == 1
+        parse_evts = debug[0].get("parse_events", [])
+        types = [e["event_type"] for e in parse_evts]
+        assert "structural_validation_failure" in types
+
+    @pytest.mark.asyncio
+    async def test_prompt_layers_ordered_safety_before_scenario(self):
+        """In the composed system prompt, SAFETY_POLICY always precedes SCENARIO_BRIEF."""
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        captured: list = []
+        import convsim_core.services.turn_pipeline as _tp
+        _orig = _tp.compose_turn_prompt
+
+        def _spy(inp):
+            result = _orig(inp)
+            captured.append(result.system_prompt)
+            return result
+
+        with patch("convsim_core.services.turn_pipeline.compose_turn_prompt", side_effect=_spy):
+            await process_turn(
+                session_row=row,
+                player_text="Good morning.",
+                scenario_data=get_scenario_data("behavioral_interview", "normal"),
+                max_turns=10,
+                runtime=FakeChatRuntime(),
+                conn=conn,
+            )
+
+        assert len(captured) == 1
+        sp = captured[0]
+        assert sp.index("LAYER:SAFETY_POLICY") < sp.index("LAYER:SCENARIO_BRIEF")
+        assert sp.index("LAYER:SCENARIO_BRIEF") < sp.index("LAYER:OUTPUT_SCHEMA")

--- a/services/convsim-core/tests/test_turn_pipeline.py
+++ b/services/convsim-core/tests/test_turn_pipeline.py
@@ -953,6 +953,58 @@ class TestPromptComposerWiring:
         assert "structural_validation_failure" in types
 
     @pytest.mark.asyncio
+    async def test_hidden_agenda_leak_reason_redacted_in_debug_event(self):
+        """A hidden_agenda_leak reason (which embeds verbatim private agenda
+        keywords) must not be persisted to the debug log (issue #199)."""
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        secret_keywords = "candidate leadership competency"
+
+        def _spy_parse(raw, runtime=None, hidden_agenda=None, turn_events=None):
+            if turn_events is not None:
+                turn_events.append(TurnEvent(
+                    event_type="output_violation_detected",
+                    category="hidden_agenda_leak",
+                    reason=(
+                        "NPC utterance contains multiple keywords from a private "
+                        f"agenda item ({secret_keywords})"
+                    ),
+                    is_recoverable=True,
+                ))
+            return _valid_turn_output()
+
+        with patch(
+            "convsim_core.services.turn_pipeline.parse_turn_output",
+            side_effect=_spy_parse,
+        ):
+            await process_turn(
+                session_row=row,
+                player_text="Tell me a secret.",
+                scenario_data=get_scenario_data("behavioral_interview", "normal"),
+                max_turns=10,
+                runtime=FakeChatRuntime(),
+                conn=conn,
+            )
+
+        rows = conn.execute(
+            "SELECT payload_json FROM turn_session_events "
+            "WHERE session_id = 'sess-unit' AND event_type = 'debug'",
+        ).fetchall()
+        assert len(rows) == 1
+        raw_payload = rows[0]["payload_json"]
+        # Private agenda keywords must not appear anywhere in the persisted log.
+        assert secret_keywords not in raw_payload
+        # The event is still recorded (type/category preserved), reason redacted.
+        debug = json.loads(raw_payload)
+        leak_evt = next(
+            e for e in debug["parse_events"]
+            if e["category"] == "hidden_agenda_leak"
+        )
+        assert leak_evt["reason"] is None
+        assert leak_evt["event_type"] == "output_violation_detected"
+
+    @pytest.mark.asyncio
     async def test_prompt_layers_ordered_safety_before_scenario(self):
         """In the composed system prompt, SAFETY_POLICY always precedes SCENARIO_BRIEF."""
         conn = _make_unit_db()


### PR DESCRIPTION
## Summary

Completes the wiring of the prompt-composer pipeline into the scenario engine's turn processing. Adds safety policy config routing, synchronous repair-call bridging for non-blocking structural and content-safety retries, hidden-agenda leak detection, and metadata persistence for debugging.

### Changes

- **Safety policy wiring**: Added `_safety_policy_config_to_prompt_policy()` to convert a pack's `SafetyPolicyConfig` (input-router type) into the prompt-composer's `SafetyPolicy`. Exposed as an optional `safety_policy_config` parameter on `process_turn` so callers can pass a pack-loaded policy; falls back to the built-in `default_pg` policy when none is provided.

- **Runtime bridge for repair calls**: Added `_SyncRuntimeBridge`, a synchronous `RuntimeProtocol` adapter over the async `ChatRuntime` interface. Runs each structural-repair or content-safety-retry call in a dedicated thread with its own event loop so `parse_turn_output` can request model repairs without conflicting with the caller's running asyncio loop. Event-loop-bound runtimes fail gracefully via the existing `except` clause in `parse_turn_output`. Fixed timeout behavior: pool is shut down with `wait=False` to ensure the 60s repair call ceiling is respected even if a runtime hangs.

- **Hidden agenda leak detection**: `parse_turn_output` now receives the NPC's `hidden_agenda` list on every turn so the output validator can detect verbatim agenda leaks in NPC utterances and apply the content-safety retry or stop path accordingly.

- **Turn parse event capture**: `TurnEvent` objects emitted by `parse_turn_output` (structural failures, safety retries, fallback decisions) are collected and stored in the `debug` event payload, making them visible to the debug drawer without additional DB queries. Hidden-agenda-leak event reasons are redacted to avoid persisting private content.

- **Prompt metadata persistence**: A `prompt_metadata` event is written to `turn_session_events` after each turn containing `estimated_token_count`, `was_truncated`, and `layers_present`. Raw prompt text and NPC private-persona content are never stored, satisfying the local-first privacy requirement.

## Testing

- All 41 existing `test_turn_pipeline.py` tests pass unchanged.
- Added `TestPromptComposerWiring` (10 unit tests) covering:
  - `prompt_metadata` event persisted after a turn
  - `layers_present` covers the full `LAYER_ORDER` set
  - Private persona text excluded from `prompt_metadata` payload
  - `was_truncated=True` stored when `compose_turn_prompt` signals truncation
  - Custom `SafetyPolicyConfig` converted and forwarded to `compose_turn_prompt`
  - Default `default_pg` policy applied when no config provided
  - `hidden_agenda` forwarded to `parse_turn_output`
  - Non-`None` runtime bridge forwarded to `parse_turn_output`
  - `TurnEvents` from `parse_turn_output` appear in the debug event
  - `SAFETY_POLICY` precedes `SCENARIO_BRIEF` precedes `OUTPUT_SCHEMA` in the composed system prompt
- Added test for hidden-agenda-leak reason redaction: verifies private keywords never appear in persisted debug payload while event is still recorded.
- All 271 `packages/prompt-composer` unit tests pass unchanged.

Closes #199