### PR TITLE
Integrate voice modes into scenario setup and conversation UI

### DIFF
--- a/apps/web/src/__tests__/Conversation.test.tsx
+++ b/apps/web/src/__tests__/Conversation.test.tsx
@@ -1021,14 +1021,14 @@ describe('Conversation screen', () => {
       })
     })
 
-    it('plays audio when tts.audio_chunk event has a cache_path', async () => {
+    it('plays audio when tts.audio_chunk event has a cache_path and tts_enabled is true', async () => {
       const mockPlay = vi.fn().mockResolvedValue(undefined)
       const mockAudio = { play: mockPlay, pause: vi.fn(), onended: null as unknown, onerror: null as unknown }
       const AudioSpy = vi.spyOn(window, 'Audio').mockReturnValue(
         mockAudio as unknown as HTMLAudioElement,
       )
 
-      renderConversation()
+      renderConversation({ tts_enabled: true })
       await waitFor(() => expect(screen.getByRole('log')).toBeInTheDocument())
 
       act(() => {
@@ -1054,13 +1054,45 @@ describe('Conversation screen', () => {
       AudioSpy.mockRestore()
     })
 
+    it('does not play audio when tts_enabled is false (text-only session)', async () => {
+      const mockPlay = vi.fn().mockResolvedValue(undefined)
+      const AudioSpy = vi.spyOn(window, 'Audio').mockReturnValue(
+        { play: mockPlay, pause: vi.fn(), onended: null, onerror: null } as unknown as HTMLAudioElement,
+      )
+
+      renderConversation({ tts_enabled: false })
+      await waitFor(() => expect(screen.getByRole('log')).toBeInTheDocument())
+
+      act(() => {
+        wsCallback?.({
+          type: 'tts.audio_chunk',
+          seq: 1,
+          session_id: SESSION_ID,
+          ts: '2026-07-01T00:00:00Z',
+          payload: {
+            chunk_index: 0,
+            total_chunks: 1,
+            text: 'Hello there.',
+            voice_id: 'af_heart',
+            cache_path: '/home/user/.convsim/tts_cache/abc123.wav',
+            error: null,
+          },
+        })
+      })
+
+      expect(AudioSpy).not.toHaveBeenCalled()
+      expect(mockPlay).not.toHaveBeenCalled()
+
+      AudioSpy.mockRestore()
+    })
+
     it('does not play audio when tts.audio_chunk cache_path is null', async () => {
       const mockPlay = vi.fn().mockResolvedValue(undefined)
       const AudioSpy = vi.spyOn(window, 'Audio').mockReturnValue(
         { play: mockPlay, pause: vi.fn(), onended: null, onerror: null } as unknown as HTMLAudioElement,
       )
 
-      renderConversation()
+      renderConversation({ tts_enabled: true })
       await waitFor(() => expect(screen.getByRole('log')).toBeInTheDocument())
 
       act(() => {
@@ -1095,7 +1127,7 @@ describe('Conversation screen', () => {
         },
       )
 
-      renderConversation()
+      renderConversation({ tts_enabled: true })
       await waitFor(() => expect(screen.getByRole('log')).toBeInTheDocument())
 
       act(() => {
@@ -1134,7 +1166,7 @@ describe('Conversation screen', () => {
         mockAudio as unknown as HTMLAudioElement,
       )
 
-      renderConversation()
+      renderConversation({ tts_enabled: true })
       await waitFor(() => expect(screen.getByRole('textbox', { name: /your response/i })).toBeInTheDocument())
 
       // Enqueue a chunk
@@ -1190,7 +1222,7 @@ describe('Conversation screen', () => {
         return el as unknown as HTMLAudioElement
       })
 
-      renderConversation()
+      renderConversation({ tts_enabled: true })
       await waitFor(() => expect(screen.getByRole('log')).toBeInTheDocument())
 
       const chunk = (name: string, seq: number): WsEvent => ({
@@ -1227,6 +1259,32 @@ describe('Conversation screen', () => {
       ])
 
       AudioSpy.mockRestore()
+    })
+  })
+
+  describe('voice mode integration', () => {
+    beforeEach(() => {
+      mockApi.startSession.mockResolvedValue(startResponse)
+    })
+
+    it('renders VoiceInput in text-only mode when input_mode is text-only', async () => {
+      renderConversation({ input_mode: 'text-only' })
+      await waitFor(() =>
+        expect(screen.getByTestId('text-only-notice')).toBeInTheDocument(),
+      )
+      expect(screen.getByTestId('text-only-notice')).toHaveTextContent(
+        /voice input disabled/i,
+      )
+    })
+
+    it('renders VoiceInput with mic button when input_mode is push-to-talk', async () => {
+      mockApiClient.uploadAudio.mockResolvedValue({ transcript: null, status: 'unavailable' })
+      renderConversation({ input_mode: 'push-to-talk' })
+      await waitFor(() =>
+        expect(screen.getByRole('textbox', { name: /your response/i })).toBeInTheDocument(),
+      )
+      // In push-to-talk mode the text-only notice must not appear
+      expect(screen.queryByTestId('text-only-notice')).not.toBeInTheDocument()
     })
   })
 

--- a/apps/web/src/__tests__/Debrief.test.tsx
+++ b/apps/web/src/__tests__/Debrief.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor, fireEvent } from '@testing-library/react'
-import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom'
 import Debrief from '../screens/Debrief'
 import type { SessionDebriefResponse } from '@convsim/shared'
 
@@ -88,6 +88,16 @@ const exportData = {
   ],
 }
 
+function ConversationRouteStub() {
+  const { state } = useLocation()
+  return (
+    <div>
+      Conversation page
+      <span data-testid="route-state">{JSON.stringify(state)}</span>
+    </div>
+  )
+}
+
 function renderDebrief() {
   return render(
     <MemoryRouter initialEntries={[`/debrief/${SESSION_ID}`]}>
@@ -95,7 +105,7 @@ function renderDebrief() {
         <Route path="/debrief/:sessionId" element={<Debrief />} />
         <Route path="/library" element={<div>Library page</div>} />
         <Route path="/setup/:scenarioId" element={<div>Setup page</div>} />
-        <Route path="/conversation/:sessionId" element={<div>Conversation page</div>} />
+        <Route path="/conversation/:sessionId" element={<ConversationRouteStub />} />
       </Routes>
     </MemoryRouter>,
   )
@@ -421,6 +431,30 @@ describe('Debrief screen', () => {
       await waitFor(() =>
         expect(screen.getByText('Conversation page')).toBeInTheDocument(),
       )
+    })
+
+    it('forwards input_mode and tts_enabled to the conversation so replayed voice sessions keep their modes', async () => {
+      const voiceSetup = { ...sampleSetup, input_mode: 'push-to-talk' as const, tts_enabled: true }
+      mockApi.generateDebrief.mockResolvedValue(fullDebriefResponse)
+      mockApi.createSession.mockResolvedValue({
+        session_id: 'new-sess-02',
+        scenario_id: 'behavioral_interview',
+        state: 'NotStarted',
+        created_at: '2024-01-02T00:00:00Z',
+        setup: voiceSetup,
+      })
+      renderDebrief()
+      await waitFor(() =>
+        expect(screen.getByTestId('replay-same-btn')).toBeInTheDocument(),
+      )
+      await waitFor(() => expect(mockApi.exportSession).toHaveBeenCalled())
+      fireEvent.click(screen.getByTestId('replay-same-btn'))
+      await waitFor(() =>
+        expect(screen.getByText('Conversation page')).toBeInTheDocument(),
+      )
+      const routeState = JSON.parse(screen.getByTestId('route-state').textContent || '{}')
+      expect(routeState.input_mode).toBe('push-to-talk')
+      expect(routeState.tts_enabled).toBe(true)
     })
 
     it('falls back to setup page when sessionSetup is unavailable', async () => {

--- a/apps/web/src/__tests__/VoiceInput.test.tsx
+++ b/apps/web/src/__tests__/VoiceInput.test.tsx
@@ -795,3 +795,116 @@ describe('VoiceInput — disabled prop', () => {
     expect(stopRecording).toHaveBeenCalledOnce()
   })
 })
+
+describe('VoiceInput — inputMode prop (mode selection)', () => {
+  it('renders text-only notice and no mic button when inputMode is text-only', () => {
+    render(<VoiceInput inputMode="text-only" />)
+
+    expect(screen.getByTestId('text-only-notice')).toBeInTheDocument()
+    expect(screen.getByTestId('text-only-notice')).toHaveTextContent(/voice input disabled/i)
+    expect(screen.queryByRole('button', { name: /record|mic/i })).not.toBeInTheDocument()
+  })
+
+  it('still accepts text submission in text-only mode', () => {
+    const onSubmit = vi.fn()
+    render(<VoiceInput inputMode="text-only" onSubmit={onSubmit} />)
+
+    const input = screen.getByRole('textbox', { name: /your response/i })
+    fireEvent.change(input, { target: { value: 'typed response' } })
+    fireEvent.submit(input.closest('form')!)
+
+    expect(onSubmit).toHaveBeenCalledWith('typed response')
+  })
+
+  it('renders mic button when inputMode is push-to-talk', () => {
+    render(<VoiceInput inputMode="push-to-talk" />)
+
+    expect(screen.queryByTestId('text-only-notice')).not.toBeInTheDocument()
+    // MicButton renders as a button; any button that is not text-only notice
+    // confirms mic controls are present
+    expect(screen.getByRole('textbox', { name: /your response/i })).toBeInTheDocument()
+  })
+
+  it('initialises VAD mode to ptt when inputMode is push-to-talk', () => {
+    const setMode = vi.fn()
+    vi.mocked(useVad).mockReturnValue(makeVadState({ setMode }))
+
+    render(<VoiceInput inputMode="push-to-talk" />)
+
+    expect(setMode).toHaveBeenCalledWith('ptt')
+  })
+
+  it('initialises VAD mode to hands-free when inputMode is hands-free', () => {
+    const setMode = vi.fn()
+    vi.mocked(useVad).mockReturnValue(makeVadState({ setMode }))
+
+    render(<VoiceInput inputMode="hands-free" />)
+
+    expect(setMode).toHaveBeenCalledWith('hands-free')
+  })
+
+  it('does not call setMode when inputMode is text-only', () => {
+    const setMode = vi.fn()
+    vi.mocked(useVad).mockReturnValue(makeVadState({ setMode }))
+
+    render(<VoiceInput inputMode="text-only" />)
+
+    expect(setMode).not.toHaveBeenCalled()
+  })
+
+  it('does not call setMode again on re-render', () => {
+    const setMode = vi.fn()
+    vi.mocked(useVad).mockReturnValue(makeVadState({ setMode }))
+
+    const { rerender } = render(<VoiceInput inputMode="push-to-talk" />)
+    rerender(<VoiceInput inputMode="push-to-talk" />)
+
+    // setMode initialises once on mount, not on every re-render
+    expect(setMode).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('VoiceInput — text-only fallback (voice-to-text switch)', () => {
+  it('shows a Switch to text-only button when mic is granted and not in text-only mode', () => {
+    vi.mocked(useMicCapture).mockReturnValue(makeMicState({ permission: 'granted' }))
+    render(<VoiceInput inputMode="push-to-talk" />)
+
+    expect(screen.getByRole('button', { name: /switch to text-only/i })).toBeInTheDocument()
+  })
+
+  it('switching to text-only shows the text-only notice and hides the mic button area', () => {
+    vi.mocked(useMicCapture).mockReturnValue(makeMicState({ permission: 'granted' }))
+    render(<VoiceInput inputMode="push-to-talk" />)
+
+    fireEvent.click(screen.getByRole('button', { name: /switch to text-only/i }))
+
+    expect(screen.getByTestId('text-only-notice')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /switch to text-only/i })).not.toBeInTheDocument()
+  })
+
+  it('stops any in-progress recording when switching to text-only', () => {
+    const stopRecording = vi.fn()
+    vi.mocked(useMicCapture).mockReturnValue(
+      makeMicState({ permission: 'granted', isRecording: true, stopRecording }),
+    )
+    render(<VoiceInput inputMode="push-to-talk" />)
+
+    fireEvent.click(screen.getByRole('button', { name: /switch to text-only/i }))
+
+    expect(stopRecording).toHaveBeenCalledOnce()
+  })
+
+  it('text input is still functional after switching to text-only', () => {
+    const onSubmit = vi.fn()
+    vi.mocked(useMicCapture).mockReturnValue(makeMicState({ permission: 'granted' }))
+    render(<VoiceInput inputMode="push-to-talk" onSubmit={onSubmit} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /switch to text-only/i }))
+
+    const input = screen.getByRole('textbox', { name: /your response/i })
+    fireEvent.change(input, { target: { value: 'fallback text' } })
+    fireEvent.submit(input.closest('form')!)
+
+    expect(onSubmit).toHaveBeenCalledWith('fallback text')
+  })
+})

--- a/apps/web/src/__tests__/VoiceInput.test.tsx
+++ b/apps/web/src/__tests__/VoiceInput.test.tsx
@@ -36,6 +36,7 @@ function makeMicState(overrides: Partial<ReturnType<typeof useMicCapture>> = {})
     requestPermission: vi.fn(),
     startRecording: vi.fn(),
     stopRecording: vi.fn(),
+    releaseStream: vi.fn(),
     ...overrides,
   }
 }
@@ -892,6 +893,19 @@ describe('VoiceInput — text-only fallback (voice-to-text switch)', () => {
     fireEvent.click(screen.getByRole('button', { name: /switch to text-only/i }))
 
     expect(stopRecording).toHaveBeenCalledOnce()
+  })
+
+  it('releases the microphone stream when switching to text-only', () => {
+    const releaseStream = vi.fn()
+    vi.mocked(useMicCapture).mockReturnValue(
+      makeMicState({ permission: 'granted', releaseStream }),
+    )
+    render(<VoiceInput inputMode="push-to-talk" />)
+
+    fireEvent.click(screen.getByRole('button', { name: /switch to text-only/i }))
+
+    // The mic must be released so the browser/OS recording indicator turns off.
+    expect(releaseStream).toHaveBeenCalledOnce()
   })
 
   it('text input is still functional after switching to text-only', () => {

--- a/apps/web/src/__tests__/VoiceInput.test.tsx
+++ b/apps/web/src/__tests__/VoiceInput.test.tsx
@@ -907,4 +907,20 @@ describe('VoiceInput — text-only fallback (voice-to-text switch)', () => {
 
     expect(onSubmit).toHaveBeenCalledWith('fallback text')
   })
+
+  it('does not start recording via the Space hotkey after switching to text-only', () => {
+    const startRecording = vi.fn()
+    vi.mocked(useMicCapture).mockReturnValue(
+      makeMicState({ permission: 'granted', startRecording }),
+    )
+    render(<VoiceInput inputMode="push-to-talk" />)
+
+    fireEvent.click(screen.getByRole('button', { name: /switch to text-only/i }))
+    // Blur the newly focused text input so the hotkey focus guard doesn't mask the switch guard.
+    if (document.activeElement instanceof HTMLElement) document.activeElement.blur()
+
+    fireEvent.keyDown(document, { code: 'Space' })
+
+    expect(startRecording).not.toHaveBeenCalled()
+  })
 })

--- a/apps/web/src/__tests__/useMicCapture.test.ts
+++ b/apps/web/src/__tests__/useMicCapture.test.ts
@@ -220,3 +220,50 @@ describe('useMicCapture — recording', () => {
     expect(result.current.isRecording).toBe(false)
   })
 })
+
+describe('useMicCapture — releaseStream', () => {
+  it('stops all stream tracks and clears the stream', async () => {
+    const trackStop = vi.fn()
+    const stream = { getTracks: () => [{ stop: trackStop }] } as unknown as MediaStream
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      mediaDevices: { getUserMedia: vi.fn().mockResolvedValue(stream) },
+    })
+
+    const { result } = renderHook(() => useMicCapture())
+
+    await act(async () => {
+      await result.current.requestPermission()
+    })
+    expect(result.current.stream).not.toBeNull()
+
+    act(() => {
+      result.current.releaseStream()
+    })
+
+    // The mic track must be stopped so the browser/OS recording indicator turns off.
+    expect(trackStop).toHaveBeenCalled()
+    expect(result.current.stream).toBeNull()
+  })
+
+  it('stops an in-progress recording before releasing the stream', async () => {
+    const { result } = renderHook(() => useMicCapture())
+
+    await act(async () => {
+      await result.current.requestPermission()
+    })
+
+    act(() => {
+      result.current.startRecording()
+    })
+    expect(result.current.isRecording).toBe(true)
+
+    act(() => {
+      result.current.releaseStream()
+    })
+
+    expect(result.current.isRecording).toBe(false)
+    expect(result.current.recordingSeconds).toBe(0)
+    expect(result.current.stream).toBeNull()
+  })
+})

--- a/apps/web/src/components/VoiceInput.tsx
+++ b/apps/web/src/components/VoiceInput.tsx
@@ -106,6 +106,7 @@ export default function VoiceInput({ onSubmit, onRawStt, onSttLatency, disabled 
     requestPermission,
     startRecording: startPttRecording,
     stopRecording: stopPttRecording,
+    releaseStream,
   } = useMicCapture(handleAudioReady)
 
   // Wrap start/stop to hook in VAD silence detection for hands-free mode.
@@ -362,6 +363,9 @@ export default function VoiceInput({ onSubmit, onRawStt, onSttLatency, disabled 
                 data-testid="switch-to-text-only"
                 onClick={() => {
                   if (isRecording) stopRecording()
+                  // Release the microphone so the recording indicator turns off —
+                  // the player has opted out of voice for the rest of the session.
+                  releaseStream()
                   setTextOnly(true)
                 }}
                 aria-label="Switch to text-only input"

--- a/apps/web/src/components/VoiceInput.tsx
+++ b/apps/web/src/components/VoiceInput.tsx
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
-import { useState, useCallback, useEffect } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
+import type { InputMode } from '@convsim/shared'
 import { apiClient } from '../api/client'
 import { useMicCapture, MAX_RECORDING_SECONDS } from '../hooks/useMicCapture'
 import { useVad } from '../hooks/useVad'
@@ -28,6 +29,12 @@ interface VoiceInputProps {
   onSttLatency?: (ms: number) => void
   disabled?: boolean
   language?: string
+  /**
+   * Input mode selected at session setup. Initialises the VAD mode and hides
+   * mic controls when set to 'text-only'. Can be overridden mid-session via the
+   * in-conversation "Switch to text-only" fallback.
+   */
+  inputMode?: InputMode
 }
 
 function isInteractiveElement(el: Element | null): boolean {
@@ -36,16 +43,28 @@ function isInteractiveElement(el: Element | null): boolean {
   return tag === 'input' || tag === 'textarea' || tag === 'select' || tag === 'button' || tag === 'a'
 }
 
-export default function VoiceInput({ onSubmit, onRawStt, onSttLatency, disabled = false, language }: VoiceInputProps) {
+export default function VoiceInput({ onSubmit, onRawStt, onSttLatency, disabled = false, language, inputMode }: VoiceInputProps) {
   const [textValue, setTextValue] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [uploadError, setUploadError] = useState<string | null>(null)
   const [showCalibration, setShowCalibration] = useState(false)
   const [reviewState, setReviewState] = useState<ReviewState | null>(null)
+  // Tracks whether the player has switched to text-only fallback mid-session.
+  const [textOnly, setTextOnly] = useState(() => inputMode === 'text-only')
 
   const vad = useVad()
   const isHandsFree = vad.settings.mode === 'hands-free'
-  const { startSilenceDetection, stopSilenceDetection } = vad
+  const { startSilenceDetection, stopSilenceDetection, setMode: vadSetMode } = vad
+
+  // Initialise VAD mode from the session setup choice on first render only.
+  const initModeRef = useRef(false)
+  useEffect(() => {
+    if (initModeRef.current) return
+    initModeRef.current = true
+    if (inputMode === 'hands-free') vadSetMode('hands-free')
+    else if (inputMode === 'push-to-talk') vadSetMode('ptt')
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const handleAudioReady = useCallback(
     async (blob: Blob) => {
@@ -197,6 +216,40 @@ export default function VoiceInput({ onSubmit, onRawStt, onSttLatency, disabled 
   const showDeniedNotice = permission === 'denied'
   const showUnsupportedNotice = permission === 'unsupported'
 
+  // Text-only mode: render a minimal input without any mic controls.
+  if (textOnly) {
+    return (
+      <div style={containerStyle}>
+        <p role="status" data-testid="text-only-notice" style={noticeStyle}>
+          Voice input disabled — using text only for this session.
+        </p>
+        {uploadError && (
+          <p role="alert" style={{ ...noticeStyle, color: '#f87171' }}>
+            {uploadError}
+          </p>
+        )}
+        <form onSubmit={handleTextSubmit} style={{ display: 'flex', flex: 1, gap: '0.5rem' }}>
+          <input
+            type="text"
+            value={textValue}
+            onChange={(e) => setTextValue(e.target.value)}
+            placeholder="Type your response…"
+            disabled={disabled}
+            aria-label="Your response"
+            style={textInputStyle}
+          />
+          <button
+            type="submit"
+            disabled={disabled || !textValue.trim()}
+            style={sendButtonStyle}
+          >
+            Submit
+          </button>
+        </form>
+      </div>
+    )
+  }
+
   return (
     <div style={containerStyle}>
       {showDeniedNotice && (
@@ -271,7 +324,7 @@ export default function VoiceInput({ onSubmit, onRawStt, onSttLatency, disabled 
             </form>
           </div>
 
-          {/* Hands-free controls row */}
+          {/* Voice controls row: mode toggle, VAD indicator, calibrate, text-only fallback */}
           {permission === 'granted' && (
             <div style={hfRowStyle}>
               <button
@@ -299,6 +352,19 @@ export default function VoiceInput({ onSubmit, onRawStt, onSttLatency, disabled 
                   </button>
                 </>
               )}
+
+              <button
+                type="button"
+                data-testid="switch-to-text-only"
+                onClick={() => {
+                  if (isRecording) stopRecording()
+                  setTextOnly(true)
+                }}
+                aria-label="Switch to text-only input"
+                style={switchToTextOnlyStyle}
+              >
+                Text only
+              </button>
             </div>
           )}
 
@@ -423,6 +489,17 @@ const modeInactiveStyle: React.CSSProperties = {
 }
 
 const calibrateBtnStyle: React.CSSProperties = {
+  padding: '0.25rem 0.6rem',
+  borderRadius: '6px',
+  border: '1px solid #3f3f46',
+  background: 'transparent',
+  color: '#71717a',
+  cursor: 'pointer',
+  fontSize: '0.78rem',
+}
+
+const switchToTextOnlyStyle: React.CSSProperties = {
+  marginLeft: 'auto',
   padding: '0.25rem 0.6rem',
   borderRadius: '6px',
   border: '1px solid #3f3f46',

--- a/apps/web/src/components/VoiceInput.tsx
+++ b/apps/web/src/components/VoiceInput.tsx
@@ -167,6 +167,9 @@ export default function VoiceInput({ onSubmit, onRawStt, onSttLatency, disabled 
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.code !== 'Space' || e.repeat) return
       if (isInteractiveElement(document.activeElement)) return
+      // In text-only mode there is no mic recording — the hotkey must be inert
+      // even when microphone permission is still granted from an active stream.
+      if (textOnly) return
       if (permission !== 'granted' || isSubmitting || disabled) return
       // Don't start recording while the transcript review panel is open.
       if (reviewState !== null) return
@@ -183,6 +186,7 @@ export default function VoiceInput({ onSubmit, onRawStt, onSttLatency, disabled 
     const handleKeyUp = (e: KeyboardEvent) => {
       if (e.code !== 'Space') return
       if (isInteractiveElement(document.activeElement)) return
+      if (textOnly) return
       if (permission !== 'granted' || isSubmitting || (disabled && !isRecording)) return
       // PTT only: release Space to stop. In hands-free mode, stop is handled on keydown.
       if (!isHandsFree) stopRecording()
@@ -194,7 +198,7 @@ export default function VoiceInput({ onSubmit, onRawStt, onSttLatency, disabled 
       document.removeEventListener('keydown', handleKeyDown)
       document.removeEventListener('keyup', handleKeyUp)
     }
-  }, [startRecording, stopRecording, permission, isRecording, isSubmitting, disabled, isHandsFree, reviewState])
+  }, [startRecording, stopRecording, permission, isRecording, isSubmitting, disabled, isHandsFree, reviewState, textOnly])
 
   const handleTextSubmit = (e: React.FormEvent) => {
     e.preventDefault()

--- a/apps/web/src/hooks/useMicCapture.ts
+++ b/apps/web/src/hooks/useMicCapture.ts
@@ -13,6 +13,13 @@ export interface UseMicCaptureReturn {
   requestPermission: () => Promise<void>
   startRecording: () => void
   stopRecording: () => void
+  /**
+   * Stops recording (if active) and releases the microphone by stopping all
+   * MediaStream tracks, so the browser/OS recording indicator turns off. Used
+   * when the player switches to text-only mid-session and voice is no longer
+   * needed. The stream is not reacquired automatically.
+   */
+  releaseStream: () => void
 }
 
 export const MAX_RECORDING_SECONDS = 60
@@ -64,6 +71,16 @@ export function useMicCapture(onAudioReady?: (blob: Blob) => void): UseMicCaptur
     if (rec && rec.state === 'recording') {
       rec.stop()
     }
+  }, [clearTimers])
+
+  const releaseStream = useCallback(() => {
+    clearTimers()
+    setRecordingSeconds(0)
+    const rec = recorderRef.current
+    if (rec && rec.state === 'recording') rec.stop()
+    streamRef.current?.getTracks().forEach((t) => t.stop())
+    streamRef.current = null
+    setStream(null)
   }, [clearTimers])
 
   const startRecording = useCallback(() => {
@@ -143,5 +160,6 @@ export function useMicCapture(onAudioReady?: (blob: Blob) => void): UseMicCaptur
     requestPermission,
     startRecording,
     stopRecording,
+    releaseStream,
   }
 }

--- a/apps/web/src/screens/Conversation.tsx
+++ b/apps/web/src/screens/Conversation.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { useParams, useNavigate, useLocation } from 'react-router-dom'
 import { api } from '../api/client'
-import type { ScenarioInfo, WsEvent } from '@convsim/shared'
+import type { InputMode, ScenarioInfo, WsEvent } from '@convsim/shared'
 import VoiceInput, { type SttReviewMeta } from '../components/VoiceInput'
 import DebugDrawer, { type DebugTurnEntry } from '../components/DebugDrawer'
 import PerformanceWarningBanner from '../components/PerformanceWarning'
@@ -75,11 +75,15 @@ export default function Conversation() {
     language?: string
     show_state_meters?: boolean
     scenario_id?: string
+    input_mode?: InputMode
+    tts_enabled?: boolean
   } | null
 
   const language = routeState?.language
   const showStateMeters = routeState?.show_state_meters ?? true
   const scenarioIdFromRoute = routeState?.scenario_id
+  const inputMode = routeState?.input_mode ?? 'text-only'
+  const ttsEnabled = routeState?.tts_enabled ?? false
 
   const [phase, setPhase] = useState<Phase>('starting')
   const [sessionState, setSessionState] = useState('NotStarted')
@@ -154,6 +158,9 @@ export default function Conversation() {
   }
 
   function _enqueueTtsChunk(cachePath: string) {
+    // Only play TTS audio when the session was started with TTS enabled.
+    // The text transcript remains authoritative regardless of this flag.
+    if (!ttsEnabled) return
     const filename = cachePath.replace(/\\/g, '/').split('/').pop()
     if (!filename) return
     const url = `/api/tts/audio/${filename}`
@@ -987,6 +994,7 @@ export default function Conversation() {
           onSttLatency={(ms) => recordValue('stt_final_ms', ms)}
           disabled={!isIdle}
           language={language}
+          inputMode={inputMode}
         />
       )}
 

--- a/apps/web/src/screens/Debrief.tsx
+++ b/apps/web/src/screens/Debrief.tsx
@@ -130,6 +130,8 @@ export default function Debrief() {
           language: newSession.setup.language,
           show_state_meters: newSession.setup.show_state_meters,
           scenario_id: newSession.scenario_id,
+          input_mode: newSession.setup.input_mode,
+          tts_enabled: newSession.setup.tts_enabled,
         },
       })
     } catch {

--- a/apps/web/src/screens/ScenarioSetup.tsx
+++ b/apps/web/src/screens/ScenarioSetup.tsx
@@ -13,6 +13,8 @@ export default function ScenarioSetup() {
         language: session.setup.language,
         show_state_meters: session.setup.show_state_meters,
         scenario_id: session.scenario_id,
+        input_mode: session.setup.input_mode,
+        tts_enabled: session.setup.tts_enabled,
       },
     })
   }


### PR DESCRIPTION
## Summary

This PR fully integrates voice input modes (push-to-talk, hands-free, text-only) and TTS configuration into the scenario setup flow and conversation UI, ensuring that player choices persist throughout a session and can be replayed.

### Key changes

**Route state forwarding** (`ScenarioSetup.tsx`, `Debrief.tsx`)
- `ScenarioSetup` now forwards `input_mode` and `tts_enabled` from the created session setup into React Router state when navigating to `Conversation`
- `Debrief` performs the same forwarding when replaying the same setup, preserving user preferences across session boundaries

**TTS playback gating** (`Conversation.tsx`)
- `Conversation` reads `tts_enabled` from route state (default `false`) and skips TTS audio enqueueing when the session was not configured for audio output
- Text transcript remains authoritative regardless of TTS state; audio chunks are silently ignored if disabled

**Voice mode initialization and text-only fallback** (`VoiceInput.tsx`)
- Accepts an `inputMode` prop specifying the session's configured input mode
- Initializes VAD mode to `ptt` or `hands-free` from the prop on first render, overriding any stale localStorage value
- When `inputMode='text-only'`: renders a minimal notice and hides all microphone controls
- Renders a **"Text only"** fallback button (visible when mic is granted and a voice mode is active) allowing players to downgrade mid-session if voice is slow or unavailable
- Clicking the button stops any in-progress recording, releases the microphone stream, and switches the component to text-only mode for the remainder of the session
- Space hotkey and mode toggle are correctly disabled in text-only mode to prevent invisible recording state

**Microphone resource management** (`useMicCapture.ts`)
- Added `releaseStream()` hook method to close the microphone stream, called when switching to text-only mid-session so the recording indicator turns off

**Test coverage**
- `Conversation.test.tsx`: TTS tests updated to pass `tts_enabled: true`; new test asserts audio is not played when `tts_enabled: false`; new tests verify text-only and push-to-talk mode propagation from route state
- `VoiceInput.test.tsx`: new `inputMode` describe block tests text-only rendering, VAD mode initialization for all three input modes, and single-call init guard; new fallback describe block tests button visibility, switch-to-text-only rendering, in-progress recording stop, and post-switch text submission
- `useMicCapture.test.ts`: new tests verify `releaseStream()` closes the audio stream and clears the ref
- `Debrief.test.tsx`: updated to assert `input_mode` and `tts_enabled` are forwarded in replay state

## Test plan

- [ ] Run `pnpm --filter @convsim/web test` — all tests pass.
- [ ] Start a session with STT loaded and select push-to-talk — mic button appears, Space hotkey works.
- [ ] Start a session with STT loaded and select hands-free — VAD auto-stop activates; "Text only" button is visible.
- [ ] Click "Text only" mid-session — mic hides, text input continues working.
- [ ] Start a session with TTS disabled — NPC audio chunks are silently ignored; text transcript populates normally.
- [ ] Start a session with TTS enabled — NPC sentences play back as WAV chunks in order.
- [ ] Start a session with text-only input mode — mic button absent; text-only notice shown.
- [ ] Replay same setup from debrief — original `input_mode` and `tts_enabled` are preserved.

Closes #217