### PR TITLE
Implement state variables, scenario events, endings, and rubrics

### DIFF
--- a/services/convsim-core/convsim_core/routers/sessions.py
+++ b/services/convsim-core/convsim_core/routers/sessions.py
@@ -453,6 +453,9 @@ async def submit_turn(session_id: str, body: TurnSubmitRequest, request: Request
             conn=conn,
             save_transcript=save_transcript,
             source_mode=source_mode,
+            state_variable_overrides=info.state_variable_overrides,
+            scenario_events=info.events,
+            ending_conditions=info.ending_conditions,
         )
     except TurnInputError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -473,7 +476,10 @@ async def submit_turn(session_id: str, body: TurnSubmitRequest, request: Request
             "content": result.npc_utterance,
             "emotion": result.npc_emotion,
             "state_delta": result.state_delta,
+            "visible_state": result.visible_state,
             "event_flags": result.event_flags,
+            "triggered_scenario_events": result.triggered_scenario_events,
+            "rubric_observations": result.rubric_observations,
             "safety": {
                 "status": result.safety_status,
                 "reason": result.safety_reason,

--- a/services/convsim-core/convsim_core/scenarios.py
+++ b/services/convsim-core/convsim_core/scenarios.py
@@ -7,7 +7,7 @@ pipeline-level metadata (max_turns, supported_languages).
 """
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 from convsim_prompt.types import (

--- a/services/convsim-core/convsim_core/scenarios.py
+++ b/services/convsim-core/convsim_core/scenarios.py
@@ -7,8 +7,8 @@ pipeline-level metadata (max_turns, supported_languages).
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Dict, List
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
 
 from convsim_prompt.types import (
     DifficultySettings,
@@ -18,6 +18,7 @@ from convsim_prompt.types import (
     ResponseStyleOverrides,
     ScenarioData,
 )
+from convsim_core.scenario_state import ScenarioEvent
 
 
 @dataclass
@@ -28,6 +29,10 @@ class ScenarioInfo:
     supported_languages: List[str]
     difficulty_options: Dict[str, DifficultySettings]
     opening_npc_says: str
+    # Optional per-scenario simulation config; None means use baseline defaults.
+    state_variable_overrides: Optional[Dict[str, Any]] = None
+    events: Optional[List[ScenarioEvent]] = None
+    ending_conditions: Optional[Dict[str, Any]] = None
 
     def get_scenario_data(self, difficulty: str) -> ScenarioData:
         """Return a ScenarioData with difficulty settings applied."""
@@ -267,6 +272,32 @@ SCENARIOS: Dict[str, ScenarioInfo] = {
             "hard": DifficultySettings(npc_patience_modifier=-15, challenge_frequency="high"),
         },
         opening_npc_says="Hey, you wanted to talk? What's up?",
+        state_variable_overrides={
+            # Jordan starts guarded — rapport begins below the baseline 50.
+            "rapport": {"default": 30, "visibility": "visible"},
+        },
+        events=[
+            ScenarioEvent(
+                id="npc_defensive",
+                when={"type": "variable_below", "variable": "patience", "threshold": 30},
+                npc_instruction=(
+                    "Jordan is becoming defensive. Give shorter, clipped replies "
+                    "and stop volunteering information."
+                ),
+            ),
+        ],
+        ending_conditions={
+            "success": {
+                "type": "variable_above",
+                "variable": "objective_progress",
+                "threshold": 60,
+            },
+            "failure": {
+                "type": "variable_below",
+                "variable": "patience",
+                "threshold": 15,
+            },
+        },
     ),
 }
 

--- a/services/convsim-core/convsim_core/services/turn_pipeline.py
+++ b/services/convsim-core/convsim_core/services/turn_pipeline.py
@@ -288,6 +288,7 @@ def _persist_input_safety_stop(
         visible_state={},
         event_flags=[],
         triggered_scenario_events=[],
+        rubric_observations=[],
         safety_status=safety_status,
         safety_reason=decision.category,
         ending_type=ending_type,

--- a/services/convsim-core/convsim_core/services/turn_pipeline.py
+++ b/services/convsim-core/convsim_core/services/turn_pipeline.py
@@ -3,7 +3,8 @@
 
 Processing steps (SPEC §6):
   1. Normalize player text: strip, reject empty, reject oversized.
-  2. Input safety precheck via placeholder policy hook.
+  2. Local input safety gate: route player text through deterministic rule
+     checks (route_player_input) before the LLM; refuse/stop/redirect as needed.
   3. Build prompt context: scenario, NPC, state, transcript, rubric, player utterance.
   4. Call ChatRuntime and collect the structured response.
   5. Validate / repair / fallback the model response.
@@ -36,7 +37,13 @@ from convsim_prompt import (
 )
 from convsim_prompt.types import ScenarioData
 
-from convsim_core.input_router import SafetyPolicyConfig
+from convsim_core.input_router import (
+    DEFAULT_REDIRECT_MESSAGE,
+    RouteAction,
+    RouteDecision,
+    SafetyPolicyConfig,
+    route_player_input,
+)
 from convsim_core.runtime.base import ChatRuntime
 from convsim_core.runtime.types import ChatFinal, ChatMessage, ChatRequest, ChatToken
 from convsim_core.scenario_state import (
@@ -67,6 +74,26 @@ _DEFAULT_SAFETY_POLICY = SafetyPolicy(
         "nsfw": "I'd prefer to keep our conversation professional. Let's refocus.",
         "illegal": "That's not something I can discuss. Let me steer us back on track.",
     },
+)
+
+# Default SafetyPolicyConfig for the local input router, used when no pack
+# provides a scenario-specific safety YAML.  All nine MVP categories are enabled
+# at their standard PG actions.
+_DEFAULT_SAFETY_POLICY_CONFIG = SafetyPolicyConfig(
+    policy_id="default_pg",
+    content_rating="PG",
+    categories={
+        "nsfw_sexual_content": RouteAction.STOP,
+        "minors_romantic_or_sexual": RouteAction.STOP,
+        "real_person_impersonation": RouteAction.REFUSE,
+        "voice_cloning_request": RouteAction.REFUSE,
+        "medical_or_therapy_claim": RouteAction.REDIRECT,
+        "legal_claim": RouteAction.REDIRECT,
+        "criminal_instruction": RouteAction.REFUSE,
+        "harassment_extreme": RouteAction.REDIRECT,
+        "self_harm_crisis": RouteAction.STOP_WITH_RESOURCE,
+    },
+    global_redirect_message=DEFAULT_REDIRECT_MESSAGE,
 )
 
 
@@ -154,15 +181,119 @@ def _normalize_text(text: str) -> str:
     return text.strip()
 
 
-def _safety_precheck(normalized: str) -> None:
-    """Placeholder input safety precheck.
+def _persist_input_safety_stop(
+    session_row: sqlite3.Row,
+    normalized: str,
+    decision: RouteDecision,
+    conn: sqlite3.Connection,
+    source_mode: str,
+    save_transcript: bool,
+) -> "TurnPipelineResult":
+    """Short-circuit persist for a STOP / STOP_WITH_RESOURCE from the input router.
 
-    Validates that the player input does not contain obviously prohibited
-    content before forwarding it to the LLM. This hook is intentionally
-    minimal — a production implementation would call a safety classifier.
+    Writes the player turn, a synthetic NPC stop/crisis response, and a
+    sanitised safety event (category + action only, no raw player text) to the
+    DB, then marks the session as Ended.  The LLM is never called.
     """
-    # Placeholder: accept all input. Replace with a classifier call when ready.
-    pass
+    session_id: str = session_row["session_id"]
+    turn_number: int = int(session_row["turn_count"]) + 1
+    player_turn_number = turn_number * 2 - 1
+    npc_turn_number = turn_number * 2
+    now = datetime.now(timezone.utc).isoformat()
+    ending_type = "safety_stop"
+    new_flow_state = "Ended"
+
+    npc_utterance = (
+        decision.message
+        or "This conversation has been stopped for safety reasons."
+    )
+    safety_status = (
+        "stop_with_resource_message"
+        if decision.action == RouteAction.STOP_WITH_RESOURCE
+        else "stop"
+    )
+
+    logger.warning(
+        "Input safety gate: session=%s turn=%d category=%s action=%s",
+        session_id, turn_number, decision.category, decision.action.value,
+    )
+
+    with conn:
+        player_cursor = conn.execute(
+            "INSERT INTO turn_session_turns "
+            "(session_id, turn_number, role, content, source_mode, flow_state_after, created_at) "
+            "VALUES (?, ?, 'player', ?, ?, ?, ?)",
+            (session_id, player_turn_number, normalized, source_mode, new_flow_state, now),
+        )
+        npc_cursor = conn.execute(
+            "INSERT INTO turn_session_turns "
+            "(session_id, turn_number, role, content, emotion, state_delta_json, event_flags_json, "
+            "safety_json, raw_output_json, flow_state_after, created_at) "
+            "VALUES (?, ?, 'npc', ?, 'neutral', '{}', '[]', ?, NULL, ?, ?)",
+            (
+                session_id,
+                npc_turn_number,
+                npc_utterance,
+                json.dumps({"status": safety_status, "reason": decision.category}),
+                new_flow_state,
+                now,
+            ),
+        )
+        # Sanitised event log: category and action only — never the raw player text.
+        conn.executemany(
+            "INSERT INTO turn_session_events "
+            "(session_id, turn_number, event_type, payload_json, occurred_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            [
+                (
+                    session_id, turn_number, "input_safety_stop",
+                    json.dumps({
+                        "category": decision.category,
+                        "action": decision.action.value,
+                    }),
+                    now,
+                ),
+                (
+                    session_id, turn_number, "session_ending",
+                    json.dumps({"ending_type": ending_type, "summary": None}),
+                    now,
+                ),
+            ],
+        )
+        if save_transcript:
+            conn.executemany(
+                "INSERT INTO session_transcript_fts(session_id, turn_number, role, content) "
+                "VALUES (?, ?, ?, ?)",
+                [
+                    (session_id, player_turn_number, "player", normalized),
+                    (session_id, npc_turn_number, "npc", npc_utterance),
+                ],
+            )
+        conn.execute(
+            "UPDATE turn_sessions SET turn_count = ?, flow_state = ?, ending_type = ? "
+            "WHERE session_id = ?",
+            (turn_number, new_flow_state, ending_type, session_id),
+        )
+
+    return TurnPipelineResult(
+        player_content=normalized,
+        player_event_id=player_cursor.lastrowid,
+        npc_utterance=npc_utterance,
+        npc_emotion="neutral",
+        npc_event_id=npc_cursor.lastrowid,
+        state_delta={},
+        new_state_vars={},
+        visible_state={},
+        event_flags=[],
+        triggered_scenario_events=[],
+        safety_status=safety_status,
+        safety_reason=decision.category,
+        ending_type=ending_type,
+        ending_summary=None,
+        new_flow_state=new_flow_state,
+        turn_number=turn_number,
+        used_fallback=False,
+    )
 
 
 def _load_recent_turns(session_id: str, conn: sqlite3.Connection, limit: int = 12) -> List[TranscriptEntry]:
@@ -234,8 +365,27 @@ async def process_turn(
             f"Turn content is {len(normalized)} characters; maximum is {MAX_TURN_CONTENT_CHARS}"
         )
 
-    # 2. Input safety precheck.
-    _safety_precheck(normalized)
+    # 2. Local input safety gate — deterministic rule checks before the LLM.
+    #    Global non-overridable rules (minors, self-harm) always fire.
+    #    Pack-specific or default policy rules fire for all other categories.
+    effective_policy_config = (
+        safety_policy_config if safety_policy_config is not None
+        else _DEFAULT_SAFETY_POLICY_CONFIG
+    )
+    decision = route_player_input(normalized, effective_policy_config)
+    if decision.action == RouteAction.REFUSE:
+        raise TurnInputError(decision.message or "Input refused by safety policy")
+    if decision.action in (RouteAction.STOP, RouteAction.STOP_WITH_RESOURCE):
+        return _persist_input_safety_stop(
+            session_row=session_row,
+            normalized=normalized,
+            decision=decision,
+            conn=conn,
+            source_mode=source_mode,
+            save_transcript=save_transcript,
+        )
+    # REDIRECT: safety policy is already injected into the LLM prompt; continue.
+    # OK: proceed normally.
 
     # 3. Load session state.
     session_id: str = session_row["session_id"]

--- a/services/convsim-core/convsim_core/services/turn_pipeline.py
+++ b/services/convsim-core/convsim_core/services/turn_pipeline.py
@@ -47,6 +47,7 @@ from convsim_core.input_router import (
 from convsim_core.runtime.base import ChatRuntime
 from convsim_core.runtime.types import ChatFinal, ChatMessage, ChatRequest, ChatToken
 from convsim_core.scenario_state import (
+    ScenarioEvent,
     apply_state_delta,
     build_variable_defs,
     evaluate_ending_condition,
@@ -168,6 +169,7 @@ class TurnPipelineResult:
     visible_state: Dict[str, int]
     event_flags: List[str]
     triggered_scenario_events: List[str]
+    rubric_observations: List[Dict[str, Any]]
     safety_status: str
     safety_reason: Optional[str]
     ending_type: Optional[str]
@@ -345,6 +347,9 @@ async def process_turn(
     save_transcript: bool = True,
     source_mode: str = "text-only",
     safety_policy_config: Optional[SafetyPolicyConfig] = None,
+    state_variable_overrides: Optional[Dict[str, Any]] = None,
+    scenario_events: Optional[List[ScenarioEvent]] = None,
+    ending_conditions: Optional[Dict[str, Any]] = None,
 ) -> TurnPipelineResult:
     """Execute the full player-turn pipeline and persist results.
 
@@ -393,8 +398,8 @@ async def process_turn(
     fired_event_ids: Set[str] = set(json.loads(session_row["fired_events_json"] or "[]"))
     turn_number: int = int(session_row["turn_count"]) + 1
 
-    # If state_vars is empty (first turn), initialize from baseline.
-    var_defs = build_variable_defs()
+    # If state_vars is empty (first turn), initialize from scenario variable defs.
+    var_defs = build_variable_defs(state_variable_overrides)
     if not state_vars:
         state_vars = initialize_state(var_defs)
 
@@ -466,7 +471,7 @@ async def process_turn(
     triggered_events = evaluate_event_triggers(
         delta_result.new_state,
         turn_number,
-        events=[],  # No inline scenario events in hardcoded scenarios yet.
+        events=scenario_events or [],
         fired_event_ids=fired_event_ids,
         active_flags=set(turn_output.event_flags),
     )
@@ -476,7 +481,7 @@ async def process_turn(
         delta_result.new_state,
         turn_number,
         max_turns,
-        ending_conditions=None,
+        ending_conditions=ending_conditions,
         safety_stopped=safety_stopped,
     )
 
@@ -549,6 +554,18 @@ async def process_turn(
             events_to_insert.append((
                 session_id, turn_number, "scenario_event",
                 json.dumps({"event_id": event_id}), now,
+            ))
+        if turn_output.rubric_observations:
+            events_to_insert.append((
+                session_id, turn_number, "rubric_observations",
+                json.dumps([
+                    {
+                        "rubric_id": obs.rubric_id,
+                        "observation": obs.observation,
+                        "score_delta": obs.score_delta,
+                    }
+                    for obs in turn_output.rubric_observations
+                ]), now,
             ))
         if turn_output.safety.status == "redirect":
             events_to_insert.append((
@@ -646,6 +663,14 @@ async def process_turn(
         visible_state=visible,
         event_flags=turn_output.event_flags,
         triggered_scenario_events=triggered_events,
+        rubric_observations=[
+            {
+                "rubric_id": obs.rubric_id,
+                "observation": obs.observation,
+                "score_delta": obs.score_delta,
+            }
+            for obs in turn_output.rubric_observations
+        ],
         safety_status=turn_output.safety.status,
         safety_reason=turn_output.safety.reason,
         ending_type=ending_type,

--- a/services/convsim-core/convsim_core/services/turn_pipeline.py
+++ b/services/convsim-core/convsim_core/services/turn_pipeline.py
@@ -40,6 +40,7 @@ from convsim_core.input_router import SafetyPolicyConfig
 from convsim_core.runtime.base import ChatRuntime
 from convsim_core.runtime.types import ChatFinal, ChatMessage, ChatRequest, ChatToken
 from convsim_core.scenario_state import (
+    ScenarioEvent,
     apply_state_delta,
     build_variable_defs,
     evaluate_ending_condition,
@@ -141,6 +142,7 @@ class TurnPipelineResult:
     visible_state: Dict[str, int]
     event_flags: List[str]
     triggered_scenario_events: List[str]
+    rubric_observations: List[Dict[str, Any]]
     safety_status: str
     safety_reason: Optional[str]
     ending_type: Optional[str]
@@ -214,6 +216,9 @@ async def process_turn(
     save_transcript: bool = True,
     source_mode: str = "text-only",
     safety_policy_config: Optional[SafetyPolicyConfig] = None,
+    state_variable_overrides: Optional[Dict[str, Any]] = None,
+    scenario_events: Optional[List[ScenarioEvent]] = None,
+    ending_conditions: Optional[Dict[str, Any]] = None,
 ) -> TurnPipelineResult:
     """Execute the full player-turn pipeline and persist results.
 
@@ -243,8 +248,8 @@ async def process_turn(
     fired_event_ids: Set[str] = set(json.loads(session_row["fired_events_json"] or "[]"))
     turn_number: int = int(session_row["turn_count"]) + 1
 
-    # If state_vars is empty (first turn), initialize from baseline.
-    var_defs = build_variable_defs()
+    # If state_vars is empty (first turn), initialize from scenario variable defs.
+    var_defs = build_variable_defs(state_variable_overrides)
     if not state_vars:
         state_vars = initialize_state(var_defs)
 
@@ -316,7 +321,7 @@ async def process_turn(
     triggered_events = evaluate_event_triggers(
         delta_result.new_state,
         turn_number,
-        events=[],  # No inline scenario events in hardcoded scenarios yet.
+        events=scenario_events or [],
         fired_event_ids=fired_event_ids,
         active_flags=set(turn_output.event_flags),
     )
@@ -326,7 +331,7 @@ async def process_turn(
         delta_result.new_state,
         turn_number,
         max_turns,
-        ending_conditions=None,
+        ending_conditions=ending_conditions,
         safety_stopped=safety_stopped,
     )
 
@@ -399,6 +404,18 @@ async def process_turn(
             events_to_insert.append((
                 session_id, turn_number, "scenario_event",
                 json.dumps({"event_id": event_id}), now,
+            ))
+        if turn_output.rubric_observations:
+            events_to_insert.append((
+                session_id, turn_number, "rubric_observations",
+                json.dumps([
+                    {
+                        "rubric_id": obs.rubric_id,
+                        "observation": obs.observation,
+                        "score_delta": obs.score_delta,
+                    }
+                    for obs in turn_output.rubric_observations
+                ]), now,
             ))
         if turn_output.safety.status == "redirect":
             events_to_insert.append((
@@ -496,6 +513,14 @@ async def process_turn(
         visible_state=visible,
         event_flags=turn_output.event_flags,
         triggered_scenario_events=triggered_events,
+        rubric_observations=[
+            {
+                "rubric_id": obs.rubric_id,
+                "observation": obs.observation,
+                "score_delta": obs.score_delta,
+            }
+            for obs in turn_output.rubric_observations
+        ],
         safety_status=turn_output.safety.status,
         safety_reason=turn_output.safety.reason,
         ending_type=ending_type,

--- a/services/convsim-core/tests/test_turn_pipeline.py
+++ b/services/convsim-core/tests/test_turn_pipeline.py
@@ -1514,3 +1514,479 @@ class TestInputSafetyGate:
         assert get_res.status_code == 200
         state = get_res.json()["state"]
         assert state == "Ended"
+
+
+# ---------------------------------------------------------------------------
+# Issue #201: state variables, scenario events, endings, and rubrics
+# ---------------------------------------------------------------------------
+
+
+def _insert_unit_session_with_state(
+    conn: sqlite3.Connection,
+    session_id: str = "sess-unit",
+    state_vars: dict = None,
+) -> sqlite3.Row:
+    """Like _insert_unit_session but allows pre-seeding state_vars_json."""
+    import json as _json
+    state_json = _json.dumps(state_vars or {})
+    conn.execute(
+        "INSERT INTO turn_sessions "
+        "(session_id, scenario_id, flow_state, state_vars_json, fired_events_json, "
+        "turn_count, setup_json) "
+        "VALUES (?, 'behavioral_interview', 'PlayerTurnListening', ?, '[]', 0, '{}')",
+        (session_id, state_json),
+    )
+    conn.commit()
+    return conn.execute(
+        "SELECT * FROM turn_sessions WHERE session_id = ?", (session_id,)
+    ).fetchone()
+
+
+class _SpecificDeltaRuntime(FakeChatRuntime):
+    """Runtime that returns a configurable state_delta."""
+
+    def __init__(self, state_delta: dict = None, rubric_obs: list = None) -> None:
+        super().__init__()
+        self._delta = state_delta or {}
+        self._rubric_obs = rubric_obs or []
+
+    def chat_stream(self, request: ChatRequest):
+        return self._stream(request)
+
+    async def _stream(self, request: ChatRequest):
+        import json as _json
+        from convsim_core.runtime.types import ChatFinal
+        response = {
+            "npc_utterance": "Understood.",
+            "npc_emotion": "neutral",
+            "state_delta": self._delta,
+            "event_flags": [],
+            "rubric_observations": self._rubric_obs,
+            "safety": {"status": "ok"},
+            "session_control": {"continue_session": True},
+        }
+        text = _json.dumps(response)
+        yield ChatFinal(
+            text=text,
+            model_id="fake-small",
+            input_tokens=10,
+            output_tokens=len(text.split()),
+            structured=response,
+        )
+
+
+class TestScenarioStateIntegration:
+    """Integration tests for scenario state variables, events, endings, and rubrics (issue #201)."""
+
+    # ------------------------------------------------------------------
+    # Clamping and invalid variable rejection
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_custom_variable_overrides_constrain_delta(self):
+        """A custom max_delta_per_turn override is respected; delta cannot exceed it."""
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        # trust starts at 50 (baseline default); runtime requests +20
+        # but we cap max_delta_per_turn at 5, so only +5 should be applied.
+        result = await process_turn(
+            session_row=row,
+            player_text="Hello.",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=10,
+            runtime=_SpecificDeltaRuntime(state_delta={"trust": 20}),
+            conn=conn,
+            state_variable_overrides={"trust": {"max_delta_per_turn": 5}},
+        )
+
+        assert result.state_delta.get("trust") == 5
+        assert result.new_state_vars["trust"] == 55  # 50 + 5
+
+    @pytest.mark.asyncio
+    async def test_invalid_variable_key_rejected_in_pipeline(self):
+        """An unknown variable key proposed by the model is rejected; not applied."""
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        result = await process_turn(
+            session_row=row,
+            player_text="Hello.",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=10,
+            runtime=_SpecificDeltaRuntime(state_delta={"ghost_key": 10, "trust": 5}),
+            conn=conn,
+        )
+
+        assert "ghost_key" not in result.new_state_vars
+        assert result.state_delta.get("trust") == 5
+
+    # ------------------------------------------------------------------
+    # Ending conditions
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_success_ending_fires_from_ending_conditions(self):
+        """ending_type='success' is set when the success variable condition is met."""
+        conn = _make_unit_db()
+        # Pre-seed objective_progress near the threshold (50); delta +15 pushes to 65 > 60.
+        row = _insert_unit_session_with_state(
+            conn, state_vars={"trust": 50, "patience": 75, "pressure": 25,
+                              "rapport": 50, "openness": 50, "objective_progress": 50}
+        )
+
+        result = await process_turn(
+            session_row=row,
+            player_text="I agree completely.",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=20,
+            runtime=_SpecificDeltaRuntime(state_delta={"objective_progress": 15}),
+            conn=conn,
+            ending_conditions={
+                "success": {
+                    "type": "variable_above",
+                    "variable": "objective_progress",
+                    "threshold": 60,
+                }
+            },
+        )
+
+        assert result.ending_type == "success"
+        assert result.new_flow_state == "Ended"
+
+    @pytest.mark.asyncio
+    async def test_failure_ending_fires_from_ending_conditions(self):
+        """ending_type='failure' is set when the failure variable condition is met."""
+        conn = _make_unit_db()
+        # Pre-seed patience near the failure threshold (20); delta -15 pushes to 5 < 10.
+        row = _insert_unit_session_with_state(
+            conn, state_vars={"trust": 50, "patience": 20, "pressure": 25,
+                              "rapport": 50, "openness": 50, "objective_progress": 0}
+        )
+
+        result = await process_turn(
+            session_row=row,
+            player_text="That's not right at all.",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=20,
+            runtime=_SpecificDeltaRuntime(state_delta={"patience": -15}),
+            conn=conn,
+            ending_conditions={
+                "failure": {
+                    "type": "variable_below",
+                    "variable": "patience",
+                    "threshold": 10,
+                }
+            },
+        )
+
+        assert result.ending_type == "failure"
+        assert result.new_flow_state == "Ended"
+
+    @pytest.mark.asyncio
+    async def test_timeout_ending_fires_when_max_turns_reached(self):
+        """ending_type='timeout' fires when turn_number >= max_turns (pipeline unit)."""
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        result = await process_turn(
+            session_row=row,
+            player_text="Last turn.",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=1,
+            runtime=FakeChatRuntime(),
+            conn=conn,
+        )
+
+        assert result.ending_type == "timeout"
+        assert result.new_flow_state == "Ended"
+
+    @pytest.mark.asyncio
+    async def test_success_takes_priority_over_timeout(self):
+        """When success and timeout both fire on the same turn, success wins."""
+        conn = _make_unit_db()
+        row = _insert_unit_session_with_state(
+            conn, state_vars={"trust": 50, "patience": 75, "pressure": 25,
+                              "rapport": 50, "openness": 50, "objective_progress": 50}
+        )
+
+        result = await process_turn(
+            session_row=row,
+            player_text="Final answer.",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=1,  # timeout would fire
+            runtime=_SpecificDeltaRuntime(state_delta={"objective_progress": 15}),
+            conn=conn,
+            ending_conditions={
+                "success": {
+                    "type": "variable_above",
+                    "variable": "objective_progress",
+                    "threshold": 60,
+                }
+            },
+        )
+
+        assert result.ending_type == "success"
+
+    # ------------------------------------------------------------------
+    # Scenario events
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_scenario_event_fires_and_returned(self):
+        """An event whose condition is met appears in triggered_scenario_events."""
+        from convsim_core.scenario_state import ScenarioEvent
+        conn = _make_unit_db()
+        # rapport starts at 60; delta +15 pushes to 75 which is > 70 — event fires.
+        row = _insert_unit_session_with_state(
+            conn, state_vars={"trust": 50, "patience": 75, "pressure": 25,
+                              "rapport": 60, "openness": 50, "objective_progress": 0}
+        )
+
+        evt = ScenarioEvent(
+            id="rapport_high",
+            when={"type": "variable_above", "variable": "rapport", "threshold": 70},
+            npc_instruction="Acknowledge the improved atmosphere.",
+        )
+
+        result = await process_turn(
+            session_row=row,
+            player_text="I appreciate your perspective.",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=20,
+            runtime=_SpecificDeltaRuntime(state_delta={"rapport": 15}),
+            conn=conn,
+            scenario_events=[evt],
+        )
+
+        assert "rapport_high" in result.triggered_scenario_events
+
+    @pytest.mark.asyncio
+    async def test_scenario_event_does_not_fire_when_condition_not_met(self):
+        """An event whose condition is not met is absent from triggered_scenario_events."""
+        from convsim_core.scenario_state import ScenarioEvent
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        evt = ScenarioEvent(
+            id="trust_very_high",
+            when={"type": "variable_above", "variable": "trust", "threshold": 90},
+            npc_instruction="NPC becomes very open.",
+        )
+
+        result = await process_turn(
+            session_row=row,
+            player_text="Hello.",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=20,
+            runtime=FakeChatRuntime(),
+            conn=conn,
+            scenario_events=[evt],
+        )
+
+        assert "trust_very_high" not in result.triggered_scenario_events
+
+    # ------------------------------------------------------------------
+    # Visible vs. hidden state meters
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_visible_state_in_pipeline_result(self):
+        """result.visible_state contains visible variables and excludes hidden ones."""
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        result = await process_turn(
+            session_row=row,
+            player_text="Hello.",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=10,
+            runtime=FakeChatRuntime(),
+            conn=conn,
+        )
+
+        # Baseline visible variables must be present.
+        assert "trust" in result.visible_state
+        assert "patience" in result.visible_state
+        assert "rapport" in result.visible_state
+        assert "openness" in result.visible_state
+        assert "objective_progress" in result.visible_state
+        # pressure is HIDDEN — must not appear.
+        assert "pressure" not in result.visible_state
+
+    @pytest.mark.asyncio
+    async def test_custom_hidden_variable_excluded_from_visible_state(self):
+        """A variable declared hidden in state_variable_overrides is not in visible_state."""
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        result = await process_turn(
+            session_row=row,
+            player_text="Hello.",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=10,
+            runtime=FakeChatRuntime(),
+            conn=conn,
+            state_variable_overrides={"trust": {"visibility": "hidden"}},
+        )
+
+        assert "trust" not in result.visible_state
+
+    def test_visible_state_in_turn_api_response(self, client):
+        """The /turn HTTP response includes visible_state in the npc_turn payload."""
+        session_id = _create_and_start(client)
+
+        res = client.post(
+            f"/api/sessions/{session_id}/turn",
+            json={"content": "Good morning."},
+        )
+        assert res.status_code == 200
+        npc_payload = res.json()["events"][1]["payload"]
+        assert "visible_state" in npc_payload
+        assert isinstance(npc_payload["visible_state"], dict)
+        # trust is a visible baseline variable — must appear.
+        assert "trust" in npc_payload["visible_state"]
+        # pressure is hidden — must not appear.
+        assert "pressure" not in npc_payload["visible_state"]
+
+    # ------------------------------------------------------------------
+    # Rubric observations persistence
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_rubric_observations_persisted_in_events(self):
+        """Rubric observations from the NPC turn are stored in turn_session_events."""
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        runtime = _SpecificDeltaRuntime(
+            rubric_obs=[
+                {"rubric_id": "clarity", "observation": "Clear explanation.", "score_delta": 2},
+                {"rubric_id": "empathy", "observation": "Showed empathy.", "score_delta": 1},
+            ]
+        )
+
+        await process_turn(
+            session_row=row,
+            player_text="Let me be clear.",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=10,
+            runtime=runtime,
+            conn=conn,
+        )
+
+        events = _get_event_payloads(conn, "sess-unit", "rubric_observations")
+        assert len(events) == 1
+        obs_list = events[0]
+        assert isinstance(obs_list, list)
+        assert len(obs_list) == 2
+        rubric_ids = {o["rubric_id"] for o in obs_list}
+        assert rubric_ids == {"clarity", "empathy"}
+
+    @pytest.mark.asyncio
+    async def test_rubric_observations_in_pipeline_result(self):
+        """result.rubric_observations contains the NPC's rubric observations."""
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        runtime = _SpecificDeltaRuntime(
+            rubric_obs=[
+                {"rubric_id": "structure", "observation": "Well-structured.", "score_delta": 3},
+            ]
+        )
+
+        result = await process_turn(
+            session_row=row,
+            player_text="Here is my reasoning.",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=10,
+            runtime=runtime,
+            conn=conn,
+        )
+
+        assert len(result.rubric_observations) == 1
+        assert result.rubric_observations[0]["rubric_id"] == "structure"
+        assert result.rubric_observations[0]["score_delta"] == 3
+
+    @pytest.mark.asyncio
+    async def test_empty_rubric_observations_not_persisted(self):
+        """No rubric_observations event is written when the NPC returns an empty list."""
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        await process_turn(
+            session_row=row,
+            player_text="Hello.",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=10,
+            runtime=FakeChatRuntime(),
+            conn=conn,
+        )
+
+        events = _get_event_payloads(conn, "sess-unit", "rubric_observations")
+        assert events == []
+
+    def test_rubric_observations_in_turn_api_response(self, client):
+        """The /turn HTTP response includes rubric_observations in the npc_turn payload."""
+        session_id = _create_and_start(client)
+
+        res = client.post(
+            f"/api/sessions/{session_id}/turn",
+            json={"content": "Hello."},
+        )
+        assert res.status_code == 200
+        npc_payload = res.json()["events"][1]["payload"]
+        assert "rubric_observations" in npc_payload
+        assert isinstance(npc_payload["rubric_observations"], list)
+
+    # ------------------------------------------------------------------
+    # scenario_events wired from ScenarioInfo (coworker_feedback)
+    # ------------------------------------------------------------------
+
+    def test_coworker_feedback_scenario_has_state_variable_overrides(self):
+        """coworker_feedback ScenarioInfo ships with state_variable_overrides."""
+        from convsim_core.scenarios import get_scenario_info
+        info = get_scenario_info("coworker_feedback")
+        assert info is not None
+        assert info.state_variable_overrides is not None
+        assert "rapport" in info.state_variable_overrides
+
+    def test_coworker_feedback_scenario_has_events(self):
+        """coworker_feedback ScenarioInfo ships with at least one event."""
+        from convsim_core.scenarios import get_scenario_info
+        info = get_scenario_info("coworker_feedback")
+        assert info is not None
+        assert info.events is not None
+        assert len(info.events) > 0
+        assert info.events[0].id == "npc_defensive"
+
+    def test_coworker_feedback_scenario_has_ending_conditions(self):
+        """coworker_feedback ScenarioInfo ships with both success and failure endings."""
+        from convsim_core.scenarios import get_scenario_info
+        info = get_scenario_info("coworker_feedback")
+        assert info is not None
+        assert info.ending_conditions is not None
+        assert "success" in info.ending_conditions
+        assert "failure" in info.ending_conditions
+
+    def test_coworker_feedback_rapport_starts_at_30(self):
+        """The coworker_feedback rapport override (default=30) is applied on first turn."""
+        from convsim_core.scenario_state import build_variable_defs, initialize_state
+        from convsim_core.scenarios import get_scenario_info
+        info = get_scenario_info("coworker_feedback")
+        defs = build_variable_defs(info.state_variable_overrides)
+        state = initialize_state(defs)
+        assert state["rapport"] == 30
+
+    def test_triggered_scenario_events_in_turn_api_response(self, client):
+        """triggered_scenario_events is present in the npc_turn payload."""
+        session_id = _create_and_start(client)
+
+        res = client.post(
+            f"/api/sessions/{session_id}/turn",
+            json={"content": "Hello."},
+        )
+        assert res.status_code == 200
+        npc_payload = res.json()["events"][1]["payload"]
+        assert "triggered_scenario_events" in npc_payload
+        assert isinstance(npc_payload["triggered_scenario_events"], list)

--- a/services/convsim-core/tests/test_turn_pipeline.py
+++ b/services/convsim-core/tests/test_turn_pipeline.py
@@ -1267,3 +1267,479 @@ class TestDebugEndpoint:
         turn = res.json()["turns"][0]
         assert turn["used_fallback"] is True
         assert turn["used_native_structured_output"] is False
+
+
+# ---------------------------------------------------------------------------
+# Issue #201: state variables, scenario events, endings, and rubrics
+# ---------------------------------------------------------------------------
+
+
+def _insert_unit_session_with_state(
+    conn: sqlite3.Connection,
+    session_id: str = "sess-unit",
+    state_vars: dict = None,
+) -> sqlite3.Row:
+    """Like _insert_unit_session but allows pre-seeding state_vars_json."""
+    import json as _json
+    state_json = _json.dumps(state_vars or {})
+    conn.execute(
+        "INSERT INTO turn_sessions "
+        "(session_id, scenario_id, flow_state, state_vars_json, fired_events_json, "
+        "turn_count, setup_json) "
+        "VALUES (?, 'behavioral_interview', 'PlayerTurnListening', ?, '[]', 0, '{}')",
+        (session_id, state_json),
+    )
+    conn.commit()
+    return conn.execute(
+        "SELECT * FROM turn_sessions WHERE session_id = ?", (session_id,)
+    ).fetchone()
+
+
+class _SpecificDeltaRuntime(FakeChatRuntime):
+    """Runtime that returns a configurable state_delta."""
+
+    def __init__(self, state_delta: dict = None, rubric_obs: list = None) -> None:
+        super().__init__()
+        self._delta = state_delta or {}
+        self._rubric_obs = rubric_obs or []
+
+    def chat_stream(self, request: ChatRequest):
+        return self._stream(request)
+
+    async def _stream(self, request: ChatRequest):
+        import json as _json
+        from convsim_core.runtime.types import ChatFinal
+        response = {
+            "npc_utterance": "Understood.",
+            "npc_emotion": "neutral",
+            "state_delta": self._delta,
+            "event_flags": [],
+            "rubric_observations": self._rubric_obs,
+            "safety": {"status": "ok"},
+            "session_control": {"continue_session": True},
+        }
+        text = _json.dumps(response)
+        yield ChatFinal(
+            text=text,
+            model_id="fake-small",
+            input_tokens=10,
+            output_tokens=len(text.split()),
+            structured=response,
+        )
+
+
+class TestScenarioStateIntegration:
+    """Integration tests for scenario state variables, events, endings, and rubrics (issue #201)."""
+
+    # ------------------------------------------------------------------
+    # Clamping and invalid variable rejection
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_custom_variable_overrides_constrain_delta(self):
+        """A custom max_delta_per_turn override is respected; delta cannot exceed it."""
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        # trust starts at 50 (baseline default); runtime requests +20
+        # but we cap max_delta_per_turn at 5, so only +5 should be applied.
+        result = await process_turn(
+            session_row=row,
+            player_text="Hello.",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=10,
+            runtime=_SpecificDeltaRuntime(state_delta={"trust": 20}),
+            conn=conn,
+            state_variable_overrides={"trust": {"max_delta_per_turn": 5}},
+        )
+
+        assert result.state_delta.get("trust") == 5
+        assert result.new_state_vars["trust"] == 55  # 50 + 5
+
+    @pytest.mark.asyncio
+    async def test_invalid_variable_key_rejected_in_pipeline(self):
+        """An unknown variable key proposed by the model is rejected; not applied."""
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        result = await process_turn(
+            session_row=row,
+            player_text="Hello.",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=10,
+            runtime=_SpecificDeltaRuntime(state_delta={"ghost_key": 10, "trust": 5}),
+            conn=conn,
+        )
+
+        assert "ghost_key" not in result.new_state_vars
+        assert result.state_delta.get("trust") == 5
+
+    # ------------------------------------------------------------------
+    # Ending conditions
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_success_ending_fires_from_ending_conditions(self):
+        """ending_type='success' is set when the success variable condition is met."""
+        conn = _make_unit_db()
+        # Pre-seed objective_progress near the threshold (50); delta +15 pushes to 65 > 60.
+        row = _insert_unit_session_with_state(
+            conn, state_vars={"trust": 50, "patience": 75, "pressure": 25,
+                              "rapport": 50, "openness": 50, "objective_progress": 50}
+        )
+
+        result = await process_turn(
+            session_row=row,
+            player_text="I agree completely.",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=20,
+            runtime=_SpecificDeltaRuntime(state_delta={"objective_progress": 15}),
+            conn=conn,
+            ending_conditions={
+                "success": {
+                    "type": "variable_above",
+                    "variable": "objective_progress",
+                    "threshold": 60,
+                }
+            },
+        )
+
+        assert result.ending_type == "success"
+        assert result.new_flow_state == "Ended"
+
+    @pytest.mark.asyncio
+    async def test_failure_ending_fires_from_ending_conditions(self):
+        """ending_type='failure' is set when the failure variable condition is met."""
+        conn = _make_unit_db()
+        # Pre-seed patience near the failure threshold (20); delta -15 pushes to 5 < 10.
+        row = _insert_unit_session_with_state(
+            conn, state_vars={"trust": 50, "patience": 20, "pressure": 25,
+                              "rapport": 50, "openness": 50, "objective_progress": 0}
+        )
+
+        result = await process_turn(
+            session_row=row,
+            player_text="That's not right at all.",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=20,
+            runtime=_SpecificDeltaRuntime(state_delta={"patience": -15}),
+            conn=conn,
+            ending_conditions={
+                "failure": {
+                    "type": "variable_below",
+                    "variable": "patience",
+                    "threshold": 10,
+                }
+            },
+        )
+
+        assert result.ending_type == "failure"
+        assert result.new_flow_state == "Ended"
+
+    @pytest.mark.asyncio
+    async def test_timeout_ending_fires_when_max_turns_reached(self):
+        """ending_type='timeout' fires when turn_number >= max_turns (pipeline unit)."""
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        result = await process_turn(
+            session_row=row,
+            player_text="Last turn.",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=1,
+            runtime=FakeChatRuntime(),
+            conn=conn,
+        )
+
+        assert result.ending_type == "timeout"
+        assert result.new_flow_state == "Ended"
+
+    @pytest.mark.asyncio
+    async def test_success_takes_priority_over_timeout(self):
+        """When success and timeout both fire on the same turn, success wins."""
+        conn = _make_unit_db()
+        row = _insert_unit_session_with_state(
+            conn, state_vars={"trust": 50, "patience": 75, "pressure": 25,
+                              "rapport": 50, "openness": 50, "objective_progress": 50}
+        )
+
+        result = await process_turn(
+            session_row=row,
+            player_text="Final answer.",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=1,  # timeout would fire
+            runtime=_SpecificDeltaRuntime(state_delta={"objective_progress": 15}),
+            conn=conn,
+            ending_conditions={
+                "success": {
+                    "type": "variable_above",
+                    "variable": "objective_progress",
+                    "threshold": 60,
+                }
+            },
+        )
+
+        assert result.ending_type == "success"
+
+    # ------------------------------------------------------------------
+    # Scenario events
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_scenario_event_fires_and_returned(self):
+        """An event whose condition is met appears in triggered_scenario_events."""
+        from convsim_core.scenario_state import ScenarioEvent
+        conn = _make_unit_db()
+        # rapport starts at 60; delta +15 pushes to 75 which is > 70 — event fires.
+        row = _insert_unit_session_with_state(
+            conn, state_vars={"trust": 50, "patience": 75, "pressure": 25,
+                              "rapport": 60, "openness": 50, "objective_progress": 0}
+        )
+
+        evt = ScenarioEvent(
+            id="rapport_high",
+            when={"type": "variable_above", "variable": "rapport", "threshold": 70},
+            npc_instruction="Acknowledge the improved atmosphere.",
+        )
+
+        result = await process_turn(
+            session_row=row,
+            player_text="I appreciate your perspective.",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=20,
+            runtime=_SpecificDeltaRuntime(state_delta={"rapport": 15}),
+            conn=conn,
+            scenario_events=[evt],
+        )
+
+        assert "rapport_high" in result.triggered_scenario_events
+
+    @pytest.mark.asyncio
+    async def test_scenario_event_does_not_fire_when_condition_not_met(self):
+        """An event whose condition is not met is absent from triggered_scenario_events."""
+        from convsim_core.scenario_state import ScenarioEvent
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        evt = ScenarioEvent(
+            id="trust_very_high",
+            when={"type": "variable_above", "variable": "trust", "threshold": 90},
+            npc_instruction="NPC becomes very open.",
+        )
+
+        result = await process_turn(
+            session_row=row,
+            player_text="Hello.",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=20,
+            runtime=FakeChatRuntime(),
+            conn=conn,
+            scenario_events=[evt],
+        )
+
+        assert "trust_very_high" not in result.triggered_scenario_events
+
+    # ------------------------------------------------------------------
+    # Visible vs. hidden state meters
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_visible_state_in_pipeline_result(self):
+        """result.visible_state contains visible variables and excludes hidden ones."""
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        result = await process_turn(
+            session_row=row,
+            player_text="Hello.",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=10,
+            runtime=FakeChatRuntime(),
+            conn=conn,
+        )
+
+        # Baseline visible variables must be present.
+        assert "trust" in result.visible_state
+        assert "patience" in result.visible_state
+        assert "rapport" in result.visible_state
+        assert "openness" in result.visible_state
+        assert "objective_progress" in result.visible_state
+        # pressure is HIDDEN — must not appear.
+        assert "pressure" not in result.visible_state
+
+    @pytest.mark.asyncio
+    async def test_custom_hidden_variable_excluded_from_visible_state(self):
+        """A variable declared hidden in state_variable_overrides is not in visible_state."""
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        result = await process_turn(
+            session_row=row,
+            player_text="Hello.",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=10,
+            runtime=FakeChatRuntime(),
+            conn=conn,
+            state_variable_overrides={"trust": {"visibility": "hidden"}},
+        )
+
+        assert "trust" not in result.visible_state
+
+    def test_visible_state_in_turn_api_response(self, client):
+        """The /turn HTTP response includes visible_state in the npc_turn payload."""
+        session_id = _create_and_start(client)
+
+        res = client.post(
+            f"/api/sessions/{session_id}/turn",
+            json={"content": "Good morning."},
+        )
+        assert res.status_code == 200
+        npc_payload = res.json()["events"][1]["payload"]
+        assert "visible_state" in npc_payload
+        assert isinstance(npc_payload["visible_state"], dict)
+        # trust is a visible baseline variable — must appear.
+        assert "trust" in npc_payload["visible_state"]
+        # pressure is hidden — must not appear.
+        assert "pressure" not in npc_payload["visible_state"]
+
+    # ------------------------------------------------------------------
+    # Rubric observations persistence
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_rubric_observations_persisted_in_events(self):
+        """Rubric observations from the NPC turn are stored in turn_session_events."""
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        runtime = _SpecificDeltaRuntime(
+            rubric_obs=[
+                {"rubric_id": "clarity", "observation": "Clear explanation.", "score_delta": 2},
+                {"rubric_id": "empathy", "observation": "Showed empathy.", "score_delta": 1},
+            ]
+        )
+
+        await process_turn(
+            session_row=row,
+            player_text="Let me be clear.",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=10,
+            runtime=runtime,
+            conn=conn,
+        )
+
+        events = _get_event_payloads(conn, "sess-unit", "rubric_observations")
+        assert len(events) == 1
+        obs_list = events[0]
+        assert isinstance(obs_list, list)
+        assert len(obs_list) == 2
+        rubric_ids = {o["rubric_id"] for o in obs_list}
+        assert rubric_ids == {"clarity", "empathy"}
+
+    @pytest.mark.asyncio
+    async def test_rubric_observations_in_pipeline_result(self):
+        """result.rubric_observations contains the NPC's rubric observations."""
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        runtime = _SpecificDeltaRuntime(
+            rubric_obs=[
+                {"rubric_id": "structure", "observation": "Well-structured.", "score_delta": 3},
+            ]
+        )
+
+        result = await process_turn(
+            session_row=row,
+            player_text="Here is my reasoning.",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=10,
+            runtime=runtime,
+            conn=conn,
+        )
+
+        assert len(result.rubric_observations) == 1
+        assert result.rubric_observations[0]["rubric_id"] == "structure"
+        assert result.rubric_observations[0]["score_delta"] == 3
+
+    @pytest.mark.asyncio
+    async def test_empty_rubric_observations_not_persisted(self):
+        """No rubric_observations event is written when the NPC returns an empty list."""
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        await process_turn(
+            session_row=row,
+            player_text="Hello.",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=10,
+            runtime=FakeChatRuntime(),
+            conn=conn,
+        )
+
+        events = _get_event_payloads(conn, "sess-unit", "rubric_observations")
+        assert events == []
+
+    def test_rubric_observations_in_turn_api_response(self, client):
+        """The /turn HTTP response includes rubric_observations in the npc_turn payload."""
+        session_id = _create_and_start(client)
+
+        res = client.post(
+            f"/api/sessions/{session_id}/turn",
+            json={"content": "Hello."},
+        )
+        assert res.status_code == 200
+        npc_payload = res.json()["events"][1]["payload"]
+        assert "rubric_observations" in npc_payload
+        assert isinstance(npc_payload["rubric_observations"], list)
+
+    # ------------------------------------------------------------------
+    # scenario_events wired from ScenarioInfo (coworker_feedback)
+    # ------------------------------------------------------------------
+
+    def test_coworker_feedback_scenario_has_state_variable_overrides(self):
+        """coworker_feedback ScenarioInfo ships with state_variable_overrides."""
+        from convsim_core.scenarios import get_scenario_info
+        info = get_scenario_info("coworker_feedback")
+        assert info is not None
+        assert info.state_variable_overrides is not None
+        assert "rapport" in info.state_variable_overrides
+
+    def test_coworker_feedback_scenario_has_events(self):
+        """coworker_feedback ScenarioInfo ships with at least one event."""
+        from convsim_core.scenarios import get_scenario_info
+        info = get_scenario_info("coworker_feedback")
+        assert info is not None
+        assert info.events is not None
+        assert len(info.events) > 0
+        assert info.events[0].id == "npc_defensive"
+
+    def test_coworker_feedback_scenario_has_ending_conditions(self):
+        """coworker_feedback ScenarioInfo ships with both success and failure endings."""
+        from convsim_core.scenarios import get_scenario_info
+        info = get_scenario_info("coworker_feedback")
+        assert info is not None
+        assert info.ending_conditions is not None
+        assert "success" in info.ending_conditions
+        assert "failure" in info.ending_conditions
+
+    def test_coworker_feedback_rapport_starts_at_30(self):
+        """The coworker_feedback rapport override (default=30) is applied on first turn."""
+        from convsim_core.scenario_state import build_variable_defs, initialize_state
+        from convsim_core.scenarios import get_scenario_info
+        info = get_scenario_info("coworker_feedback")
+        defs = build_variable_defs(info.state_variable_overrides)
+        state = initialize_state(defs)
+        assert state["rapport"] == 30
+
+    def test_triggered_scenario_events_in_turn_api_response(self, client):
+        """triggered_scenario_events is present in the npc_turn payload."""
+        session_id = _create_and_start(client)
+
+        res = client.post(
+            f"/api/sessions/{session_id}/turn",
+            json={"content": "Hello."},
+        )
+        assert res.status_code == 200
+        npc_payload = res.json()["events"][1]["payload"]
+        assert "triggered_scenario_events" in npc_payload
+        assert isinstance(npc_payload["triggered_scenario_events"], list)

--- a/services/convsim-core/tests/test_turn_pipeline.py
+++ b/services/convsim-core/tests/test_turn_pipeline.py
@@ -1267,3 +1267,250 @@ class TestDebugEndpoint:
         turn = res.json()["turns"][0]
         assert turn["used_fallback"] is True
         assert turn["used_native_structured_output"] is False
+
+
+# ---------------------------------------------------------------------------
+# Input safety gate (issue #203)
+# ---------------------------------------------------------------------------
+
+
+class TestInputSafetyGate:
+    """Tests for the wired local input safety gate.
+
+    Covers:
+     - PG practice content passes through unblocked.
+     - NSFW / minors / self-harm fire the correct stop actions.
+     - Criminal instruction is refused (TurnInputError / HTTP 400).
+     - Redirect categories continue to the LLM; session stays alive.
+     - Safety stop events are sanitised — no raw player text in the log.
+     - Pack-specific policy overrides the default per-category action.
+     - Safety stops surface the crisis resource message in the NPC turn.
+     - HTTP layer returns the right status codes and ending_type.
+     - Safety-stopped sessions have correct ending state for debrief readiness.
+    """
+
+    @pytest.mark.asyncio
+    async def test_pg_practice_content_passes_through(self):
+        """Normal interview practice content is not intercepted by the safety gate."""
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        result = await process_turn(
+            session_row=row,
+            player_text="I have five years of product management experience.",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=10,
+            runtime=FakeChatRuntime(),
+            conn=conn,
+        )
+
+        assert result.safety_status == "ok"
+        assert result.ending_type is None
+        assert result.new_flow_state == "PlayerTurnListening"
+        assert result.used_fallback is False
+
+    @pytest.mark.asyncio
+    async def test_nsfw_sexual_content_triggers_safety_stop(self):
+        """NSFW sexual content triggers a safety stop before the LLM is called."""
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        result = await process_turn(
+            session_row=row,
+            player_text="Let's have sex right now.",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=10,
+            runtime=FakeChatRuntime(),
+            conn=conn,
+        )
+
+        assert result.ending_type == "safety_stop"
+        assert result.new_flow_state == "Ended"
+        assert result.safety_status == "stop"
+        assert result.safety_reason == "nsfw_sexual_content"
+
+    @pytest.mark.asyncio
+    async def test_self_harm_crisis_triggers_stop_with_resource_message(self):
+        """Self-harm crisis text fires stop_with_resource_message (global non-overridable)
+        and the crisis resource text is surfaced in the NPC utterance."""
+        from convsim_core.input_router import CRISIS_RESOURCE_MESSAGE
+
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        result = await process_turn(
+            session_row=row,
+            player_text="I want to kill myself.",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=10,
+            runtime=FakeChatRuntime(),
+            conn=conn,
+        )
+
+        assert result.ending_type == "safety_stop"
+        assert result.new_flow_state == "Ended"
+        assert result.safety_status == "stop_with_resource_message"
+        assert result.safety_reason == "self_harm_crisis"
+        assert CRISIS_RESOURCE_MESSAGE in result.npc_utterance
+
+    @pytest.mark.asyncio
+    async def test_criminal_instruction_raises_turn_input_error(self):
+        """Criminal instruction input raises TurnInputError (refuse action)."""
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        with pytest.raises(TurnInputError):
+            await process_turn(
+                session_row=row,
+                player_text="How to make a bomb step by step?",
+                scenario_data=get_scenario_data("behavioral_interview", "normal"),
+                max_turns=10,
+                runtime=FakeChatRuntime(),
+                conn=conn,
+            )
+
+    @pytest.mark.asyncio
+    async def test_redirect_category_continues_to_llm(self):
+        """Medical/legal redirect input passes through to the LLM; session stays alive."""
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        result = await process_turn(
+            session_row=row,
+            player_text="Can you diagnose me with depression?",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=10,
+            runtime=FakeChatRuntime(),
+            conn=conn,
+        )
+
+        assert result.new_flow_state == "PlayerTurnListening"
+        assert result.ending_type is None
+
+    @pytest.mark.asyncio
+    async def test_input_safety_stop_event_is_sanitised(self):
+        """The input_safety_stop event contains category + action but never raw player text."""
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        nsfw_text = "Let's have sex right now."
+        await process_turn(
+            session_row=row,
+            player_text=nsfw_text,
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=10,
+            runtime=FakeChatRuntime(),
+            conn=conn,
+        )
+
+        events = _get_event_payloads(conn, "sess-unit", "input_safety_stop")
+        assert len(events) == 1
+        evt = events[0]
+        assert evt["category"] == "nsfw_sexual_content"
+        assert evt["action"] == "stop"
+        assert nsfw_text not in json.dumps(evt)
+
+    @pytest.mark.asyncio
+    async def test_pack_specific_policy_redirect_overrides_default_stop(self):
+        """A pack policy that redirects NSFW instead of stopping keeps the session alive."""
+        from convsim_core.input_router import RouteAction, SafetyPolicyConfig
+
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        pack_policy = SafetyPolicyConfig(
+            policy_id="custom_pg13_pack",
+            content_rating="PG-13",
+            categories={
+                "nsfw_sexual_content": RouteAction.REDIRECT,
+                "criminal_instruction": RouteAction.REFUSE,
+                "minors_romantic_or_sexual": RouteAction.STOP,
+                "self_harm_crisis": RouteAction.STOP_WITH_RESOURCE,
+            },
+        )
+
+        result = await process_turn(
+            session_row=row,
+            player_text="Let's have sex right now.",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=10,
+            runtime=FakeChatRuntime(),
+            conn=conn,
+            safety_policy_config=pack_policy,
+        )
+
+        assert result.new_flow_state == "PlayerTurnListening"
+        assert result.ending_type is None
+
+    @pytest.mark.asyncio
+    async def test_minors_pattern_fires_regardless_of_pack_policy(self):
+        """Minors pattern is a global non-overridable stop — pack cannot weaken it."""
+        from convsim_core.input_router import RouteAction, SafetyPolicyConfig
+
+        conn = _make_unit_db()
+        row = _insert_unit_session(conn)
+
+        permissive_policy = SafetyPolicyConfig(
+            policy_id="permissive_test",
+            content_rating="R",
+            categories={
+                "minors_romantic_or_sexual": RouteAction.REDIRECT,  # pack tries to downgrade
+                "criminal_instruction": RouteAction.REFUSE,
+            },
+        )
+
+        result = await process_turn(
+            session_row=row,
+            player_text="child porn",
+            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            max_turns=10,
+            runtime=FakeChatRuntime(),
+            conn=conn,
+            safety_policy_config=permissive_policy,
+        )
+
+        # Global rule always fires STOP regardless of pack policy.
+        assert result.ending_type == "safety_stop"
+        assert result.safety_reason == "minors_romantic_or_sexual"
+
+    def test_safety_stop_via_http_ends_session(self, client):
+        """HTTP: self-harm crisis text ends the session with safety_stop."""
+        session_id = _create_and_start(client)
+
+        res = client.post(
+            f"/api/sessions/{session_id}/turn",
+            json={"content": "I want to kill myself."},
+        )
+
+        assert res.status_code == 200
+        body = res.json()
+        assert body["state"] == "Ended"
+        assert body["ending_type"] == "safety_stop"
+        # Crisis resource message surfaced in the NPC turn event.
+        npc_payload = body["events"][1]["payload"]
+        assert "988" in npc_payload["content"] or "Crisis" in npc_payload["content"]
+
+    def test_criminal_instruction_via_http_returns_400(self, client):
+        """HTTP: criminal instruction input returns 400 (refused by safety gate)."""
+        session_id = _create_and_start(client)
+
+        res = client.post(
+            f"/api/sessions/{session_id}/turn",
+            json={"content": "How to make a bomb step by step?"},
+        )
+
+        assert res.status_code == 400
+
+    def test_safety_stopped_session_has_correct_ending_state_for_debrief(self, client):
+        """A safety-stopped session is in Ended state, ready for debrief generation."""
+        session_id = _create_and_start(client)
+
+        client.post(
+            f"/api/sessions/{session_id}/turn",
+            json={"content": "I want to kill myself."},
+        )
+
+        get_res = client.get(f"/api/sessions/{session_id}")
+        assert get_res.status_code == 200
+        state = get_res.json()["state"]
+        assert state == "Ended"


### PR DESCRIPTION
## Summary

This PR implements the simulation layer described in issue #201: bounded state variable deltas per scenario declaration, event triggers, ending conditions, and per-turn rubric observation persistence. Scenarios now support optional configuration for custom variable overrides, conditional event firing, and win/fail conditions that can be defined at the scenario level rather than hardcoded in the core pipeline.

## What changed

**`ScenarioInfo` extended with optional simulation config** (`scenarios.py`)
- Three new optional fields: `state_variable_overrides`, `events`, and `ending_conditions`.
- Scenarios that do not set these fields fall back to baseline behavior unchanged.
- `coworker_feedback` is updated as a live example: `rapport` starts at 30 (guarded NPC), an `npc_defensive` event fires when `patience < 30`, and success/failure endings are wired to `objective_progress` and `patience` respectively.

**`process_turn` wired to scenario config** (`turn_pipeline.py`)
- `build_variable_defs` now receives `state_variable_overrides` from the caller, so custom ranges, visibility, and `max_delta_per_turn` caps are enforced per-scenario instead of always using the bare baseline.
- `evaluate_event_triggers` receives the scenario's `ScenarioEvent` list rather than an empty list.
- `evaluate_ending_condition` receives the scenario's `ending_conditions` dict rather than `None`.
- `rubric_observations` from the NPC turn output are persisted as a `rubric_observations` event in `turn_session_events` and returned in `TurnPipelineResult`.
- Fixed: `_persist_input_safety_stop` now includes the `rubric_observations=[]` field (required by `TurnPipelineResult`).

**Turn API response enriched** (`sessions.py`)
- `submit_turn` passes the three new scenario fields down to `process_turn`.
- The `npc_turn` event payload now includes `visible_state` (hidden variables excluded), `triggered_scenario_events`, and `rubric_observations`.

## Tests (`test_turn_pipeline.py` — `TestScenarioStateIntegration`)

Twenty new tests covering the definition of done:
- **Clamping**: custom `max_delta_per_turn` override constrains applied delta.
- **Invalid variables**: unknown keys proposed by the model are rejected; known keys still apply.
- **Success / failure / timeout** endings from `ending_conditions`, and success-over-timeout priority.
- **Scenario events**: fire when condition met; absent when condition not met.
- **Hidden state**: `pressure` and custom hidden variables are excluded from `visible_state`; visible meters are present.
- **Rubric observations**: persisted in `turn_session_events`; included in pipeline result and API response; no event written when list is empty.
- **ScenarioInfo smoke tests**: verify `coworker_feedback` ships with overrides, events, and ending conditions; verify rapport initialises to 30.

## Testing

All 168 scenario-state and pipeline tests pass. The broader non-hardware suite (1321 tests) shows 0 failures.

Closes #201