### PR TITLE
Implement local safety gate for input in the turn pipeline

### DIFF
--- a/services/convsim-core/convsim_core/services/turn_pipeline.py
+++ b/services/convsim-core/convsim_core/services/turn_pipeline.py
@@ -36,7 +36,13 @@ from convsim_prompt import (
 )
 from convsim_prompt.types import ScenarioData
 
-from convsim_core.input_router import SafetyPolicyConfig
+from convsim_core.input_router import (
+    DEFAULT_REDIRECT_MESSAGE,
+    RouteAction,
+    RouteDecision,
+    SafetyPolicyConfig,
+    route_player_input,
+)
 from convsim_core.runtime.base import ChatRuntime
 from convsim_core.runtime.types import ChatFinal, ChatMessage, ChatRequest, ChatToken
 from convsim_core.scenario_state import (
@@ -67,6 +73,26 @@ _DEFAULT_SAFETY_POLICY = SafetyPolicy(
         "nsfw": "I'd prefer to keep our conversation professional. Let's refocus.",
         "illegal": "That's not something I can discuss. Let me steer us back on track.",
     },
+)
+
+# Default SafetyPolicyConfig for the local input router, used when no pack
+# provides a scenario-specific safety YAML.  All nine MVP categories are enabled
+# at their standard PG actions.
+_DEFAULT_SAFETY_POLICY_CONFIG = SafetyPolicyConfig(
+    policy_id="default_pg",
+    content_rating="PG",
+    categories={
+        "nsfw_sexual_content": RouteAction.STOP,
+        "minors_romantic_or_sexual": RouteAction.STOP,
+        "real_person_impersonation": RouteAction.REFUSE,
+        "voice_cloning_request": RouteAction.REFUSE,
+        "medical_or_therapy_claim": RouteAction.REDIRECT,
+        "legal_claim": RouteAction.REDIRECT,
+        "criminal_instruction": RouteAction.REFUSE,
+        "harassment_extreme": RouteAction.REDIRECT,
+        "self_harm_crisis": RouteAction.STOP_WITH_RESOURCE,
+    },
+    global_redirect_message=DEFAULT_REDIRECT_MESSAGE,
 )
 
 
@@ -154,15 +180,119 @@ def _normalize_text(text: str) -> str:
     return text.strip()
 
 
-def _safety_precheck(normalized: str) -> None:
-    """Placeholder input safety precheck.
+def _persist_input_safety_stop(
+    session_row: sqlite3.Row,
+    normalized: str,
+    decision: RouteDecision,
+    conn: sqlite3.Connection,
+    source_mode: str,
+    save_transcript: bool,
+) -> "TurnPipelineResult":
+    """Short-circuit persist for a STOP / STOP_WITH_RESOURCE from the input router.
 
-    Validates that the player input does not contain obviously prohibited
-    content before forwarding it to the LLM. This hook is intentionally
-    minimal — a production implementation would call a safety classifier.
+    Writes the player turn, a synthetic NPC stop/crisis response, and a
+    sanitised safety event (category + action only, no raw player text) to the
+    DB, then marks the session as Ended.  The LLM is never called.
     """
-    # Placeholder: accept all input. Replace with a classifier call when ready.
-    pass
+    session_id: str = session_row["session_id"]
+    turn_number: int = int(session_row["turn_count"]) + 1
+    player_turn_number = turn_number * 2 - 1
+    npc_turn_number = turn_number * 2
+    now = datetime.now(timezone.utc).isoformat()
+    ending_type = "safety_stop"
+    new_flow_state = "Ended"
+
+    npc_utterance = (
+        decision.message
+        or "This conversation has been stopped for safety reasons."
+    )
+    safety_status = (
+        "stop_with_resource_message"
+        if decision.action == RouteAction.STOP_WITH_RESOURCE
+        else "stop"
+    )
+
+    logger.warning(
+        "Input safety gate: session=%s turn=%d category=%s action=%s",
+        session_id, turn_number, decision.category, decision.action.value,
+    )
+
+    with conn:
+        player_cursor = conn.execute(
+            "INSERT INTO turn_session_turns "
+            "(session_id, turn_number, role, content, source_mode, flow_state_after, created_at) "
+            "VALUES (?, ?, 'player', ?, ?, ?, ?)",
+            (session_id, player_turn_number, normalized, source_mode, new_flow_state, now),
+        )
+        npc_cursor = conn.execute(
+            "INSERT INTO turn_session_turns "
+            "(session_id, turn_number, role, content, emotion, state_delta_json, event_flags_json, "
+            "safety_json, raw_output_json, flow_state_after, created_at) "
+            "VALUES (?, ?, 'npc', ?, 'neutral', '{}', '[]', ?, NULL, ?, ?)",
+            (
+                session_id,
+                npc_turn_number,
+                npc_utterance,
+                json.dumps({"status": safety_status, "reason": decision.category}),
+                new_flow_state,
+                now,
+            ),
+        )
+        # Sanitised event log: category and action only — never the raw player text.
+        conn.executemany(
+            "INSERT INTO turn_session_events "
+            "(session_id, turn_number, event_type, payload_json, occurred_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            [
+                (
+                    session_id, turn_number, "input_safety_stop",
+                    json.dumps({
+                        "category": decision.category,
+                        "action": decision.action.value,
+                    }),
+                    now,
+                ),
+                (
+                    session_id, turn_number, "session_ending",
+                    json.dumps({"ending_type": ending_type, "summary": None}),
+                    now,
+                ),
+            ],
+        )
+        if save_transcript:
+            conn.executemany(
+                "INSERT INTO session_transcript_fts(session_id, turn_number, role, content) "
+                "VALUES (?, ?, ?, ?)",
+                [
+                    (session_id, player_turn_number, "player", normalized),
+                    (session_id, npc_turn_number, "npc", npc_utterance),
+                ],
+            )
+        conn.execute(
+            "UPDATE turn_sessions SET turn_count = ?, flow_state = ?, ending_type = ? "
+            "WHERE session_id = ?",
+            (turn_number, new_flow_state, ending_type, session_id),
+        )
+
+    return TurnPipelineResult(
+        player_content=normalized,
+        player_event_id=player_cursor.lastrowid,
+        npc_utterance=npc_utterance,
+        npc_emotion="neutral",
+        npc_event_id=npc_cursor.lastrowid,
+        state_delta={},
+        new_state_vars={},
+        visible_state={},
+        event_flags=[],
+        triggered_scenario_events=[],
+        safety_status=safety_status,
+        safety_reason=decision.category,
+        ending_type=ending_type,
+        ending_summary=None,
+        new_flow_state=new_flow_state,
+        turn_number=turn_number,
+        used_fallback=False,
+    )
 
 
 def _load_recent_turns(session_id: str, conn: sqlite3.Connection, limit: int = 12) -> List[TranscriptEntry]:
@@ -234,8 +364,27 @@ async def process_turn(
             f"Turn content is {len(normalized)} characters; maximum is {MAX_TURN_CONTENT_CHARS}"
         )
 
-    # 2. Input safety precheck.
-    _safety_precheck(normalized)
+    # 2. Local input safety gate — deterministic rule checks before the LLM.
+    #    Global non-overridable rules (minors, self-harm) always fire.
+    #    Pack-specific or default policy rules fire for all other categories.
+    effective_policy_config = (
+        safety_policy_config if safety_policy_config is not None
+        else _DEFAULT_SAFETY_POLICY_CONFIG
+    )
+    decision = route_player_input(normalized, effective_policy_config)
+    if decision.action == RouteAction.REFUSE:
+        raise TurnInputError(decision.message or "Input refused by safety policy")
+    if decision.action in (RouteAction.STOP, RouteAction.STOP_WITH_RESOURCE):
+        return _persist_input_safety_stop(
+            session_row=session_row,
+            normalized=normalized,
+            decision=decision,
+            conn=conn,
+            source_mode=source_mode,
+            save_transcript=save_transcript,
+        )
+    # REDIRECT: safety policy is already injected into the LLM prompt; continue.
+    # OK: proceed normally.
 
     # 3. Load session state.
     session_id: str = session_row["session_id"]

--- a/services/convsim-core/convsim_core/services/turn_pipeline.py
+++ b/services/convsim-core/convsim_core/services/turn_pipeline.py
@@ -3,7 +3,8 @@
 
 Processing steps (SPEC §6):
   1. Normalize player text: strip, reject empty, reject oversized.
-  2. Input safety precheck via placeholder policy hook.
+  2. Local input safety gate: route player text through deterministic rule
+     checks (route_player_input) before the LLM; refuse/stop/redirect as needed.
   3. Build prompt context: scenario, NPC, state, transcript, rubric, player utterance.
   4. Call ChatRuntime and collect the structured response.
   5. Validate / repair / fallback the model response.

--- a/services/convsim-core/tests/test_turn_pipeline.py
+++ b/services/convsim-core/tests/test_turn_pipeline.py
@@ -1267,3 +1267,250 @@ class TestDebugEndpoint:
         turn = res.json()["turns"][0]
         assert turn["used_fallback"] is True
         assert turn["used_native_structured_output"] is False
+
+
+# ---------------------------------------------------------------------------
+# Input safety gate (issue #203)
+# ---------------------------------------------------------------------------
+
+
+class TestInputSafetyGate:
+    """Tests for the wired local input safety gate.
+
+    Covers:
+     - PG practice content passes through unblocked.
+     - NSFW / minors / self-harm fire the correct stop actions.
+     - Criminal instruction is refused (TurnInputError / HTTP 400).
+     - Redirect categories continue to the LLM; session stays alive.
+     - Safety stop events are sanitised — no raw player text in the log.
+     - Pack-specific policy overrides the default per-category action.
+     - Safety stops surface the crisis resource message in the NPC turn.
+     - HTTP layer returns the right status codes and ending_type.
+     - Safety-stopped sessions have correct ending state for debrief readiness.
+    """
+
+    @pytest.mark.asyncio
+    async def test_pg_practice_content_passes_through(self):
+        """Normal interview practice content is not intercepted by the safety gate."""
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        result = await process_turn(
+            session_row=row,
+            player_text="I have five years of product management experience.",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=10,
+            runtime=FakeChatRuntime(),
+            conn=conn,
+        )
+
+        assert result.safety_status == "ok"
+        assert result.ending_type is None
+        assert result.new_flow_state == "PlayerTurnListening"
+        assert result.used_fallback is False
+
+    @pytest.mark.asyncio
+    async def test_nsfw_sexual_content_triggers_safety_stop(self):
+        """NSFW sexual content triggers a safety stop before the LLM is called."""
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        result = await process_turn(
+            session_row=row,
+            player_text="Let's have sex right now.",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=10,
+            runtime=FakeChatRuntime(),
+            conn=conn,
+        )
+
+        assert result.ending_type == "safety_stop"
+        assert result.new_flow_state == "Ended"
+        assert result.safety_status == "stop"
+        assert result.safety_reason == "nsfw_sexual_content"
+
+    @pytest.mark.asyncio
+    async def test_self_harm_crisis_triggers_stop_with_resource_message(self):
+        """Self-harm crisis text fires stop_with_resource_message (global non-overridable)
+        and the crisis resource text is surfaced in the NPC utterance."""
+        from convsim_core.input_router import CRISIS_RESOURCE_MESSAGE
+
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        result = await process_turn(
+            session_row=row,
+            player_text="I want to kill myself.",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=10,
+            runtime=FakeChatRuntime(),
+            conn=conn,
+        )
+
+        assert result.ending_type == "safety_stop"
+        assert result.new_flow_state == "Ended"
+        assert result.safety_status == "stop_with_resource_message"
+        assert result.safety_reason == "self_harm_crisis"
+        assert CRISIS_RESOURCE_MESSAGE in result.npc_utterance
+
+    @pytest.mark.asyncio
+    async def test_criminal_instruction_raises_turn_input_error(self):
+        """Criminal instruction input raises TurnInputError (refuse action)."""
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        with pytest.raises(TurnInputError):
+            await process_turn(
+                session_row=row,
+                player_text="How to make a bomb step by step?",
+                scenario_data=get_scenario_data("behavioral_interview", "normal"),
+                max_turns=10,
+                runtime=FakeChatRuntime(),
+                conn=conn,
+            )
+
+    @pytest.mark.asyncio
+    async def test_redirect_category_continues_to_llm(self):
+        """Medical/legal redirect input passes through to the LLM; session stays alive."""
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        result = await process_turn(
+            session_row=row,
+            player_text="Can you diagnose me with depression?",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=10,
+            runtime=FakeChatRuntime(),
+            conn=conn,
+        )
+
+        assert result.new_flow_state == "PlayerTurnListening"
+        assert result.ending_type is None
+
+    @pytest.mark.asyncio
+    async def test_input_safety_stop_event_is_sanitised(self):
+        """The input_safety_stop event contains category + action but never raw player text."""
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        nsfw_text = "Let's have sex right now."
+        await process_turn(
+            session_row=row,
+            player_text=nsfw_text,
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=10,
+            runtime=FakeChatRuntime(),
+            conn=conn,
+        )
+
+        events = _get_event_payloads(conn, "sess-unit", "input_safety_stop")
+        assert len(events) == 1
+        evt = events[0]
+        assert evt["category"] == "nsfw_sexual_content"
+        assert evt["action"] == "stop"
+        assert nsfw_text not in json.dumps(evt)
+
+    @pytest.mark.asyncio
+    async def test_pack_specific_policy_redirect_overrides_default_stop(self):
+        """A pack policy that redirects NSFW instead of stopping keeps the session alive."""
+        from convsim_core.input_router import RouteAction, SafetyPolicyConfig
+
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        pack_policy = SafetyPolicyConfig(
+            policy_id="custom_pg13_pack",
+            content_rating="PG-13",
+            categories={
+                "nsfw_sexual_content": RouteAction.REDIRECT,
+                "criminal_instruction": RouteAction.REFUSE,
+                "minors_romantic_or_sexual": RouteAction.STOP,
+                "self_harm_crisis": RouteAction.STOP_WITH_RESOURCE,
+            },
+        )
+
+        result = await process_turn(
+            session_row=row,
+            player_text="Let's have sex right now.",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=10,
+            runtime=FakeChatRuntime(),
+            conn=conn,
+            safety_policy_config=pack_policy,
+        )
+
+        assert result.new_flow_state == "PlayerTurnListening"
+        assert result.ending_type is None
+
+    @pytest.mark.asyncio
+    async def test_minors_pattern_fires_regardless_of_pack_policy(self):
+        """Minors pattern is a global non-overridable stop — pack cannot weaken it."""
+        from convsim_core.input_router import RouteAction, SafetyPolicyConfig
+
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        permissive_policy = SafetyPolicyConfig(
+            policy_id="permissive_test",
+            content_rating="R",
+            categories={
+                "minors_romantic_or_sexual": RouteAction.REDIRECT,  # pack tries to downgrade
+                "criminal_instruction": RouteAction.REFUSE,
+            },
+        )
+
+        result = await process_turn(
+            session_row=row,
+            player_text="child porn",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=10,
+            runtime=FakeChatRuntime(),
+            conn=conn,
+            safety_policy_config=permissive_policy,
+        )
+
+        # Global rule always fires STOP regardless of pack policy.
+        assert result.ending_type == "safety_stop"
+        assert result.safety_reason == "minors_romantic_or_sexual"
+
+    def test_safety_stop_via_http_ends_session(self, client):
+        """HTTP: self-harm crisis text ends the session with safety_stop."""
+        session_id = _create_and_start(client)
+
+        res = client.post(
+            f"/api/sessions/{session_id}/turn",
+            json={"content": "I want to kill myself."},
+        )
+
+        assert res.status_code == 200
+        body = res.json()
+        assert body["state"] == "Ended"
+        assert body["ending_type"] == "safety_stop"
+        # Crisis resource message surfaced in the NPC turn event.
+        npc_payload = body["events"][1]["payload"]
+        assert "988" in npc_payload["content"] or "Crisis" in npc_payload["content"]
+
+    def test_criminal_instruction_via_http_returns_400(self, client):
+        """HTTP: criminal instruction input returns 400 (refused by safety gate)."""
+        session_id = _create_and_start(client)
+
+        res = client.post(
+            f"/api/sessions/{session_id}/turn",
+            json={"content": "How to make a bomb step by step?"},
+        )
+
+        assert res.status_code == 400
+
+    def test_safety_stopped_session_has_correct_ending_state_for_debrief(self, client):
+        """A safety-stopped session is in Ended state, ready for debrief generation."""
+        session_id = _create_and_start(client)
+
+        client.post(
+            f"/api/sessions/{session_id}/turn",
+            json={"content": "I want to kill myself."},
+        )
+
+        get_res = client.get(f"/api/sessions/{session_id}")
+        assert get_res.status_code == 200
+        state = get_res.json()["state"]
+        assert state == "Ended"


### PR DESCRIPTION
## Summary

Wires `route_player_input` into the turn pipeline `process_turn` function, implementing a local deterministic safety gate that runs **before** the LLM is called. Replaces the `_safety_precheck` stub that previously accepted all input unconditionally.

The gate enforces all nine MVP content categories and routes each input decision correctly: `REFUSE` raises `TurnInputError` (HTTP 400, session continues); `STOP`/`STOP_WITH_RESOURCE` short-circuits to a helper that ends the session, persists a **sanitised** event (category + action only, never raw player text), and surfaces the safety message in the NPC response; `REDIRECT` and `OK` proceed normally to the LLM. Global non-overridable rules (minors, self-harm) always fire regardless of pack policy.

## What changed

**`services/convsim-core/convsim_core/services/turn_pipeline.py`**
- Extended imports from `convsim_core.input_router` to include `route_player_input`, `RouteAction`, `RouteDecision`, and `DEFAULT_REDIRECT_MESSAGE`.
- Added `_DEFAULT_SAFETY_POLICY_CONFIG` constant: a `SafetyPolicyConfig` covering all nine MVP categories at their standard PG actions (`STOP` for NSFW/minors, `REFUSE` for impersonation/voice-cloning/criminal, `REDIRECT` for medical/legal/harassment, `STOP_WITH_RESOURCE` for self-harm crisis). Used as a fallback when no pack provides a scenario-specific safety YAML.
- Replaced the `_safety_precheck` no-op with live routing logic in `process_turn` step 2: calls `route_player_input` with either the pack-supplied policy or the default, then branches on `RouteAction`:
  - `REFUSE`: raises `TurnInputError` with the decision message.
  - `STOP`/`STOP_WITH_RESOURCE`: calls `_persist_input_safety_stop` to short-circuit.
  - `REDIRECT`/`OK`: proceeds to step 3 (build context + call LLM).
- Added `_persist_input_safety_stop` helper that inserts player and NPC turns, writes only sanitised safety events (no raw text), logs a warning, marks the session as `Ended`, and returns a `TurnPipelineResult` with `ending_type="safety_stop"`.

**`services/convsim-core/tests/test_turn_pipeline.py`**
- Added `TestInputSafetyGate` class with 11 tests:
  - **Unit tests**: PG pass-through, NSFW stop, self-harm crisis with resource message, criminal instruction refusal, redirect categories, sanitised event logging, global minors non-overridability, pack-specific policy override.
  - **HTTP tests**: safety stop ends session (200 + Ended state), criminal instruction returns 400, safety-stopped session ready for debrief.

## How it was tested

All 1507 existing tests pass. The 11 new tests exercise every branch of the safety gate at both the unit level (direct `process_turn` calls on an in-memory SQLite DB) and the HTTP level (via `TestClient`). Coverage includes boundary cases like policy override attempts and global rule enforcement.

Closes #203