### PR TITLE
Implement Scenario Setup launch flow with LLM readiness block and tests

### DIFF
--- a/apps/web/src/pages/ScenarioSetup.test.tsx
+++ b/apps/web/src/pages/ScenarioSetup.test.tsx
@@ -644,6 +644,54 @@ describe('ScenarioSetupPage', () => {
     });
   });
 
+  describe('missing runtime (LLM not loaded)', () => {
+    const healthNoLlm: HealthResponse = {
+      status: 'error',
+      version: '0.1.0',
+      runtime: {
+        llm_ready: false,
+        llm_model_name: null,
+        stt_ready: false,
+        tts_ready: false,
+        tts_voice_name: null,
+        network_required: false,
+      },
+    };
+
+    it('shows a missing-runtime block when no LLM model is loaded', async () => {
+      mockApi.getScenario.mockResolvedValue(mockScenario);
+      mockApi.health.mockResolvedValue(healthNoLlm);
+      renderSetup();
+      await waitFor(() => screen.getByText('Behavioral Interview'));
+      expect(screen.getByTestId('missing-runtime-block')).toBeInTheDocument();
+      expect(screen.getByText(/no llm model is loaded/i)).toBeInTheDocument();
+    });
+
+    it('disables the start button when no LLM model is loaded', async () => {
+      mockApi.getScenario.mockResolvedValue(mockScenario);
+      mockApi.health.mockResolvedValue(healthNoLlm);
+      renderSetup();
+      await waitFor(() => screen.getByText('Behavioral Interview'));
+      expect(screen.getByRole('button', { name: /start scenario/i })).toBeDisabled();
+    });
+
+    it('shows a model manager hint in the missing-runtime block', async () => {
+      mockApi.getScenario.mockResolvedValue(mockScenario);
+      mockApi.health.mockResolvedValue(healthNoLlm);
+      renderSetup();
+      await waitFor(() => screen.getByText('Behavioral Interview'));
+      expect(screen.getByTestId('missing-runtime-block')).toHaveTextContent(/model manager/i);
+    });
+
+    it('does not show the missing-runtime block when LLM is ready', async () => {
+      mockApi.getScenario.mockResolvedValue(mockScenario);
+      mockApi.health.mockResolvedValue(healthReady);
+      renderSetup();
+      await waitFor(() => screen.getByText('Behavioral Interview'));
+      expect(screen.queryByTestId('missing-runtime-block')).not.toBeInTheDocument();
+    });
+  });
+
   describe('back navigation', () => {
     it('calls onBack when the back button is clicked', async () => {
       mockApi.getScenario.mockResolvedValue(mockScenario);

--- a/apps/web/src/pages/ScenarioSetup.tsx
+++ b/apps/web/src/pages/ScenarioSetup.tsx
@@ -191,6 +191,8 @@ export function ScenarioSetupPage({ scenarioId, onSessionCreated, onBack }: Prop
     validationResult.errors.map((e) => [e.field, e.message]),
   );
 
+  const formLevelErrors = validationResult.errors.filter((e) => e.field === '_form');
+
   return (
     <div className="setup-page" data-testid="setup-page">
       <header className="setup-header">
@@ -206,6 +208,22 @@ export function ScenarioSetupPage({ scenarioId, onSessionCreated, onBack }: Prop
 
       <div className="setup-layout">
         <form className="setup-form" onSubmit={handleSubmit} noValidate>
+          {formLevelErrors.length > 0 && (
+            <div
+              className="setup-missing-runtime"
+              role="alert"
+              data-testid="missing-runtime-block"
+            >
+              {formLevelErrors.map((e, i) => (
+                <p key={i} className="setup-missing-runtime-message">{e.message}</p>
+              ))}
+              <p className="setup-missing-runtime-hint">
+                Go to <strong>Settings → Model Manager</strong> to install a model, then return
+                here to launch your scenario.
+              </p>
+            </div>
+          )}
+
           <section className="setup-section" aria-labelledby="difficulty-heading">
             <h2 id="difficulty-heading" className="setup-section-title">
               Difficulty

--- a/packages/shared/src/types/setup.test.ts
+++ b/packages/shared/src/types/setup.test.ts
@@ -34,6 +34,18 @@ const validForm: SetupFormValues = {
 };
 
 describe('validateSetup', () => {
+  it('fails when LLM is not loaded', () => {
+    const result = validateSetup(
+      validForm,
+      { ...runtimeReady, llm_ready: false, llm_model_name: null },
+      false,
+    );
+    expect(result.valid).toBe(false);
+    const formError = result.errors.find((e) => e.field === '_form');
+    expect(formError).toBeDefined();
+    expect(formError!.message).toMatch(/LLM|model/i);
+  });
+
   it('passes a valid form with all runtime ready', () => {
     const result = validateSetup(
       { ...validForm, input_mode: 'push-to-talk', tts_enabled: true },

--- a/packages/shared/src/types/setup.ts
+++ b/packages/shared/src/types/setup.ts
@@ -32,6 +32,14 @@ export function validateSetup(
 ): SetupValidationResult {
   const errors: SetupValidationError[] = [];
 
+  if (!runtime.llm_ready) {
+    errors.push({
+      field: '_form',
+      message:
+        'No LLM model is loaded. Install a model via Model Manager to start this scenario.',
+    });
+  }
+
   if (values.tts_enabled && !runtime.tts_ready) {
     errors.push({
       field: 'tts_enabled',


### PR DESCRIPTION
## Summary

Adds LLM-readiness validation to the Scenario Setup launch flow:

- **Validation layer**: `validateSetup` in `@convsim/shared` now blocks form submission with a `_form` error when `runtime.llm_ready` is false
- **UI alert**: Renders a prominent `missing-runtime` block with `role="alert"` at the top of the setup form when no LLM model is loaded, displaying a message and directing players to **Settings → Model Manager**
- **Test coverage**: Four new UI tests verify the block appears/disappears correctly and the start button is disabled; one unit test confirms the validation error is returned when LLM is not ready

## What changed

| File | Changes |
|------|---------|
| `packages/shared/src/types/setup.ts` | Added LLM-readiness check to `validateSetup`, returns `_form` error if `llm_ready` is false |
| `packages/shared/src/types/setup.test.ts` | New unit test verifying validation fails when LLM not loaded |
| `apps/web/src/pages/ScenarioSetup.tsx` | Renders missing-runtime alert block filtered from form-level errors |
| `apps/web/src/pages/ScenarioSetup.test.tsx` | Four new UI tests for the missing-runtime block behavior |

## Test results

- `pnpm --filter=@convsim/web exec vitest run` — 712 tests pass
- `pnpm --filter=@convsim/api exec vitest run` — shared setup validation test passes

New test group: `ScenarioSetupPage > missing runtime (LLM not loaded)` covers all four scenarios:
- Block is shown when no LLM model is loaded
- Start button is disabled when no LLM model is loaded  
- Model Manager hint is present in the block
- Block is absent when LLM is ready

Closes #206