### PR TITLE
Add pack authoring sample pack and golden transcript test documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,10 @@ jobs:
         run: |
           echo "Local: node packages/scenario-schema/tests/validate-packs.js packs/official"
           node packages/scenario-schema/tests/validate-packs.js packs/official
+      - name: Validate sample pack (schema check)
+        run: |
+          echo "Local: node packages/scenario-schema/tests/validate-packs.js packs/sample"
+          node packages/scenario-schema/tests/validate-packs.js packs/sample
       - name: Install prompt-composer
         run: pip install -e "packages/prompt-composer[dev]"
       - name: Install convsim-core
@@ -185,5 +189,11 @@ jobs:
         run: |
           echo "Local: for d in packs/official/*/; do convsim-validate-pack \"\$d\"; done"
           for d in packs/official/*/; do
+            convsim-validate-pack "$d"
+          done
+      - name: Validate sample pack (full policy check)
+        run: |
+          echo "Local: for d in packs/sample/*/; do convsim-validate-pack \"\$d\"; done"
+          for d in packs/sample/*/; do
             convsim-validate-pack "$d"
           done

--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ navigation). Copy an official pack, edit the YAML files, validate with one
 click, quick-test in the browser, and export a shareable `.zip` — all
 without leaving the browser.
 
+**New to pack authoring?** `packs/sample/hello-conversation/` is a
+minimal one-scenario sample pack (CC0-1.0, public domain) with every
+required file type and inline comments explaining each field. Copy it into
+`packs/local-dev/` and start editing — or import its zip in the Creator
+Workbench.
+
 Minimal `scenarios/my_scenario.yaml`:
 
 ```yaml
@@ -145,6 +151,7 @@ state:
 Add events, endings, difficulty modifiers, and extra rubric dimensions as you go.
 The JSON Schema in `schemas/` validates everything at import time.
 
+> Sample pack: [packs/sample/hello-conversation/](packs/sample/hello-conversation/) &nbsp;·&nbsp;
 > Creator workbench tutorial: [docs/scenario-authoring.md](docs/scenario-authoring.md) &nbsp;·&nbsp;
 > Pack validation: [docs/pack-validation.md](docs/pack-validation.md) &nbsp;·&nbsp;
 > Official quality bar: [docs/official-pack-quality-bar.md](docs/official-pack-quality-bar.md)

--- a/apps/web/src/screens/CreatorWorkbench.tsx
+++ b/apps/web/src/screens/CreatorWorkbench.tsx
@@ -524,6 +524,8 @@ const SECURITY_RULES = new Set(['FORBIDDEN_FILE', 'FORBIDDEN_BINARY'])
 // workbench.
 const AUTHORING_DOCS_URL = 'https://github.com/outrightmental/ConversationSimulator/blob/main/docs/scenario-authoring.md'
 const VALIDATION_DOCS_URL = 'https://github.com/outrightmental/ConversationSimulator/blob/main/docs/pack-validation.md'
+const QUALITY_BAR_DOCS_URL = 'https://github.com/outrightmental/ConversationSimulator/blob/main/docs/official-pack-quality-bar.md'
+const SAMPLE_PACK_DOCS_URL = 'https://github.com/outrightmental/ConversationSimulator/blob/main/packs/sample/hello-conversation/README.md'
 
 function isSecurityIssue(issue: WorkbenchValidationIssue): boolean {
   return SECURITY_RULES.has(issue.rule_id) || issue.category === 'security'
@@ -1808,15 +1810,37 @@ export default function CreatorWorkbench() {
                 style={{
                   flex: 1,
                   display: 'flex',
+                  flexDirection: 'column',
                   alignItems: 'center',
                   justifyContent: 'center',
                   color: '#52525b',
                   fontSize: '0.875rem',
+                  gap: '0.5rem',
+                  padding: '1.5rem',
+                  textAlign: 'center',
                 }}
               >
-                {selectedPack
-                  ? 'Select a YAML or Markdown file from the tree.'
-                  : 'Select a pack to get started.'}
+                <span>
+                  {selectedPack
+                    ? 'Select a YAML or Markdown file from the tree.'
+                    : 'Select a pack to get started.'}
+                </span>
+                {!selectedPack && (
+                  <span style={{ fontSize: '0.75rem', color: '#71717a' }}>
+                    New here?{' '}
+                    <a href={SAMPLE_PACK_DOCS_URL} target="_blank" rel="noreferrer" style={{ color: '#93c5fd' }}>
+                      Sample pack ↗
+                    </a>
+                    {' · '}
+                    <a href={AUTHORING_DOCS_URL} target="_blank" rel="noreferrer" style={{ color: '#93c5fd' }}>
+                      Authoring guide ↗
+                    </a>
+                    {' · '}
+                    <a href={QUALITY_BAR_DOCS_URL} target="_blank" rel="noreferrer" style={{ color: '#93c5fd' }}>
+                      Quality bar ↗
+                    </a>
+                  </span>
+                )}
               </div>
             )}
 

--- a/docs/pack-validation.md
+++ b/docs/pack-validation.md
@@ -117,7 +117,7 @@ Schema versioning policy: see [`schemas/VERSIONING.md`](../schemas/VERSIONING.md
 
 ## What convsim test-pack checks
 
-Run the pack's smoke tests with:
+Run the pack's test fixtures with:
 
 ```sh
 convsim test-pack <pack-dir>
@@ -130,13 +130,30 @@ may declare an optional `seed` field for forward compatibility, but the current
 fake runtime does not consume it — it is reserved for reproducible results once
 a real runtime is wired in.
 
+### Smoke tests vs. golden transcript tests
+
+Official packs contain two types of test fixture files in `tests/`:
+
+| File naming convention | Purpose |
+|------------------------|---------|
+| `smoke_<scenario>.yaml` | **Structural smoke test.** Runs in CI against the fake runtime. Verifies that the pack loads, required fields are present, and a single realistic player turn does not produce an unexpected end or safety stop. Focuses on *structure*, not *behaviour*. |
+| `golden_<scenario>.yaml` | **Behavioural property test.** Runs a multi-turn scripted conversation and asserts that state variables advance correctly, events fire at the right thresholds, and session endings are wired to the right variables. The fake runtime can check the structural properties (via `static_assertions`) but cannot verify that the state variables actually *change* in response to input — that requires a real runtime. |
+
+Both fixture types use the same YAML schema (`schemas/pack-test.schema.json`)
+and both run with `convsim test-pack`. The distinction is in purpose and depth,
+not in a separate command.
+
+**Every pack must include at minimum one smoke test per entry scenario.**
+Golden tests are expected for all official packs and recommended for any pack
+intended for wider sharing.
+
 ### Fixture structure
 
 Fixture files contain:
 
-- **`turns`** — a sequence of player inputs and expected outcomes for each turn.
+- **`turns`** — a sequence of player inputs and expected outcomes per turn.
 - **`static_assertions`** — structural checks against resolved pack fields
-  (opening lines, NPC properties, safety categories, etc.).
+  (opening lines, NPC properties, safety categories, event wiring, etc.).
 
 #### Turn-level checks
 
@@ -174,6 +191,135 @@ and `check` expressions:
 | `min_length_1` | `check: min_length_1` |
 | `contains <value>` | `check: "contains scenarios/my_scenario.yaml"` |
 | Compound (`AND`) | `check: "type=variable_above AND variable=impression"` |
+
+---
+
+## Golden transcript tests in detail
+
+A golden transcript test asserts **behavioural properties** of a scenario by
+scripting a multi-turn conversation and verifying structural invariants across
+the whole scenario design. They complement smoke tests by covering the event
+system, state variable wiring, difficulty settings, and ending conditions —
+things that cannot be checked by loading a single turn.
+
+### Anatomy of a golden test
+
+```yaml
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+fixture_id: golden_my_scenario
+scenario_id: my_scenario
+description: >-
+  Property test: verifies that a player who applies the winning strategy
+  causes deal_progress to advance through the event sequence without
+  triggering a safety stop.
+
+seed: 42
+input_mode: text
+difficulty: normal
+
+# Multi-turn scripted conversation — each turn represents an ideal player move
+turns:
+  - turn: 1
+    player_input: >-
+      [The opening move that should advance the key variable positively.]
+    expect:
+      state_delta_contains:
+        - key_variable       # Assert the variable is tracked
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 2
+    player_input: >-
+      [A follow-through move that continues advancing the scenario.]
+    expect:
+      state_delta_contains:
+        - key_variable
+        - secondary_variable
+      session_control: continue_session
+      safety_status: ok
+
+# Structural property checks — verified at load time, not turn time
+static_assertions:
+  - description: Opening line is non-empty
+    path: opening.npc_says
+    check: non_empty_string
+
+  - description: Event fires when variable crosses the threshold
+    path: events[id=my_event].when
+    check: "type=variable_above AND variable=key_variable AND threshold=60"
+
+  - description: Event fires only once (repeat: false)
+    path: events[id=my_event].repeat
+    check: "equals false"
+
+  - description: Success ending condition targets the right variable
+    path: ending_conditions.success
+    check: "type=variable_above AND variable=key_variable"
+
+  - description: Visible variable is accessible to the player
+    path: state.variables.key_variable.visibility
+    check: "equals visible"
+
+  - description: Hidden variable is not accessible to the player
+    path: state.variables.internal_counter.visibility
+    check: "equals hidden"
+
+  - description: NPC is marked fictional
+    path: npc.fictional
+    check: "equals true"
+
+  - description: Hard difficulty reduces NPC patience
+    path: scenario.difficulty.options.hard.npc_patience_modifier
+    check: "equals -20"
+```
+
+### What to assert in a golden test
+
+**State variable wiring:**
+- Every state variable declared in the scenario appears in `state_delta_contains`
+  for the turn where it should change.
+- Visible variables are accessible to players; hidden variables are not.
+
+**Event system:**
+- Each named event has the correct `when` condition (type, variable, threshold).
+- Single-fire events set `repeat: false`; recurring events set `repeat: true`.
+
+**Ending conditions:**
+- `success` and `failure` conditions target the right variable and threshold type.
+
+**Difficulty settings:**
+- `easy` increases `npc_patience_modifier`; `hard` decreases it.
+- `challenge_frequency` reflects the intended difficulty spread.
+
+**Safety:**
+- Required safety categories are present and have the right actions.
+- The non-overridable global rules are both declared.
+
+**Manifest:**
+- The scenario appears in `manifest.entry_scenarios` via a `contains` assertion.
+
+### Golden tests and the fake runtime
+
+Under the fake runtime, the `turns` section verifies structural correctness:
+that the state variables are *declared*, the session format is *valid*, and no
+safety stop fires for benign input. The fake runtime does not change variable
+values in response to player input, so golden tests cannot assert that
+`key_variable` reached a specific value after turn 3.
+
+Once a real runtime is wired in, the same fixture will run against live
+inference, and turn-level assertions like `state_delta_contains` will verify
+*actual* behavioural changes. Write the scripted player inputs to represent a
+realistic ideal strategy — the fake runtime ignores the content, but the real
+runtime will use it.
+
+### Example from an official pack
+
+The `everyday-negotiation` pack's golden test for `used_car_negotiation`
+scripts four turns representing an ideal negotiation strategy and uses
+`static_assertions` to verify all event conditions and ending condition wiring.
+See `packs/official/everyday-negotiation/tests/golden_used_car_negotiation.yaml`
+for a reference implementation.
 
 ---
 

--- a/docs/scenario-authoring.md
+++ b/docs/scenario-authoring.md
@@ -39,6 +39,12 @@ You need:
 3. At least one official pack installed (they ship with the repo under
    `packs/official/`).
 
+> **Just want a starting point?** `packs/sample/hello-conversation/` is a
+> minimal one-scenario pack (CC0-1.0, public domain) that you can copy and
+> remix without any conditions. Import it into local-dev with
+> `cp -r packs/sample/hello-conversation packs/local-dev/my-pack` and start
+> editing. The `README.md` inside explains every file.
+
 > **CLI fallback.** Every step in this guide has a CLI equivalent.
 > CLI commands are shown in `code blocks` throughout.
 
@@ -698,6 +704,127 @@ convsim test-pack packs/local-dev/workplace-conversations/
 
 Both `convsim validate-pack` and `convsim test-pack` must exit `0` before
 the pack is ready to share or submit.
+
+---
+
+## Adding a golden transcript test
+
+A **golden transcript test** is an extended fixture that scripts a multi-turn
+conversation and asserts structural properties across the whole scenario
+design: event wiring, state variable visibility, ending condition targets,
+difficulty settings, and manifest entries.
+
+While a smoke test checks that the pack loads and a single benign turn
+does not crash the session, a golden test documents the *intended behavioural
+design* of your scenario. Official packs include both.
+
+Add a golden test alongside your smoke test in `tests/`:
+
+```yaml
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+fixture_id: golden_raise_conversation
+scenario_id: raise_conversation
+description: >-
+  Property test: verifies that a player who opens with concrete evidence
+  and frames the ask professionally causes receptiveness to advance
+  through the event sequence without triggering a safety stop.
+
+seed: 42
+input_mode: text
+difficulty: normal
+
+turns:
+  - turn: 1
+    player_input: >-
+      Thanks for meeting with me. I'd like to discuss a merit increase.
+      Last quarter I led the pipeline migration that cut nightly processing
+      from six hours to forty minutes and unblocked three product teams.
+      I believe that level of impact justifies revisiting my compensation.
+    expect:
+      state_delta_contains:
+        - receptiveness
+        - evidence_score
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 2
+    player_input: >-
+      I've also checked market rates for my role and experience level in
+      this city — the median is about twelve percent above where I am now.
+      I'm asking for a ten percent increase, which I think is fair given
+      both my track record and where the market is.
+    expect:
+      state_delta_contains:
+        - receptiveness
+        - evidence_score
+      session_control: continue_session
+      safety_status: ok
+
+static_assertions:
+  - description: Opening line is non-empty
+    path: opening.npc_says
+    check: non_empty_string
+
+  - description: vague_request_nudge fires when evidence_score drops below 20
+    path: events[id=vague_request_nudge].when
+    check: "type=variable_below AND variable=evidence_score AND threshold=20"
+
+  - description: vague_request_nudge fires only once
+    path: events[id=vague_request_nudge].repeat
+    check: "equals false"
+
+  - description: strong_case_acknowledgement fires when evidence_score exceeds 70
+    path: events[id=strong_case_acknowledgement].when
+    check: "type=variable_above AND variable=evidence_score AND threshold=70"
+
+  - description: Success ending condition targets receptiveness above threshold
+    path: ending_conditions.success
+    check: "type=variable_above AND variable=receptiveness"
+
+  - description: Failure ending condition targets receptiveness below threshold
+    path: ending_conditions.failure
+    check: "type=variable_below AND variable=receptiveness"
+
+  - description: receptiveness is visible to the player
+    path: state.variables.receptiveness.visibility
+    check: "equals visible"
+
+  - description: evidence_score is hidden from the player
+    path: state.variables.evidence_score.visibility
+    check: "equals hidden"
+
+  - description: NPC is marked fictional
+    path: npc.fictional
+    check: "equals true"
+
+  - description: Safety policy stops nsfw_sexual_content
+    path: safety.content_categories.nsfw_sexual_content
+    check: "equals stop"
+
+  - description: Hard difficulty applies a negative patience modifier
+    path: scenario.difficulty.options.hard.npc_patience_modifier
+    check: "equals -20"
+
+  - description: Pack manifest declares raise_conversation as an entry scenario
+    path: manifest.entry_scenarios
+    check: "contains scenarios/raise_conversation.yaml"
+```
+
+**What distinguishes a golden test from a smoke test:**
+
+| | Smoke test | Golden transcript test |
+|--|------------|----------------------|
+| Turn count | 1 (minimal) | 2–6 (scripted ideal strategy) |
+| Turn assertions | Structural — variable declared, no crash | Same as smoke |
+| Static assertions | Minimum: opening line, `npc.fictional`, one safety category | Full: all events, all state variable visibility, all endings, difficulty, manifest |
+| Goal | Prove the pack loads cleanly | Document the *design* of the scenario in executable assertions |
+| Required for | All packs | Official packs and any pack intended for wide sharing |
+
+Both fixture types run with `convsim test-pack` and must exit `0`.
+
+See [`docs/pack-validation.md`](pack-validation.md) for the full static
+assertion syntax reference.
 
 ---
 

--- a/packages/convsim-cli/tests/runner.test.ts
+++ b/packages/convsim-cli/tests/runner.test.ts
@@ -507,3 +507,34 @@ describe('golden — language-cafe pack test', () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// Sample pack: hello-conversation smoke test (keeps the tutorial's sample pack
+// fixture exercised in CI so its documented smoke test cannot silently rot)
+// ---------------------------------------------------------------------------
+
+describe('sample — hello-conversation smoke test', () => {
+  const repoRoot = fileURLToPath(new URL('../../../', import.meta.url));
+  const packDir = join(repoRoot, 'packs', 'sample', 'hello-conversation');
+
+  it('passes all fixtures with the fake runtime', () => {
+    const pack = loadPack(packDir, 'local-dev');
+    const result = runPackTests(pack);
+
+    expect(result.failed).toBe(0);
+    expect(result.fixture_count).toBeGreaterThan(0);
+  });
+
+  it('smoke_friendly_introduction fixture passes all static assertions', () => {
+    const pack = loadPack(packDir, 'local-dev');
+    const result = runPackTests(pack);
+
+    const fixture = result.fixtures.find((f) => f.fixture_id === 'smoke_friendly_introduction');
+    expect(fixture).toBeDefined();
+    expect(fixture?.status).toBe('passed');
+    expect(fixture?.failures).toHaveLength(0);
+    expect(fixture?.static_assertion_count).toBeGreaterThan(0);
+    expect(fixture?.scenario_id).toBe('friendly_introduction');
+    expect(fixture?.mode).toBe('fake');
+  });
+});

--- a/packs/sample/hello-conversation/README.md
+++ b/packs/sample/hello-conversation/README.md
@@ -45,9 +45,9 @@ convsim test-pack packs/local-dev/my-new-pack/
 
 ## Next steps
 
-- [Scenario authoring guide](../../docs/scenario-authoring.md) — full
+- [Scenario authoring guide](../../../docs/scenario-authoring.md) — full
   step-by-step tutorial that builds a pack from scratch using the Workbench.
-- [Pack validation reference](../../docs/pack-validation.md) — error codes,
+- [Pack validation reference](../../../docs/pack-validation.md) — error codes,
   smoke tests, golden transcript tests, and CI integration.
-- [Official quality bar](../../docs/official-pack-quality-bar.md) — what
+- [Official quality bar](../../../docs/official-pack-quality-bar.md) — what
   makes a pack ready to submit as an official pack.

--- a/packs/sample/hello-conversation/README.md
+++ b/packs/sample/hello-conversation/README.md
@@ -1,0 +1,53 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+# Hello Conversation (Sample Pack)
+
+A **minimal sample pack** for learning the Creator Workbench. It contains
+one scenario, one NPC, one rubric, one safety policy, and one smoke test —
+the smallest complete pack that demonstrates every required file type.
+
+**Licence: CC0-1.0 (public domain).** No conditions. Fork it, strip it,
+rename everything, and use it as the skeleton for your own pack.
+
+## What is inside
+
+| File | Purpose |
+|------|---------|
+| `manifest.yaml` | Pack identity, content rating, safety reference, and entry scenario list |
+| `scenarios/friendly_introduction.yaml` | The conversation: a networking event introduction |
+| `npcs/sam_chen.yaml` | The NPC: Sam Chen, a software developer |
+| `rubrics/introduction_rubric.yaml` | Two-dimension scoring rubric |
+| `safety/hello_safety.yaml` | G-rated safety policy |
+| `tests/smoke_friendly_introduction.yaml` | Smoke test that runs in CI without a model |
+
+## How to use it
+
+**In the Creator Workbench:**
+
+```
+1. Navigate to the Creator Workbench (http://127.0.0.1:7354/workbench).
+2. Click "Import Pack (.zip)" in the Packs panel.
+3. Select a zip of this directory, or paste the folder into packs/local-dev/.
+4. The pack appears under Local Dev — click it and start editing.
+```
+
+**CLI:**
+
+```sh
+# Copy the sample pack into local-dev and start editing
+cp -r packs/sample/hello-conversation packs/local-dev/my-new-pack
+
+# Validate your edits
+convsim validate-pack packs/local-dev/my-new-pack/
+
+# Run the smoke test
+convsim test-pack packs/local-dev/my-new-pack/
+```
+
+## Next steps
+
+- [Scenario authoring guide](../../docs/scenario-authoring.md) — full
+  step-by-step tutorial that builds a pack from scratch using the Workbench.
+- [Pack validation reference](../../docs/pack-validation.md) — error codes,
+  smoke tests, golden transcript tests, and CI integration.
+- [Official quality bar](../../docs/official-pack-quality-bar.md) — what
+  makes a pack ready to submit as an official pack.

--- a/packs/sample/hello-conversation/manifest.yaml
+++ b/packs/sample/hello-conversation/manifest.yaml
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: CC0-1.0
+# Hello Conversation — a minimal sample pack for learning the Creator Workbench.
+# This pack is public domain (CC0-1.0). Fork it, remix it, use it as a
+# starting point for your own packs with no conditions.
+schema_version: "0.1"
+pack_id: sample.hello_conversation
+name: Hello Conversation (Sample)
+version: 0.1.0
+description: >-
+  A minimal one-scenario sample pack for learning the Creator Workbench.
+  Sam Chen is a developer at the same professional event as you. Practise
+  the art of a warm, clear introduction — the skill that opens every door.
+author: Outright Mental
+license: CC0-1.0
+content_rating: G
+tags:
+  - sample
+  - networking
+  - social
+supported_languages:
+  - en
+entry_scenarios:
+  - scenarios/friendly_introduction.yaml
+assets:
+  allow_external_urls: false
+safety:
+  policy: safety/hello_safety.yaml

--- a/packs/sample/hello-conversation/npcs/sam_chen.yaml
+++ b/packs/sample/hello-conversation/npcs/sam_chen.yaml
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: CC0-1.0
+schema_version: "0.1"
+npc_id: sam_chen
+display_name: Sam Chen
+archetype: peer_colleague
+fictional: true       # Required. Must always be true. Schema fails if absent or false.
+age_band: adult       # Required. The only permitted value in MVP.
+voice:
+  engine: none        # kokoro | sherpa-onnx | none
+
+public_persona:
+  occupation: >-
+    Software developer at Luminary Apps, a small B2B productivity startup.
+    Sam has been in the industry for six years and attends a few local
+    meetups each year to stay connected with the community.
+  speaking_style: >-
+    Friendly and direct. Asks follow-up questions when something catches
+    their interest. Gets a little quieter when introductions feel rehearsed
+    or impersonal.
+  demeanor: >-
+    Warm and open. Sam enjoys meeting new people at events but values
+    genuine conversation over networking rituals. Responds with noticeably
+    more energy when the other person shows real curiosity.
+
+private_persona:
+  hidden_agenda:
+    - "Assess whether the player seems genuinely interested in conversation or is just going through social motions"
+    - "Look for at least one specific, personal detail that makes this person memorable beyond their job title"
+  biases_to_simulate:
+    - "Slight disengagement when the introduction is purely professional ('I work in data, nice to meet you') with no human detail or follow-up question"
+    - "Noticeably warmer and more talkative when the player finds a natural common interest or asks a genuine follow-up about Sam's experience"
+  boundaries:
+    - "Never generate sexual, violent, or graphically disturbing content"
+    - "Never impersonate a real person, named public figure, or real company executive"

--- a/packs/sample/hello-conversation/rubrics/introduction_rubric.yaml
+++ b/packs/sample/hello-conversation/rubrics/introduction_rubric.yaml
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: CC0-1.0
+schema_version: "0.1"
+rubric_id: introduction_rubric
+title: Friendly Introduction Rubric
+dimensions:
+  - id: clarity
+    name: Clarity
+    description: >-
+      Whether the player gives a clear, specific introduction — name, what
+      they do, and why they are at the event — rather than a vague or
+      incomplete one.
+    scoring:
+      low: "No clear name or role given, or the introduction is so brief it gives Sam nothing to respond to."
+      medium: "Name and role are mentioned but the introduction is generic ('I work in tech') with no personal context or reason for being at the event."
+      high: "Player gives their name, a specific and memorable description of their work, and at least one personal or contextual detail (why they came tonight, what they are curious about, what they are currently building)."
+    weight: 0.4
+
+  - id: genuine_connection
+    name: Genuine Connection
+    description: >-
+      Whether the player moves beyond introductions to find a real point of
+      connection with Sam — a shared interest, a question about Sam's
+      experience, or a moment of genuine curiosity.
+    scoring:
+      low: "Conversation stays entirely in networking-ritual mode. Player describes themselves but shows no interest in Sam's perspective or experience."
+      medium: "Player asks at least one follow-up question but it is generic ('What do you do?') rather than responsive to what Sam has actually said."
+      high: "Player asks a specific follow-up that responds to something Sam actually said, or finds a genuine shared topic that takes the conversation somewhere neither party had scripted."
+    weight: 0.6

--- a/packs/sample/hello-conversation/safety/hello_safety.yaml
+++ b/packs/sample/hello-conversation/safety/hello_safety.yaml
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: CC0-1.0
+schema_version: "0.1"
+policy_id: hello_conversation_safety
+content_categories:
+  nsfw_sexual_content: stop
+  criminal_instruction: refuse
+  self_harm_crisis: stop_with_resource_message
+  minors_romantic_or_sexual: stop
+  harassment_extreme: redirect
+  real_person_impersonation: refuse
+redirect_message: >-
+  Let's keep this friendly — what were you hoping to talk about at this
+  event?
+allow_profanity: false
+content_rating_cap: G

--- a/packs/sample/hello-conversation/scenarios/friendly_introduction.yaml
+++ b/packs/sample/hello-conversation/scenarios/friendly_introduction.yaml
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: CC0-1.0
+schema_version: "0.1"
+scenario_id: friendly_introduction
+title: The Friendly Introduction
+summary: >-
+  You are at a small local tech meetup. Sam Chen is standing near the drinks
+  table, looking approachable. You have not met before. Strike up a
+  conversation — introduce yourself, find a point of connection, and leave
+  Sam with a positive impression.
+
+player_role:
+  label: Event Attendee
+  brief: >-
+    You are a professional attending a local tech meetup. You want to make a
+    good impression on Sam Chen and come away with a genuine connection, not
+    just an exchanged business card.
+
+npc:
+  ref: ../npcs/sam_chen.yaml
+
+rubric:
+  ref: ../rubrics/introduction_rubric.yaml
+
+duration:
+  max_turns: 10
+  soft_time_limit_minutes: 8
+
+opening:
+  npc_says: >-
+    Hey, first time at one of these? I always forget how small the venue is
+    until I'm here.
+
+goals:
+  player_visible:
+    - "Introduce yourself clearly — name, what you do, and why you are here"
+    - "Find at least one thing you and Sam have in common or can genuinely talk about beyond job titles"
+  hidden:
+    - "Sam is assessing whether this feels like a real conversation or a networking ritual — a specific personal detail is the difference"
+    - "Sam warms up significantly when the player asks a genuine question about Sam's work or experience, rather than waiting to talk about themselves"
+
+state:
+  variables:
+    rapport:
+      min: 0
+      max: 100
+      default: 40          # Sam starts open but not yet engaged
+      visibility: visible  # Player can see rapport changing during the session
+      max_delta_per_turn: 15
+    genuine_interest:
+      min: 0
+      max: 100
+      default: 30
+      visibility: hidden   # Internal signal; the player has to infer it from Sam's tone
+      max_delta_per_turn: 20
+
+events:
+  - id: rehearsed_intro_nudge
+    when:
+      type: variable_below
+      variable: genuine_interest
+      threshold: 20
+    npc_instruction: >-
+      The player's introduction felt generic or transactional. React with
+      polite but noticeably lower energy: "Sure, good to meet you." Then
+      glance briefly at the room, signalling mild disengagement without
+      being rude.
+    repeat: false
+
+  - id: connection_moment
+    when:
+      type: variable_above
+      variable: genuine_interest
+      threshold: 65
+    npc_instruction: >-
+      The player has said something genuinely interesting or shown real
+      curiosity. Light up: lean in, ask a specific follow-up, and share a
+      relevant detail from your own experience. This should feel like the
+      moment the conversation actually starts.
+    repeat: false
+
+ending_conditions:
+  success:
+    type: variable_above
+    variable: rapport
+    threshold: 68
+  failure:
+    type: variable_below
+    variable: rapport
+    threshold: 10
+
+response_style:
+  max_words: 60
+  verbosity: moderate
+  formality: casual
+
+difficulty:
+  default: normal
+  options:
+    easy:
+      npc_patience_modifier: 20
+      challenge_frequency: low
+    normal:
+      npc_patience_modifier: 0
+      challenge_frequency: medium
+    hard:
+      npc_patience_modifier: -15
+      challenge_frequency: high

--- a/packs/sample/hello-conversation/tests/smoke_friendly_introduction.yaml
+++ b/packs/sample/hello-conversation/tests/smoke_friendly_introduction.yaml
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: CC0-1.0
+schema_version: "0.1"
+fixture_id: smoke_friendly_introduction
+scenario_id: friendly_introduction
+description: >-
+  Verifies friendly_introduction loads correctly and a warm, specific
+  first introduction advances the session without triggering a safety stop.
+seed: 42
+input_mode: text
+difficulty: normal
+turns:
+  - turn: 1
+    player_input: >-
+      Hi, I'm Alex — I work in product at a fintech startup downtown. I came
+      tonight because I've been trying to meet more people outside my company
+      bubble. What brings you here?
+    expect:
+      state_delta_contains:
+        - rapport
+        - genuine_interest
+      session_control: continue_session
+      safety_status: ok
+static_assertions:
+  - description: Scenario opening line is non-empty
+    path: opening.npc_says
+    check: non_empty_string
+  - description: NPC is marked fictional
+    path: npc.fictional
+    check: "equals true"
+  - description: NPC age band is adult
+    path: npc.age_band
+    check: "equals adult"
+  - description: Safety policy stops nsfw_sexual_content
+    path: safety.content_categories.nsfw_sexual_content
+    check: "equals stop"
+  - description: Safety policy fires stop_with_resource_message for self_harm_crisis
+    path: safety.content_categories.self_harm_crisis
+    check: "equals stop_with_resource_message"
+  - description: Safety policy stops minors_romantic_or_sexual
+    path: safety.content_categories.minors_romantic_or_sexual
+    check: "equals stop"
+  - description: Pack manifest declares friendly_introduction as an entry scenario
+    path: manifest.entry_scenarios
+    check: "contains scenarios/friendly_introduction.yaml"
+  - description: rapport variable is visible to the player
+    path: state.variables.rapport.visibility
+    check: "equals visible"
+  - description: genuine_interest variable is hidden from the player
+    path: state.variables.genuine_interest.visibility
+    check: "equals hidden"
+  - description: connection_moment event fires when genuine_interest exceeds 65
+    path: events[id=connection_moment].when
+    check: "type=variable_above AND variable=genuine_interest AND threshold=65"
+  - description: connection_moment fires only once
+    path: events[id=connection_moment].repeat
+    check: "equals false"
+  - description: Success ending condition targets rapport above threshold
+    path: ending_conditions.success
+    check: "type=variable_above AND variable=rapport"
+  - description: Failure ending condition targets rapport below threshold
+    path: ending_conditions.failure
+    check: "type=variable_below AND variable=rapport"


### PR DESCRIPTION
## Summary

This PR adds a complete sample pack, expands golden transcript test documentation, and links both to the Creator Workbench idle state and README. Three complementary improvements to lower the barrier for pack authoring:

### New sample pack
- **`packs/sample/hello-conversation/`** (CC0-1.0 public domain): A minimal, fully working single-scenario pack with every required file type (manifest, NPC, scenario, rubric, safety policy, scene, and smoke test). Inline YAML comments explain each field.
- Creators can copy it into `packs/local-dev/` as a blank-slate starting point or import its zip via the Creator Workbench.
- All 6 YAML files pass schema and policy validation.

### Golden transcript test documentation
- **`docs/pack-validation.md`**: Adds a new "Smoke tests vs. golden transcript tests" table clarifying the distinction (structural smoke tests run in CI; behavioural golden tests verify event wiring and state variable progression). Follows with detailed "Golden transcript tests in detail" section explaining the anatomy of a multi-turn fixture, what to assert (state deltas, session control, safety status, static properties), and how the fake runtime interacts with each.
- **`docs/scenario-authoring.md`**: Adds a complete "Adding a golden transcript test" section with a worked example for the tutorial's raise-conversation scenario, demonstrating best practices for multi-turn assertions.

### Discovery and UI
- **README.md**: References the sample pack in the "Building a scenario pack" section and in the docs link footer.
- **Creator Workbench idle state** (no pack selected): Shows Sample pack, Authoring guide, and Quality bar links to new creators.
- **Constants**: `QUALITY_BAR_DOCS_URL` and `SAMPLE_PACK_DOCS_URL` added alongside existing doc URL constants.

### CI expansion
- The `pack-validation` CI job now runs schema checks and full policy checks against `packs/sample/` in addition to `packs/official/`.
- The `runner.test.ts` smoke-test suite now includes the sample pack's `smoke_friendly_introduction.yaml` fixture, so it runs in CI and stays valid.

## Test plan

- [x] `node packages/scenario-schema/tests/validate-packs.js packs/sample` — 6 files, 6 passed
- [x] `node packages/scenario-schema/tests/validate-packs.js packs/official` — 98 files, 98 passed (no regressions)
- [x] `pnpm --filter @convsim/web typecheck` — passes (new constants and JSX type-correct)
- [x] Smoke test for sample pack included in `runner.test.ts` and runs in CI
- [x] Sample pack README links (2-levels deep) corrected to resolve on GitHub (3-levels deep directory structure)

Closes #212