### PR TITLE
Implement first-run model setup wizard for non-technical Steam players

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { Routes, Route } from 'react-router-dom'
+import { Routes, Route, Navigate, Outlet } from 'react-router-dom'
 import AppLayout from './layout/AppLayout'
 import ErrorBoundary from './components/ErrorBoundary'
 import Home from './screens/Home'
@@ -10,20 +10,36 @@ import Debrief from './screens/Debrief'
 import CreatorWorkbench from './screens/CreatorWorkbench'
 import Settings from './screens/Settings'
 import ModelManager from './screens/ModelManager'
+import FirstRunWizard from './screens/FirstRunWizard'
+import { SETUP_KEYS } from './privacyPrefs'
+
+// Redirects to /first-run until the setup wizard has been completed once.
+function FirstRunGuard() {
+  const complete = localStorage.getItem(SETUP_KEYS.firstRunComplete) === 'true'
+  if (!complete) {
+    return <Navigate to="/first-run" replace />
+  }
+  return <Outlet />
+}
 
 export default function App() {
   return (
     <ErrorBoundary>
       <Routes>
+        {/* First-run wizard shown outside the main app layout */}
+        <Route path="/first-run" element={<FirstRunWizard />} />
+
         <Route element={<AppLayout />}>
-          <Route path="/" element={<Home />} />
-          <Route path="/library" element={<ScenarioLibrary />} />
-          <Route path="/setup/:scenarioId" element={<ScenarioSetup />} />
-          <Route path="/conversation/:sessionId" element={<Conversation />} />
-          <Route path="/debrief/:sessionId" element={<Debrief />} />
-          <Route path="/workbench" element={<CreatorWorkbench />} />
-          <Route path="/settings" element={<Settings />} />
-          <Route path="/model-manager" element={<ModelManager />} />
+          <Route element={<FirstRunGuard />}>
+            <Route path="/" element={<Home />} />
+            <Route path="/library" element={<ScenarioLibrary />} />
+            <Route path="/setup/:scenarioId" element={<ScenarioSetup />} />
+            <Route path="/conversation/:sessionId" element={<Conversation />} />
+            <Route path="/debrief/:sessionId" element={<Debrief />} />
+            <Route path="/workbench" element={<CreatorWorkbench />} />
+            <Route path="/settings" element={<Settings />} />
+            <Route path="/model-manager" element={<ModelManager />} />
+          </Route>
         </Route>
       </Routes>
     </ErrorBoundary>

--- a/apps/web/src/__tests__/App.test.tsx
+++ b/apps/web/src/__tests__/App.test.tsx
@@ -94,3 +94,29 @@ describe('App shell', () => {
     expect(await screen.findByText('Local runtime: Unavailable')).toBeInTheDocument()
   })
 })
+
+describe('First-run guard', () => {
+  it('redirects a first-time user from a protected route to the setup wizard', () => {
+    // A fresh install has no completion flag; beforeEach sets it, so clear it here.
+    localStorage.removeItem('convsim.setup.complete')
+    renderAt('/')
+    // The wizard renders outside AppLayout, so no nav chrome is present…
+    expect(screen.queryByRole('link', { name: /settings/i })).not.toBeInTheDocument()
+    // …and the welcome step's "Get started" call to action is shown instead.
+    expect(screen.getByRole('button', { name: /get started/i })).toBeInTheDocument()
+  })
+
+  it('redirects a first-time user away from a deep protected route too', () => {
+    localStorage.removeItem('convsim.setup.complete')
+    renderAt('/settings')
+    expect(screen.getByRole('button', { name: /get started/i })).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: /^settings$/i })).not.toBeInTheDocument()
+  })
+
+  it('lets a returning user reach protected routes without the wizard', () => {
+    // beforeEach already set the completion flag.
+    renderAt('/settings')
+    expect(screen.getByRole('heading', { name: /settings/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /get started/i })).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/__tests__/App.test.tsx
+++ b/apps/web/src/__tests__/App.test.tsx
@@ -20,7 +20,9 @@ function mockFetch(response: object) {
 
 // Prevent real fetch calls; return a promise that never resolves so the
 // pending-state async health check never triggers a post-render state update.
+// Simulate a returning user so the FirstRunGuard allows access to all routes.
 beforeEach(() => {
+  localStorage.setItem('convsim.setup.complete', 'true')
   vi.stubGlobal('fetch', vi.fn(() => new Promise(() => {})))
 })
 

--- a/apps/web/src/__tests__/FirstRunWizard.test.tsx
+++ b/apps/web/src/__tests__/FirstRunWizard.test.tsx
@@ -1,0 +1,886 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import FirstRunWizard from '../screens/FirstRunWizard'
+import { SETUP_KEYS } from '../privacyPrefs'
+import type { ModelsResponse, BenchmarkResponse } from '@convsim/shared'
+
+vi.mock('../api/client', () => ({
+  api: {
+    getModels: vi.fn(),
+    useModel: vi.fn(),
+    installModel: vi.fn(),
+    getInstallStatus: vi.fn(),
+    cancelInstall: vi.fn(),
+    registerGguf: vi.fn(),
+    startSidecar: vi.fn(),
+    benchmarkModel: vi.fn(),
+  },
+}))
+
+import { api } from '../api/client'
+const mockApi = vi.mocked(api)
+
+const REGISTRY_ENTRY = {
+  id: 'qwen3-4b-instruct-q4_k_m',
+  name: 'Qwen3 4B Instruct Q4_K_M',
+  provider: 'huggingface',
+  family: 'qwen3',
+  role: 'starter',
+  format: 'gguf',
+  license_spdx: 'Apache-2.0',
+  license_url: 'https://www.apache.org/licenses/LICENSE-2.0',
+  source_type: 'registry',
+  download_url: 'PENDING',
+  sha256: 'PENDING',
+  size_gb: 2.6,
+  min_vram_gb: 4,
+  recommended_vram_gb: 6,
+  context_length: 8192,
+  registered_at: '2026-01-01T00:00:00.000Z',
+}
+
+const DEFAULT_BENCHMARK: BenchmarkResponse = {
+  model_id: 'qwen3-4b-instruct-q4_k_m',
+  runtime_id: 'llama_cpp',
+  tokens_per_sec: 14.2,
+  context_length: 8192,
+  warnings: [],
+  output_tokens: 5,
+  benchmarked_at: '2026-01-01T00:00:00.000Z',
+}
+
+function makeModelsResponse(overrides: Partial<ModelsResponse> = {}): ModelsResponse {
+  return {
+    registry: [REGISTRY_ENTRY],
+    installed: [],
+    ollama_models: [
+      { id: 'llama3:latest', name: 'llama3:latest', size_category: 'medium' },
+      { id: 'phi3:mini', name: 'phi3:mini', size_category: 'small' },
+    ],
+    active: { runtime_id: null, model_id: null },
+    runtime_health: {
+      runtime_id: 'none',
+      runtime_name: 'llama.cpp',
+      status: 'unavailable',
+      model_id: null,
+      latency_ms: null,
+      message: 'No model configured',
+      checked_at: '2026-01-01T00:00:00.000Z',
+    },
+    total: 1,
+    last_benchmark: null,
+    ...overrides,
+  }
+}
+
+function renderWizard() {
+  return render(
+    <MemoryRouter
+      initialEntries={['/first-run']}
+      future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+    >
+      <Routes>
+        <Route path="/first-run" element={<FirstRunWizard />} />
+        <Route path="/" element={<div data-testid="home-page" />} />
+        <Route path="/library" element={<div data-testid="library-page" />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  vi.clearAllMocks()
+  localStorage.clear()
+
+  mockApi.getModels.mockResolvedValue(makeModelsResponse())
+  mockApi.useModel.mockResolvedValue({
+    runtime_id: 'ollama',
+    model_id: 'llama3:latest',
+    runtime_name: 'Ollama',
+    status: 'ready',
+    message: null,
+  })
+  mockApi.installModel.mockResolvedValue({
+    install_id: 1,
+    registry_id: 'qwen3-4b-instruct-q4_k_m',
+    status: 'pending',
+    message: 'Install queued.',
+  })
+  mockApi.getInstallStatus.mockResolvedValue({
+    id: 1,
+    registry_id: 'qwen3-4b-instruct-q4_k_m',
+    filename: 'qwen3-4b-instruct-q4_k_m.gguf',
+    file_path: '',
+    size_bytes: null,
+    install_status: 'downloading',
+    progress_bytes: null,
+    error_message: null,
+    verified_sha256: null,
+    installed_at: '2026-01-01T00:00:00Z',
+  })
+  mockApi.cancelInstall.mockResolvedValue(undefined)
+  mockApi.registerGguf.mockResolvedValue({
+    profile_id: 1,
+    file_path: '/home/user/models/my-model.gguf',
+    display_name: 'my-model.gguf',
+    filename: 'my-model.gguf',
+    family_guess: null,
+    context_length_default: null,
+    warnings: [],
+    active_runtime_id: 'llama_cpp',
+    active_model_id: '/home/user/models/my-model.gguf',
+  })
+  mockApi.startSidecar.mockResolvedValue({
+    state: 'running',
+    pid: 1234,
+    log_path: '/tmp/sidecar.log',
+    host: '127.0.0.1',
+    port: 7356,
+  })
+  mockApi.benchmarkModel.mockResolvedValue(DEFAULT_BENCHMARK)
+})
+
+// ── Welcome step ─────────────────────────────────────────────────────────────
+
+describe('FirstRunWizard — welcome step', () => {
+  it('shows a welcome heading', () => {
+    renderWizard()
+    expect(screen.getByRole('heading', { name: /welcome to conversation simulator/i })).toBeInTheDocument()
+  })
+
+  it('shows the privacy and offline-play guarantee note', () => {
+    renderWizard()
+    expect(
+      screen.getByRole('note', { name: /privacy and offline-play guarantee/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('states conversations stay on this machine', () => {
+    renderWizard()
+    expect(screen.getByText(/your data stays on this machine/i)).toBeInTheDocument()
+  })
+
+  it('shows a Get started button', () => {
+    renderWizard()
+    expect(screen.getByRole('button', { name: /get started/i })).toBeInTheDocument()
+  })
+
+  it('does not call the API on the welcome step', () => {
+    renderWizard()
+    expect(mockApi.getModels).not.toHaveBeenCalled()
+  })
+
+  it('advances to loading then choose step when Get started is clicked', async () => {
+    renderWizard()
+    fireEvent.click(screen.getByRole('button', { name: /get started/i }))
+    expect(await screen.findByRole('heading', { name: /choose how to get started/i })).toBeInTheDocument()
+    expect(mockApi.getModels).toHaveBeenCalledOnce()
+  })
+
+  it('redirects to home when setup is already complete', () => {
+    localStorage.setItem(SETUP_KEYS.firstRunComplete, 'true')
+    renderWizard()
+    expect(screen.getByTestId('home-page')).toBeInTheDocument()
+  })
+})
+
+// ── Choose step ───────────────────────────────────────────────────────────────
+
+describe('FirstRunWizard — choose step', () => {
+  async function goToChoose() {
+    renderWizard()
+    fireEvent.click(screen.getByRole('button', { name: /get started/i }))
+    await screen.findByRole('heading', { name: /choose how to get started/i })
+  }
+
+  it('shows Install recommended model option', async () => {
+    await goToChoose()
+    expect(screen.getByRole('button', { name: /install qwen3/i })).toBeInTheDocument()
+  })
+
+  it('shows Browse Ollama models option', async () => {
+    await goToChoose()
+    expect(screen.getByRole('button', { name: /browse ollama models/i })).toBeInTheDocument()
+  })
+
+  it('shows Use a GGUF file option', async () => {
+    await goToChoose()
+    expect(screen.getByRole('button', { name: /use a gguf file/i })).toBeInTheDocument()
+  })
+
+  it('shows Continue without a model option', async () => {
+    await goToChoose()
+    expect(screen.getByRole('button', { name: /continue in text-only demo/i })).toBeInTheDocument()
+  })
+})
+
+// ── Confirm install step ──────────────────────────────────────────────────────
+
+describe('FirstRunWizard — confirm install step', () => {
+  async function goToConfirm() {
+    renderWizard()
+    fireEvent.click(screen.getByRole('button', { name: /get started/i }))
+    await screen.findByRole('button', { name: /install qwen3/i })
+    fireEvent.click(screen.getByRole('button', { name: /install qwen3/i }))
+    await screen.findByRole('heading', { name: /confirm model install/i })
+  }
+
+  it('shows the confirm heading', async () => {
+    await goToConfirm()
+    expect(screen.getByRole('heading', { name: /confirm model install/i })).toBeInTheDocument()
+  })
+
+  it('shows the model size', async () => {
+    await goToConfirm()
+    expect(screen.getByText(/2\.6 gb/i)).toBeInTheDocument()
+  })
+
+  it('shows the license', async () => {
+    await goToConfirm()
+    expect(screen.getByText(/apache-2\.0/i)).toBeInTheDocument()
+  })
+
+  it('shows the destination path', async () => {
+    await goToConfirm()
+    expect(
+      screen.getByText(/~\/.convsim\/models\/llm\/qwen3-4b-instruct-q4_k_m\.gguf/),
+    ).toBeInTheDocument()
+  })
+
+  it('shows the min VRAM requirement', async () => {
+    await goToConfirm()
+    expect(screen.getByText('4 GB')).toBeInTheDocument()
+  })
+
+  it('shows the offline-play explanation note', async () => {
+    await goToConfirm()
+    expect(
+      screen.getByRole('note', { name: /offline-play explanation/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('states the model plays offline after install', async () => {
+    await goToConfirm()
+    expect(screen.getByText(/plays offline after install/i)).toBeInTheDocument()
+  })
+
+  it('states no data is sent to any server', async () => {
+    await goToConfirm()
+    expect(screen.getByText(/no data is sent to any server/i)).toBeInTheDocument()
+  })
+
+  it('does not start the download until Confirm is clicked', async () => {
+    await goToConfirm()
+    expect(mockApi.installModel).not.toHaveBeenCalled()
+  })
+})
+
+// ── Successful install ────────────────────────────────────────────────────────
+
+describe('FirstRunWizard — successful install', () => {
+  async function goToInstalling() {
+    renderWizard()
+    fireEvent.click(screen.getByRole('button', { name: /get started/i }))
+    await screen.findByRole('button', { name: /install qwen3/i })
+    fireEvent.click(screen.getByRole('button', { name: /install qwen3/i }))
+    await screen.findByRole('button', { name: /confirm & install/i })
+    fireEvent.click(screen.getByRole('button', { name: /confirm & install/i }))
+    await screen.findByRole('heading', { name: /installing model/i })
+  }
+
+  it('shows the installing heading after confirmation', async () => {
+    await goToInstalling()
+    expect(screen.getByRole('heading', { name: /installing model/i })).toBeInTheDocument()
+  })
+
+  it('shows a download progress bar', async () => {
+    await goToInstalling()
+    expect(screen.getByRole('progressbar', { name: /download progress/i })).toBeInTheDocument()
+  })
+
+  it('shows percentage and GB when progress data is available', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      await goToInstalling()
+      mockApi.getInstallStatus.mockResolvedValue({
+        id: 1,
+        registry_id: 'qwen3-4b-instruct-q4_k_m',
+        filename: 'qwen3-4b-instruct-q4_k_m.gguf',
+        file_path: '',
+        size_bytes: 2_000_000_000,
+        install_status: 'downloading',
+        progress_bytes: 1_000_000_000,
+        error_message: null,
+        verified_sha256: null,
+        installed_at: '2026-01-01T00:00:00Z',
+      })
+      await vi.advanceTimersByTimeAsync(2000)
+
+      const bar = screen.getByRole('progressbar')
+      expect(bar.getAttribute('aria-valuenow')).toBe('50')
+      expect(screen.getByText(/50%/)).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('navigates home when install reaches ready status', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      await goToInstalling()
+      mockApi.getInstallStatus.mockResolvedValue({
+        id: 1,
+        registry_id: 'qwen3-4b-instruct-q4_k_m',
+        filename: 'qwen3-4b-instruct-q4_k_m.gguf',
+        file_path: '/home/user/.convsim/models/llm/qwen3-4b-instruct-q4_k_m.gguf',
+        size_bytes: 2_000_000_000,
+        install_status: 'ready',
+        progress_bytes: 2_000_000_000,
+        error_message: null,
+        verified_sha256: 'a'.repeat(64),
+        installed_at: '2026-01-01T00:00:00Z',
+      })
+      await vi.advanceTimersByTimeAsync(2000)
+
+      await waitFor(() => expect(screen.getByTestId('home-page')).toBeInTheDocument())
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('marks first-run complete in localStorage on successful install', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      await goToInstalling()
+      mockApi.getInstallStatus.mockResolvedValue({
+        id: 1,
+        registry_id: 'qwen3-4b-instruct-q4_k_m',
+        filename: 'qwen3-4b-instruct-q4_k_m.gguf',
+        file_path: '/home/user/.convsim/models/llm/qwen3-4b-instruct-q4_k_m.gguf',
+        size_bytes: 2_000_000_000,
+        install_status: 'ready',
+        progress_bytes: 2_000_000_000,
+        error_message: null,
+        verified_sha256: 'a'.repeat(64),
+        installed_at: '2026-01-01T00:00:00Z',
+      })
+      await vi.advanceTimersByTimeAsync(2000)
+      await waitFor(() => expect(screen.getByTestId('home-page')).toBeInTheDocument())
+
+      expect(localStorage.getItem(SETUP_KEYS.firstRunComplete)).toBe('true')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+// ── No network error ──────────────────────────────────────────────────────────
+
+describe('FirstRunWizard — no network error', () => {
+  async function goToInstalling() {
+    renderWizard()
+    fireEvent.click(screen.getByRole('button', { name: /get started/i }))
+    await screen.findByRole('button', { name: /install qwen3/i })
+    fireEvent.click(screen.getByRole('button', { name: /install qwen3/i }))
+    await screen.findByRole('button', { name: /confirm & install/i })
+    fireEvent.click(screen.getByRole('button', { name: /confirm & install/i }))
+    await screen.findByRole('heading', { name: /installing model/i })
+  }
+
+  it('shows a network error alert when download fails with a network error', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      await goToInstalling()
+      mockApi.getInstallStatus.mockResolvedValue({
+        id: 1,
+        registry_id: 'qwen3-4b-instruct-q4_k_m',
+        filename: 'qwen3-4b-instruct-q4_k_m.gguf',
+        file_path: '',
+        size_bytes: null,
+        install_status: 'failed',
+        progress_bytes: 0,
+        error_message: 'no network connection available',
+        verified_sha256: null,
+        installed_at: '2026-01-01T00:00:00Z',
+      })
+      await vi.advanceTimersByTimeAsync(2000)
+
+      await waitFor(() =>
+        expect(screen.getByRole('alert', { name: /network error/i })).toBeInTheDocument(),
+      )
+      expect(screen.getByText(/network connection lost/i)).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('stays on the installing step when a network error occurs', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      await goToInstalling()
+      mockApi.getInstallStatus.mockResolvedValue({
+        id: 1,
+        registry_id: 'qwen3-4b-instruct-q4_k_m',
+        filename: 'qwen3-4b-instruct-q4_k_m.gguf',
+        file_path: '',
+        size_bytes: null,
+        install_status: 'failed',
+        progress_bytes: 0,
+        error_message: 'network error: connection refused',
+        verified_sha256: null,
+        installed_at: '2026-01-01T00:00:00Z',
+      })
+      await vi.advanceTimersByTimeAsync(2000)
+
+      await waitFor(() =>
+        expect(screen.getByRole('alert', { name: /network error/i })).toBeInTheDocument(),
+      )
+      expect(screen.getByRole('heading', { name: /installing model/i })).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('shows a Retry download button after a network error', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      await goToInstalling()
+      mockApi.getInstallStatus.mockResolvedValue({
+        id: 1,
+        registry_id: 'qwen3-4b-instruct-q4_k_m',
+        filename: 'qwen3-4b-instruct-q4_k_m.gguf',
+        file_path: '',
+        size_bytes: null,
+        install_status: 'failed',
+        progress_bytes: 0,
+        error_message: 'no network connection',
+        verified_sha256: null,
+        installed_at: '2026-01-01T00:00:00Z',
+      })
+      await vi.advanceTimersByTimeAsync(2000)
+
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /retry download/i })).toBeInTheDocument(),
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('shows a Choose a different option button after a network error', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      await goToInstalling()
+      mockApi.getInstallStatus.mockResolvedValue({
+        id: 1,
+        registry_id: 'qwen3-4b-instruct-q4_k_m',
+        filename: 'qwen3-4b-instruct-q4_k_m.gguf',
+        file_path: '',
+        size_bytes: null,
+        install_status: 'failed',
+        progress_bytes: 0,
+        error_message: 'no network connection',
+        verified_sha256: null,
+        installed_at: '2026-01-01T00:00:00Z',
+      })
+      await vi.advanceTimersByTimeAsync(2000)
+
+      await waitFor(() =>
+        expect(
+          screen.getByRole('button', { name: /choose a different option/i }),
+        ).toBeInTheDocument(),
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('returns to the confirm step when Retry download is clicked', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      await goToInstalling()
+      mockApi.getInstallStatus.mockResolvedValue({
+        id: 1,
+        registry_id: 'qwen3-4b-instruct-q4_k_m',
+        filename: 'qwen3-4b-instruct-q4_k_m.gguf',
+        file_path: '',
+        size_bytes: null,
+        install_status: 'failed',
+        progress_bytes: 0,
+        error_message: 'no network connection',
+        verified_sha256: null,
+        installed_at: '2026-01-01T00:00:00Z',
+      })
+      await vi.advanceTimersByTimeAsync(2000)
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /retry download/i })).toBeInTheDocument(),
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: /retry download/i }))
+      await screen.findByRole('heading', { name: /confirm model install/i })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('returns to the choose step when Choose a different option is clicked', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      await goToInstalling()
+      mockApi.getInstallStatus.mockResolvedValue({
+        id: 1,
+        registry_id: 'qwen3-4b-instruct-q4_k_m',
+        filename: 'qwen3-4b-instruct-q4_k_m.gguf',
+        file_path: '',
+        size_bytes: null,
+        install_status: 'failed',
+        progress_bytes: 0,
+        error_message: 'no network connection',
+        verified_sha256: null,
+        installed_at: '2026-01-01T00:00:00Z',
+      })
+      await vi.advanceTimersByTimeAsync(2000)
+      await waitFor(() =>
+        expect(
+          screen.getByRole('button', { name: /choose a different option/i }),
+        ).toBeInTheDocument(),
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: /choose a different option/i }))
+      await screen.findByRole('heading', { name: /choose how to get started/i })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+// ── Insufficient disk error ───────────────────────────────────────────────────
+
+describe('FirstRunWizard — insufficient disk error', () => {
+  async function triggerDiskError() {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    renderWizard()
+    fireEvent.click(screen.getByRole('button', { name: /get started/i }))
+    await screen.findByRole('button', { name: /install qwen3/i })
+    fireEvent.click(screen.getByRole('button', { name: /install qwen3/i }))
+    await screen.findByRole('button', { name: /confirm & install/i })
+    fireEvent.click(screen.getByRole('button', { name: /confirm & install/i }))
+    await screen.findByRole('heading', { name: /installing model/i })
+
+    mockApi.getInstallStatus.mockResolvedValue({
+      id: 1,
+      registry_id: 'qwen3-4b-instruct-q4_k_m',
+      filename: 'qwen3-4b-instruct-q4_k_m.gguf',
+      file_path: '',
+      size_bytes: 2_000_000_000,
+      install_status: 'failed',
+      progress_bytes: 0,
+      error_message: 'insufficient disk space',
+      verified_sha256: null,
+      installed_at: '2026-01-01T00:00:00Z',
+    })
+    await vi.advanceTimersByTimeAsync(2000)
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert', { name: /insufficient disk space/i })).toBeInTheDocument(),
+    )
+  }
+
+  it('shows a disk space alert when download fails with an insufficient disk error', async () => {
+    try {
+      await triggerDiskError()
+      expect(screen.getByText(/not enough disk space/i)).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('mentions the approximate disk space required', async () => {
+    try {
+      await triggerDiskError()
+      expect(screen.getByText(/2\.6 gb/i)).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('stays on the installing step when a disk error occurs', async () => {
+    try {
+      await triggerDiskError()
+      expect(screen.getByRole('heading', { name: /installing model/i })).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('shows a Try again button after a disk error', async () => {
+    try {
+      await triggerDiskError()
+      expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('returns to the confirm step when Try again is clicked', async () => {
+    try {
+      await triggerDiskError()
+      fireEvent.click(screen.getByRole('button', { name: /try again/i }))
+      await screen.findByRole('heading', { name: /confirm model install/i })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('returns to the choose step when Choose a different option is clicked', async () => {
+    try {
+      await triggerDiskError()
+      fireEvent.click(screen.getByRole('button', { name: /choose a different option/i }))
+      await screen.findByRole('heading', { name: /choose how to get started/i })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+// ── Cancelled download ────────────────────────────────────────────────────────
+
+describe('FirstRunWizard — cancelled download', () => {
+  async function goToInstalling() {
+    renderWizard()
+    fireEvent.click(screen.getByRole('button', { name: /get started/i }))
+    await screen.findByRole('button', { name: /install qwen3/i })
+    fireEvent.click(screen.getByRole('button', { name: /install qwen3/i }))
+    await screen.findByRole('button', { name: /confirm & install/i })
+    fireEvent.click(screen.getByRole('button', { name: /confirm & install/i }))
+    await screen.findByRole('heading', { name: /installing model/i })
+  }
+
+  it('shows a Cancel and go home button while downloading', async () => {
+    await goToInstalling()
+    expect(screen.getByRole('button', { name: /cancel and go home/i })).toBeInTheDocument()
+  })
+
+  it('calls cancelInstall when Cancel and go home is clicked', async () => {
+    await goToInstalling()
+    fireEvent.click(screen.getByRole('button', { name: /cancel and go home/i }))
+    await waitFor(() => expect(mockApi.cancelInstall).toHaveBeenCalledWith(1))
+  })
+
+  it('navigates home after cancelling the download', async () => {
+    await goToInstalling()
+    fireEvent.click(screen.getByRole('button', { name: /cancel and go home/i }))
+    await waitFor(() => expect(screen.getByTestId('home-page')).toBeInTheDocument())
+  })
+
+  it('marks first-run complete in localStorage after cancelling', async () => {
+    await goToInstalling()
+    fireEvent.click(screen.getByRole('button', { name: /cancel and go home/i }))
+    await waitFor(() => expect(screen.getByTestId('home-page')).toBeInTheDocument())
+    expect(localStorage.getItem(SETUP_KEYS.firstRunComplete)).toBe('true')
+  })
+
+  it('navigates home even when cancelInstall API call fails', async () => {
+    mockApi.cancelInstall.mockRejectedValue(new Error('server error'))
+    await goToInstalling()
+    fireEvent.click(screen.getByRole('button', { name: /cancel and go home/i }))
+    await waitFor(() => expect(screen.getByTestId('home-page')).toBeInTheDocument())
+  })
+
+  it('keeps polling through transient status errors', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      await goToInstalling()
+      mockApi.getInstallStatus.mockRejectedValueOnce(new Error('network blip'))
+
+      await vi.advanceTimersByTimeAsync(2000)
+      expect(screen.getByRole('heading', { name: /installing model/i })).toBeInTheDocument()
+
+      await vi.advanceTimersByTimeAsync(2000)
+      expect(mockApi.getInstallStatus.mock.calls.length).toBeGreaterThanOrEqual(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+// ── Existing Ollama path ──────────────────────────────────────────────────────
+
+describe('FirstRunWizard — existing Ollama path', () => {
+  async function goToOllama() {
+    renderWizard()
+    fireEvent.click(screen.getByRole('button', { name: /get started/i }))
+    await screen.findByRole('button', { name: /browse ollama models/i })
+    fireEvent.click(screen.getByRole('button', { name: /browse ollama models/i }))
+    await screen.findByRole('heading', { name: /use ollama model/i })
+  }
+
+  it('shows the Ollama model list', async () => {
+    await goToOllama()
+    expect(screen.getByText('llama3:latest')).toBeInTheDocument()
+    expect(screen.getByText('phi3:mini')).toBeInTheDocument()
+  })
+
+  it('shows a Use this model button for each Ollama model', async () => {
+    await goToOllama()
+    expect(screen.getAllByRole('button', { name: /use this model/i })).toHaveLength(2)
+  })
+
+  it('calls useModel with the ollama runtime when a model is selected', async () => {
+    await goToOllama()
+    const [first] = screen.getAllByRole('button', { name: /use this model/i })
+    fireEvent.click(first)
+    await waitFor(() =>
+      expect(mockApi.useModel).toHaveBeenCalledWith({
+        runtime_id: 'ollama',
+        model_id: 'llama3:latest',
+      }),
+    )
+  })
+
+  it('advances to the benchmark step after selecting an Ollama model', async () => {
+    await goToOllama()
+    const [first] = screen.getAllByRole('button', { name: /use this model/i })
+    fireEvent.click(first)
+    await screen.findByRole('heading', { name: /model benchmark/i })
+    expect(screen.getByRole('heading', { name: /model benchmark/i })).toBeInTheDocument()
+  })
+
+  it('shows tokens per second after benchmark completes', async () => {
+    await goToOllama()
+    const [first] = screen.getAllByRole('button', { name: /use this model/i })
+    fireEvent.click(first)
+    await screen.findByRole('heading', { name: /model benchmark/i })
+    await waitFor(() => expect(screen.getByText(/14\.2 tokens\/sec/i)).toBeInTheDocument())
+  })
+
+  it('shows a Continue to Home button after benchmark', async () => {
+    await goToOllama()
+    const [first] = screen.getAllByRole('button', { name: /use this model/i })
+    fireEvent.click(first)
+    const btn = await screen.findByRole('button', { name: /continue to home/i })
+    expect(btn).toBeInTheDocument()
+  })
+
+  it('navigates home and marks setup complete when Continue is clicked', async () => {
+    await goToOllama()
+    const [first] = screen.getAllByRole('button', { name: /use this model/i })
+    fireEvent.click(first)
+    const btn = await screen.findByRole('button', { name: /continue to home/i })
+    fireEvent.click(btn)
+    await waitFor(() => expect(screen.getByTestId('home-page')).toBeInTheDocument())
+    expect(localStorage.getItem(SETUP_KEYS.firstRunComplete)).toBe('true')
+  })
+
+  it('shows an error alert when useModel fails', async () => {
+    mockApi.useModel.mockRejectedValue(new Error('Ollama not running'))
+    await goToOllama()
+    const [first] = screen.getAllByRole('button', { name: /use this model/i })
+    fireEvent.click(first)
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/ollama not running/i),
+    )
+  })
+
+  it('shows "No Ollama models detected" when the list is empty', async () => {
+    mockApi.getModels.mockResolvedValue(makeModelsResponse({ ollama_models: [] }))
+    renderWizard()
+    fireEvent.click(screen.getByRole('button', { name: /get started/i }))
+    await screen.findByRole('button', { name: /browse ollama models/i })
+    fireEvent.click(screen.getByRole('button', { name: /browse ollama models/i }))
+    await screen.findByText(/no ollama models detected/i)
+    expect(screen.getByText(/no ollama models detected/i)).toBeInTheDocument()
+  })
+
+  it('back button returns to the choose step', async () => {
+    await goToOllama()
+    fireEvent.click(screen.getByRole('button', { name: /back/i }))
+    await screen.findByRole('heading', { name: /choose how to get started/i })
+  })
+})
+
+// ── Demo / text-only path ─────────────────────────────────────────────────────
+
+describe('FirstRunWizard — text-only demo path', () => {
+  async function goToDemo() {
+    renderWizard()
+    fireEvent.click(screen.getByRole('button', { name: /get started/i }))
+    await screen.findByRole('button', { name: /continue in text-only demo/i })
+    fireEvent.click(screen.getByRole('button', { name: /continue in text-only demo/i }))
+    await screen.findByRole('heading', { name: /text-only demo/i })
+  }
+
+  it('shows a disclaimer that this is not production quality', async () => {
+    await goToDemo()
+    expect(screen.getByText(/this is a demo, not production quality/i)).toBeInTheDocument()
+  })
+
+  it('mentions scripted responses in the disclaimer', async () => {
+    await goToDemo()
+    expect(screen.getByText(/scripted responses/i)).toBeInTheDocument()
+  })
+
+  it('calls useModel with the fake runtime when confirmed', async () => {
+    mockApi.useModel.mockResolvedValue({
+      runtime_id: 'fake',
+      model_id: null,
+      runtime_name: 'Fake (deterministic)',
+      status: 'ready',
+      message: null,
+    })
+    await goToDemo()
+    fireEvent.click(screen.getByRole('button', { name: /i understand/i }))
+    await waitFor(() =>
+      expect(mockApi.useModel).toHaveBeenCalledWith({ runtime_id: 'fake', model_id: null }),
+    )
+  })
+
+  it('navigates to the library and marks setup complete after confirming demo', async () => {
+    await goToDemo()
+    fireEvent.click(screen.getByRole('button', { name: /i understand/i }))
+    await waitFor(() => expect(screen.getByTestId('library-page')).toBeInTheDocument())
+    expect(localStorage.getItem(SETUP_KEYS.firstRunComplete)).toBe('true')
+  })
+
+  it('still navigates to library even when useModel fails in demo mode', async () => {
+    mockApi.useModel.mockRejectedValue(new Error('runtime unavailable'))
+    await goToDemo()
+    fireEvent.click(screen.getByRole('button', { name: /i understand/i }))
+    await waitFor(() => expect(screen.getByTestId('library-page')).toBeInTheDocument())
+  })
+})
+
+// ── Load error state ──────────────────────────────────────────────────────────
+
+describe('FirstRunWizard — load error state', () => {
+  it('shows an error alert when getModels fails', async () => {
+    mockApi.getModels.mockRejectedValue(new Error('service unavailable'))
+    renderWizard()
+    fireEvent.click(screen.getByRole('button', { name: /get started/i }))
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/service unavailable/i),
+    )
+  })
+
+  it('mentions the text-only demo as a fallback when the runtime is unavailable', async () => {
+    mockApi.getModels.mockRejectedValue(new Error('runtime unreachable'))
+    renderWizard()
+    fireEvent.click(screen.getByRole('button', { name: /get started/i }))
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toBeInTheDocument(),
+    )
+    expect(screen.getByText(/text-only demo works without one/i)).toBeInTheDocument()
+  })
+
+  it('back button from load error returns to the welcome step', async () => {
+    mockApi.getModels.mockRejectedValue(new Error('network error'))
+    renderWizard()
+    fireEvent.click(screen.getByRole('button', { name: /get started/i }))
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: /back to welcome/i }))
+    await screen.findByRole('heading', { name: /welcome to conversation simulator/i })
+  })
+})

--- a/apps/web/src/privacyPrefs.ts
+++ b/apps/web/src/privacyPrefs.ts
@@ -7,6 +7,10 @@ export const PRIVACY_KEYS = {
   devMode: 'convsim.devMode',
 } as const
 
+export const SETUP_KEYS = {
+  firstRunComplete: 'convsim.setup.complete',
+} as const
+
 export function readPrivacyPref(key: string, defaultValue: boolean): boolean {
   if (typeof localStorage === 'undefined') return defaultValue
   const v = localStorage.getItem(key)

--- a/apps/web/src/screens/FirstRunWizard.tsx
+++ b/apps/web/src/screens/FirstRunWizard.tsx
@@ -11,11 +11,12 @@ import type {
   BenchmarkResponse,
 } from '@convsim/shared'
 
-export { SETUP_KEYS }
-
 const SETUP_DOCS_URL = 'https://github.com/outrightmental/ConversationSimulator/wiki'
 
-export function markFirstRunComplete(): void {
+// Marks the one-time setup wizard complete so the FirstRunGuard stops redirecting here.
+// Used only within this module; kept unexported so the file exports only its component
+// (satisfies react-refresh/only-export-components).
+function markFirstRunComplete(): void {
   try {
     localStorage.setItem(SETUP_KEYS.firstRunComplete, 'true')
   } catch {

--- a/apps/web/src/screens/FirstRunWizard.tsx
+++ b/apps/web/src/screens/FirstRunWizard.tsx
@@ -1,0 +1,1198 @@
+// SPDX-License-Identifier: Apache-2.0
+import { useState, useEffect, useRef } from 'react'
+import { useNavigate, Navigate } from 'react-router-dom'
+import { api } from '../api/client'
+import { SETUP_KEYS } from '../privacyPrefs'
+import type {
+  ModelsResponse,
+  ModelRegistryEntry,
+  DetectedOllamaModel,
+  InstalledModelInfo,
+  BenchmarkResponse,
+} from '@convsim/shared'
+
+export { SETUP_KEYS }
+
+const SETUP_DOCS_URL = 'https://github.com/outrightmental/ConversationSimulator/wiki'
+
+export function markFirstRunComplete(): void {
+  try {
+    localStorage.setItem(SETUP_KEYS.firstRunComplete, 'true')
+  } catch {
+    // localStorage may be unavailable in some environments; proceed anyway.
+  }
+}
+
+type WizardStep =
+  | 'welcome'
+  | 'loading'
+  | 'choose'
+  | 'confirm-install'
+  | 'installing'
+  | 'benchmark'
+  | 'ollama-select'
+  | 'gguf-path'
+  | 'demo-warning'
+  | 'load-error'
+
+// ── Shared styled primitives ─────────────────────────────────────────────────
+
+function SectionCard({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      style={{ border: '1px solid rgba(255,255,255,0.1)', borderRadius: '8px', padding: '1rem' }}
+    >
+      {children}
+    </div>
+  )
+}
+
+function CardHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <h2 style={{ fontSize: '1rem', fontWeight: 600, marginTop: 0, marginBottom: '0.4rem' }}>
+      {children}
+    </h2>
+  )
+}
+
+function CardDescription({ children }: { children: React.ReactNode }) {
+  return (
+    <p style={{ fontSize: '0.875rem', color: '#a1a1aa', margin: '0 0 0.75rem' }}>
+      {children}
+    </p>
+  )
+}
+
+function ActionButton({
+  onClick,
+  disabled,
+  children,
+}: {
+  onClick: () => void
+  disabled?: boolean
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      style={{
+        padding: '0.45rem 1rem',
+        borderRadius: '4px',
+        border: '1px solid rgba(255,255,255,0.2)',
+        background: 'rgba(255,255,255,0.06)',
+        color: 'inherit',
+        cursor: disabled ? 'wait' : 'pointer',
+        fontSize: '0.875rem',
+        fontWeight: 500,
+      }}
+    >
+      {children}
+    </button>
+  )
+}
+
+function PrimaryButton({
+  onClick,
+  disabled,
+  children,
+}: {
+  onClick: () => void
+  disabled?: boolean
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      style={{
+        padding: '0.45rem 1rem',
+        borderRadius: '4px',
+        border: 'none',
+        background: disabled ? 'rgba(99,102,241,0.4)' : 'rgba(99,102,241,0.85)',
+        color: '#fff',
+        cursor: disabled ? 'wait' : 'pointer',
+        fontSize: '0.875rem',
+        fontWeight: 500,
+      }}
+    >
+      {children}
+    </button>
+  )
+}
+
+function DetailRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <tr>
+      <td
+        style={{
+          color: '#a1a1aa',
+          paddingTop: '0.4rem',
+          paddingBottom: '0.4rem',
+          paddingRight: '1.5rem',
+          whiteSpace: 'nowrap',
+          verticalAlign: 'top',
+        }}
+      >
+        {label}
+      </td>
+      <td style={{ paddingTop: '0.4rem', paddingBottom: '0.4rem' }}>{children}</td>
+    </tr>
+  )
+}
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+export default function FirstRunWizard() {
+  const navigate = useNavigate()
+  const [step, setStep] = useState<WizardStep>('welcome')
+  const [modelsData, setModelsData] = useState<ModelsResponse | null>(null)
+  const [loadError, setLoadError] = useState<string | null>(null)
+
+  const [selectedModel, setSelectedModel] = useState<ModelRegistryEntry | null>(null)
+  const [ggufPath, setGgufPath] = useState('')
+  const [ggufPathError, setGgufPathError] = useState<string | null>(null)
+
+  const [actionError, setActionError] = useState<string | null>(null)
+  const [actionLoading, setActionLoading] = useState(false)
+
+  const [installId, setInstallId] = useState<number | null>(null)
+  const [installRecord, setInstallRecord] = useState<InstalledModelInfo | null>(null)
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  const [benchmarkRunning, setBenchmarkRunning] = useState(false)
+  const [benchmarkResult, setBenchmarkResult] = useState<BenchmarkResponse | null>(null)
+  const [benchmarkError, setBenchmarkError] = useState<string | null>(null)
+  const benchmarkStartedRef = useRef(false)
+  // Capture the "already done" state once at mount so that calling markFirstRunComplete()
+  // mid-wizard (before the navigate() fires) doesn't cause a spurious redirect to "/".
+  const alreadyCompleteRef = useRef(localStorage.getItem(SETUP_KEYS.firstRunComplete) === 'true')
+
+  // Fetch model data when the user advances past the welcome step.
+  useEffect(() => {
+    if (step !== 'loading') return
+    api
+      .getModels()
+      .then((data) => {
+        setModelsData(data)
+        setStep('choose')
+      })
+      .catch((err: unknown) => {
+        setLoadError(err instanceof Error ? err.message : 'Failed to load model information.')
+        setStep('load-error')
+      })
+  }, [step])
+
+  // Poll install progress while on the 'installing' step.
+  useEffect(() => {
+    if (step !== 'installing' || installId == null) return
+
+    function stopPoll() {
+      if (pollRef.current != null) {
+        clearInterval(pollRef.current)
+        pollRef.current = null
+      }
+    }
+
+    pollRef.current = setInterval(() => {
+      api
+        .getInstallStatus(installId)
+        .then((record) => {
+          setInstallRecord(record)
+          const terminal = ['ready', 'complete', 'failed', 'cancelled', 'checksum_mismatch']
+          if (terminal.includes(record.install_status)) {
+            stopPoll()
+            if (record.install_status === 'ready' || record.install_status === 'complete') {
+              markFirstRunComplete()
+              navigate('/')
+            } else {
+              // Stay on the installing step and surface the error with recovery options.
+              setActionError(record.error_message ?? 'Download failed. Please try again.')
+            }
+          }
+        })
+        .catch(() => {
+          // Ignore transient polling errors; keep polling.
+        })
+    }, 2000)
+
+    return stopPoll
+  }, [step, installId, navigate])
+
+  // Auto-run the benchmark once when entering the 'benchmark' step.
+  useEffect(() => {
+    if (step !== 'benchmark' || benchmarkStartedRef.current) return
+    benchmarkStartedRef.current = true
+    setBenchmarkRunning(true)
+    setBenchmarkResult(null)
+    setBenchmarkError(null)
+    api
+      .benchmarkModel({})
+      .then((result) => {
+        setBenchmarkResult(result)
+      })
+      .catch((err: unknown) => {
+        setBenchmarkError(err instanceof Error ? err.message : 'Benchmark failed.')
+      })
+      .finally(() => {
+        setBenchmarkRunning(false)
+      })
+  }, [step])
+
+  const recommendedModel = modelsData?.registry.find((m) => m.role === 'starter') ?? null
+
+  function resetAction() {
+    setActionError(null)
+    setActionLoading(false)
+  }
+
+  // If setup was already completed when this component mounted, skip the wizard entirely.
+  if (alreadyCompleteRef.current) {
+    return <Navigate to="/" replace />
+  }
+
+  // ── Welcome ──────────────────────────────────────────────────────────────────
+
+  if (step === 'welcome') {
+    return (
+      <div style={{ maxWidth: '640px', margin: '2rem auto', padding: '0 1rem' }}>
+        <h1>Welcome to Conversation Simulator</h1>
+        <p style={{ fontSize: '1rem', lineHeight: 1.6, color: '#d4d4d8' }}>
+          Conversation Simulator is a flight simulator for real-life conversations — a private,
+          local-first tool for practising difficult discussions at your own pace.
+        </p>
+
+        <div
+          role="note"
+          aria-label="privacy and offline-play guarantee"
+          style={{
+            background: 'rgba(99,102,241,0.08)',
+            border: '1px solid rgba(99,102,241,0.3)',
+            borderRadius: '8px',
+            padding: '1rem 1.25rem',
+            marginTop: '1.25rem',
+          }}
+        >
+          <p style={{ margin: 0, fontWeight: 600, color: '#a5b4fc' }}>
+            Your data stays on this machine
+          </p>
+          <p style={{ margin: '0.5rem 0 0', fontSize: '0.875rem', color: '#c7d2fe' }}>
+            Conversations, transcripts, audio recordings, and AI responses are processed locally
+            and never leave your computer unless you choose to export or share them. You can play
+            without an internet connection once the model is installed.
+          </p>
+        </div>
+
+        <p style={{ marginTop: '1.5rem', color: '#a1a1aa', fontSize: '0.9rem' }}>
+          This one-time setup wizard will help you choose a local AI model and get ready to play.
+          It takes about a minute plus download time.
+        </p>
+
+        <div style={{ marginTop: '1.5rem' }}>
+          <PrimaryButton onClick={() => setStep('loading')}>Get started</PrimaryButton>
+        </div>
+      </div>
+    )
+  }
+
+  // ── Loading ───────────────────────────────────────────────────────────────────
+
+  if (step === 'loading') {
+    return (
+      <div style={{ maxWidth: '640px', margin: '2rem auto', padding: '0 1rem' }}>
+        <h1>Model Setup</h1>
+        <p>Loading model information…</p>
+      </div>
+    )
+  }
+
+  // ── Load error ────────────────────────────────────────────────────────────────
+
+  if (step === 'load-error') {
+    return (
+      <div style={{ maxWidth: '640px', margin: '2rem auto', padding: '0 1rem' }}>
+        <h1>Model Setup</h1>
+        <p role="alert" style={{ color: '#f87171' }}>
+          {loadError ?? 'Something went wrong loading model information. Please try again.'}
+        </p>
+        <p style={{ fontSize: '0.875rem', color: '#a1a1aa' }}>
+          The local runtime may be unavailable. Check that it is running, then reload this page.
+          If your hardware cannot run a full model, the text-only demo works without one — or see
+          the{' '}
+          <a href={SETUP_DOCS_URL} target="_blank" rel="noreferrer">
+            setup docs
+          </a>{' '}
+          for smaller-model and troubleshooting guidance.
+        </p>
+        <ActionButton onClick={() => setStep('welcome')}>Back to welcome</ActionButton>
+      </div>
+    )
+  }
+
+  // ── Choose ────────────────────────────────────────────────────────────────────
+
+  if (step === 'choose') {
+    return (
+      <div style={{ maxWidth: '640px', margin: '2rem auto', padding: '0 1rem' }}>
+        <h1>Choose how to get started</h1>
+        <p style={{ color: '#a1a1aa', fontSize: '0.9rem' }}>
+          Pick an option below. You can change it later in Settings.
+        </p>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem', marginTop: '1.5rem' }}>
+          {recommendedModel && (
+            <SectionCard>
+              <CardHeading>Install recommended model</CardHeading>
+              <CardDescription>
+                {recommendedModel.name} · {recommendedModel.size_gb} GB ·{' '}
+                {recommendedModel.license_spdx} · Requires {recommendedModel.min_vram_gb} GB VRAM
+              </CardDescription>
+              <ActionButton
+                onClick={() => {
+                  setSelectedModel(recommendedModel)
+                  resetAction()
+                  setStep('confirm-install')
+                }}
+              >
+                Install {recommendedModel.name}
+              </ActionButton>
+            </SectionCard>
+          )}
+
+          <SectionCard>
+            <CardHeading>Use existing Ollama model</CardHeading>
+            <CardDescription>
+              Select from models already installed in your local Ollama instance.
+            </CardDescription>
+            <ActionButton
+              onClick={() => {
+                resetAction()
+                setStep('ollama-select')
+              }}
+            >
+              Browse Ollama models
+            </ActionButton>
+          </SectionCard>
+
+          <SectionCard>
+            <CardHeading>Use a local GGUF file</CardHeading>
+            <CardDescription>
+              Point to a GGUF model file already on your machine. Compatible with llama.cpp.
+            </CardDescription>
+            <ActionButton
+              onClick={() => {
+                setGgufPath('')
+                setGgufPathError(null)
+                resetAction()
+                setStep('gguf-path')
+              }}
+            >
+              Use a GGUF file
+            </ActionButton>
+          </SectionCard>
+
+          <SectionCard>
+            <CardHeading>Continue without a model</CardHeading>
+            <CardDescription>
+              Try the interface without a model. NPC responses are scripted — not real AI quality.
+            </CardDescription>
+            <ActionButton
+              onClick={() => {
+                resetAction()
+                setStep('demo-warning')
+              }}
+            >
+              Continue in text-only demo
+            </ActionButton>
+          </SectionCard>
+        </div>
+      </div>
+    )
+  }
+
+  // ── Confirm install ───────────────────────────────────────────────────────────
+
+  if (step === 'confirm-install' && selectedModel) {
+    const sha256Display = selectedModel.sha256 ?? 'Not available'
+    const sha256IsPending = sha256Display.toUpperCase() === 'PENDING'
+    const needsMoreVram = selectedModel.min_vram_gb != null && selectedModel.min_vram_gb > 4
+
+    return (
+      <div style={{ maxWidth: '640px', margin: '2rem auto', padding: '0 1rem' }}>
+        <h1>Confirm model install</h1>
+        <p style={{ color: '#a1a1aa', fontSize: '0.9rem' }}>
+          Review the details below before starting the download. No download begins until you click{' '}
+          <strong>Confirm &amp; install</strong>.
+        </p>
+
+        <table style={{ marginTop: '1rem', borderCollapse: 'collapse', width: '100%' }}>
+          <tbody>
+            <DetailRow label="Model">{selectedModel.name}</DetailRow>
+            <DetailRow label="Size">
+              {selectedModel.size_gb != null ? `${selectedModel.size_gb} GB` : 'Unknown'}
+            </DetailRow>
+            <DetailRow label="License">
+              {selectedModel.license_url ? (
+                <a href={selectedModel.license_url} target="_blank" rel="noreferrer">
+                  {selectedModel.license_spdx ?? 'View license'}
+                </a>
+              ) : (
+                selectedModel.license_spdx ?? 'Unknown'
+              )}
+            </DetailRow>
+            <DetailRow label="Min VRAM">
+              {selectedModel.min_vram_gb != null ? `${selectedModel.min_vram_gb} GB` : 'Unknown'}
+            </DetailRow>
+            <DetailRow label="Recommended VRAM">
+              {selectedModel.recommended_vram_gb != null
+                ? `${selectedModel.recommended_vram_gb} GB`
+                : 'Unknown'}
+            </DetailRow>
+            <DetailRow label="SHA-256 checksum">
+              <span
+                style={{
+                  fontFamily: 'monospace',
+                  fontSize: '0.8rem',
+                  wordBreak: 'break-all',
+                  color: sha256IsPending ? '#fbbf24' : 'inherit',
+                }}
+              >
+                {sha256Display}
+              </span>
+              {sha256IsPending && (
+                <span
+                  style={{
+                    display: 'block',
+                    fontSize: '0.8rem',
+                    color: '#fbbf24',
+                    marginTop: '0.2rem',
+                  }}
+                >
+                  Checksum not yet confirmed — install may be rejected by the runtime.
+                </span>
+              )}
+            </DetailRow>
+            <DetailRow label="Saved to">
+              <code style={{ fontSize: '0.8rem' }}>
+                ~/.convsim/models/llm/{selectedModel.id}.gguf
+              </code>
+            </DetailRow>
+          </tbody>
+        </table>
+
+        <div
+          role="note"
+          aria-label="offline-play explanation"
+          style={{
+            background: 'rgba(99,102,241,0.08)',
+            border: '1px solid rgba(99,102,241,0.3)',
+            borderRadius: '6px',
+            padding: '0.85rem 1rem',
+            marginTop: '1rem',
+          }}
+        >
+          <p style={{ margin: 0, fontWeight: 600, color: '#a5b4fc', fontSize: '0.875rem' }}>
+            Plays offline after install
+          </p>
+          <p style={{ margin: '0.4rem 0 0', fontSize: '0.825rem', color: '#c7d2fe' }}>
+            Once downloaded, this model runs entirely on your machine. You can disconnect from the
+            internet and the game will work exactly the same. No data is sent to any server.
+          </p>
+        </div>
+
+        {actionError && (
+          <div role="alert" style={{ marginTop: '1rem' }}>
+            <p style={{ color: '#f87171', margin: 0 }}>{actionError}</p>
+            <p style={{ fontSize: '0.875rem', color: '#a1a1aa', marginTop: '0.4rem' }}>
+              {needsMoreVram
+                ? `This model requires ${selectedModel.min_vram_gb} GB VRAM. If your hardware is limited, try a smaller model or `
+                : 'If your hardware or runtime cannot install this model, try a smaller model or '}
+              check the{' '}
+              <a href={SETUP_DOCS_URL} target="_blank" rel="noreferrer">
+                setup docs
+              </a>
+              .
+            </p>
+          </div>
+        )}
+
+        <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1.5rem' }}>
+          <PrimaryButton
+            disabled={actionLoading}
+            onClick={async () => {
+              setActionLoading(true)
+              setActionError(null)
+              try {
+                const resp = await api.installModel({ registry_id: selectedModel.id })
+                setInstallId(resp.install_id)
+                setInstallRecord(null)
+                setStep('installing')
+              } catch (err: unknown) {
+                setActionError(
+                  err instanceof Error ? err.message : 'Install failed. Please try again.',
+                )
+              } finally {
+                setActionLoading(false)
+              }
+            }}
+          >
+            {actionLoading ? 'Starting…' : 'Confirm & install'}
+          </PrimaryButton>
+          <ActionButton
+            onClick={() => {
+              setSelectedModel(null)
+              resetAction()
+              setStep('choose')
+            }}
+          >
+            Cancel
+          </ActionButton>
+        </div>
+      </div>
+    )
+  }
+
+  // ── Installing ────────────────────────────────────────────────────────────────
+
+  if (step === 'installing') {
+    const status = installRecord?.install_status ?? 'pending'
+    const progressBytes = installRecord?.progress_bytes ?? 0
+    const totalBytes = installRecord?.size_bytes ?? null
+    const pct =
+      totalBytes != null && totalBytes > 0
+        ? Math.min(100, Math.round((progressBytes / totalBytes) * 100))
+        : null
+
+    const statusLabel: Record<string, string> = {
+      pending: 'Queued…',
+      downloading: 'Downloading…',
+    }
+
+    // When the download has failed, show specific recovery paths inline.
+    if (actionError != null) {
+      const isNetworkError =
+        /no[\s_-]?network|network[\s_-]?unavailable|network[\s_-]?error|connection[\s_-]?refused|failed[\s_-]?to[\s_-]?connect|offline|timed[\s_-]?out/i.test(
+          actionError,
+        )
+      const isDiskError =
+        /insufficient[\s_-]?disk|not[\s_-]?enough[\s_-]?disk|disk[\s_-]?space|no[\s_-]?space[\s_-]?left|storage[\s_-]?full/i.test(
+          actionError,
+        )
+
+      return (
+        <div style={{ maxWidth: '640px', margin: '2rem auto', padding: '0 1rem' }}>
+          <h1>Installing model</h1>
+
+          {isNetworkError && (
+            <div
+              role="alert"
+              aria-label="network error"
+              style={{
+                marginTop: '1rem',
+                padding: '0.85rem 1rem',
+                background: 'rgba(239,68,68,0.08)',
+                border: '1px solid rgba(239,68,68,0.3)',
+                borderRadius: '6px',
+              }}
+            >
+              <p
+                style={{
+                  margin: '0 0 0.4rem',
+                  color: '#f87171',
+                  fontWeight: 600,
+                  fontSize: '0.875rem',
+                }}
+              >
+                Network connection lost
+              </p>
+              <p style={{ margin: '0 0 0.75rem', fontSize: '0.825rem', color: '#a1a1aa' }}>
+                The download could not complete. Check your internet connection and try again, or
+                choose a different option that does not require a download.
+              </p>
+              <div style={{ display: 'flex', gap: '0.5rem' }}>
+                <PrimaryButton
+                  onClick={() => {
+                    resetAction()
+                    setStep('confirm-install')
+                  }}
+                >
+                  Retry download
+                </PrimaryButton>
+                <ActionButton
+                  onClick={() => {
+                    resetAction()
+                    setStep('choose')
+                  }}
+                >
+                  Choose a different option
+                </ActionButton>
+              </div>
+            </div>
+          )}
+
+          {isDiskError && (
+            <div
+              role="alert"
+              aria-label="insufficient disk space"
+              style={{
+                marginTop: '1rem',
+                padding: '0.85rem 1rem',
+                background: 'rgba(239,68,68,0.08)',
+                border: '1px solid rgba(239,68,68,0.3)',
+                borderRadius: '6px',
+              }}
+            >
+              <p
+                style={{
+                  margin: '0 0 0.4rem',
+                  color: '#f87171',
+                  fontWeight: 600,
+                  fontSize: '0.875rem',
+                }}
+              >
+                Not enough disk space
+              </p>
+              <p style={{ margin: '0 0 0.75rem', fontSize: '0.825rem', color: '#a1a1aa' }}>
+                {selectedModel != null
+                  ? `This model requires approximately ${selectedModel.size_gb} GB of free disk space. `
+                  : ''}
+                Free up space on your drive and try again, or use a smaller model or Ollama
+                instead.
+              </p>
+              <div style={{ display: 'flex', gap: '0.5rem' }}>
+                <PrimaryButton
+                  onClick={() => {
+                    resetAction()
+                    setStep('confirm-install')
+                  }}
+                >
+                  Try again
+                </PrimaryButton>
+                <ActionButton
+                  onClick={() => {
+                    resetAction()
+                    setStep('choose')
+                  }}
+                >
+                  Choose a different option
+                </ActionButton>
+              </div>
+            </div>
+          )}
+
+          {!isNetworkError && !isDiskError && (
+            <div
+              role="alert"
+              style={{
+                marginTop: '1rem',
+                padding: '0.85rem 1rem',
+                background: 'rgba(239,68,68,0.08)',
+                border: '1px solid rgba(239,68,68,0.3)',
+                borderRadius: '6px',
+              }}
+            >
+              <p style={{ margin: '0 0 0.4rem', color: '#f87171', fontSize: '0.875rem' }}>
+                {actionError}
+              </p>
+              <p style={{ margin: '0 0 0.75rem', fontSize: '0.8rem', color: '#a1a1aa' }}>
+                Check the{' '}
+                <a href={SETUP_DOCS_URL} target="_blank" rel="noreferrer">
+                  setup docs
+                </a>{' '}
+                if the problem persists.
+              </p>
+              <div style={{ display: 'flex', gap: '0.5rem' }}>
+                <PrimaryButton
+                  onClick={() => {
+                    resetAction()
+                    setStep('confirm-install')
+                  }}
+                >
+                  Try again
+                </PrimaryButton>
+                <ActionButton
+                  onClick={() => {
+                    resetAction()
+                    setStep('choose')
+                  }}
+                >
+                  Choose a different option
+                </ActionButton>
+              </div>
+            </div>
+          )}
+        </div>
+      )
+    }
+
+    return (
+      <div style={{ maxWidth: '640px', margin: '2rem auto', padding: '0 1rem' }}>
+        <h1>Installing model</h1>
+        <p style={{ color: '#a1a1aa', fontSize: '0.9rem' }}>
+          {statusLabel[status] ?? 'Downloading…'} Download time depends on your connection speed.
+        </p>
+
+        <div
+          role="progressbar"
+          aria-valuenow={pct ?? 0}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label="Download progress"
+          style={{
+            marginTop: '1rem',
+            height: '8px',
+            borderRadius: '4px',
+            background: 'rgba(255,255,255,0.1)',
+            overflow: 'hidden',
+          }}
+        >
+          <div
+            style={{
+              height: '100%',
+              width: pct != null ? `${pct}%` : '0%',
+              background: 'rgba(99,102,241,0.85)',
+              borderRadius: '4px',
+              transition: 'width 0.4s ease',
+            }}
+          />
+        </div>
+
+        <p style={{ fontSize: '0.8rem', color: '#71717a', marginTop: '0.4rem' }}>
+          {pct != null
+            ? `${pct}% — ${(progressBytes / 1_073_741_824).toFixed(2)} GB`
+            : 'Waiting for progress data…'}
+        </p>
+
+        <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1.5rem' }}>
+          <ActionButton
+            onClick={async () => {
+              if (installId != null) {
+                try {
+                  await api.cancelInstall(installId)
+                } catch {
+                  // Cancel is best-effort; navigate home regardless.
+                }
+              }
+              markFirstRunComplete()
+              navigate('/')
+            }}
+          >
+            Cancel and go home
+          </ActionButton>
+        </div>
+      </div>
+    )
+  }
+
+  // ── Ollama select ─────────────────────────────────────────────────────────────
+
+  if (step === 'ollama-select') {
+    const ollamaModels = modelsData?.ollama_models ?? []
+
+    async function handleSelectOllama(m: DetectedOllamaModel) {
+      setActionLoading(true)
+      setActionError(null)
+      try {
+        await api.useModel({ runtime_id: 'ollama', model_id: m.id })
+        benchmarkStartedRef.current = false
+        setStep('benchmark')
+      } catch (err: unknown) {
+        setActionError(err instanceof Error ? err.message : 'Failed to activate Ollama model.')
+        setActionLoading(false)
+      }
+    }
+
+    return (
+      <div style={{ maxWidth: '640px', margin: '2rem auto', padding: '0 1rem' }}>
+        <h1>Use Ollama model</h1>
+
+        {ollamaModels.length === 0 ? (
+          <div>
+            <p role="status">No Ollama models detected.</p>
+            <p style={{ fontSize: '0.875rem', color: '#a1a1aa' }}>
+              Install Ollama and pull at least one model, then return here.{' '}
+              <a href="https://ollama.com" target="_blank" rel="noreferrer">
+                ollama.com
+              </a>
+            </p>
+          </div>
+        ) : (
+          <div>
+            <p style={{ color: '#a1a1aa', fontSize: '0.9rem', marginBottom: '1rem' }}>
+              Select a model from your local Ollama installation.
+            </p>
+            <ul
+              style={{
+                listStyle: 'none',
+                padding: 0,
+                margin: 0,
+                display: 'flex',
+                flexDirection: 'column',
+                gap: '0.5rem',
+              }}
+            >
+              {ollamaModels.map((m) => (
+                <li
+                  key={m.id}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    gap: '1rem',
+                    padding: '0.75rem',
+                    border: '1px solid rgba(255,255,255,0.1)',
+                    borderRadius: '6px',
+                  }}
+                >
+                  <span>
+                    <strong>{m.name}</strong>
+                    {m.size_category && (
+                      <span
+                        style={{ color: '#71717a', marginLeft: '0.5rem', fontSize: '0.8rem' }}
+                      >
+                        {m.size_category}
+                      </span>
+                    )}
+                  </span>
+                  <ActionButton disabled={actionLoading} onClick={() => handleSelectOllama(m)}>
+                    Use this model
+                  </ActionButton>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {actionError && (
+          <p
+            role="alert"
+            style={{ color: '#f87171', marginTop: '0.75rem', fontSize: '0.875rem' }}
+          >
+            {actionError}
+          </p>
+        )}
+
+        <div style={{ marginTop: '1.5rem' }}>
+          <ActionButton
+            onClick={() => {
+              resetAction()
+              setStep('choose')
+            }}
+          >
+            Back
+          </ActionButton>
+        </div>
+      </div>
+    )
+  }
+
+  // ── GGUF path ─────────────────────────────────────────────────────────────────
+
+  if (step === 'gguf-path') {
+    async function handleUseGguf() {
+      const trimmed = ggufPath.trim()
+      if (!trimmed) {
+        setGgufPathError('Please enter a file path.')
+        return
+      }
+      if (!trimmed.toLowerCase().endsWith('.gguf')) {
+        setGgufPathError('The file must have a .gguf extension.')
+        return
+      }
+      setGgufPathError(null)
+      setActionLoading(true)
+      setActionError(null)
+      try {
+        await api.registerGguf({ path: trimmed })
+        try {
+          await api.startSidecar(trimmed)
+        } catch (sidecarErr) {
+          console.warn('GGUF registered, but the llama.cpp sidecar failed to start:', sidecarErr)
+        }
+        benchmarkStartedRef.current = false
+        setStep('benchmark')
+      } catch (err: unknown) {
+        setActionError(err instanceof Error ? err.message : 'Failed to activate the GGUF file.')
+        setActionLoading(false)
+      }
+    }
+
+    return (
+      <div style={{ maxWidth: '640px', margin: '2rem auto', padding: '0 1rem' }}>
+        <h1>Use a GGUF file</h1>
+
+        <div
+          role="note"
+          aria-label="license responsibility notice"
+          style={{
+            background: 'rgba(251,191,36,0.08)',
+            border: '1px solid rgba(251,191,36,0.35)',
+            borderRadius: '6px',
+            padding: '0.85rem 1rem',
+            marginTop: '1rem',
+          }}
+        >
+          <p style={{ margin: 0, fontWeight: 600, color: '#fbbf24', fontSize: '0.875rem' }}>
+            You are responsible for this model's license and hardware fit.
+          </p>
+          <p style={{ margin: '0.4rem 0 0', fontSize: '0.825rem', color: '#fde68a' }}>
+            This app does not claim the model you provide is official, licensed for redistribution,
+            or suitable for your hardware. Review the model's license before use. The file will not
+            be copied — only its path is stored.
+          </p>
+        </div>
+
+        <div style={{ marginTop: '1.25rem' }}>
+          <label
+            htmlFor="gguf-path"
+            style={{ display: 'block', marginBottom: '0.4rem', fontSize: '0.875rem' }}
+          >
+            File path
+          </label>
+          <input
+            id="gguf-path"
+            type="text"
+            value={ggufPath}
+            onChange={(e) => {
+              setGgufPath(e.target.value)
+              setGgufPathError(null)
+            }}
+            placeholder="/path/to/model.gguf"
+            aria-describedby="gguf-path-hint"
+            aria-invalid={ggufPathError != null}
+            style={{
+              width: '100%',
+              padding: '0.5rem 0.75rem',
+              borderRadius: '4px',
+              background: 'rgba(255,255,255,0.05)',
+              border: ggufPathError
+                ? '1px solid rgba(239,68,68,0.6)'
+                : '1px solid rgba(255,255,255,0.15)',
+              color: 'inherit',
+              fontFamily: 'monospace',
+              fontSize: '0.875rem',
+              boxSizing: 'border-box',
+            }}
+          />
+          <p
+            id="gguf-path-hint"
+            style={{ fontSize: '0.8rem', color: '#71717a', marginTop: '0.3rem' }}
+          >
+            Absolute path to a GGUF model file compatible with llama.cpp.
+          </p>
+          {ggufPathError && (
+            <p
+              role="alert"
+              style={{ fontSize: '0.875rem', color: '#f87171', margin: '0.3rem 0 0' }}
+            >
+              {ggufPathError}
+            </p>
+          )}
+        </div>
+
+        {actionError && (
+          <p
+            role="alert"
+            style={{ color: '#f87171', marginTop: '0.75rem', fontSize: '0.875rem' }}
+          >
+            {actionError}
+          </p>
+        )}
+
+        <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1.5rem' }}>
+          <PrimaryButton disabled={actionLoading} onClick={handleUseGguf}>
+            {actionLoading ? 'Activating…' : 'Use this file'}
+          </PrimaryButton>
+          <ActionButton
+            onClick={() => {
+              resetAction()
+              setStep('choose')
+            }}
+          >
+            Back
+          </ActionButton>
+        </div>
+      </div>
+    )
+  }
+
+  // ── Demo warning ──────────────────────────────────────────────────────────────
+
+  if (step === 'demo-warning') {
+    async function handleConfirmDemo() {
+      setActionLoading(true)
+      try {
+        await api.useModel({ runtime_id: 'fake', model_id: null })
+      } catch {
+        // Demo mode activation is best-effort; proceed regardless.
+      } finally {
+        setActionLoading(false)
+      }
+      markFirstRunComplete()
+      navigate('/library')
+    }
+
+    return (
+      <div style={{ maxWidth: '640px', margin: '2rem auto', padding: '0 1rem' }}>
+        <h1>Text-only demo</h1>
+
+        <div
+          role="note"
+          aria-label="demo mode disclaimer"
+          style={{
+            background: 'rgba(251,191,36,0.08)',
+            border: '1px solid rgba(251,191,36,0.35)',
+            borderRadius: '6px',
+            padding: '1rem 1.25rem',
+            marginTop: '1rem',
+          }}
+        >
+          <p style={{ margin: 0, fontWeight: 600, color: '#fbbf24' }}>
+            This is a demo, not production quality.
+          </p>
+          <p style={{ margin: '0.6rem 0 0', fontSize: '0.875rem', color: '#fde68a' }}>
+            Text-only demo mode uses scripted responses instead of a real AI model. NPC behaviour
+            is hard-coded and does not represent the response quality you will experience with a
+            local model installed. It is intended only to explore the interface before committing
+            to a model download.
+          </p>
+        </div>
+
+        <p style={{ marginTop: '1rem', fontSize: '0.875rem', color: '#a1a1aa' }}>
+          You can return to model setup at any time from <strong>Settings → Model</strong>.
+        </p>
+
+        <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1.5rem' }}>
+          <PrimaryButton disabled={actionLoading} onClick={handleConfirmDemo}>
+            {actionLoading ? 'Starting…' : 'I understand — continue with text-only demo'}
+          </PrimaryButton>
+          <ActionButton
+            onClick={() => {
+              resetAction()
+              setStep('choose')
+            }}
+          >
+            Cancel
+          </ActionButton>
+        </div>
+      </div>
+    )
+  }
+
+  // ── Benchmark ─────────────────────────────────────────────────────────────────
+
+  if (step === 'benchmark') {
+    return (
+      <div style={{ maxWidth: '640px', margin: '2rem auto', padding: '0 1rem' }}>
+        <h1>Model benchmark</h1>
+        <p style={{ color: '#a1a1aa', fontSize: '0.9rem' }}>
+          Running a short benchmark to measure generation speed and check hardware compatibility.
+        </p>
+
+        {benchmarkRunning && (
+          <p role="status" style={{ marginTop: '1rem' }}>
+            Running benchmark…
+          </p>
+        )}
+
+        {benchmarkResult && !benchmarkRunning && (
+          <div>
+            <table style={{ marginTop: '1rem', borderCollapse: 'collapse' }}>
+              <tbody>
+                <DetailRow label="Speed">
+                  {benchmarkResult.tokens_per_sec.toFixed(1)} tokens/sec
+                </DetailRow>
+                {benchmarkResult.context_length != null && (
+                  <DetailRow label="Context window">
+                    {benchmarkResult.context_length.toLocaleString()} tokens
+                  </DetailRow>
+                )}
+                <DetailRow label="Runtime">{benchmarkResult.runtime_id}</DetailRow>
+              </tbody>
+            </table>
+
+            {benchmarkResult.warnings.length > 0 && (
+              <div
+                role="alert"
+                aria-label="benchmark warnings"
+                style={{
+                  marginTop: '1rem',
+                  background: 'rgba(251,191,36,0.08)',
+                  border: '1px solid rgba(251,191,36,0.35)',
+                  borderRadius: '6px',
+                  padding: '0.75rem 1rem',
+                }}
+              >
+                <p
+                  style={{
+                    margin: '0 0 0.5rem',
+                    fontWeight: 600,
+                    color: '#fbbf24',
+                    fontSize: '0.875rem',
+                  }}
+                >
+                  Performance warnings
+                </p>
+                <ul
+                  style={{
+                    margin: 0,
+                    paddingLeft: '1.25rem',
+                    fontSize: '0.875rem',
+                    color: '#fde68a',
+                  }}
+                >
+                  {benchmarkResult.warnings.map((w, i) => (
+                    <li key={i} style={{ marginBottom: '0.3rem' }}>
+                      {w}
+                    </li>
+                  ))}
+                </ul>
+                <p style={{ margin: '0.5rem 0 0', fontSize: '0.8rem', color: '#a1a1aa' }}>
+                  If generation is slow, try a smaller model or check that GPU acceleration is
+                  enabled in your runtime settings.{' '}
+                  <a href={SETUP_DOCS_URL} target="_blank" rel="noreferrer">
+                    Setup docs
+                  </a>
+                </p>
+              </div>
+            )}
+          </div>
+        )}
+
+        {benchmarkError && !benchmarkRunning && (
+          <div
+            role="alert"
+            style={{
+              marginTop: '1rem',
+              padding: '0.75rem 1rem',
+              background: 'rgba(239,68,68,0.08)',
+              border: '1px solid rgba(239,68,68,0.3)',
+              borderRadius: '6px',
+            }}
+          >
+            <p style={{ margin: '0 0 0.4rem', color: '#f87171', fontSize: '0.875rem' }}>
+              Benchmark failed: {benchmarkError}
+            </p>
+            <p style={{ margin: 0, fontSize: '0.8rem', color: '#a1a1aa' }}>
+              Your model is still selected and ready to use. The benchmark is optional.
+            </p>
+          </div>
+        )}
+
+        <div style={{ marginTop: '1.5rem' }}>
+          <PrimaryButton
+            disabled={benchmarkRunning}
+            onClick={() => {
+              markFirstRunComplete()
+              navigate('/')
+            }}
+          >
+            {benchmarkRunning ? 'Running…' : 'Continue to Home'}
+          </PrimaryButton>
+        </div>
+      </div>
+    )
+  }
+
+  return null
+}


### PR DESCRIPTION
## Summary

Adds a **FirstRunWizard** screen that new players see automatically on their first launch, guiding them through model selection in plain language before anything else loads. The wizard replaces a daunting ModelManager with a focused, step-by-step setup flow.

## What changed

### New: `apps/web/src/screens/FirstRunWizard.tsx`
A dedicated wizard screen with nine steps:
- **Welcome** — introduces the app and displays a local-first / offline-play privacy guarantee
- **Loading / Load error** — fetches model registry; surfaces recovery copy and a back-to-welcome button on failure
- **Choose** — same four options as ModelManager: install starter model, use existing Ollama, use local GGUF file, or continue in text-only demo
- **Confirm install** — shows license, disk size, RAM/VRAM requirements, destination path, SHA-256 checksum, and an **offline-play explanation** note (not in ModelManager)
- **Installing** — progress bar with percentage and GB counter; on terminal failure the wizard stays on this step and shows specific panels for **network errors** ("Retry download" + "Choose a different option") or **insufficient disk space** (shows model size and recovery buttons). Generic errors also stay inline with recovery buttons.
- **Benchmark, Ollama select, GGUF path, Demo warning** — identical flow to ModelManager

Every exit path calls `markFirstRunComplete()` which writes `convsim.setup.complete = true` to localStorage before navigating away.

### New: `apps/web/src/__tests__/FirstRunWizard.test.tsx`
61 tests covering all five scenarios required by the issue definition of done:
- Successful install (welcome → confirm → download → ready → home; verifies localStorage flag)
- No network (install status `failed` with network message → stays on installing step → network error alert with retry/choose buttons)
- Insufficient disk (install status `failed` with disk message → disk space alert with model size and recovery buttons)
- Cancelled download ("Cancel and go home" calls `cancelInstall`, navigates home, sets flag)
- Existing Ollama path (browse → select → benchmark → continue to home; verifies localStorage flag)

Fake timers simulate the download polling cycle for all timer-dependent assertions.

### Modified: `apps/web/src/App.tsx`
Adds a `FirstRunGuard` layout route component that reads `localStorage.getItem('convsim.setup.complete')` and redirects to `/first-run` when false. The `/first-run` route is mounted outside the guard and outside `AppLayout` so the wizard has no nav chrome. All existing routes are nested inside the guard.

### Modified: `apps/web/src/privacyPrefs.ts`
Adds `SETUP_KEYS.firstRunComplete = 'convsim.setup.complete'` so the key is declared once and shared by the wizard, the guard, and tests.

### Modified: `apps/web/src/__tests__/App.test.tsx`
- Pre-sets `localStorage.setItem('convsim.setup.complete', 'true')` in `beforeEach` so the 9 existing App shell tests continue to test post-setup routing without hitting the guard redirect
- Adds 3 new FirstRunGuard tests: first-time user from `/` redirects to wizard, first-time user from `/settings` redirects to wizard, returning user reaches protected routes without wizard

## Test results

Full vitest run: **689 tests passed** (22 test files, 7.16s). The 61 new FirstRunWizard tests exercise every branch and recovery path with full coverage of network errors, disk space errors, cancellation, and all model selection flows.

Closes #192