### PR TITLE
Implement Scenario Library from pack APIs with import, folder, and model-missing actions

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -6,7 +6,7 @@ import cors from '@fastify/cors';
 import websocket from '@fastify/websocket';
 import { healthRoutes } from './routes/health.js';
 import { packsRoutes, packRoutes, setPacksDbPath, setPacksDataDir } from './routes/packs.js';
-import { scenarioRoutes } from './routes/scenarios.js';
+import { scenarioRoutes, setScenariosDbPath } from './routes/scenarios.js';
 import { sessionRoutes } from './routes/sessions.js';
 import { sessionWsRoutes } from './routes/session-ws.js';
 import { privacyRoutes, setDataFolderPath } from './routes/privacy.js';
@@ -66,6 +66,7 @@ if (process.argv[1] === new URL(import.meta.url).pathname) {
   setDataFolderPath(path.dirname(dbPath));
   setPacksDbPath(packsDbPath);
   setPacksDataDir(packsDataDir);
+  setScenariosDbPath(packsDbPath);
   setWorkbenchRoots(
     process.env['PACKS_OFFICIAL_ROOT'] ?? path.join(process.cwd(), 'packs', 'official'),
     process.env['PACKS_LOCAL_DEV_ROOT'] ?? path.join(os.homedir(), '.convsim', 'packs', 'local-dev'),

--- a/apps/api/src/routes/pack-library.test.ts
+++ b/apps/api/src/routes/pack-library.test.ts
@@ -188,6 +188,10 @@ describe('GET /api/scenarios — dynamic pack merge', () => {
     expect(dynamic.duration.max_turns).toBe(10);
     expect(dynamic.duration.soft_time_limit_minutes).toBe(12);
     expect(dynamic.estimated_length_label).toMatch(/minutes/);
+    // Voice is a runtime capability applied to every scenario, so imported
+    // pack scenarios must be voice_supported like the built-ins — otherwise
+    // the library's voice filter/chip would silently exclude them.
+    expect(dynamic.voice_supported).toBe(true);
   });
 
   it('does not double-serve a scenario whose id also exists as a static built-in', async () => {

--- a/apps/api/src/routes/pack-library.test.ts
+++ b/apps/api/src/routes/pack-library.test.ts
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import AdmZip from 'adm-zip';
+import { buildApp } from '../index.js';
+import type { FastifyInstance } from 'fastify';
+import type { ScenarioInfo } from '@convsim/shared';
+import { setPacksDbPath, setPacksDataDir } from './packs.js';
+import type { PackDetail } from './packs.js';
+import { setScenariosDbPath } from './scenarios.js';
+import { SCENARIOS } from '../data/scenarios.js';
+
+// ---------------------------------------------------------------------------
+// Pack fixture helpers — a community pack whose scenario_id does not collide
+// with any built-in static scenario, so it must appear as a *dynamic* result.
+// ---------------------------------------------------------------------------
+
+const MANIFEST = `schema_version: "0.1"
+pack_id: community.library_pack
+name: Community Library Pack
+version: 2.3.1
+description: A community pack for exercising the library merge path.
+author: Library Test Suite
+license: MIT
+content_rating: PG
+tags:
+  - practice
+  - community
+supported_languages:
+  - en
+  - es
+requirements:
+  recommended_llm:
+    - llama-3-8b
+safety:
+  policy: safety/policy.yaml
+`;
+
+const SAFETY = `schema_version: "0.1"
+policy_id: library_test_safety
+content_rating_cap: PG
+content_categories:
+  nsfw_sexual: block
+  real_person_impersonation: block
+  instructional_criminal: block
+  crisis_content: redirect
+redirect_message: "Redirected."
+`;
+
+const NPC = `schema_version: "0.1"
+npc_id: library_test_npc
+display_name: Library NPC
+archetype: test_archetype
+fictional: true
+age_band: adult
+public_persona:
+  occupation: A test NPC for library tests
+  speaking_style: Direct
+  demeanor: Neutral
+private_persona: {}
+`;
+
+const RUBRIC = `schema_version: "0.1"
+rubric_id: library_test_rubric
+title: Library Rubric
+dimensions:
+  - id: accuracy
+    name: Accuracy
+    description: Test accuracy
+    scoring:
+      low: Low
+      medium: Medium
+      high: High
+`;
+
+const SCENARIO = `schema_version: "0.1"
+scenario_id: community_library_scenario
+title: Community Library Scenario
+summary: A dynamic scenario served from the pack index.
+player_role:
+  label: Learner
+  brief: You are practicing with a community pack.
+npc:
+  ref: ../npcs/library_test_npc.yaml
+rubric:
+  ref: ../rubrics/library_test_rubric.yaml
+duration:
+  max_turns: 10
+  soft_time_limit_minutes: 12
+opening:
+  npc_says: "Welcome to the community pack."
+goals:
+  player_visible:
+    - Practice the conversation
+difficulty:
+  default: hard
+  options:
+    normal: { npc_patience_modifier: 0, challenge_frequency: medium }
+    hard: { npc_patience_modifier: -20, challenge_frequency: high }
+`;
+
+function makePackZip(parent: string): Buffer {
+  const root = join(parent, 'pack');
+  for (const sub of ['scenarios', 'npcs', 'rubrics', 'safety']) {
+    mkdirSync(join(root, sub), { recursive: true });
+  }
+  writeFileSync(join(root, 'manifest.yaml'), MANIFEST);
+  writeFileSync(join(root, 'safety', 'policy.yaml'), SAFETY);
+  writeFileSync(join(root, 'npcs', 'library_test_npc.yaml'), NPC);
+  writeFileSync(join(root, 'rubrics', 'library_test_rubric.yaml'), RUBRIC);
+  writeFileSync(join(root, 'scenarios', 'community_library_scenario.yaml'), SCENARIO);
+  const zip = new AdmZip();
+  zip.addLocalFolder(root, '');
+  return zip.toBuffer();
+}
+
+let app: FastifyInstance;
+let tempDir: string;
+
+beforeEach(async () => {
+  tempDir = mkdtempSync(join(tmpdir(), 'convsim-api-library-test-'));
+  const dbPath = join(tempDir, 'packs.db');
+  setPacksDbPath(dbPath);
+  setPacksDataDir(join(tempDir, 'packs'));
+  setScenariosDbPath(dbPath);
+  app = await buildApp();
+});
+
+afterEach(async () => {
+  await app.close();
+  setPacksDbPath(null);
+  setPacksDataDir(null);
+  setScenariosDbPath(null);
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+async function importPack(): Promise<void> {
+  const res = await app.inject({
+    method: 'POST',
+    url: '/api/packs/import',
+    headers: { 'content-type': 'application/zip' },
+    payload: makePackZip(tempDir),
+  });
+  expect(res.statusCode).toBe(201);
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/scenarios — dynamic merge from the pack index
+// ---------------------------------------------------------------------------
+
+describe('GET /api/scenarios — dynamic pack merge', () => {
+  it('returns only static scenarios before any pack is imported', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/scenarios' });
+    const body = res.json<ScenarioInfo[]>();
+    expect(body.length).toBe(Object.keys(SCENARIOS).length);
+  });
+
+  it('includes an imported pack scenario alongside the static ones', async () => {
+    await importPack();
+    const res = await app.inject({ method: 'GET', url: '/api/scenarios' });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<ScenarioInfo[]>();
+    expect(body.length).toBe(Object.keys(SCENARIOS).length + 1);
+    const dynamic = body.find((s) => s.scenario_id === 'community_library_scenario');
+    expect(dynamic).toBeDefined();
+  });
+
+  it('maps manifest and scenario fields onto ScenarioInfo', async () => {
+    await importPack();
+    const res = await app.inject({ method: 'GET', url: '/api/scenarios' });
+    const body = res.json<ScenarioInfo[]>();
+    const dynamic = body.find((s) => s.scenario_id === 'community_library_scenario')!;
+    expect(dynamic.pack_id).toBe('community.library_pack');
+    expect(dynamic.pack_name).toBe('Community Library Pack');
+    expect(dynamic.content_rating).toBe('PG');
+    expect(dynamic.title).toBe('Community Library Scenario');
+    expect(dynamic.player_role.label).toBe('Learner');
+    expect(dynamic.supported_languages).toEqual(['en', 'es']);
+    expect(dynamic.tags).toEqual(['practice', 'community']);
+    expect(dynamic.recommended_model).toEqual(['llama-3-8b']);
+    expect(dynamic.difficulty.default).toBe('hard');
+    expect(dynamic.difficulty.options.hard).toEqual({
+      npc_patience_modifier: -20,
+      challenge_frequency: 'high',
+    });
+    expect(dynamic.duration.max_turns).toBe(10);
+    expect(dynamic.duration.soft_time_limit_minutes).toBe(12);
+    expect(dynamic.estimated_length_label).toMatch(/minutes/);
+  });
+
+  it('does not double-serve a scenario whose id also exists as a static built-in', async () => {
+    // Guard the skip-dedup path: import twice must not duplicate, and no
+    // dynamic scenario may shadow a static id.
+    await importPack();
+    const res = await app.inject({ method: 'GET', url: '/api/scenarios' });
+    const body = res.json<ScenarioInfo[]>();
+    const ids = body.map((s) => s.scenario_id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/scenarios/:id — PackIndex fallback
+// ---------------------------------------------------------------------------
+
+describe('GET /api/scenarios/:id — pack index fallback', () => {
+  it('still returns a static scenario by id', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/scenarios/behavioral_interview',
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json<ScenarioInfo>().scenario_id).toBe('behavioral_interview');
+  });
+
+  it('resolves a dynamic pack scenario by id after import', async () => {
+    await importPack();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/scenarios/community_library_scenario',
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<ScenarioInfo>();
+    expect(body.scenario_id).toBe('community_library_scenario');
+    expect(body.pack_id).toBe('community.library_pack');
+  });
+
+  it('returns 404 for a scenario that exists in no pack', async () => {
+    await importPack();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/scenarios/does_not_exist',
+    });
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/packs/:pack_id — pack detail (folder path source)
+// ---------------------------------------------------------------------------
+
+describe('GET /api/packs/:pack_id', () => {
+  it('returns full pack detail including pack_root for an imported pack', async () => {
+    await importPack();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/packs/community.library_pack',
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<PackDetail>();
+    expect(body.pack_id).toBe('community.library_pack');
+    expect(body.name).toBe('Community Library Pack');
+    expect(body.version).toBe('2.3.1');
+    expect(typeof body.pack_root).toBe('string');
+    expect(body.pack_root.length).toBeGreaterThan(0);
+  });
+
+  it('returns 404 for an unknown pack id', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/packs/no_such_pack',
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('exposes pack_root on the GET /api/packs summary rows', async () => {
+    await importPack();
+    const res = await app.inject({ method: 'GET', url: '/api/packs' });
+    const { packs } = res.json<{ packs: Array<{ pack_id: string; pack_root?: string }> }>();
+    const entry = packs.find((p) => p.pack_id === 'community.library_pack');
+    expect(entry?.pack_root).toBeTruthy();
+  });
+});

--- a/apps/api/src/routes/pack-library.test.ts
+++ b/apps/api/src/routes/pack-library.test.ts
@@ -277,3 +277,58 @@ describe('GET /api/packs/:pack_id', () => {
     expect(entry?.pack_root).toBeTruthy();
   });
 });
+
+// ---------------------------------------------------------------------------
+// POST /api/sessions — launch a scenario served from the pack index
+// ---------------------------------------------------------------------------
+
+describe('POST /api/sessions — launch imported pack scenario', () => {
+  function launchPayload(overrides: Record<string, unknown> = {}) {
+    return {
+      scenario_id: 'community_library_scenario',
+      difficulty: 'hard',
+      player_role_name: 'Learner',
+      language: 'en',
+      input_mode: 'text-only',
+      tts_enabled: false,
+      show_state_meters: false,
+      save_transcript: true,
+      seed: null,
+      ...overrides,
+    };
+  }
+
+  it('creates a session for a scenario that only exists in an imported pack', async () => {
+    await importPack();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/sessions',
+      payload: launchPayload(),
+    });
+    expect(res.statusCode).toBe(201);
+    expect(res.json<{ scenario_id: string }>().scenario_id).toBe(
+      'community_library_scenario',
+    );
+  });
+
+  it('rejects a difficulty the imported scenario does not define', async () => {
+    await importPack();
+    // The pack scenario defines only normal/hard; easy must be rejected.
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/sessions',
+      payload: launchPayload({ difficulty: 'easy' }),
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('still rejects a scenario id that exists in no pack', async () => {
+    await importPack();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/sessions',
+      payload: launchPayload({ scenario_id: 'does_not_exist' }),
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/apps/api/src/routes/packs.ts
+++ b/apps/api/src/routes/packs.ts
@@ -13,6 +13,15 @@ export interface PackSummary {
   pack_id: string;
   name: string;
   scenario_count: number;
+  pack_root: string;
+}
+
+export interface PackDetail {
+  pack_id: string;
+  name: string;
+  version: string;
+  scenario_count: number;
+  pack_root: string;
 }
 
 export interface PacksResponse {
@@ -91,7 +100,7 @@ export async function packsRoutes(app: FastifyInstance): Promise<void> {
       const db = new Database(_packsDbPath, { readonly: true, fileMustExist: true });
       try {
         const rows = db
-          .prepare('SELECT pack_id, name, scenario_count FROM installed_packs ORDER BY name')
+          .prepare('SELECT pack_id, name, scenario_count, pack_root FROM installed_packs ORDER BY name')
           .all() as PackSummary[];
         return { packs: rows, total: rows.length };
       } finally {
@@ -194,6 +203,42 @@ export async function packsRoutes(app: FastifyInstance): Promise<void> {
 }
 
 export async function packRoutes(app: FastifyInstance) {
+  app.get<{ Params: { pack_id: string } }>(
+    '/api/packs/:pack_id',
+    async (req, reply): Promise<PackDetail> => {
+      const { pack_id } = req.params;
+
+      if (!_packsDbPath) {
+        reply.status(404);
+        throw Object.assign(new Error(`Pack '${pack_id}' not found.`), {
+          statusCode: 404,
+          code: 'NOT_FOUND',
+        });
+      }
+
+      const index = PackIndex.open(_packsDbPath);
+      try {
+        const entry = index.getPack(pack_id);
+        if (!entry) {
+          reply.status(404);
+          throw Object.assign(new Error(`Pack '${pack_id}' not found.`), {
+            statusCode: 404,
+            code: 'NOT_FOUND',
+          });
+        }
+        return {
+          pack_id: entry.pack_id,
+          name: entry.name,
+          version: entry.version,
+          scenario_count: entry.scenario_count,
+          pack_root: entry.pack_root,
+        };
+      } finally {
+        index.close();
+      }
+    },
+  );
+
   app.post<{ Params: { pack_id: string } }>(
     '/api/packs/:pack_id/validate',
     async (req, reply): Promise<PackValidationResult> => {

--- a/apps/api/src/routes/scenarios.ts
+++ b/apps/api/src/routes/scenarios.ts
@@ -103,6 +103,32 @@ function loadScenariosFromPackIndex(dbPath: string, skipIds: Set<string>): Scena
   return results;
 }
 
+/**
+ * Resolve a scenario by id from the static built-ins first, then falling back
+ * to any pack tracked in the PackIndex. Returns undefined when the id matches
+ * neither, letting callers decide how to signal "not found". Shared by the
+ * scenario detail route and session creation so an imported pack scenario can
+ * be launched, not just browsed.
+ */
+export function findScenarioInfo(scenarioId: string): ScenarioInfo | undefined {
+  const staticScenario = SCENARIOS[scenarioId];
+  if (staticScenario) return staticScenario;
+
+  if (_scenariosDbPath) {
+    try {
+      const allDynamic = loadScenariosFromPackIndex(
+        _scenariosDbPath,
+        new Set(Object.keys(SCENARIOS)),
+      );
+      return allDynamic.find((s) => s.scenario_id === scenarioId);
+    } catch {
+      return undefined;
+    }
+  }
+
+  return undefined;
+}
+
 export async function scenarioRoutes(app: FastifyInstance) {
   app.get('/api/scenarios', async (): Promise<ScenarioInfo[]> => {
     const staticScenarios = Object.values(SCENARIOS);
@@ -125,21 +151,8 @@ export async function scenarioRoutes(app: FastifyInstance) {
     async (req, reply): Promise<ScenarioInfo> => {
       const { scenario_id } = req.params;
 
-      const staticScenario = SCENARIOS[scenario_id];
-      if (staticScenario) return staticScenario;
-
-      if (_scenariosDbPath) {
-        try {
-          const allDynamic = loadScenariosFromPackIndex(
-            _scenariosDbPath,
-            new Set(Object.keys(SCENARIOS)),
-          );
-          const found = allDynamic.find((s) => s.scenario_id === scenario_id);
-          if (found) return found;
-        } catch {
-          // fall through to 404
-        }
-      }
+      const found = findScenarioInfo(scenario_id);
+      if (found) return found;
 
       reply.status(404);
       throw new Error(`Scenario '${scenario_id}' not found`);

--- a/apps/api/src/routes/scenarios.ts
+++ b/apps/api/src/routes/scenarios.ts
@@ -1,21 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
 import type { FastifyInstance } from 'fastify';
-import type { ScenarioInfo } from '@convsim/shared';
+import type { ScenarioInfo, ScenarioDifficulty, DifficultyOption } from '@convsim/shared';
+import { loadPack, PackIndex } from '@convsim/pack-loader';
+import type { LoadedPack, LoadedScenario, PackRootKind } from '@convsim/pack-loader';
 import { SCENARIOS } from '../data/scenarios.js';
+
+let _scenariosDbPath: string | null = null;
+
+export function setScenariosDbPath(dbPath: string | null): void {
+  _scenariosDbPath = dbPath;
+}
+
+function buildDifficultyConfig(
+  rawDiff: { default?: string; options?: Record<string, unknown> } | undefined,
+): ScenarioInfo['difficulty'] {
+  const defaultDiff = (rawDiff?.default ?? 'normal') as ScenarioDifficulty;
+  const rawOptions = (rawDiff?.options ?? {}) as Record<string, Record<string, unknown>>;
+  const options: Partial<Record<ScenarioDifficulty, DifficultyOption>> = {};
+
+  for (const [key, val] of Object.entries(rawOptions)) {
+    if (key === 'easy' || key === 'normal' || key === 'hard') {
+      options[key] = {
+        npc_patience_modifier: (val['npc_patience_modifier'] as number | undefined) ?? 0,
+        challenge_frequency:
+          (val['challenge_frequency'] as 'low' | 'medium' | 'high' | undefined) ?? 'medium',
+      };
+    }
+  }
+
+  if (Object.keys(options).length === 0) {
+    options['normal'] = { npc_patience_modifier: 0, challenge_frequency: 'medium' };
+  }
+
+  return { default: defaultDiff, options };
+}
+
+function packScenarioToScenarioInfo(
+  pack: LoadedPack,
+  scenario: LoadedScenario,
+): ScenarioInfo {
+  const m = pack.manifest;
+  const s = scenario.data;
+
+  const softLimit =
+    s.duration.soft_time_limit_minutes ??
+    Math.ceil(s.duration.max_turns * 1.2);
+  const minMin = Math.max(5, Math.round(softLimit * 0.75));
+  const estimatedLengthLabel =
+    minMin < softLimit
+      ? `${minMin}–${softLimit} minutes`
+      : `${softLimit} minutes`;
+
+  return {
+    scenario_id: s.scenario_id,
+    title: s.title,
+    summary: s.summary,
+    content_rating: m.content_rating,
+    pack_id: m.pack_id,
+    pack_name: m.name,
+    player_role: { label: s.player_role.label, brief: s.player_role.brief },
+    difficulty: buildDifficultyConfig(
+      s.difficulty as { default?: string; options?: Record<string, unknown> } | undefined,
+    ),
+    supported_languages: m.supported_languages ?? ['en'],
+    duration: {
+      max_turns: s.duration.max_turns,
+      soft_time_limit_minutes: softLimit,
+    },
+    state_meters_permitted: false,
+    voice_supported: false,
+    safety_summary: `${m.content_rating} rated. Content cap: ${pack.safety.content_rating_cap}.`,
+    estimated_length_label: estimatedLengthLabel,
+    tags: m.tags ?? [],
+    recommended_model: m.requirements?.recommended_llm ?? [],
+  };
+}
+
+function loadScenariosFromPackIndex(dbPath: string, skipIds: Set<string>): ScenarioInfo[] {
+  const index = PackIndex.open(dbPath);
+  const results: ScenarioInfo[] = [];
+  try {
+    const packs = index.listPacks();
+    for (const packEntry of packs) {
+      try {
+        const pack = loadPack(packEntry.pack_root, packEntry.pack_root_kind as PackRootKind);
+        for (const scenario of pack.scenarios) {
+          if (!skipIds.has(scenario.data.scenario_id)) {
+            results.push(packScenarioToScenarioInfo(pack, scenario));
+          }
+        }
+      } catch {
+        // Skip packs that fail to load (corrupt, deleted, etc.)
+      }
+    }
+  } finally {
+    index.close();
+  }
+  return results;
+}
 
 export async function scenarioRoutes(app: FastifyInstance) {
   app.get('/api/scenarios', async (): Promise<ScenarioInfo[]> => {
-    return Object.values(SCENARIOS);
+    const staticScenarios = Object.values(SCENARIOS);
+
+    if (!_scenariosDbPath) {
+      return staticScenarios;
+    }
+
+    try {
+      const staticIds = new Set(staticScenarios.map((s) => s.scenario_id));
+      const dynamicScenarios = loadScenariosFromPackIndex(_scenariosDbPath, staticIds);
+      return [...staticScenarios, ...dynamicScenarios];
+    } catch {
+      return staticScenarios;
+    }
   });
 
   app.get<{ Params: { scenario_id: string } }>(
     '/api/scenarios/:scenario_id',
     async (req, reply): Promise<ScenarioInfo> => {
-      const scenario = SCENARIOS[req.params.scenario_id];
-      if (!scenario) {
-        reply.status(404);
-        throw new Error(`Scenario '${req.params.scenario_id}' not found`);
+      const { scenario_id } = req.params;
+
+      const staticScenario = SCENARIOS[scenario_id];
+      if (staticScenario) return staticScenario;
+
+      if (_scenariosDbPath) {
+        try {
+          const allDynamic = loadScenariosFromPackIndex(
+            _scenariosDbPath,
+            new Set(Object.keys(SCENARIOS)),
+          );
+          const found = allDynamic.find((s) => s.scenario_id === scenario_id);
+          if (found) return found;
+        } catch {
+          // fall through to 404
+        }
       }
-      return scenario;
+
+      reply.status(404);
+      throw new Error(`Scenario '${scenario_id}' not found`);
     },
   );
 }

--- a/apps/api/src/routes/scenarios.ts
+++ b/apps/api/src/routes/scenarios.ts
@@ -68,7 +68,11 @@ function packScenarioToScenarioInfo(
       soft_time_limit_minutes: softLimit,
     },
     state_meters_permitted: false,
-    voice_supported: false,
+    // Voice is a runtime TTS/STT capability applied to every scenario, not a
+    // per-pack content flag (the pack schema has no voice field). Match the
+    // built-in scenarios (all voice_supported) so the library's "Voice only"
+    // filter and "Voice supported" chip treat imported packs consistently.
+    voice_supported: true,
     safety_summary: `${m.content_rating} rated. Content cap: ${pack.safety.content_rating_cap}.`,
     estimated_length_label: estimatedLengthLabel,
     tags: m.tags ?? [],

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -11,7 +11,7 @@ import type {
   SessionTranscriptResponse,
   EndingType,
 } from '@convsim/shared';
-import { SCENARIOS } from '../data/scenarios.js';
+import { findScenarioInfo } from './scenarios.js';
 import { getDb, WORKBENCH_TEST_SCENARIO_ID } from '../db.js';
 import { broadcast, closeSessionSockets } from '../ws/session-events.js';
 
@@ -226,12 +226,14 @@ export async function sessionRoutes(app: FastifyInstance) {
         throw new Error('player_role_name cannot be blank');
       }
 
-      if (!SCENARIOS[body.scenario_id]) {
+      // Resolve from the static built-ins *and* imported packs tracked in the
+      // PackIndex, so scenarios surfaced by the library's dynamic merge can be
+      // launched, not just browsed.
+      const scenario = findScenarioInfo(body.scenario_id);
+      if (!scenario) {
         reply.status(400);
         throw new Error(`Unknown scenario_id: ${body.scenario_id}`);
       }
-
-      const scenario = SCENARIOS[body.scenario_id]!;
 
       if (!Object.prototype.hasOwnProperty.call(scenario.difficulty.options, body.difficulty)) {
         reply.status(400);
@@ -425,7 +427,9 @@ export async function sessionRoutes(app: FastifyInstance) {
       // 2. Input safety precheck — placeholder hook, always passes.
       // A production implementation would call a safety classifier here.
 
-      const scenario = SCENARIOS[row.scenario_id];
+      // Resolve statically first (fast path) and fall back to imported packs so
+      // a launched pack scenario is capped by its own max_turns, not the default.
+      const scenario = findScenarioInfo(row.scenario_id);
       const newTurnCount = row.turn_count + 1;
       const maxTurns = scenario?.duration.max_turns ?? 20;
 

--- a/apps/web/src/__tests__/ScenarioLibrary.test.tsx
+++ b/apps/web/src/__tests__/ScenarioLibrary.test.tsx
@@ -9,10 +9,14 @@ vi.mock('../api/client', () => ({
   api: {
     listScenarios: vi.fn(),
     validatePack: vi.fn(),
+    listPacks: vi.fn(),
+    importPack: vi.fn(),
+    getModels: vi.fn(),
   },
 }))
 
 import { api } from '../api/client'
+import type { ModelsResponse } from '@convsim/shared'
 const mockApi = vi.mocked(api)
 
 // ---------------------------------------------------------------------------
@@ -122,11 +126,48 @@ function renderLibrary() {
   )
 }
 
+const MODELS_READY: ModelsResponse = {
+  runtime_health: { status: 'ready', runtime_id: 'llama', runtime_name: 'llama.cpp', model_id: 'test', latency_ms: null, message: null, checked_at: '' },
+  active: { runtime_id: 'llama', model_id: 'test' },
+  registry: [],
+  installed: [],
+  ollama_models: [],
+  total: 0,
+  last_benchmark: null,
+}
+
+const MODELS_UNAVAILABLE: ModelsResponse = {
+  ...MODELS_READY,
+  runtime_health: { ...MODELS_READY.runtime_health, status: 'unavailable' },
+}
+
+const INDEXED_PACKS_EMPTY = { packs: [], total: 0 }
+
+const INDEXED_PACKS_WITH_JOB = {
+  packs: [
+    {
+      pack_id: 'official.job_interview_basic',
+      name: 'Job Interview Basics',
+      scenario_count: 2,
+      pack_root: '/home/user/.convsim/packs/official.job_interview_basic',
+    },
+  ],
+  total: 1,
+}
+
 beforeEach(() => {
   vi.restoreAllMocks()
   vi.clearAllMocks()
   mockApi.listScenarios.mockResolvedValue(ALL_SCENARIOS)
   mockApi.validatePack.mockResolvedValue(VALID_RESULT)
+  mockApi.listPacks.mockResolvedValue(INDEXED_PACKS_EMPTY)
+  mockApi.getModels.mockResolvedValue(MODELS_READY)
+  mockApi.importPack.mockResolvedValue({
+    pack_id: 'community.test_pack',
+    name: 'Test Pack',
+    version: '1.0.0',
+    dest: '/home/user/.convsim/packs/community.test_pack',
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -181,15 +222,11 @@ describe('empty state', () => {
     )
   })
 
-  it('empty state links to settings', async () => {
+  it('empty state has an import pack button', async () => {
     mockApi.listScenarios.mockResolvedValue([])
     renderLibrary()
     await waitFor(() => screen.getByTestId('empty-state'))
-    const settingsLinks = screen.getAllByRole('link', { name: /settings/i })
-    expect(settingsLinks.length).toBeGreaterThan(0)
-    for (const link of settingsLinks) {
-      expect(link).toHaveAttribute('href', '/settings')
-    }
+    expect(screen.getByTestId('empty-import-pack-button')).toBeInTheDocument()
   })
 })
 
@@ -650,5 +687,196 @@ describe('accessibility', () => {
     const lists = screen.getAllByRole('list')
     const labelledLists = lists.filter((l) => l.getAttribute('aria-label'))
     expect(labelledLists.length).toBeGreaterThan(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Import pack
+// ---------------------------------------------------------------------------
+
+describe('import pack', () => {
+  it('renders an import pack button', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+    expect(screen.getByTestId('import-pack-button')).toBeInTheDocument()
+  })
+
+  it('import pack button has aria-label', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+    expect(screen.getByRole('button', { name: /import pack/i })).toBeInTheDocument()
+  })
+
+  it('shows success message after successful import', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+    const fileInput = screen.getByTestId('import-file-input')
+    const file = new File(['PK'], 'test.zip', { type: 'application/zip' })
+    fireEvent.change(fileInput, { target: { files: [file] } })
+    await waitFor(() => screen.getByTestId('import-success'))
+    expect(screen.getByTestId('import-success')).toHaveTextContent(/test pack/i)
+  })
+
+  it('calls importPack with the selected file', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+    const fileInput = screen.getByTestId('import-file-input')
+    const file = new File(['PK'], 'mypack.zip', { type: 'application/zip' })
+    fireEvent.change(fileInput, { target: { files: [file] } })
+    await waitFor(() => expect(mockApi.importPack).toHaveBeenCalledWith(file))
+  })
+
+  it('shows error message when import fails', async () => {
+    mockApi.importPack.mockRejectedValue(new Error('Invalid pack format'))
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+    const fileInput = screen.getByTestId('import-file-input')
+    const file = new File(['bad'], 'bad.zip', { type: 'application/zip' })
+    fireEvent.change(fileInput, { target: { files: [file] } })
+    await waitFor(() => screen.getByTestId('import-error'))
+    expect(screen.getByTestId('import-error')).toHaveTextContent(/invalid pack format/i)
+  })
+
+  it('reloads scenarios after successful import', async () => {
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+    mockApi.listScenarios.mockClear()
+    const fileInput = screen.getByTestId('import-file-input')
+    const file = new File(['PK'], 'mypack.zip', { type: 'application/zip' })
+    fireEvent.change(fileInput, { target: { files: [file] } })
+    await waitFor(() => screen.getByTestId('import-success'))
+    expect(mockApi.listScenarios).toHaveBeenCalled()
+  })
+
+  it('empty state shows an import pack button', async () => {
+    mockApi.listScenarios.mockResolvedValue([])
+    renderLibrary()
+    await waitFor(() => screen.getByTestId('empty-state'))
+    expect(screen.getByTestId('empty-import-pack-button')).toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Open pack folder
+// ---------------------------------------------------------------------------
+
+describe('open pack folder', () => {
+  it('shows open-folder button for indexed (imported) packs', async () => {
+    mockApi.listPacks.mockResolvedValue(INDEXED_PACKS_WITH_JOB)
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+    await waitFor(() =>
+      expect(
+        screen.getByTestId('open-folder-official.job_interview_basic'),
+      ).toBeInTheDocument(),
+    )
+  })
+
+  it('does not show open-folder button for packs not in index', async () => {
+    mockApi.listPacks.mockResolvedValue(INDEXED_PACKS_EMPTY)
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+    expect(
+      screen.queryByTestId('open-folder-official.job_interview_basic'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('clicking open-folder reveals the pack root path', async () => {
+    mockApi.listPacks.mockResolvedValue(INDEXED_PACKS_WITH_JOB)
+    renderLibrary()
+    await waitFor(() => screen.getByTestId('open-folder-official.job_interview_basic'))
+    fireEvent.click(screen.getByTestId('open-folder-official.job_interview_basic'))
+    await waitFor(() =>
+      expect(
+        screen.getByTestId('folder-path-official.job_interview_basic'),
+      ).toBeInTheDocument(),
+    )
+    expect(
+      screen.getByTestId('folder-path-official.job_interview_basic'),
+    ).toHaveTextContent('/home/user/.convsim/packs/official.job_interview_basic')
+  })
+
+  it('open-folder button has an accessible aria-label', async () => {
+    mockApi.listPacks.mockResolvedValue(INDEXED_PACKS_WITH_JOB)
+    renderLibrary()
+    await waitFor(() => screen.getByTestId('open-folder-official.job_interview_basic'))
+    expect(
+      screen.getByRole('button', { name: /open folder for pack job interview basics/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('clicking open-folder again hides the path', async () => {
+    mockApi.listPacks.mockResolvedValue(INDEXED_PACKS_WITH_JOB)
+    renderLibrary()
+    await waitFor(() => screen.getByTestId('open-folder-official.job_interview_basic'))
+    fireEvent.click(screen.getByTestId('open-folder-official.job_interview_basic'))
+    await waitFor(() =>
+      screen.getByTestId('folder-path-official.job_interview_basic'),
+    )
+    fireEvent.click(screen.getByTestId('open-folder-official.job_interview_basic'))
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId('folder-path-official.job_interview_basic'),
+      ).not.toBeInTheDocument(),
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Model-missing state
+// ---------------------------------------------------------------------------
+
+describe('model-missing state', () => {
+  it('does not show model-missing banner when runtime is ready', async () => {
+    mockApi.getModels.mockResolvedValue(MODELS_READY)
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+    expect(screen.queryByTestId('model-missing-banner')).not.toBeInTheDocument()
+  })
+
+  it('does not show model-missing banner when runtime is degraded', async () => {
+    mockApi.getModels.mockResolvedValue({
+      ...MODELS_READY,
+      runtime_health: { ...MODELS_READY.runtime_health, status: 'degraded' },
+    })
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+    expect(screen.queryByTestId('model-missing-banner')).not.toBeInTheDocument()
+  })
+
+  it('shows model-missing banner when runtime is unavailable', async () => {
+    mockApi.getModels.mockResolvedValue(MODELS_UNAVAILABLE)
+    renderLibrary()
+    await waitFor(() => screen.getByTestId('model-missing-banner'))
+    expect(screen.getByTestId('model-missing-banner')).toBeInTheDocument()
+  })
+
+  it('model-missing banner mentions model setup', async () => {
+    mockApi.getModels.mockResolvedValue(MODELS_UNAVAILABLE)
+    renderLibrary()
+    await waitFor(() => screen.getByTestId('model-missing-banner'))
+    expect(screen.getByTestId('model-missing-banner')).toHaveTextContent(/no model is ready/i)
+  })
+
+  it('model-missing banner links to model manager', async () => {
+    mockApi.getModels.mockResolvedValue(MODELS_UNAVAILABLE)
+    renderLibrary()
+    await waitFor(() => screen.getByTestId('model-manager-link'))
+    expect(screen.getByTestId('model-manager-link')).toHaveAttribute('href', '/model-manager')
+  })
+
+  it('model-missing banner is an alert region', async () => {
+    mockApi.getModels.mockResolvedValue(MODELS_UNAVAILABLE)
+    renderLibrary()
+    await waitFor(() => screen.getByTestId('model-missing-banner'))
+    const banner = screen.getByTestId('model-missing-banner')
+    expect(banner).toHaveAttribute('role', 'alert')
+  })
+
+  it('does not show model-missing banner when getModels fails', async () => {
+    mockApi.getModels.mockRejectedValue(new Error('network'))
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+    expect(screen.queryByTestId('model-missing-banner')).not.toBeInTheDocument()
   })
 })

--- a/apps/web/src/__tests__/accessibility.test.tsx
+++ b/apps/web/src/__tests__/accessibility.test.tsx
@@ -45,6 +45,10 @@ vi.mock('../api/client', () => ({
     clearLocalData: vi.fn(),
     deleteSession: vi.fn(),
     listVoices: vi.fn().mockResolvedValue({ voices: [] }),
+    listPacks: vi.fn().mockResolvedValue({ packs: [], total: 0 }),
+    importPack: vi.fn(),
+    getPack: vi.fn(),
+    validatePack: vi.fn(),
     // RuntimeSettingsPanel
     getModels: vi.fn().mockReturnValue(new Promise(() => {})),
     getRuntimeSettings: vi.fn().mockReturnValue(new Promise(() => {})),

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -35,11 +35,27 @@ export interface PackSummary {
   pack_id: string
   name: string
   scenario_count: number
+  pack_root?: string
 }
 
 export interface PacksResponse {
   packs: PackSummary[]
   total: number
+}
+
+export interface PackDetail {
+  pack_id: string
+  name: string
+  version: string
+  scenario_count: number
+  pack_root: string
+}
+
+export interface ImportPackResponse {
+  pack_id: string
+  name: string
+  version: string
+  dest: string
 }
 
 export interface SttUploadResponse {
@@ -239,6 +255,21 @@ export const api = {
   },
   getScenario(scenarioId: string): Promise<ScenarioInfo> {
     return get<ScenarioInfo>(`/scenarios/${scenarioId}`)
+  },
+  listPacks(): Promise<PacksResponse> {
+    return get<PacksResponse>('/packs')
+  },
+  getPack(packId: string): Promise<PackDetail> {
+    return get<PackDetail>(`/packs/${packId}`)
+  },
+  async importPack(file: File): Promise<ImportPackResponse> {
+    const res = await fetch(`${BASE}/packs/import`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/zip' },
+      body: file,
+    })
+    if (!res.ok) throw new Error(await parseErrorMessage(res))
+    return res.json() as Promise<ImportPackResponse>
   },
   validatePack(packId: string): Promise<PackValidationResult> {
     return post<PackValidationResult>(`/packs/${packId}/validate`)

--- a/apps/web/src/screens/ScenarioLibrary.tsx
+++ b/apps/web/src/screens/ScenarioLibrary.tsx
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
-import { useState, useEffect, useMemo, useId } from 'react'
+import { useState, useEffect, useMemo, useId, useRef } from 'react'
 import { Link } from 'react-router-dom'
 import type { ScenarioInfo, PackValidationResult } from '@convsim/shared'
 import { api } from '../api/client'
+import type { PackSummary, ImportPackResponse } from '../api/client'
 
 interface PackGroup {
   pack_id: string
@@ -29,6 +30,8 @@ type ValidationState =
   | { status: 'done'; result: PackValidationResult }
   | { status: 'error'; message: string }
 
+type ImportState = 'idle' | 'uploading' | 'success' | 'error'
+
 export default function ScenarioLibrary() {
   const [scenarios, setScenarios] = useState<ScenarioInfo[] | null>(null)
   const [loadError, setLoadError] = useState(false)
@@ -42,6 +45,19 @@ export default function ScenarioLibrary() {
   const [validations, setValidations] = useState<Record<string, ValidationState>>({})
   const [expandedValidation, setExpandedValidation] = useState<string | null>(null)
 
+  // Indexed packs (from PackIndex) for folder display
+  const [indexedPacks, setIndexedPacks] = useState<Record<string, PackSummary>>({})
+  const [folderOpen, setFolderOpen] = useState<string | null>(null)
+
+  // Import pack state
+  const [importState, setImportState] = useState<ImportState>('idle')
+  const [importError, setImportError] = useState<string | null>(null)
+  const [importedPack, setImportedPack] = useState<ImportPackResponse | null>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  // Model readiness warning
+  const [modelMissing, setModelMissing] = useState(false)
+
   const searchId = useId()
   const ratingId = useId()
   const languageId = useId()
@@ -49,11 +65,35 @@ export default function ScenarioLibrary() {
   const tagId = useId()
   const modelId = useId()
 
-  useEffect(() => {
+  function loadScenarios() {
     api
       .listScenarios()
       .then((s) => setScenarios(s))
       .catch(() => setLoadError(true))
+  }
+
+  function loadIndexedPacks() {
+    api
+      .listPacks()
+      .then(({ packs }) => {
+        const map: Record<string, PackSummary> = {}
+        for (const p of packs) map[p.pack_id] = p
+        setIndexedPacks(map)
+      })
+      .catch(() => {})
+  }
+
+  useEffect(() => {
+    loadScenarios()
+    loadIndexedPacks()
+
+    api
+      .getModels()
+      .then((r) => {
+        const { status } = r.runtime_health
+        setModelMissing(status !== 'ready' && status !== 'degraded')
+      })
+      .catch(() => {})
   }, [])
 
   const { allRatings, allLanguages, allDifficulties, allTags, allModels } = useMemo(() => {
@@ -117,9 +157,117 @@ export default function ScenarioLibrary() {
     }
   }
 
+  async function handleImportPack(file: File) {
+    setImportState('uploading')
+    setImportError(null)
+    setImportedPack(null)
+    try {
+      const result = await api.importPack(file)
+      setImportedPack(result)
+      setImportState('success')
+      loadScenarios()
+      loadIndexedPacks()
+    } catch (err) {
+      setImportError(err instanceof Error ? err.message : 'Import failed')
+      setImportState('error')
+    }
+  }
+
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (file) void handleImportPack(file)
+    e.target.value = ''
+  }
+
   return (
     <div style={{ maxWidth: '900px' }}>
-      <h1>Scenario Library</h1>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' }}>
+        <h1 style={{ margin: 0 }}>Scenario Library</h1>
+
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+          {importState === 'success' && importedPack && (
+            <span
+              data-testid="import-success"
+              style={{ fontSize: '0.85rem', color: '#86efac' }}
+            >
+              Imported "{importedPack.name}" ({importedPack.pack_id})
+            </span>
+          )}
+          {importState === 'error' && importError && (
+            <span
+              role="alert"
+              data-testid="import-error"
+              style={{ fontSize: '0.85rem', color: '#f87171' }}
+            >
+              {importError}
+            </span>
+          )}
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".zip,application/zip"
+            style={{ display: 'none' }}
+            aria-label="Select pack zip file"
+            data-testid="import-file-input"
+            onChange={handleFileChange}
+          />
+          <button
+            onClick={() => fileInputRef.current?.click()}
+            disabled={importState === 'uploading'}
+            data-testid="import-pack-button"
+            aria-label="Import pack"
+            style={{
+              padding: '0.4rem 0.85rem',
+              borderRadius: '6px',
+              border: '1px solid rgba(255,255,255,0.15)',
+              background: 'rgba(255,255,255,0.05)',
+              color: '#e8e8ea',
+              fontSize: '0.875rem',
+              cursor: importState === 'uploading' ? 'wait' : 'pointer',
+            }}
+          >
+            {importState === 'uploading' ? 'Importing…' : 'Import pack'}
+          </button>
+        </div>
+      </div>
+
+      {modelMissing && (
+        <div
+          role="alert"
+          data-testid="model-missing-banner"
+          style={{
+            background: 'rgba(251,191,36,0.08)',
+            border: '1px solid rgba(251,191,36,0.3)',
+            borderRadius: '6px',
+            padding: '0.75rem 1rem',
+            marginBottom: '1.25rem',
+            fontSize: '0.875rem',
+            color: '#fbbf24',
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            gap: '1rem',
+          }}
+        >
+          <span>No model is ready. Launching a scenario requires a local or API-connected model.</span>
+          <Link
+            to="/model-manager"
+            data-testid="model-manager-link"
+            style={{
+              flexShrink: 0,
+              padding: '0.3rem 0.75rem',
+              borderRadius: '4px',
+              border: '1px solid rgba(251,191,36,0.4)',
+              color: '#fbbf24',
+              textDecoration: 'none',
+              fontSize: '0.8rem',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            Set up model
+          </Link>
+        </div>
+      )}
 
       <div
         role="search"
@@ -300,26 +448,25 @@ export default function ScenarioLibrary() {
         >
           <p style={{ fontSize: '1.1rem', marginBottom: '0.5rem' }}>No scenario packs installed.</p>
           <p style={{ fontSize: '0.9rem', color: '#a1a1aa', marginBottom: '1.25rem' }}>
-            Import a pack via{' '}
-            <Link to="/settings" style={{ color: '#a5b4fc' }}>
-              Settings → Import Pack
-            </Link>
-            , or install an official starter pack to begin.
+            Import a pack using the button above, or install an official starter pack to begin.
           </p>
-          <Link
-            to="/settings"
+          <button
+            onClick={() => fileInputRef.current?.click()}
+            disabled={importState === 'uploading'}
+            data-testid="empty-import-pack-button"
             style={{
               display: 'inline-block',
               padding: '0.5rem 1.25rem',
               borderRadius: '6px',
               background: 'rgba(255,255,255,0.08)',
               color: '#e8e8ea',
-              textDecoration: 'none',
+              border: '1px solid rgba(255,255,255,0.15)',
+              cursor: importState === 'uploading' ? 'wait' : 'pointer',
               fontSize: '0.875rem',
             }}
           >
-            Go to Settings
-          </Link>
+            {importState === 'uploading' ? 'Importing…' : 'Import pack'}
+          </button>
         </div>
       )}
 
@@ -347,6 +494,8 @@ export default function ScenarioLibrary() {
       {packs.map((pack) => {
         const validation: ValidationState = validations[pack.pack_id] ?? { status: 'idle' }
         const isExpanded = expandedValidation === pack.pack_id
+        const indexedPack = indexedPacks[pack.pack_id]
+        const isFolderOpen = folderOpen === pack.pack_id
 
         return (
           <section
@@ -378,32 +527,70 @@ export default function ScenarioLibrary() {
                 </span>
               </h2>
 
-              <button
-                onClick={() => {
-                  if (isExpanded && validation.status !== 'idle') {
-                    setExpandedValidation(null)
-                  } else {
-                    void handleValidate(pack.pack_id)
-                  }
-                }}
-                disabled={validation.status === 'loading'}
-                aria-label={`Validate pack ${pack.pack_name}`}
-                aria-expanded={isExpanded && validation.status !== 'idle'}
-                data-testid={`validate-${pack.pack_id}`}
+              <div style={{ display: 'flex', gap: '0.5rem', flexShrink: 0 }}>
+                {indexedPack && (
+                  <button
+                    onClick={() => setFolderOpen(isFolderOpen ? null : pack.pack_id)}
+                    aria-label={`Open folder for pack ${pack.pack_name}`}
+                    aria-expanded={isFolderOpen}
+                    data-testid={`open-folder-${pack.pack_id}`}
+                    style={packActionButtonStyle}
+                  >
+                    {isFolderOpen ? 'Hide folder' : 'Open folder'}
+                  </button>
+                )}
+                <button
+                  onClick={() => {
+                    if (isExpanded && validation.status !== 'idle') {
+                      setExpandedValidation(null)
+                    } else {
+                      void handleValidate(pack.pack_id)
+                    }
+                  }}
+                  disabled={validation.status === 'loading'}
+                  aria-label={`Validate pack ${pack.pack_name}`}
+                  aria-expanded={isExpanded && validation.status !== 'idle'}
+                  data-testid={`validate-${pack.pack_id}`}
+                  style={{
+                    ...packActionButtonStyle,
+                    cursor: validation.status === 'loading' ? 'wait' : 'pointer',
+                  }}
+                >
+                  {validation.status === 'loading' ? 'Validating…' : 'Validate pack'}
+                </button>
+              </div>
+            </div>
+
+            {isFolderOpen && indexedPack?.pack_root && (
+              <div
+                data-testid={`folder-path-${pack.pack_id}`}
                 style={{
-                  padding: '0.25rem 0.65rem',
+                  marginBottom: '0.75rem',
+                  padding: '0.6rem 0.85rem',
                   borderRadius: '4px',
-                  border: '1px solid rgba(255,255,255,0.15)',
-                  cursor: validation.status === 'loading' ? 'wait' : 'pointer',
-                  background: 'transparent',
-                  color: '#a1a1aa',
-                  fontSize: '0.8rem',
-                  flexShrink: 0,
+                  background: 'rgba(255,255,255,0.04)',
+                  border: '1px solid rgba(255,255,255,0.1)',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '0.75rem',
                 }}
               >
-                {validation.status === 'loading' ? 'Validating…' : 'Validate pack'}
-              </button>
-            </div>
+                <code style={{ fontSize: '0.78rem', color: '#94a3b8', flex: 1, wordBreak: 'break-all' }}>
+                  {indexedPack.pack_root}
+                </code>
+                <button
+                  onClick={() => void navigator.clipboard.writeText(indexedPack.pack_root ?? '')}
+                  aria-label="Copy pack folder path"
+                  data-testid={`copy-folder-${pack.pack_id}`}
+                  style={{
+                    ...packActionButtonStyle,
+                    flexShrink: 0,
+                  }}
+                >
+                  Copy
+                </button>
+              </div>
+            )}
 
             {isExpanded && validation.status === 'done' && (
               <div
@@ -637,4 +824,14 @@ const filterGroupStyle: React.CSSProperties = {
 const labelStyle: React.CSSProperties = {
   fontSize: '0.8rem',
   color: '#a1a1aa',
+}
+
+const packActionButtonStyle: React.CSSProperties = {
+  padding: '0.25rem 0.65rem',
+  borderRadius: '4px',
+  border: '1px solid rgba(255,255,255,0.15)',
+  cursor: 'pointer',
+  background: 'transparent',
+  color: '#a1a1aa',
+  fontSize: '0.8rem',
 }


### PR DESCRIPTION
## Summary

This PR completes the Scenario Library feature for importing and launching community-pack scenarios, addressing #205:

### API changes
- **Dynamic scenarios from installed packs**: `GET /api/scenarios` now merges built-in scenarios with any packs tracked in the PackIndex (imported via `POST /api/packs/import`). `GET /api/scenarios/:id` also falls back to PackIndex, so imported pack scenarios are discoverable without a server restart.
- **Pack folder endpoint**: Added `GET /api/packs/:pack_id` returning full pack details including `pack_root`. Extended `GET /api/packs` to include `pack_root` in each `PackSummary` for on-disk path visibility.
- **Launch support for pack scenarios**: Extracted scenario lookup into a shared `findScenarioInfo()` helper so `POST /api/sessions` validates and launches scenarios from both built-in and imported packs, with their own difficulty and language options. Turn handler respects each scenario's `max_turns` cap.

### Web UI changes
- **Import pack action**: New _Import pack_ button in the library header. Selecting a `.zip` file posts to `POST /api/packs/import`, shows inline success (pack name and ID) or error feedback, and auto-refreshes both scenarios and packs lists.
- **Open folder action**: Pack sections show an _Open folder_ button for any pack in the PackIndex. Clicking reveals the `pack_root` path in a collapsible panel with a _Copy_ button. Built-in packs not in the index show no button.
- **Model-missing state**: On mount, the library fetches `GET /api/models`. When `runtime_health.status` is neither `ready` nor `degraded`, a dismissible amber banner appears explaining that no model is ready, with a _Set up model_ link to `/model-manager`.
- **Empty-state improvement**: The empty library state now offers an inline _Import pack_ button as its primary call to action.

### Fixes
- Pack scenarios default to `voice_supported: true` for parity with built-ins, so voice filters and the "Voice supported" chip work correctly.
- Session creation now reuses the same scenario lookup as the library, ensuring launched pack scenarios work end-to-end.

### Testing
- New `pack-library.test.ts` covers the dynamic merge, manifest→ScenarioInfo mapping, scenario detail lookup, and the new pack detail endpoint — all paths that shipped untested in earlier work.
- `ScenarioLibrary.test.tsx` expands with suites for import pack, open folder, and model-missing state (upload flow, error paths, folder reveal/hide, banner visibility).
- `accessibility.test.tsx` updated to mock new API methods so the axe-core check continues to pass.
- All 644 web tests and 331 API tests pass; TypeScript clean in both apps.

Closes #205