### PR TITLE
Implement hands-free VAD manual override and add VAD/STT tests

### DIFF
--- a/apps/web/src/__tests__/MicButton.test.tsx
+++ b/apps/web/src/__tests__/MicButton.test.tsx
@@ -119,3 +119,77 @@ describe('MicButton — PTT behavior (granted)', () => {
     expect(onRecordStart).not.toHaveBeenCalled()
   })
 })
+
+describe('MicButton — hands-free mode', () => {
+  it('renders tap-to-start button when idle in hands-free mode', () => {
+    render(<MicButton {...makeProps({ isHandsFree: true })} />)
+    expect(screen.getByRole('button', { name: /tap to start recording/i })).toBeInTheDocument()
+  })
+
+  it('calls onRecordStart on pointer down when not recording in hands-free mode', () => {
+    const onRecordStart = vi.fn()
+    render(<MicButton {...makeProps({ isHandsFree: true, isRecording: false, onRecordStart })} />)
+    fireEvent.pointerDown(screen.getByRole('button'))
+    expect(onRecordStart).toHaveBeenCalledOnce()
+  })
+
+  it('calls onRecordStop on pointer down when recording in hands-free mode (manual override)', () => {
+    const onRecordStop = vi.fn()
+    render(
+      <MicButton {...makeProps({ isHandsFree: true, isRecording: true, recordingSeconds: 5, onRecordStop })} />,
+    )
+    fireEvent.pointerDown(screen.getByRole('button'))
+    expect(onRecordStop).toHaveBeenCalledOnce()
+  })
+
+  it('does not call onRecordStart on pointer down when already recording in hands-free mode', () => {
+    const onRecordStart = vi.fn()
+    render(
+      <MicButton {...makeProps({ isHandsFree: true, isRecording: true, recordingSeconds: 2, onRecordStart })} />,
+    )
+    fireEvent.pointerDown(screen.getByRole('button'))
+    expect(onRecordStart).not.toHaveBeenCalled()
+  })
+
+  it('does not call onRecordStop on pointer up in hands-free mode', () => {
+    const onRecordStop = vi.fn()
+    render(<MicButton {...makeProps({ isHandsFree: true, onRecordStop })} />)
+    fireEvent.pointerUp(screen.getByRole('button'))
+    expect(onRecordStop).not.toHaveBeenCalled()
+  })
+
+  it('does not call onRecordStop on pointer leave in hands-free mode', () => {
+    const onRecordStop = vi.fn()
+    render(<MicButton {...makeProps({ isHandsFree: true, onRecordStop })} />)
+    fireEvent.pointerLeave(screen.getByRole('button'))
+    expect(onRecordStop).not.toHaveBeenCalled()
+  })
+
+  it('calls onRecordStop on Space keydown when recording in hands-free mode', () => {
+    const onRecordStop = vi.fn()
+    render(
+      <MicButton {...makeProps({ isHandsFree: true, isRecording: true, recordingSeconds: 3, onRecordStop })} />,
+    )
+    fireEvent.keyDown(screen.getByRole('button'), { code: 'Space' })
+    expect(onRecordStop).toHaveBeenCalledOnce()
+  })
+
+  it('calls onRecordStart on Space keydown when not recording in hands-free mode', () => {
+    const onRecordStart = vi.fn()
+    render(<MicButton {...makeProps({ isHandsFree: true, isRecording: false, onRecordStart })} />)
+    fireEvent.keyDown(screen.getByRole('button'), { code: 'Space' })
+    expect(onRecordStart).toHaveBeenCalledOnce()
+  })
+
+  it('does not call onRecordStop on Space keyup in hands-free mode', () => {
+    const onRecordStop = vi.fn()
+    render(<MicButton {...makeProps({ isHandsFree: true, onRecordStop })} />)
+    fireEvent.keyUp(screen.getByRole('button'), { code: 'Space' })
+    expect(onRecordStop).not.toHaveBeenCalled()
+  })
+
+  it('shows tap-to-stop label when recording in hands-free mode', () => {
+    render(<MicButton {...makeProps({ isHandsFree: true, isRecording: true, recordingSeconds: 7 })} />)
+    expect(screen.getByRole('button', { name: /tap to stop or wait for silence/i })).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/__tests__/VoiceInput.test.tsx
+++ b/apps/web/src/__tests__/VoiceInput.test.tsx
@@ -537,6 +537,32 @@ describe('VoiceInput — audio upload flow', () => {
     expect(screen.getByRole('alert')).toHaveTextContent(/failed to process audio/i)
   })
 
+  it('text input remains available and usable when STT is unavailable (unavailable STT fallback)', async () => {
+    const onSubmit = vi.fn()
+    let capturedOnAudioReady: ((blob: Blob) => void) | undefined
+    vi.mocked(useMicCapture).mockImplementation((cb) => {
+      capturedOnAudioReady = cb
+      return makeMicState()
+    })
+    vi.mocked(apiClient.uploadAudio).mockResolvedValueOnce({ transcript: null, status: 'unavailable' })
+
+    render(<VoiceInput onSubmit={onSubmit} />)
+
+    await act(async () => {
+      capturedOnAudioReady?.(new Blob(['audio'], { type: 'audio/webm' }))
+    })
+
+    // Alert shown for STT unavailable
+    expect(screen.getByRole('alert')).toHaveTextContent(/not installed/i)
+
+    // Text input still visible and usable — the player can type their turn
+    const textInput = screen.getByRole('textbox', { name: /your response/i })
+    expect(textInput).toBeInTheDocument()
+    fireEvent.change(textInput, { target: { value: 'typed fallback response' } })
+    fireEvent.submit(textInput.closest('form')!)
+    expect(onSubmit).toHaveBeenCalledWith('typed fallback response')
+  })
+
   it('shows review panel when disabled, then populates text input after confirmation', async () => {
     const onSubmit = vi.fn()
     let capturedOnAudioReady: ((blob: Blob) => void) | undefined
@@ -562,6 +588,112 @@ describe('VoiceInput — audio upload flow', () => {
     expect(screen.queryByTestId('transcript-review-panel')).not.toBeInTheDocument()
     // After confirm, the text input (the standard response field) gets the transcript value
     expect(screen.getByRole('textbox', { name: /your response/i })).toHaveValue('hello world')
+  })
+})
+
+describe('VoiceInput — hands-free VAD auto-stop (VAD timeout)', () => {
+  it('calls stopRecording when the VAD silence callback fires during hands-free recording', () => {
+    const stopRecording = vi.fn()
+    let capturedOnSilence: (() => void) | undefined
+
+    vi.mocked(useVad).mockReturnValue(
+      makeVadState({
+        settings: { mode: 'hands-free', threshold: 0.05, silenceDurationMs: 1500, calibratedAt: null },
+        startSilenceDetection: vi.fn().mockImplementation((_stream: MediaStream, onSilence: () => void) => {
+          capturedOnSilence = onSilence
+        }),
+      }),
+    )
+    vi.mocked(useMicCapture).mockReturnValue(
+      makeMicState({ stopRecording, stream: {} as MediaStream }),
+    )
+
+    render(<VoiceInput />)
+    if (document.activeElement instanceof HTMLElement) document.activeElement.blur()
+
+    // Start hands-free recording — this arms the VAD silence callback
+    fireEvent.keyDown(document, { code: 'Space' })
+
+    expect(capturedOnSilence).toBeDefined()
+
+    // VAD silence timer fires — simulates auto-stop after sustained silence
+    capturedOnSilence?.()
+
+    expect(stopRecording).toHaveBeenCalledOnce()
+  })
+
+  it('shows review panel after VAD auto-stop triggers audio upload', async () => {
+    let capturedOnAudioReady: ((blob: Blob) => void) | undefined
+    let capturedOnSilence: (() => void) | undefined
+    const stopRecording = vi.fn().mockImplementation(() => {
+      capturedOnAudioReady?.(new Blob(['audio'], { type: 'audio/webm' }))
+    })
+
+    vi.mocked(useVad).mockReturnValue(
+      makeVadState({
+        settings: { mode: 'hands-free', threshold: 0.05, silenceDurationMs: 1500, calibratedAt: null },
+        startSilenceDetection: vi.fn().mockImplementation((_stream: MediaStream, onSilence: () => void) => {
+          capturedOnSilence = onSilence
+        }),
+      }),
+    )
+    vi.mocked(useMicCapture).mockImplementation((cb) => {
+      capturedOnAudioReady = cb
+      return makeMicState({ stopRecording, stream: {} as MediaStream })
+    })
+    vi.mocked(apiClient.uploadAudio).mockResolvedValueOnce({ transcript: 'VAD stopped me', status: 'ok' })
+
+    render(<VoiceInput />)
+    if (document.activeElement instanceof HTMLElement) document.activeElement.blur()
+
+    fireEvent.keyDown(document, { code: 'Space' })
+
+    await act(async () => {
+      capturedOnSilence?.()
+    })
+
+    expect(screen.getByTestId('transcript-review-panel')).toBeInTheDocument()
+    expect(screen.getByRole('textbox', { name: /edit transcript/i })).toHaveValue('VAD stopped me')
+  })
+})
+
+describe('VoiceInput — hands-free manual override', () => {
+  it('stops recording when Space is pressed while already recording in hands-free mode', () => {
+    const stopRecording = vi.fn()
+    vi.mocked(useVad).mockReturnValue(
+      makeVadState({
+        settings: { mode: 'hands-free', threshold: 0.05, silenceDurationMs: 1500, calibratedAt: null },
+      }),
+    )
+    vi.mocked(useMicCapture).mockReturnValue(
+      makeMicState({ isRecording: true, stopRecording }),
+    )
+
+    render(<VoiceInput />)
+    if (document.activeElement instanceof HTMLElement) document.activeElement.blur()
+
+    fireEvent.keyDown(document, { code: 'Space' })
+
+    expect(stopRecording).toHaveBeenCalledOnce()
+  })
+
+  it('does not start a new recording when Space is pressed while already recording in hands-free mode', () => {
+    const startRecording = vi.fn()
+    vi.mocked(useVad).mockReturnValue(
+      makeVadState({
+        settings: { mode: 'hands-free', threshold: 0.05, silenceDurationMs: 1500, calibratedAt: null },
+      }),
+    )
+    vi.mocked(useMicCapture).mockReturnValue(
+      makeMicState({ isRecording: true, startRecording }),
+    )
+
+    render(<VoiceInput />)
+    if (document.activeElement instanceof HTMLElement) document.activeElement.blur()
+
+    fireEvent.keyDown(document, { code: 'Space' })
+
+    expect(startRecording).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/web/src/__tests__/useVad.test.ts
+++ b/apps/web/src/__tests__/useVad.test.ts
@@ -299,6 +299,69 @@ describe('useVad — auto-stop arms only after speech', () => {
 // Threshold configuration
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Conservative fallback — AudioContext unavailable
+// ---------------------------------------------------------------------------
+
+describe('useVad — conservative fallback (AudioContext unavailable)', () => {
+  it('does not throw when AudioContext constructor is unavailable', () => {
+    vi.stubGlobal('AudioContext', vi.fn(() => { throw new Error('AudioContext not supported') }))
+    const { result } = renderHook(() => useVad())
+    expect(() => act(() => result.current.startSilenceDetection(makeStream(), vi.fn()))).not.toThrow()
+  })
+
+  it('stays in idle state when AudioContext constructor throws', () => {
+    vi.stubGlobal('AudioContext', vi.fn(() => { throw new Error('not supported') }))
+    const { result } = renderHook(() => useVad())
+    act(() => result.current.startSilenceDetection(makeStream(), vi.fn()))
+    // startSilenceDetection fails silently — conservative fallback: recording continues
+    // until useMicCapture's MAX_RECORDING_SECONDS fires externally.
+    expect(result.current.vadState).toBe('idle')
+  })
+
+  it('does not fire onSilence when AudioContext is unavailable', () => {
+    vi.stubGlobal('AudioContext', vi.fn(() => { throw new Error('not supported') }))
+    const { result } = renderHook(() => useVad())
+    const onSilence = vi.fn()
+    act(() => result.current.startSilenceDetection(makeStream(), onSilence))
+    act(() => { vi.advanceTimersByTime(30_000) })
+    expect(onSilence).not.toHaveBeenCalled()
+  })
+
+  it('does not throw when AudioContext.createMediaStreamSource throws', () => {
+    const mockCtx = {
+      createAnalyser: () => ({
+        fftSize: 512,
+        smoothingTimeConstant: 0,
+        connect: vi.fn(),
+      }),
+      createMediaStreamSource: () => { throw new Error('stream unavailable') },
+      close: vi.fn().mockResolvedValue(undefined),
+    }
+    vi.stubGlobal('AudioContext', vi.fn(() => mockCtx))
+    const { result } = renderHook(() => useVad())
+    expect(() => act(() => result.current.startSilenceDetection(makeStream(), vi.fn()))).not.toThrow()
+  })
+
+  it('stays in idle state when createMediaStreamSource throws', () => {
+    const mockCtx = {
+      createAnalyser: () => ({
+        fftSize: 512,
+        smoothingTimeConstant: 0,
+        connect: vi.fn(),
+      }),
+      createMediaStreamSource: () => { throw new Error('stream unavailable') },
+      close: vi.fn().mockResolvedValue(undefined),
+    }
+    vi.stubGlobal('AudioContext', vi.fn(() => mockCtx))
+    const { result } = renderHook(() => useVad())
+    act(() => result.current.startSilenceDetection(makeStream(), vi.fn()))
+    expect(result.current.vadState).toBe('idle')
+  })
+})
+
+// ---------------------------------------------------------------------------
+
 describe('useVad — threshold range', () => {
   it('default threshold is between 0 and 1', () => {
     const { result } = renderHook(() => useVad())

--- a/apps/web/src/components/MicButton.tsx
+++ b/apps/web/src/components/MicButton.tsx
@@ -78,7 +78,7 @@ export default function MicButton({
 
   const label = isRecording
     ? isHandsFree
-      ? `Recording ${formatDuration(recordingSeconds)} — auto-stops on silence`
+      ? `Recording ${formatDuration(recordingSeconds)} — tap to stop or wait for silence`
       : `Recording ${formatDuration(recordingSeconds)} of ${MAX_RECORDING_SECONDS}s — release to stop`
     : isHandsFree
       ? 'Tap to start recording (auto-stops on silence)'
@@ -91,13 +91,14 @@ export default function MicButton({
         aria-label={label}
         aria-pressed={isRecording}
         disabled={disabled && !isRecording}
-        onPointerDown={onRecordStart}
+        onPointerDown={isHandsFree ? (isRecording ? onRecordStop : onRecordStart) : onRecordStart}
         onPointerUp={isHandsFree ? undefined : onRecordStop}
         onPointerLeave={isHandsFree ? undefined : onRecordStop}
         onKeyDown={(e) => {
           if (e.code === 'Space' && !e.repeat) {
             e.preventDefault()
-            onRecordStart()
+            if (isHandsFree && isRecording) onRecordStop()
+            else onRecordStart()
           }
         }}
         onKeyUp={(e) => {

--- a/apps/web/src/components/VoiceInput.tsx
+++ b/apps/web/src/components/VoiceInput.tsx
@@ -151,9 +151,12 @@ export default function VoiceInput({ onSubmit, onRawStt, onSttLatency, disabled 
       if (permission !== 'granted' || isSubmitting || disabled) return
       // Don't start recording while the transcript review panel is open.
       if (reviewState !== null) return
-      // In hands-free mode Space starts recording; once recording, VAD drives the stop so
-      // we ignore further presses to avoid resetting the auto-stop countdown.
-      if (isHandsFree && isRecording) return
+      // In hands-free mode: Space toggles — starts if idle, manually stops if already recording.
+      if (isHandsFree && isRecording) {
+        e.preventDefault()
+        stopRecording()
+        return
+      }
       e.preventDefault()
       startRecording()
     }
@@ -162,8 +165,7 @@ export default function VoiceInput({ onSubmit, onRawStt, onSttLatency, disabled 
       if (e.code !== 'Space') return
       if (isInteractiveElement(document.activeElement)) return
       if (permission !== 'granted' || isSubmitting || (disabled && !isRecording)) return
-      // In hands-free mode, Space also starts/stops but VAD drives the stop.
-      // Releasing Space should always stop when PTT is active.
+      // PTT only: release Space to stop. In hands-free mode, stop is handled on keydown.
       if (!isHandsFree) stopRecording()
     }
 
@@ -240,7 +242,7 @@ export default function VoiceInput({ onSubmit, onRawStt, onSttLatency, disabled 
               isHandsFree={isHandsFree}
               onRequestPermission={requestPermission}
               onRecordStart={startRecording}
-              onRecordStop={isHandsFree ? () => {} : stopRecording}
+              onRecordStop={stopRecording}
             />
 
             <form onSubmit={handleTextSubmit} style={{ display: 'flex', flex: 1, gap: '0.5rem' }}>
@@ -322,8 +324,8 @@ export default function VoiceInput({ onSubmit, onRawStt, onSttLatency, disabled 
       {/* Hands-free hint */}
       {permission === 'granted' && !isRecording && !isSubmitting && isHandsFree && !reviewState && (
         <p style={hintStyle}>
-          Press <kbd style={kbdStyle}>Space</kbd> or tap the mic — recording stops automatically
-          after silence.{' '}
+          Press <kbd style={kbdStyle}>Space</kbd> or tap the mic — auto-stops on silence; press
+          again to stop manually.{' '}
           {!vad.settings.calibratedAt && (
             <span style={{ color: '#fbbf24' }}>Calibrate noise for best results.</span>
           )}


### PR DESCRIPTION
## Summary

In hands-free VAD mode, players previously had to wait for the VAD silence timer to trigger — there was no way to manually stop a recording once started. This PR adds manual override: players can now press Space again or tap the mic button a second time to stop recording immediately, while maintaining the silent-stop timer as a fallback.

## Changes

**`MicButton.tsx`**
- `onPointerDown` now toggles in hands-free mode: starts recording if idle, calls `onRecordStop` if already recording
- `onKeyDown` (Space) applies the same toggle logic — stops if recording, starts if idle
- Updated aria-label and hint text to communicate the tap-to-stop affordance

**`VoiceInput.tsx`**
- Space keydown handler now stops an active hands-free recording instead of being a no-op
- `onRecordStop` is always passed as-is to `MicButton` (removed the `isHandsFree ? () => {} : stopRecording` no-op gate)
- Updated hint text to clarify: "auto-stops on silence; press again to stop manually"

**`MicButton.test.tsx`** — 9 new tests covering:
- Tap-to-start and tap-to-stop in hands-free mode
- Space keydown to stop while recording in hands-free mode
- Pointer-up and pointer-leave remain no-ops in hands-free (PTT release semantics stay off)
- Correct aria-labels for recording state

**`VoiceInput.test.tsx`** — 4 new tests covering:
- VAD timeout: `onSilence` callback stops recording and shows the review panel
- Manual override: Space stops an active hands-free recording without starting a new one
- Unavailable STT fallback: alert is shown and text input remains fully usable
- Global Space hotkey behavior in hands-free mode

**`useVad.test.ts`** — 5 new tests covering:
- Conservative fallback: when `AudioContext` constructor or `createMediaStreamSource` throws, `startSilenceDetection` fails silently, `vadState` stays idle, and `onSilence` is never called — recording continues until the 60s max timer in `useMicCapture`

## Test results

- `pnpm --filter web test --run`: 760 tests, all pass
- `python3 -m pytest tests/test_stt.py tests/test_vad.py`: 36 tests, all pass

Closes #215