### PR TITLE
[Creator] Implement Creator Workbench MVP

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
     "lint": "eslint src"
   },
   "dependencies": {
+    "@convsim/scenario-schema": "workspace:*",
     "@convsim/shared": "workspace:*",
     "@convsim/ui": "workspace:*",
     "react": "^18.3.1",

--- a/apps/web/src/__tests__/CreatorWorkbench.test.tsx
+++ b/apps/web/src/__tests__/CreatorWorkbench.test.tsx
@@ -5,6 +5,19 @@ import { MemoryRouter } from 'react-router-dom'
 import CreatorWorkbench from '../screens/CreatorWorkbench'
 import type { WorkbenchPack, FileNode } from '../api/client'
 
+vi.mock('@convsim/ui', () => ({
+  FormEditor: ({ initialYaml, onChange }: { fileType: string; initialYaml: string; onChange?: (yaml: string) => void }) => (
+    <div data-testid="form-editor">
+      <textarea
+        data-testid="form-editor-yaml"
+        aria-label="Form editor YAML"
+        defaultValue={initialYaml}
+        onChange={(e) => onChange?.(e.target.value)}
+      />
+    </div>
+  ),
+}))
+
 const OFFICIAL_PACK: WorkbenchPack = {
   kind: 'official',
   slug: 'job-interview',
@@ -1117,6 +1130,60 @@ describe('CreatorWorkbench — Test Chat', () => {
     await waitFor(() => {
       const editor = screen.getByTestId('file-editor') as HTMLTextAreaElement
       expect(editor.value).toContain('name: My Pack')
+    })
+  })
+
+  it('shows form editor mode toggle for editable recognized YAML files', async () => {
+    const localContent = 'pack_id: local.my_pack\nname: My Pack\n'
+    stubFetch((url) => {
+      if (url.includes('/files')) return okJson({ tree: MOCK_TREE })
+      if (url.includes('/file?')) return okJson({ content: localContent, editable: true })
+      return okJson([OFFICIAL_PACK, LOCAL_PACK])
+    })
+
+    renderWorkbench()
+    fireEvent.click(await screen.findByRole('button', { name: /my pack/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /open manifest\.yaml/i }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('editor-mode-toggle')).toBeInTheDocument()
+      expect(screen.getByTestId('editor-mode-yaml')).toBeInTheDocument()
+      expect(screen.getByTestId('editor-mode-form')).toBeInTheDocument()
+    })
+  })
+
+  it('switches to form editor when form mode button is clicked', async () => {
+    const localContent = 'pack_id: local.my_pack\nname: My Pack\n'
+    stubFetch((url) => {
+      if (url.includes('/files')) return okJson({ tree: MOCK_TREE })
+      if (url.includes('/file?')) return okJson({ content: localContent, editable: true })
+      return okJson([OFFICIAL_PACK, LOCAL_PACK])
+    })
+
+    renderWorkbench()
+    fireEvent.click(await screen.findByRole('button', { name: /my pack/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /open manifest\.yaml/i }))
+
+    await waitFor(() => expect(screen.getByTestId('editor-mode-form')).toBeInTheDocument())
+
+    // Default is YAML mode — raw textarea is visible
+    expect(screen.getByTestId('file-editor')).toBeInTheDocument()
+    expect(screen.queryByTestId('form-editor')).not.toBeInTheDocument()
+
+    // Switch to form mode
+    fireEvent.click(screen.getByTestId('editor-mode-form'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('form-editor')).toBeInTheDocument()
+      expect(screen.queryByTestId('file-editor')).not.toBeInTheDocument()
+    })
+
+    // Switch back to YAML mode
+    fireEvent.click(screen.getByTestId('editor-mode-yaml'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('file-editor')).toBeInTheDocument()
+      expect(screen.queryByTestId('form-editor')).not.toBeInTheDocument()
     })
   })
 })

--- a/apps/web/src/screens/CreatorWorkbench.tsx
+++ b/apps/web/src/screens/CreatorWorkbench.tsx
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import { useState, useEffect, useCallback, useRef, type CSSProperties } from 'react'
 import { useBlocker } from 'react-router-dom'
+import { FormEditor } from '@convsim/ui'
+import type { PackFileType } from '@convsim/scenario-schema'
 import { api, type WorkbenchPack, type FileNode, type WorkbenchValidation, type WorkbenchValidationIssue, type WorkbenchImportValidationError } from '../api/client'
 
 // A validation response is only usable if it carries the expected error/warning
@@ -299,6 +301,19 @@ function FileTree({ nodes, selected, onSelect, depth = 0 }: FileTreeProps) {
 // FileEditor
 // ---------------------------------------------------------------------------
 
+function detectPackFileType(filePath: string): PackFileType | null {
+  const parts = filePath.split('/')
+  const name = parts[parts.length - 1] ?? ''
+  if (name === 'manifest.yaml' || name === 'manifest.yml') return 'manifest'
+  if (parts.length >= 2 && (name.endsWith('.yaml') || name.endsWith('.yml'))) {
+    const dir = parts[parts.length - 2]
+    if (dir === 'scenarios') return 'scenario'
+    if (dir === 'npcs') return 'npc'
+    if (dir === 'rubrics') return 'rubric'
+  }
+  return null
+}
+
 interface FileEditorProps {
   filePath: string
   content: string
@@ -308,6 +323,7 @@ interface FileEditorProps {
   saveError: string | null
   copying: boolean
   copyError: string | null
+  fileType: PackFileType | null
   onChange: (v: string) => void
   onSave: () => void
   onCopyToLocal?: () => void
@@ -322,12 +338,20 @@ function FileEditor({
   saveError,
   copying,
   copyError,
+  fileType,
   onChange,
   onSave,
   onCopyToLocal,
 }: FileEditorProps) {
   const ext = filePath.split('.').pop()?.toLowerCase() ?? ''
   const isMarkdown = ext === 'md'
+  const [editorMode, setEditorMode] = useState<'yaml' | 'form'>('yaml')
+
+  useEffect(() => {
+    setEditorMode('yaml')
+  }, [filePath])
+
+  const canUseFormEditor = editable && fileType !== null
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
@@ -346,6 +370,47 @@ function FileEditor({
         <code style={{ fontSize: '0.8rem', color: '#a1a1aa', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
           {filePath}
         </code>
+
+        {canUseFormEditor && (
+          <div
+            data-testid="editor-mode-toggle"
+            style={{ display: 'flex', border: '1px solid rgba(255,255,255,0.12)', borderRadius: '4px', overflow: 'hidden' }}
+          >
+            <button
+              data-testid="editor-mode-yaml"
+              onClick={() => setEditorMode('yaml')}
+              aria-pressed={editorMode === 'yaml'}
+              aria-label="YAML editor mode"
+              style={{
+                ...BTN,
+                padding: '0.15rem 0.5rem',
+                border: 'none',
+                borderRadius: 0,
+                background: editorMode === 'yaml' ? 'rgba(99,102,241,0.2)' : 'transparent',
+                color: editorMode === 'yaml' ? '#a5b4fc' : '#71717a',
+              }}
+            >
+              YAML
+            </button>
+            <button
+              data-testid="editor-mode-form"
+              onClick={() => setEditorMode('form')}
+              aria-pressed={editorMode === 'form'}
+              aria-label="Form editor mode"
+              style={{
+                ...BTN,
+                padding: '0.15rem 0.5rem',
+                border: 'none',
+                borderLeft: '1px solid rgba(255,255,255,0.12)',
+                borderRadius: 0,
+                background: editorMode === 'form' ? 'rgba(99,102,241,0.2)' : 'transparent',
+                color: editorMode === 'form' ? '#a5b4fc' : '#71717a',
+              }}
+            >
+              Form
+            </button>
+          </div>
+        )}
 
         {!editable && (
           <span
@@ -412,28 +477,38 @@ function FileEditor({
         </p>
       )}
 
-      {/* Editor */}
-      <textarea
-        data-testid="file-editor"
-        aria-label={`${isMarkdown ? 'Markdown' : 'YAML'} editor: ${filePath}`}
-        readOnly={!editable}
-        value={content}
-        onChange={(e) => onChange(e.target.value)}
-        spellCheck={false}
-        style={{
-          flex: 1,
-          padding: '0.75rem',
-          background: editable ? 'rgba(0,0,0,0.3)' : 'rgba(0,0,0,0.15)',
-          color: editable ? '#e8e8ea' : '#71717a',
-          border: 'none',
-          outline: 'none',
-          fontFamily: 'monospace',
-          fontSize: '0.85rem',
-          lineHeight: 1.6,
-          resize: 'none',
-          cursor: editable ? 'text' : 'default',
-        }}
-      />
+      {/* Editor — form mode for recognized YAML types, raw textarea otherwise */}
+      {editorMode === 'form' && canUseFormEditor ? (
+        <div style={{ flex: 1, overflow: 'auto', padding: '0.75rem' }}>
+          <FormEditor
+            fileType={fileType}
+            initialYaml={content}
+            onChange={onChange}
+          />
+        </div>
+      ) : (
+        <textarea
+          data-testid="file-editor"
+          aria-label={`${isMarkdown ? 'Markdown' : 'YAML'} editor: ${filePath}`}
+          readOnly={!editable}
+          value={content}
+          onChange={(e) => onChange(e.target.value)}
+          spellCheck={false}
+          style={{
+            flex: 1,
+            padding: '0.75rem',
+            background: editable ? 'rgba(0,0,0,0.3)' : 'rgba(0,0,0,0.15)',
+            color: editable ? '#e8e8ea' : '#71717a',
+            border: 'none',
+            outline: 'none',
+            fontFamily: 'monospace',
+            fontSize: '0.85rem',
+            lineHeight: 1.6,
+            resize: 'none',
+            cursor: editable ? 'text' : 'default',
+          }}
+        />
+      )}
     </div>
   )
 }
@@ -1769,6 +1844,7 @@ export default function CreatorWorkbench() {
                 saveError={saveError}
                 copying={copying}
                 copyError={copyError}
+                fileType={detectPackFileType(selectedFile)}
                 onChange={setEditorContent}
                 onSave={handleSave}
                 onCopyToLocal={!editorEditable ? handleCopyToLocal : undefined}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@convsim/scenario-schema':
+        specifier: workspace:*
+        version: link:../../packages/scenario-schema
       '@convsim/shared':
         specifier: workspace:*
         version: link:../../packages/shared

--- a/services/convsim-core/convsim_core/routers/workbench.py
+++ b/services/convsim-core/convsim_core/routers/workbench.py
@@ -8,20 +8,28 @@ unauthenticated local endpoint cannot be used to write arbitrary files.
 """
 from __future__ import annotations
 
+import io
+import json
 import os
 import re
 import secrets
 import shutil
+import tempfile
+import uuid
+import zipfile
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Literal, Optional
+from typing import Dict, List, Literal, Optional
 
 from fastapi import APIRouter, Query, Request
+from fastapi.responses import Response
 from pydantic import BaseModel
 
 from convsim_core.config import ServiceConfig
 from convsim_core.errors import ConvsimError
+from convsim_core.packs.importer import safe_extract_zip
 from convsim_core.packs.models import ValidationResult
-from convsim_core.packs.validator import validate_pack_cached
+from convsim_core.packs.validator import validate_pack_cached, validate_pack_dir
 
 router = APIRouter(prefix="/api/workbench", tags=["workbench"])
 
@@ -336,4 +344,285 @@ async def copy_to_local(request: Request, kind: str, slug: str) -> WorkbenchPack
         pack_id=pack_id,
         name=name or dest_slug,
         editable=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Import / Export
+# ---------------------------------------------------------------------------
+
+_MAX_IMPORT_BYTES = 100 * 1024 * 1024  # 100 MB
+
+
+class WorkbenchImportResult(BaseModel):
+    """Successful pack import result — a WorkbenchPackSummary plus an optional rename notice."""
+
+    kind: Literal["official", "local-dev"]
+    slug: str
+    pack_id: Optional[str] = None
+    name: Optional[str] = None
+    editable: bool
+    # Set when the slug was changed to avoid a collision with an existing local-dev pack.
+    renamed_from: Optional[str] = None
+
+
+def _slugify_pack_id(pack_id: str) -> str:
+    """Derive a filesystem-safe slug from a pack_id."""
+    return pack_id.replace("/", "_").replace("\\", "_")
+
+
+def _unique_local_slug(local_root: Path, base_slug: str) -> tuple[str, Optional[str]]:
+    """Return (slug, renamed_from) where renamed_from is the original if a collision occurred."""
+    dest = local_root / base_slug
+    if not dest.exists():
+        return base_slug, None
+    # Collision: find a unique name by appending -2, -3, …
+    n = 2
+    while (local_root / f"{base_slug}-{n}").exists():
+        n += 1
+    return f"{base_slug}-{n}", base_slug
+
+
+@router.post("/packs/import", response_model=WorkbenchImportResult, status_code=201)
+async def import_pack(request: Request) -> WorkbenchImportResult:
+    """Import a pack from a raw zip body into the local-dev directory.
+
+    The zip is validated before extraction. If the pack content fails schema
+    validation, a 422 with the ValidationResult is returned so the UI can show
+    actionable errors.  Slug collisions are resolved by renaming the incoming
+    pack (appending -2, -3, …) and recording the original name in
+    ``renamed_from``.
+    """
+    config = _config(request)
+    zip_bytes = await request.body()
+
+    if len(zip_bytes) > _MAX_IMPORT_BYTES:
+        raise ConvsimError(
+            "FILE_TOO_LARGE",
+            f"Uploaded file exceeds the {_MAX_IMPORT_BYTES // (1024 * 1024)} MB limit.",
+            status_code=413,
+        )
+
+    if not zipfile.is_zipfile(io.BytesIO(zip_bytes)):
+        raise ConvsimError(
+            "INVALID_ZIP",
+            "Uploaded file is not a valid .zip archive.",
+            status_code=422,
+        )
+
+    local_root = _local_dev_root(config)
+    local_root.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(prefix="convsim_wb_import_") as tmp_root:
+        extract_dir = Path(tmp_root) / "extracted"
+        extract_dir.mkdir()
+        safe_extract_zip(zip_bytes, extract_dir)
+
+        top_level = list(extract_dir.iterdir())
+        pack_source = top_level[0] if len(top_level) == 1 and top_level[0].is_dir() else extract_dir
+
+        validation = validate_pack_dir(pack_source)
+        if validation.errors:
+            from fastapi.responses import JSONResponse
+            return JSONResponse(
+                status_code=422,
+                content=validation.model_dump(exclude={"manifest"}),
+            )
+
+        pack_id, name = _read_manifest_basics(pack_source)
+        base_slug = _slugify_pack_id(pack_id) if pack_id else pack_source.name
+        dest_slug, renamed_from = _unique_local_slug(local_root, base_slug)
+        dest_path = local_root / dest_slug
+
+        shutil.copytree(str(pack_source), str(dest_path))
+
+    return WorkbenchImportResult(
+        kind="local-dev",
+        slug=dest_slug,
+        pack_id=pack_id,
+        name=name or dest_slug,
+        editable=True,
+        renamed_from=renamed_from,
+    )
+
+
+@router.get("/packs/{kind}/{slug}/export")
+async def export_pack(request: Request, kind: str, slug: str) -> Response:
+    """Export a pack directory as a zip archive.
+
+    Runs a validation preflight: if the pack has schema errors the request
+    returns 422 with the ValidationResult body so the client can surface them
+    before the download starts.  Warnings do not block export.
+    """
+    config = _config(request)
+    valid_kind = _assert_valid_kind(kind)
+    pack_root = _pack_root(config, valid_kind, slug)
+    if not pack_root.exists():
+        raise ConvsimError("PACK_NOT_FOUND", f'Pack "{slug}" not found', status_code=404)
+
+    validation = validate_pack_dir(pack_root)
+    if validation.errors:
+        from fastapi.responses import JSONResponse
+        return JSONResponse(
+            status_code=422,
+            content=validation.model_dump(exclude={"manifest"}),
+        )
+
+    # Determine a version string for the filename from manifest if possible.
+    import yaml as _yaml  # local import — only needed here
+    version = "0.1.0"
+    manifest_path = pack_root / "manifest.yaml"
+    if manifest_path.is_file():
+        try:
+            manifest_raw = _yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+            if isinstance(manifest_raw, dict):
+                version = str(manifest_raw.get("version") or version)
+        except Exception:  # noqa: BLE001
+            pass
+
+    # Build the zip in memory.
+    _slug_safe = "".join(c for c in slug.replace("/", "_") if c not in ('"', "\r", "\n"))
+    _ver_safe = "".join(c for c in version if c not in ('"', "\\", "/", "\r", "\n"))
+    filename = f"{_slug_safe}-{_ver_safe}.zip"
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for file_path in sorted(pack_root.rglob("*")):
+            if file_path.is_file():
+                rel = str(file_path.relative_to(pack_root)).replace("\\", "/")
+                zf.write(file_path, f"{_slug_safe}/{rel}")
+
+    return Response(
+        content=buf.getvalue(),
+        media_type="application/zip",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test session
+# ---------------------------------------------------------------------------
+
+
+class WorkbenchTestSessionResponse(BaseModel):
+    """Response from starting a workbench test session."""
+
+    session_id: str
+    state: str
+    npc_opening: str
+    state_vars: Dict[str, int]
+
+
+def _first_scenario_path(pack_root: Path) -> Optional[str]:
+    """Return the relative path of the first usable scenario file in the pack."""
+    import yaml as _yaml
+
+    manifest_path = pack_root / "manifest.yaml"
+    if manifest_path.is_file():
+        try:
+            raw = _yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+            if isinstance(raw, dict):
+                entries: List[str] = list(raw.get("entry_scenarios") or [])
+                for ref in entries:
+                    if (pack_root / ref).is_file():
+                        return ref
+        except Exception:  # noqa: BLE001
+            pass
+
+    scenarios_dir = pack_root / "scenarios"
+    if scenarios_dir.is_dir():
+        for f in sorted(scenarios_dir.iterdir()):
+            if f.is_file() and f.suffix.lower() in (".yaml", ".yml"):
+                return f"scenarios/{f.name}"
+
+    return None
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@router.post("/packs/{kind}/{slug}/test-session", response_model=WorkbenchTestSessionResponse)
+async def start_test_session(request: Request, kind: str, slug: str) -> WorkbenchTestSessionResponse:
+    """Start a temporary text-only test session for a workbench pack.
+
+    Finds the first entry scenario in the pack, loads it from disk, registers
+    it in the process-local scenario registry, and creates a DB session that
+    can be used with the standard ``/api/sessions/{id}/turn`` endpoint.
+
+    The session is flagged with ``save_transcript: false`` so it never appears
+    in the player's session history.
+    """
+    from convsim_core.scenarios import load_scenario_info_from_pack, register_dynamic_scenario
+    from convsim_core.scenario_state import build_variable_defs, initialize_state
+
+    config = _config(request)
+    valid_kind = _assert_valid_kind(kind)
+    pack_root = _pack_root(config, valid_kind, slug)
+    if not pack_root.exists():
+        raise ConvsimError("PACK_NOT_FOUND", f'Pack "{slug}" not found', status_code=404)
+
+    scenario_rel = _first_scenario_path(pack_root)
+    if scenario_rel is None:
+        raise ConvsimError(
+            "NO_SCENARIO",
+            "No scenario found in pack. Add a .yaml file under scenarios/ to test.",
+            status_code=422,
+        )
+
+    try:
+        scenario_info = load_scenario_info_from_pack(pack_root, scenario_rel)
+    except Exception as exc:
+        raise ConvsimError(
+            "SCENARIO_LOAD_ERROR",
+            f"Could not load scenario '{scenario_rel}': {exc}",
+            status_code=422,
+        ) from exc
+
+    # Register under a unique ID so the standard turn endpoint can find it.
+    dynamic_id = f"__wbtest__{uuid.uuid4().hex}"
+    register_dynamic_scenario(dynamic_id, scenario_info)
+
+    # Compute initial state (shown in the state inspector immediately on start).
+    var_defs = build_variable_defs(scenario_info.state_variable_overrides)
+    initial_state = initialize_state(var_defs)
+    opening_text = scenario_info.opening_npc_says or "Hello. Let's begin."
+
+    db = request.app.state.db
+    conn = db.connection()
+    session_id = f"wbtest-{secrets.token_hex(8)}"
+    now = _now_iso()
+
+    setup = {
+        "scenario_id": dynamic_id,
+        "difficulty": "normal",
+        "player_role_name": "Workbench Tester",
+        "language": "en",
+        "input_mode": "text-only",
+        "tts_enabled": False,
+        "tts_voice_id": "af_heart",
+        "show_state_meters": True,
+        "save_transcript": False,
+        "_workbench_test": True,
+    }
+
+    with conn:
+        conn.execute(
+            "INSERT INTO turn_sessions "
+            "(session_id, scenario_id, flow_state, state_vars_json, fired_events_json, turn_count, setup_json, created_at) "
+            "VALUES (?, ?, 'PlayerTurnListening', ?, '[]', 0, ?, ?)",
+            (session_id, dynamic_id, json.dumps(initial_state), json.dumps(setup), now),
+        )
+        conn.execute(
+            "INSERT INTO turn_session_turns "
+            "(session_id, turn_number, role, content, flow_state_after, created_at) "
+            "VALUES (?, 0, 'npc_opening', ?, 'PlayerTurnListening', ?)",
+            (session_id, opening_text, now),
+        )
+
+    return WorkbenchTestSessionResponse(
+        session_id=session_id,
+        state="PlayerTurnListening",
+        npc_opening=opening_text,
+        state_vars=initial_state,
     )

--- a/services/convsim-core/convsim_core/scenarios.py
+++ b/services/convsim-core/convsim_core/scenarios.py
@@ -7,7 +7,9 @@ pipeline-level metadata (max_turns, supported_languages).
 """
 from __future__ import annotations
 
+import threading
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from convsim_prompt.types import (
@@ -302,14 +304,121 @@ SCENARIOS: Dict[str, ScenarioInfo] = {
 }
 
 
+# ---------------------------------------------------------------------------
+# Dynamic scenario registry (workbench test sessions)
+# ---------------------------------------------------------------------------
+
+# Process-local registry for scenarios loaded from pack directories at runtime.
+# Entries persist for the lifetime of the process; the data volume is negligible
+# (one ScenarioInfo per active workbench test session).  Sessions cleaned up
+# through DELETE /api/sessions/{id} do not remove entries here — that's
+# acceptable for the workbench MVP where test sessions are short-lived.
+_dynamic_registry: Dict[str, ScenarioInfo] = {}
+_dynamic_lock = threading.Lock()
+
+
+def register_dynamic_scenario(scenario_id: str, info: ScenarioInfo) -> None:
+    """Register a temporary scenario (e.g., for a workbench test session)."""
+    with _dynamic_lock:
+        _dynamic_registry[scenario_id] = info
+
+
+def unregister_dynamic_scenario(scenario_id: str) -> None:
+    """Remove a dynamic scenario registration if present."""
+    with _dynamic_lock:
+        _dynamic_registry.pop(scenario_id, None)
+
+
 def get_scenario_info(scenario_id: str) -> ScenarioInfo | None:
     """Return the ScenarioInfo for the given ID, or None if unknown."""
-    return SCENARIOS.get(scenario_id)
+    return SCENARIOS.get(scenario_id) or _dynamic_registry.get(scenario_id)
 
 
 def get_scenario_data(scenario_id: str, difficulty: str = "normal") -> ScenarioData | None:
     """Return a ScenarioData configured for the given difficulty, or None if unknown."""
-    info = SCENARIOS.get(scenario_id)
+    info = get_scenario_info(scenario_id)
     if info is None:
         return None
     return info.get_scenario_data(difficulty)
+
+
+# ---------------------------------------------------------------------------
+# Pack scenario loader (for workbench test sessions)
+# ---------------------------------------------------------------------------
+
+
+def _npc_data_from_dict(raw: Dict[str, Any]) -> NpcData:
+    """Build an NpcData from a parsed NPC YAML dict (inline or file-loaded)."""
+    pub = raw.get("public_persona") or {}
+    priv = raw.get("private_persona") or {}
+    return NpcData(
+        npc_id=raw.get("npc_id") or "npc",
+        display_name=raw.get("display_name") or "NPC",
+        public_persona=NpcPublicPersona(
+            occupation=pub.get("occupation") or "",
+            speaking_style=pub.get("speaking_style") or "",
+            demeanor=pub.get("demeanor") or "",
+        ),
+        private_persona=NpcPrivatePersona(
+            hidden_agenda=list(priv.get("hidden_agenda") or []),
+            biases_to_simulate=list(priv.get("biases_to_simulate") or []),
+            boundaries=list(priv.get("boundaries") or []),
+        ),
+    )
+
+
+def load_scenario_info_from_pack(pack_dir: Path, scenario_rel_path: str) -> ScenarioInfo:
+    """Load a ScenarioInfo by reading scenario (and NPC) YAML files from a pack directory.
+
+    Raises ``ValueError`` or ``OSError`` if the files cannot be read or parsed.
+    """
+    import yaml  # local import — only needed for workbench test sessions
+
+    scenario_file = (pack_dir / scenario_rel_path).resolve()
+    raw: Dict[str, Any] = yaml.safe_load(scenario_file.read_text(encoding="utf-8")) or {}
+    if not isinstance(raw, dict):
+        raise ValueError(f"Scenario YAML is not a mapping: {scenario_rel_path}")
+
+    # NPC: resolve ref or use inline dict
+    npc_section = raw.get("npc") or {}
+    npc_ref: Optional[str] = npc_section.get("ref") if isinstance(npc_section, dict) else None
+    if npc_ref:
+        npc_file = (scenario_file.parent / npc_ref).resolve()
+        npc_raw: Dict[str, Any] = yaml.safe_load(npc_file.read_text(encoding="utf-8")) or {}
+        if not isinstance(npc_raw, dict):
+            npc_raw = {}
+    else:
+        npc_raw = npc_section if isinstance(npc_section, dict) else {}
+
+    npc = _npc_data_from_dict(npc_raw)
+
+    player_role = raw.get("player_role") or {}
+    opening_section = raw.get("opening") or {}
+    opening_npc_says: str = opening_section.get("npc_says") or "Hello. Let's begin."
+
+    goals_section = raw.get("goals") or {}
+    player_visible_goals: List[str] = list(goals_section.get("player_visible") or [])
+
+    duration = raw.get("duration") or {}
+    max_turns: int = int(duration.get("max_turns") or 12)
+
+    state_section = raw.get("state") or {}
+    state_variable_overrides: Optional[Dict[str, Any]] = state_section.get("variables") or None
+
+    scenario_data = ScenarioData(
+        scenario_id=raw.get("scenario_id") or "workbench_test",
+        title=raw.get("title") or "Workbench Test",
+        player_role_label=player_role.get("label") or "Player",
+        player_role_brief=player_role.get("brief") or "",
+        npc=npc,
+        player_visible_goals=player_visible_goals,
+    )
+
+    return ScenarioInfo(
+        scenario_data=scenario_data,
+        max_turns=max_turns,
+        supported_languages=["en"],
+        difficulty_options={"normal": DifficultySettings()},
+        opening_npc_says=opening_npc_says,
+        state_variable_overrides=state_variable_overrides,
+    )

--- a/services/convsim-core/tests/test_workbench_api.py
+++ b/services/convsim-core/tests/test_workbench_api.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Integration tests for Creator Workbench API endpoints."""
+import io
+import zipfile
 from pathlib import Path
 
 import pytest
@@ -319,3 +321,425 @@ def test_write_refreshes_validation(client):
     assert body["validation"] is not None
     assert body["validation"]["valid"] is False
     assert len(body["validation"]["errors"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# POST /api/workbench/packs/import
+# ---------------------------------------------------------------------------
+
+
+def _make_minimal_pack_zip(pack_id: str = "local.test_import") -> bytes:
+    """Build an in-memory zip containing a minimal valid pack."""
+    buf = io.BytesIO()
+    top = "test-import-pack"
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr(f"{top}/manifest.yaml", (
+            f'schema_version: "0.1"\n'
+            f'pack_id: {pack_id}\n'
+            f'name: Test Import Pack\n'
+            f'version: 1.0.0\n'
+            f'description: Minimal import test pack.\n'
+            f'author: Test Suite\n'
+            f'license: CC-BY-4.0\n'
+            f'content_rating: G\n'
+            f'tags:\n'
+            f'  - test\n'
+            f'supported_languages:\n'
+            f'  - en\n'
+            f'entry_scenarios:\n'
+            f'  - scenarios/intro.yaml\n'
+            f'assets:\n'
+            f'  allow_external_urls: false\n'
+            f'safety:\n'
+            f'  policy: safety/policy.yaml\n'
+        ))
+        zf.writestr(f"{top}/safety/policy.yaml", (
+            'schema_version: "0.1"\n'
+            'policy_id: test_import_policy\n'
+            'content_rating_cap: G\n'
+            'content_categories:\n'
+            '  nsfw_sexual: block\n'
+            '  real_person_impersonation: block\n'
+            '  instructional_criminal: block\n'
+            '  crisis_content: redirect\n'
+            'redirect_message: "Let\'s keep things on topic."\n'
+        ))
+        zf.writestr(f"{top}/npcs/npc.yaml", (
+            'schema_version: "0.1"\n'
+            'npc_id: test_npc\n'
+            'display_name: Test NPC\n'
+            'archetype: guide\n'
+            'fictional: true\n'
+            'age_band: adult\n'
+            'public_persona:\n'
+            '  occupation: Test Guide\n'
+            '  speaking_style: Neutral\n'
+            '  demeanor: Friendly\n'
+            'private_persona: {}\n'
+        ))
+        zf.writestr(f"{top}/rubrics/rubric.yaml", (
+            'schema_version: "0.1"\n'
+            'rubric_id: test_rubric\n'
+            'title: Test Rubric\n'
+            'dimensions:\n'
+            '  - id: clarity\n'
+            '    name: Clarity\n'
+            '    description: Clear communication.\n'
+            '    scoring:\n'
+            '      low: Unclear\n'
+            '      medium: Adequate\n'
+            '      high: Excellent\n'
+        ))
+        zf.writestr(f"{top}/scenarios/intro.yaml", (
+            'schema_version: "0.1"\n'
+            'scenario_id: test_intro\n'
+            'title: Test Introduction\n'
+            'summary: Minimal import test scenario.\n'
+            'player_role:\n'
+            '  label: Tester\n'
+            '  brief: You are testing the import flow.\n'
+            'npc:\n'
+            '  ref: ../npcs/npc.yaml\n'
+            'rubric:\n'
+            '  ref: ../rubrics/rubric.yaml\n'
+            'duration:\n'
+            '  max_turns: 5\n'
+            'opening:\n'
+            '  npc_says: "Welcome. This is an import test."\n'
+            'goals:\n'
+            '  player_visible:\n'
+            '    - Verify import works\n'
+        ))
+    return buf.getvalue()
+
+
+def test_import_pack_success(client):
+    zip_bytes = _make_minimal_pack_zip("local.test_import")
+    resp = client.post(
+        "/api/workbench/packs/import",
+        content=zip_bytes,
+        headers={"Content-Type": "application/zip"},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["kind"] == "local-dev"
+    assert body["editable"] is True
+    assert body["pack_id"] == "local.test_import"
+    assert body.get("renamed_from") is None
+
+    # The imported pack should appear in the pack list.
+    packs = client.get("/api/workbench/packs").json()
+    assert any(p["slug"] == body["slug"] for p in packs)
+
+
+def test_import_pack_slug_collision_renames(client):
+    # Import the same pack twice; the second import should be renamed.
+    zip_bytes = _make_minimal_pack_zip("local.test_collision")
+    first = client.post(
+        "/api/workbench/packs/import",
+        content=zip_bytes,
+        headers={"Content-Type": "application/zip"},
+    )
+    assert first.status_code == 201
+    assert first.json().get("renamed_from") is None
+
+    second = client.post(
+        "/api/workbench/packs/import",
+        content=zip_bytes,
+        headers={"Content-Type": "application/zip"},
+    )
+    assert second.status_code == 201
+    body = second.json()
+    assert body["renamed_from"] is not None
+    assert body["slug"] != first.json()["slug"]
+
+
+def test_import_pack_invalid_zip_returns_422(client):
+    resp = client.post(
+        "/api/workbench/packs/import",
+        content=b"not a zip",
+        headers={"Content-Type": "application/zip"},
+    )
+    assert resp.status_code == 422
+
+
+def test_import_pack_validation_failure_returns_422(client):
+    # A zip with a broken manifest (missing required fields) must return 422
+    # with a structured errors list so the UI can show actionable findings.
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("bad-pack/manifest.yaml", "schema_version: '0.1'\nnot_a_valid_field: true\n")
+    resp = client.post(
+        "/api/workbench/packs/import",
+        content=buf.getvalue(),
+        headers={"Content-Type": "application/zip"},
+    )
+    assert resp.status_code == 422
+    body = resp.json()
+    assert isinstance(body.get("errors"), list)
+    assert len(body["errors"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# GET /api/workbench/packs/{kind}/{slug}/export
+# ---------------------------------------------------------------------------
+
+
+def test_export_pack_returns_zip(client, tmp_path, roots):
+    """A valid local-dev pack can be exported as a zip."""
+    # The fixture pack is missing required manifest fields, so write a valid one first.
+    official, local_dev = roots
+    _make_full_pack(local_dev / "export-pack")
+
+    resp = client.get("/api/workbench/packs/local-dev/export-pack/export")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "application/zip"
+    cd = resp.headers.get("content-disposition", "")
+    assert "attachment" in cd
+    assert ".zip" in cd
+    assert zipfile.is_zipfile(io.BytesIO(resp.content))
+
+
+def test_export_pack_validation_preflight_returns_422(client):
+    """A pack with schema errors must return 422 with an error list before zipping."""
+    resp = client.get("/api/workbench/packs/local-dev/my-pack/export")
+    # The minimal fixture pack is missing required manifest fields.
+    assert resp.status_code == 422
+    body = resp.json()
+    assert isinstance(body.get("errors"), list)
+    assert len(body["errors"]) > 0
+
+
+def test_export_pack_unknown_returns_404(client):
+    resp = client.get("/api/workbench/packs/local-dev/does-not-exist/export")
+    assert resp.status_code == 404
+
+
+def _make_full_pack(pack_dir: Path, pack_id: str = "local.full_export_pack") -> None:
+    """Write a complete, schema-valid pack to pack_dir."""
+    (pack_dir / "scenarios").mkdir(parents=True, exist_ok=True)
+    (pack_dir / "npcs").mkdir(parents=True, exist_ok=True)
+    (pack_dir / "rubrics").mkdir(parents=True, exist_ok=True)
+    (pack_dir / "safety").mkdir(parents=True, exist_ok=True)
+
+    (pack_dir / "manifest.yaml").write_text(
+        f'schema_version: "0.1"\n'
+        f'pack_id: {pack_id}\n'
+        f'name: Full Export Pack\n'
+        f'version: 1.0.0\n'
+        f'description: A schema-valid pack for export testing.\n'
+        f'author: Test Suite\n'
+        f'license: CC-BY-4.0\n'
+        f'content_rating: G\n'
+        f'tags:\n'
+        f'  - test\n'
+        f'supported_languages:\n'
+        f'  - en\n'
+        f'entry_scenarios:\n'
+        f'  - scenarios/intro.yaml\n'
+        f'assets:\n'
+        f'  allow_external_urls: false\n'
+        f'safety:\n'
+        f'  policy: safety/policy.yaml\n',
+        encoding="utf-8",
+    )
+    (pack_dir / "safety" / "policy.yaml").write_text(
+        'schema_version: "0.1"\n'
+        'policy_id: export_test_policy\n'
+        'content_rating_cap: G\n'
+        'content_categories:\n'
+        '  nsfw_sexual: block\n'
+        '  real_person_impersonation: block\n'
+        '  instructional_criminal: block\n'
+        '  crisis_content: redirect\n'
+        'redirect_message: "Let\'s stay on topic."\n',
+        encoding="utf-8",
+    )
+    (pack_dir / "npcs" / "npc.yaml").write_text(
+        'schema_version: "0.1"\n'
+        'npc_id: export_npc\n'
+        'display_name: Export NPC\n'
+        'archetype: guide\n'
+        'fictional: true\n'
+        'age_band: adult\n'
+        'public_persona:\n'
+        '  occupation: Tester\n'
+        '  speaking_style: Neutral\n'
+        '  demeanor: Friendly\n'
+        'private_persona: {}\n',
+        encoding="utf-8",
+    )
+    (pack_dir / "rubrics" / "rubric.yaml").write_text(
+        'schema_version: "0.1"\n'
+        'rubric_id: export_rubric\n'
+        'title: Export Rubric\n'
+        'dimensions:\n'
+        '  - id: clarity\n'
+        '    name: Clarity\n'
+        '    description: Clear communication.\n'
+        '    scoring:\n'
+        '      low: Unclear\n'
+        '      medium: OK\n'
+        '      high: Great\n',
+        encoding="utf-8",
+    )
+    (pack_dir / "scenarios" / "intro.yaml").write_text(
+        'schema_version: "0.1"\n'
+        'scenario_id: export_intro\n'
+        'title: Export Introduction\n'
+        'summary: A valid scenario for export testing.\n'
+        'player_role:\n'
+        '  label: Tester\n'
+        '  brief: You are testing export.\n'
+        'npc:\n'
+        '  ref: ../npcs/npc.yaml\n'
+        'rubric:\n'
+        '  ref: ../rubrics/rubric.yaml\n'
+        'duration:\n'
+        '  max_turns: 5\n'
+        'opening:\n'
+        '  npc_says: "Export test ready."\n'
+        'goals:\n'
+        '  player_visible:\n'
+        '    - Verify export works\n',
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST /api/workbench/packs/{kind}/{slug}/test-session
+# ---------------------------------------------------------------------------
+
+
+def _make_test_session_pack(root: Path, slug: str) -> Path:
+    """Write a pack with a proper scenario for test-session testing."""
+    pack_dir = root / slug
+    pack_dir.mkdir(parents=True, exist_ok=True)
+    (pack_dir / "scenarios").mkdir(exist_ok=True)
+    (pack_dir / "npcs").mkdir(exist_ok=True)
+
+    (pack_dir / "manifest.yaml").write_text(
+        'schema_version: "0.1"\n'
+        f'pack_id: local.{slug.replace("-", "_")}\n'
+        f'name: {slug}\n'
+        'version: 0.1.0\n'
+        'entry_scenarios:\n'
+        '  - scenarios/intro.yaml\n',
+        encoding="utf-8",
+    )
+    (pack_dir / "npcs" / "guide.yaml").write_text(
+        'schema_version: "0.1"\n'
+        'npc_id: guide\n'
+        'display_name: Guide\n'
+        'archetype: guide\n'
+        'fictional: true\n'
+        'age_band: adult\n'
+        'public_persona:\n'
+        '  occupation: Guide\n'
+        '  speaking_style: Helpful\n'
+        '  demeanor: Warm\n'
+        'private_persona:\n'
+        '  hidden_agenda:\n'
+        '    - Help the player\n',
+        encoding="utf-8",
+    )
+    (pack_dir / "scenarios" / "intro.yaml").write_text(
+        'schema_version: "0.1"\n'
+        'scenario_id: ts_intro\n'
+        'title: Test Session Intro\n'
+        'summary: Minimal scenario for test session.\n'
+        'player_role:\n'
+        '  label: Player\n'
+        '  brief: You are testing the workbench.\n'
+        'npc:\n'
+        '  ref: ../npcs/guide.yaml\n'
+        'rubric:\n'
+        '  ref: ../rubrics/rubric.yaml\n'
+        'duration:\n'
+        '  max_turns: 5\n'
+        'opening:\n'
+        '  npc_says: "Hello from the workbench test session."\n'
+        'goals:\n'
+        '  player_visible:\n'
+        '    - Test the session\n',
+        encoding="utf-8",
+    )
+    return pack_dir
+
+
+@pytest.fixture()
+def ts_client(tmp_path, monkeypatch):
+    """Client fixture with a pack that has a loadable scenario for test-session tests."""
+    official = tmp_path / "official"
+    local_dev = tmp_path / "local-dev"
+    official.mkdir()
+    local_dev.mkdir()
+    _make_test_session_pack(local_dev, "ts-pack")
+
+    monkeypatch.setenv("CONVSIM_WHISPER_CPP_BINARY_PATH", str(tmp_path / "no-whisper-cli"))
+    config = ServiceConfig(
+        host="127.0.0.1",
+        port=7355,
+        data_dir=str(tmp_path / "data"),
+        log_dir=str(tmp_path / "logs"),
+        db_dir=str(tmp_path / "db"),
+        packs_dir=str(tmp_path / "packs"),
+        official_packs_dir=str(official),
+        local_dev_packs_dir=str(local_dev),
+    )
+    app = create_app(config)
+    with TestClient(app) as c:
+        yield c
+
+
+def test_start_test_session_returns_session(ts_client):
+    resp = ts_client.post("/api/workbench/packs/local-dev/ts-pack/test-session")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "session_id" in body
+    assert body["state"] == "PlayerTurnListening"
+    assert isinstance(body["npc_opening"], str)
+    assert len(body["npc_opening"]) > 0
+    assert isinstance(body["state_vars"], dict)
+    assert len(body["state_vars"]) > 0
+
+
+def test_start_test_session_npc_opening_matches_scenario(ts_client):
+    resp = ts_client.post("/api/workbench/packs/local-dev/ts-pack/test-session")
+    assert resp.status_code == 200
+    assert "Hello from the workbench test session." in resp.json()["npc_opening"]
+
+
+def test_start_test_session_session_deletable(ts_client):
+    resp = ts_client.post("/api/workbench/packs/local-dev/ts-pack/test-session")
+    session_id = resp.json()["session_id"]
+    del_resp = ts_client.delete(f"/api/sessions/{session_id}")
+    assert del_resp.status_code == 204
+
+
+def test_start_test_session_no_scenario_returns_422(client):
+    # The minimal fixture pack (my-pack) has a scenario file but it's just a stub
+    # without player_role/npc/opening. However there IS a scenarios/basic.yaml file,
+    # so it will be found. The real 422 case is when the pack has NO scenario at all.
+    official, local_dev = _get_roots_from_client(client)
+    empty_pack = local_dev / "empty-pack"
+    empty_pack.mkdir(exist_ok=True)
+    (empty_pack / "manifest.yaml").write_text(
+        'schema_version: "0.1"\npack_id: local.empty\nname: Empty\nversion: 0.1.0\n',
+        encoding="utf-8",
+    )
+
+    resp = client.post("/api/workbench/packs/local-dev/empty-pack/test-session")
+    assert resp.status_code == 422
+
+
+def test_start_test_session_unknown_pack_returns_404(client):
+    resp = client.post("/api/workbench/packs/local-dev/does-not-exist/test-session")
+    assert resp.status_code == 404
+
+
+def _get_roots_from_client(client) -> tuple:
+    """Extract root directories from the test client's app state."""
+    config = client.app.state.service_config
+    from pathlib import Path
+    return Path(config.official_packs_dir), Path(config.local_dev_packs_dir)


### PR DESCRIPTION
## Summary

This PR completes the Creator Workbench MVP by implementing three essential backend endpoints for pack management and testing, plus a beginner-friendly form editor UI for YAML file editing.

### Backend: Pack Import/Export and Test Sessions

Added three new endpoints to the workbench API (`workbench.py`):

- **POST /packs/import** — Accepts a raw zip file, validates pack content against the schema, and extracts it to the local-dev directory. Handles slug collisions by renaming (returning `renamed_from` in the response) and returns structured validation errors (422) when validation fails so the UI can surface actionable issues.

- **GET /packs/{kind}/{slug}/export** — Validates the pack before zipping (preflight validation returns 422 with errors), then returns the pack as an application/zip download with a derived filename.

- **POST /packs/{kind}/{slug}/test-session** — Loads the first entry scenario and its NPC from pack YAML, registers the scenario in a process-local dynamic registry, creates a database session with `save_transcript=false`, and returns `session_id`, `npc_opening`, and `state_vars` for the TestChatPanel to begin a conversation.

### Backend: Dynamic Scenario Registry

Extended `scenarios.py` with:
- **Thread-safe dynamic scenario registry** — `register_dynamic_scenario()` and `unregister_dynamic_scenario()` allow workbench test sessions to register scenarios at runtime without modifying the static SCENARIOS dict.
- **`load_scenario_info_from_pack()`** — Loads a ScenarioInfo by reading scenario and NPC YAML files from a pack directory, resolving NPC refs, extracting opening text, goals, and state overrides.

### Frontend: Form Editor Mode

Enhanced the FileEditor component in CreatorWorkbench to support beginner-friendly editing:

- **YAML/Form toggle** — Editable manifest, scenario, NPC, and rubric YAML files now display a mode toggle button allowing users to switch between raw YAML and a structured form editor.
- **FormEditor integration** — Integrates the `@convsim/ui` FormEditor component for these file types, defaults to YAML mode so existing tests and workflows are unaffected.
- **File type detection** — Added `detectPackFileType()` to identify manifest, scenario, NPC, and rubric files by path and filename.

### Testing

- **12 new workbench API tests** covering import (success, collision rename, invalid zip, validation failure), export (success, preflight, not found), and test-session (start, opening, delete, no scenario, not found).
- **2 new frontend tests** verifying the form editor toggle appears and switches between YAML and form modes.
- All 38 workbench tests, 1554 core tests, and 740 web tests pass.

Closes #210