### PR TITLE
Add Steam store page copy, assets spec, system requirements, genres/tags, and age disclosures

### DIFF
--- a/publishing/STEAM_APP_REGISTRATION.md
+++ b/publishing/STEAM_APP_REGISTRATION.md
@@ -245,4 +245,6 @@ error:
 - [`.github/workflows/steam-deploy.yml`](../.github/workflows/steam-deploy.yml) — Steam deploy workflow
 - [`docs/STEAM_ROADMAP.md`](../docs/STEAM_ROADMAP.md) — Release train and release principles
 - [`docs/steam-mvp-scope.md`](../docs/steam-mvp-scope.md) — Stage gate criteria
+- [`publishing/STEAM_STORE_PAGE.md`](STEAM_STORE_PAGE.md) — Canonical store copy, system requirements, genres/tags, age disclosures, and store review checklist
+- [`publishing/STEAM_ASSETS_SPEC.md`](STEAM_ASSETS_SPEC.md) — Capsule art, screenshot, and trailer production briefs
 - [`publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md`](STEAM_COMPLIANCE_AND_RISK_REGISTER.md) — Risk register (MD-04, SR-08)

--- a/publishing/STEAM_ASSETS_SPEC.md
+++ b/publishing/STEAM_ASSETS_SPEC.md
@@ -1,0 +1,326 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+# Steam Store Assets — Production Brief
+
+> **Purpose:** Specify the exact sizes, content requirements, and production
+> briefs for every visual and video asset required on the Conversation Simulator
+> Steam store page. Use this document to brief a designer or to self-produce
+> assets.
+>
+> **Audience:** Designer, marketing, and platform team. Outright Mental must
+> approve all assets before they are uploaded to Steamworks.
+>
+> **Source of truth for content constraints:** All assets must comply with the
+> content-boundary rules in
+> [`publishing/STEAM_STORE_PAGE.md`](STEAM_STORE_PAGE.md) — Content boundaries.
+> No real people, no real voices, no sensitive data.
+
+---
+
+## Asset inventory
+
+| Asset | Required? | Steam specification | Status |
+|-------|-----------|---------------------|--------|
+| Header capsule | Yes | 460 × 215 px, JPG or PNG | Not started |
+| Small capsule | Yes | 231 × 87 px, JPG or PNG | Not started |
+| Main capsule (library hero) | Yes | 3840 × 1240 px, JPG or PNG | Not started |
+| Library capsule | Yes | 600 × 900 px, JPG or PNG | Not started |
+| Page background | Optional | 1438 × 810 px, JPG or PNG | Not started |
+| Screenshots (min 5, max 20) | Yes | 1920 × 1080 px (or 1280 × 720 px min), JPG or PNG | Placeholders exist (see `docs/assets/screenshots/`) |
+| Gameplay trailer | Yes | MP4, H.264, 1920 × 1080 px, 30–120 seconds | Not started |
+
+---
+
+## Capsule art
+
+### Design brief
+
+The capsule art must communicate the core concept — conversation practice with
+AI — at very small sizes. The primary visual constraint is that the header
+capsule is 460 × 215 px and will be viewed at 1× in a search result list.
+
+**Core concept to convey:**
+- A one-on-one conversation between a player and an AI character
+- The practice/simulation context (not entertainment, not therapy)
+- The local, private nature of the interaction
+
+**Visual language guidelines:**
+- Clean, modern, slightly clinical aesthetic — closer to a professional
+  productivity tool than a game
+- No photorealistic faces that could be mistaken for real people
+- Use abstract or stylised character representations (silhouettes, icons,
+  illustrated characters) to represent the NPC and player
+- A speech-bubble or transcript motif can anchor the conversation theme
+- Colour palette: dark neutral base (near-black) with a strong accent —
+  the app UI uses deep purple (`#4C1D95` area) for player turns and dark
+  green for NPC turns; either can anchor the capsule art
+
+**Text on capsules:**
+- Header capsule (460 × 215): include "Conversation Simulator" logotype
+  and optionally the tagline "Flight Simulator for conversations."
+- Small capsule (231 × 87): logotype only — no tagline at this size
+- Main capsule / library hero (3840 × 1240): logotype, tagline, and the
+  Outright Mental publisher mark
+
+**Prohibited:**
+- Photographs of real people
+- AI-generated images of recognisable individuals
+- UI screenshots composited into the capsule (too small to read)
+- Price or "Free" badges baked into the art — Steam overlays these
+- Mature, suggestive, or violent imagery
+
+### File requirements
+
+| Asset | Size | Format | Colour space | Max file size |
+|-------|------|--------|-------------|--------------|
+| Header capsule | 460 × 215 px | JPG or PNG | sRGB | 1 MB |
+| Small capsule | 231 × 87 px | JPG or PNG | sRGB | 256 KB |
+| Main capsule (library hero) | 3840 × 1240 px | JPG or PNG | sRGB | 5 MB |
+| Library capsule | 600 × 900 px | JPG or PNG | sRGB | 2 MB |
+| Page background | 1438 × 810 px | JPG or PNG | sRGB | 2 MB |
+
+Provide source files (Figma, Illustrator, or equivalent) alongside exported
+assets so that future updates can be made without re-commissioning from scratch.
+
+---
+
+## Screenshots
+
+Steam requires a minimum of five screenshots. Upload up to 20. At least three
+must show actual in-game content (not capsule art or promotional text).
+
+The placeholder SVGs in `docs/assets/screenshots/` define the six scenes that
+must be covered. See [`docs/screenshots.md`](../docs/screenshots.md) for the
+full inventory, alt text, and replacement checklist. This section restates the
+brief in Steam-submission terms.
+
+### Required screenshots
+
+Capture these six screens from the live application at 1920 × 1080 px
+(or 1280 × 720 px minimum). Use a macOS or Linux build for consistent rendering.
+Do not use Windows-specific window chrome unless a Windows screenshot is
+explicitly needed for platform coverage.
+
+#### Screenshot 1 — Home screen
+
+**File:** `docs/assets/screenshots/01-home.svg` (replace with PNG)
+**Steam caption (max 300 chars):**
+```
+Home screen showing all services ready: local AI runtime, speech recognition,
+and text-to-speech — all running on your computer, no internet required.
+```
+
+**What to show:**
+- The home screen with the status panel showing all services green
+- Four official packs listed as installed
+- Clean, uncluttered layout
+- No personal data visible
+
+---
+
+#### Screenshot 2 — Scenario Library
+
+**File:** `docs/assets/screenshots/02-scenario-library.svg` (replace with PNG)
+**Steam caption:**
+```
+Choose from four built-in scenario packs covering job interviews, negotiations,
+difficult conversations, and language practice. Each scenario shows difficulty,
+duration, and content rating before you start.
+```
+
+**What to show:**
+- The Scenario Library with at least two packs visible
+- A scenario card expanded to show metadata (difficulty, duration, content
+  rating, language, tags, Launch button)
+- Use a Job Interview Basics or Everyday Negotiation scenario for the expanded
+  card — these are the most universally relatable
+
+---
+
+#### Screenshot 3 — Active conversation (mid-session)
+
+**File:** `docs/assets/screenshots/03-conversation.svg` (replace with PNG)
+**Steam caption:**
+```
+A mid-session conversation with an AI interviewer. NPC state meters update in
+real time as the conversation unfolds — watch the dynamic shift based on what
+you say.
+```
+
+**What to show:**
+- An active conversation with a fictional NPC (e.g. Victor Hargrove in the
+  hostile executive interview scenario)
+- Player and NPC turns visible in the transcript
+- NPC state variable meters (credibility, composure, pressure_level or
+  equivalent) displayed below the transcript
+- A scenario event banner if one has triggered (adds visual interest)
+- Do not use real personal data; use the sample/fixture data if needed
+
+---
+
+#### Screenshot 4 — Session Debrief
+
+**File:** `docs/assets/screenshots/04-debrief.svg` (replace with PNG)
+**Steam caption:**
+```
+After every session, a scored debrief breaks down your performance by rubric
+dimension and highlights the moments that changed the conversation.
+```
+
+**What to show:**
+- The debrief screen for a completed session
+- Overall score and outcome badge (Success or Partial success)
+- Scorecard with at least two or three rubric dimensions and their scores
+- Key moments section with at least one positive and one negative turning
+  point
+- Transcript export option visible
+
+---
+
+#### Screenshot 5 — Model Manager
+
+**File:** `docs/assets/screenshots/06-model-manager.svg` (replace with PNG)
+**Steam caption:**
+```
+Download and switch between open-weight AI models. Every download shows the
+model name, source, licence, size, checksum, and destination path before a
+single byte transfers.
+```
+
+**What to show:**
+- The Model Manager with one installed model (green "Loaded" badge) and
+  at least one model available for download
+- The six mandatory disclosure fields visible for a model in the registry
+  (name, source, licence, size, SHA-256, destination path)
+- Optionally: an in-progress download with a progress bar
+- Do not show a download in progress for a model the player has not
+  confirmed — this would misrepresent the model download transparency policy
+
+---
+
+#### Screenshot 6 — Creator Workbench (optional, recommended)
+
+**File:** `docs/assets/screenshots/05-creator-workbench.svg` (replace with PNG)
+**Steam caption:**
+```
+Build your own scenario packs in the Creator Workbench. Define the NPC,
+scenario state, and scoring rubric — then share your pack with other players.
+```
+
+**What to show:**
+- The three-panel Creator Workbench layout
+- A pack file tree visible in the middle panel
+- A YAML file open in the editor panel
+- A green validation banner confirming the pack is valid
+- Use the sample pack or fixture data — do not use any real player data
+
+---
+
+### Screenshot production rules
+
+- **Resolution:** 1920 × 1080 px preferred; 1280 × 720 px minimum.
+- **Format:** PNG (lossless) for screenshots with fine text; JPG (quality 90+)
+  acceptable for screenshots where compression artefacts are not visible.
+- **Colour profile:** sRGB.
+- **Content safety:** All NPCs must be fictional. No real faces, real voices,
+  or personal data. Run a content review before uploading.
+- **UI accuracy:** The UI shown must match the current release build. Do not
+  use mocked or outdated UI states.
+- **Annotations:** Minimal or none. If annotations are added, use a consistent
+  font and avoid covering UI elements.
+- **File size:** Keep each screenshot under 10 MB; under 5 MB preferred for
+  fast page load.
+
+---
+
+## Gameplay trailer
+
+### Overview
+
+| Attribute | Value |
+|-----------|-------|
+| Duration | 30–120 seconds (target: 60–90 seconds) |
+| Resolution | 1920 × 1080 px |
+| Frame rate | 30 fps minimum; 60 fps preferred |
+| Format | MP4, H.264, AAC audio |
+| Audio | Optional narration or on-screen text cards; no real voices of players |
+| File size | Under 500 MB (Steam limit) |
+
+### Content structure
+
+The trailer must show the actual application in use — not animated mockups,
+not stock footage. Structure it to answer the viewer's main question ("What
+do I actually do?") within the first 15 seconds.
+
+**Recommended structure:**
+
+| Timestamp | Content |
+|-----------|---------|
+| 0:00–0:05 | Title card: "Conversation Simulator" + tagline "Flight Simulator for conversations." |
+| 0:05–0:15 | Home screen → Scenario Library → scenario card selection (fast cut). Show the app is approachable and immediately understandable. |
+| 0:15–0:45 | **Core loop — 30 seconds of actual conversation.** Show a mid-session exchange in one of the four built-in packs. Player types a response; NPC replies; a state meter changes; a scenario event triggers. Show at least one moment where the NPC pushes back or the dynamic shifts. |
+| 0:45–1:00 | Debrief screen. Show the overall score, at least one scorecard dimension, and a key moment. Convey that the session produced useful feedback, not just a score. |
+| 1:00–1:10 | Optional: 3-second cuts showing Model Manager, Creator Workbench, and voice mode in action. Convey depth without dwelling. |
+| 1:10–1:20 | Closing title card: "Free forever. Everything runs on your computer." + Outright Mental mark. |
+
+**Narration / text cards:**
+- No voice-over is required. Text cards at key transitions are sufficient.
+- If voice-over is used, it must be performed by a consented voice actor —
+  do not use AI-synthesised voice-over for the trailer itself. (Kokoro TTS
+  in the app is fine; synthetic voice-over for the marketing trailer is not.)
+- Text card copy must be consistent with
+  [`publishing/STEAM_STORE_PAGE.md`](STEAM_STORE_PAGE.md).
+
+**Music / sound:**
+- Background music is optional. If used, ensure the licence permits use in
+  commercial promotional content.
+- In-app TTS audio (Kokoro NPC voice output) may be included in the trailer
+  to demonstrate the voice feature — this is synthesised NPC audio, not a
+  real person's voice, and is permitted.
+
+### Content safety rules
+
+- All NPC characters shown must be fictional. Do not use names or
+  descriptions that could be construed as real-person impersonation.
+- No real player audio. If voice input is demonstrated, use a consented
+  test voice or on-screen text to represent the player's turn.
+- All content shown must be within PG-13. Do not record a session where
+  the conversation reaches content that approaches the safety-policy
+  boundaries.
+- Run a content review before submitting the trailer to Valve.
+
+### Technical delivery
+
+- Deliver the trailer as an MP4 (H.264 video, AAC audio).
+- Deliver a still frame (1920 × 1080 px PNG) for the thumbnail — this is
+  the frame Steam displays before the trailer plays. Use the mid-session
+  conversation frame (NPC state meters visible, event banner triggered) as
+  the thumbnail.
+- Keep a lossless source export (ProRes or equivalent) for future re-edits.
+
+---
+
+## Placeholder asset status
+
+The following placeholder SVGs exist in `docs/assets/screenshots/` and must
+be replaced with real screenshots before the store page goes live. See
+[`docs/screenshots.md`](../docs/screenshots.md) for the full replacement
+checklist.
+
+| Placeholder | Replaces with | Status |
+|------------|---------------|--------|
+| `01-home.svg` | Real home-screen PNG | Not started |
+| `02-scenario-library.svg` | Real scenario-library PNG | Not started |
+| `03-conversation.svg` | Real mid-session PNG | Not started |
+| `04-debrief.svg` | Real debrief PNG | Not started |
+| `05-creator-workbench.svg` | Real Creator Workbench PNG | Not started |
+| `06-model-manager.svg` | Real Model Manager PNG | Not started |
+| `docs/assets/demo-placeholder.svg` | Animated GIF or MP4 (README hero) | Not started |
+
+---
+
+## Links
+
+- [`publishing/STEAM_STORE_PAGE.md`](STEAM_STORE_PAGE.md) — canonical store copy and review checklist
+- [`publishing/STEAM_APP_REGISTRATION.md`](STEAM_APP_REGISTRATION.md) — app identity and Steamworks partner portal setup
+- [`docs/screenshots.md`](../docs/screenshots.md) — existing placeholder asset inventory and replacement checklist
+- [`docs/assets/screenshots/`](../docs/assets/screenshots/) — placeholder SVG files

--- a/publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md
+++ b/publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md
@@ -391,8 +391,11 @@ gate (Stage 3) or the public release gate (Stage 4).
 - [ ] macOS build is notarised with Apple Developer ID; Gatekeeper passes on a clean macOS install.
 - [ ] Windows build is code-signed; SmartScreen does not block installation on a clean Windows install.
 - [ ] Steam Deck verification checklist in `docs/STEAM_ROADMAP.md` is complete and all items pass.
-- [ ] Steam store page copy has been reviewed for accuracy; no language claims AI therapy, diagnosis, or legal advice.
-- [ ] Steam store page does not imply paid content or a marketplace that does not exist in v1.
+- [ ] Steam store page copy has been reviewed using the checklist in [`publishing/STEAM_STORE_PAGE.md`](STEAM_STORE_PAGE.md) — Store page review checklist.
+- [ ] Store page copy accuracy: no language claims AI therapy, diagnosis, or legal advice (gate G4-04).
+- [ ] Steam store page does not imply paid content or a marketplace that does not exist in v1 (gate G4-04).
+- [ ] All store page copy sign-off rows in [`publishing/STEAM_STORE_PAGE.md`](STEAM_STORE_PAGE.md) — Sign-off table are completed with reviewer name and date.
+- [ ] All capsule assets, screenshots, and trailer reviewed against the production brief in [`publishing/STEAM_ASSETS_SPEC.md`](STEAM_ASSETS_SPEC.md) and uploaded to Steamworks.
 
 ### SR-08 — Depot content audit
 
@@ -456,6 +459,9 @@ team is unblocked.
 
 ## Links
 
+- [`publishing/STEAM_STORE_PAGE.md`](STEAM_STORE_PAGE.md) — canonical store copy, system requirements, genres/tags, age disclosures, and store review checklist (SR-07 reference)
+- [`publishing/STEAM_ASSETS_SPEC.md`](STEAM_ASSETS_SPEC.md) — capsule art, screenshot, and trailer production briefs
+- [`publishing/STEAM_APP_REGISTRATION.md`](STEAM_APP_REGISTRATION.md) — app identity, depot layout, and CI credentials
 - [`docs/STEAM_ROADMAP.md`](../docs/STEAM_ROADMAP.md) — release train, principles, and model download transparency spec
 - [`docs/privacy.md`](../docs/privacy.md) — local-first data handling details
 - [`docs/network-security.md`](../docs/network-security.md) — runtime network enforcement

--- a/publishing/STEAM_STORE_PAGE.md
+++ b/publishing/STEAM_STORE_PAGE.md
@@ -338,7 +338,7 @@ comfortable experience with larger AI models.
 | **Processor** | Intel Core i5 or AMD Ryzen 5 | Intel Core i7 or AMD Ryzen 7 |
 | **Memory** | 8 GB RAM | 16 GB RAM |
 | **Storage** | 500 MB for the app; 2–8 GB per AI model | 500 MB for the app; 8–20 GB for larger models |
-| **Additional Notes** | Flatpak or AppImage distribution. No root access required during play. |
+| **Additional Notes** | Flatpak or AppImage distribution. No root access required during play. | |
 
 ### SteamOS / Steam Deck
 

--- a/publishing/STEAM_STORE_PAGE.md
+++ b/publishing/STEAM_STORE_PAGE.md
@@ -1,0 +1,554 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+# Steam Store Page Copy
+
+> **Purpose:** Canonical store copy for the Conversation Simulator Steam page.
+> All text in this document must be approved by Outright Mental before it is
+> entered into the Steamworks partner portal. When the copy is live or scheduled,
+> record the approval date in the [sign-off table](#sign-off) at the bottom.
+>
+> **Audience:** Publishing team, copywriter, Outright Mental staff, and any
+> Valve reviewer who requests source copy.
+>
+> **Constraints enforced here:**
+> - No language claiming AI therapy, diagnosis, or legal advice (gate G4-04).
+> - No implied marketplace or paid content (gate G4-04, SP-05).
+> - Local-first and privacy-first copy must be factually accurate (PR-01–PR-03).
+> - Content-boundary statements must match the safety policy in
+>   [`schemas/safety.schema.json`](../schemas/safety.schema.json).
+> - Steam Deck notes must reflect the state of AU-03 (text-only fallback).
+
+---
+
+## App title
+
+```
+Conversation Simulator
+```
+
+---
+
+## Short description
+
+Steam short descriptions are displayed in search results and store capsules.
+Limit: **300 characters**.
+
+```
+Flight Simulator for conversations. Practice job interviews, negotiations,
+difficult talks, and language skills with AI characters that run entirely on
+your computer. No internet needed during play. Free forever.
+```
+
+Character count: 213. Within the 300-character limit.
+
+---
+
+## Long description
+
+This is the full store page body. Enter it as HTML in the Steamworks rich text
+editor. The structure mirrors Steam's recommended layout: hook → what you do →
+features → privacy pitch → content boundaries → system note → free edition
+statement.
+
+```html
+<h2>Flight Simulator for conversations.</h2>
+
+<p>
+  Conversation Simulator is a free, local-first practice tool that lets you
+  rehearse real-life conversations before they happen. Choose a scenario, talk
+  to an AI character running entirely on your computer, watch the situation
+  evolve, and review what went well — or what you would say differently next
+  time.
+</p>
+
+<p>
+  Think of it like a flight simulator, but for conversations that matter.
+  No judgment. No audience. No internet connection during play. Just the
+  scenario, the AI, and you.
+</p>
+
+<h2>What you do</h2>
+
+<p>
+  Pick a scenario from the built-in packs, type or speak your lines, and
+  respond to an AI character whose reactions evolve based on how the conversation
+  unfolds. After the session, you get a scored debrief: what you said clearly,
+  where you hedged, and the moments that changed the dynamic.
+</p>
+
+<h2>Built-in scenario packs</h2>
+
+<ul>
+  <li>
+    <strong>Job Interview Basics</strong> — Four interview styles from a
+    friendly HR screen to a hostile executive gauntlet. Practice giving specific
+    answers under real pressure without the cost of a bad first impression.
+  </li>
+  <li>
+    <strong>Everyday Negotiation</strong> — Negotiate a used car price, push
+    back on a lease renewal, handle freelance scope creep, and resolve a customer
+    service dispute. Build the habit of advocating for yourself.
+  </li>
+  <li>
+    <strong>Difficult Conversations</strong> — Give honest feedback to a
+    coworker, apologise for a missed deadline, set a limit with a friend, and ask
+    for a raise. Build the clarity and composure that most people only find in
+    hindsight.
+  </li>
+  <li>
+    <strong>Language Café</strong> — Practice Spanish, French, Japanese, and
+    English through low-stakes everyday conversations: ordering coffee, checking
+    into a hotel, shopping at a convenience store. Optional gentle correction
+    included.
+  </li>
+</ul>
+
+<h2>Key features</h2>
+
+<ul>
+  <li>
+    <strong>Everything runs on your computer.</strong> The AI model runs locally
+    using llama.cpp. No cloud inference, no API keys, no subscription required
+    to use the core features. An internet connection is required only for the
+    initial model download — not during play.
+  </li>
+  <li>
+    <strong>Text and voice.</strong> Type your lines or speak them aloud using
+    local speech recognition (Whisper). The AI character responds in text, or
+    with synthesised speech via a local TTS engine (Kokoro). Voice is entirely
+    optional — text mode works everywhere, including Steam Deck.
+  </li>
+  <li>
+    <strong>Scored debrief after every session.</strong> Each scenario has a
+    rubric. After you end a session, you get a breakdown of your performance:
+    scores by dimension, key turning points, and a transcript you can review.
+  </li>
+  <li>
+    <strong>Creator Workbench.</strong> Build your own scenario packs in YAML.
+    Define the NPC, the opening situation, the state variables that evolve during
+    the conversation, and the rubric by which your answers will be scored. Share
+    your packs with other players.
+  </li>
+  <li>
+    <strong>Choose your AI model.</strong> The Model Manager lets you download
+    and switch between open-weight language models. Smaller models (4B parameters)
+    run on most machines. Larger models produce more natural, context-aware
+    responses. You pick the trade-off.
+  </li>
+</ul>
+
+<h2>Your conversations stay on your computer</h2>
+
+<p>
+  Conversation Simulator is built on a local-first architecture. During play,
+  nothing is transmitted to any server — no transcripts, no audio, no model
+  outputs, no usage events. Your conversation history is stored only in a
+  database on your own machine at <code>~/.convsim/</code>. You can clear it
+  at any time from the Settings screen.
+</p>
+
+<p>
+  There is no crash reporter, no analytics SDK, and no background ping in the
+  release build. The offline smoke test — a CI gate that runs on every
+  commit — fails the build if any outbound TCP connection occurs during a play
+  session.
+</p>
+
+<h2>Content boundaries</h2>
+
+<p>
+  This tool is rated <strong>PG to PG-13</strong> across all built-in packs.
+  The built-in safety policy enforces the following hard limits — they apply to
+  all packs, including community packs, and cannot be disabled:
+</p>
+
+<ul>
+  <li>No NSFW sexual content.</li>
+  <li>No sexual or romantic content involving minors — absolute prohibition.</li>
+  <li>No real-person impersonation.</li>
+  <li>No voice cloning or audio deepfakes.</li>
+  <li>
+    No claims of clinical authority: the AI can play a professional in a
+    practice context but will not position itself as a real therapist, doctor,
+    or lawyer.
+  </li>
+  <li>
+    Self-harm crisis content is intercepted and replaced with a resource
+    message — this rule cannot be overridden by any pack.
+  </li>
+</ul>
+
+<p>
+  Conversation Simulator is a <em>practice tool</em>, not a therapy service,
+  a mental-health app, or a clinical resource. If you are in crisis, please
+  contact a qualified professional or a crisis helpline.
+</p>
+
+<h2>Steam Deck</h2>
+
+<p>
+  Conversation Simulator runs on Steam Deck in both Gaming Mode and Desktop
+  Mode. The on-screen keyboard works for all text input. Text-only mode
+  (no microphone required) is fully supported. Voice input requires an
+  external USB-C or Bluetooth microphone, which is not included with the
+  Steam Deck. Smaller AI models (4B parameters) are recommended for the
+  Steam Deck's shared RAM configuration.
+</p>
+
+<h2>Free forever</h2>
+
+<p>
+  Conversation Simulator is free to download and play. There is no base
+  purchase price, no subscription, and no pay-to-unlock core content.
+  The Steam release is sponsored by <strong>Outright Mental</strong>, who
+  covers distribution costs so this tool can reach players who benefit from
+  it.
+</p>
+
+<p>
+  The source code is open and available on GitHub. Community-created scenario
+  packs can be installed manually and shared freely.
+</p>
+```
+
+---
+
+## Feature bullets
+
+Steam allows up to five feature bullets in the "About This Game" sidebar.
+These must be short — one clause each.
+
+```
+• AI characters run entirely on your computer — no cloud, no API keys
+• Practice job interviews, negotiations, and difficult conversations
+• Scored debrief after every session with turn-by-turn analysis
+• Text mode and optional local voice I/O (Whisper STT + Kokoro TTS)
+• Build your own scenario packs with the Creator Workbench
+```
+
+---
+
+## Local-first privacy copy
+
+This is the authoritative privacy statement for the store page and any
+supplemental privacy notices submitted to Valve. It must remain consistent
+with [`docs/privacy.md`](../docs/privacy.md).
+
+```
+During play, Conversation Simulator does not transmit data of any kind to
+any server. This includes:
+
+  - Conversation text and transcripts
+  - Voice audio (raw microphone input and TTS output)
+  - AI model outputs
+  - Session history and scores
+  - Usage events and analytics
+
+All processing happens on your computer. Conversation history is stored in
+a local SQLite database at ~/.convsim/db/sessions.db (Windows: %APPDATA%\
+convsim\). You can view, export, or permanently delete your session history
+from the Settings screen at any time.
+
+The release build contains no crash reporter, telemetry SDK, or background
+network service. An internet connection is required only for the initial
+model download and for any community pack you choose to install manually —
+not during play.
+```
+
+---
+
+## Content boundaries (store page version)
+
+This is the short-form content-boundaries statement for the store page
+"Content Descriptors" and any Valve content review questionnaire.
+
+### What this game contains
+
+- Simulated interpersonal conflict in professional and social contexts
+- Mild workplace language appropriate to the scenario (e.g. a tense
+  performance-review conversation)
+- Optional local voice output using a synthetic TTS voice
+- Scenarios involving emotionally challenging topics (e.g. apologising for
+  a mistake, delivering critical feedback) handled at a PG/PG-13 level
+
+### What this game does not contain
+
+- Sexual content of any kind
+- Violence or depictions of physical harm
+- Real people or their likenesses
+- Gambling or simulated gambling
+- Horror or jump-scare content
+- Substances or drug references
+- Clinical mental-health treatment, therapy, diagnosis, or medical advice
+
+---
+
+## Free edition wording
+
+Use this copy wherever the free-to-play nature needs to be stated explicitly
+(store description, FAQ, press kit).
+
+```
+Free forever — not a demo, not a time-limited trial.
+
+Conversation Simulator is free to download and play on Steam. There is no
+purchase price, no subscription, and no paywall in front of the built-in
+scenario packs. Outright Mental sponsors distribution so the tool reaches
+players who can benefit from it.
+
+There are no microtransactions, no premium content tier, and no in-app
+purchase system in the current release. Community packs can be installed
+manually and are distributed outside the app by their authors — the app
+itself does not host or sell them.
+```
+
+---
+
+## System requirements
+
+Enter these into the Steamworks system requirements section. Use the
+Minimum column for the base requirement and the Recommended column for a
+comfortable experience with larger AI models.
+
+### Windows
+
+| | Minimum | Recommended |
+|-|---------|-------------|
+| **OS** | Windows 10 (64-bit) | Windows 11 (64-bit) |
+| **Processor** | Intel Core i5 (6th gen) or AMD Ryzen 5 (1000 series) | Intel Core i7 (10th gen+) or AMD Ryzen 7 (3000 series+) |
+| **Memory** | 8 GB RAM | 16 GB RAM |
+| **Storage** | 500 MB for the app; 2–8 GB per AI model (downloaded separately) | 500 MB for the app; 8–20 GB for a larger model |
+| **Sound Card** | Not required for text mode; any microphone-capable sound card for voice input | — |
+| **Additional Notes** | No dedicated GPU required. Model inference runs on CPU. A GPU with Vulkan support can accelerate some models. Internet required for initial model download only. | |
+
+### macOS
+
+| | Minimum | Recommended |
+|-|---------|-------------|
+| **OS** | macOS 13 Ventura | macOS 14 Sonoma or later |
+| **Processor** | Apple M1 or Intel Core i5 (8th gen) | Apple M2 or later |
+| **Memory** | 8 GB RAM | 16 GB unified memory |
+| **Storage** | 500 MB for the app; 2–8 GB per AI model | 500 MB for the app; 8–20 GB for larger models |
+| **Additional Notes** | Apple Silicon Macs run local models significantly faster than Intel Macs due to unified memory architecture. Gatekeeper notarisation required — install via the official .dmg only. | |
+
+### Linux
+
+| | Minimum | Recommended |
+|-|---------|-------------|
+| **OS** | Ubuntu 22.04 LTS or Fedora 40 (x86-64, glibc 2.35+) | Ubuntu 24.04 LTS or Fedora 41 |
+| **Processor** | Intel Core i5 or AMD Ryzen 5 | Intel Core i7 or AMD Ryzen 7 |
+| **Memory** | 8 GB RAM | 16 GB RAM |
+| **Storage** | 500 MB for the app; 2–8 GB per AI model | 500 MB for the app; 8–20 GB for larger models |
+| **Additional Notes** | Flatpak or AppImage distribution. No root access required during play. |
+
+### SteamOS / Steam Deck
+
+> Add these as additional notes in the Linux system requirements section.
+
+```
+Steam Deck: Text mode runs without a microphone. Voice input requires an
+external USB-C or Bluetooth microphone (not included). Smaller AI models
+(4B parameters, approx. 2–3 GB) are recommended for the Steam Deck's shared
+RAM. Models should be stored on the SD card or internal storage — a minimum
+of 8 GB of free space is needed. All features, including the Creator
+Workbench and Model Manager, are accessible in Gaming Mode using the
+on-screen keyboard and controller navigation.
+```
+
+---
+
+## Steam genres and tags
+
+### Primary genre
+
+Select **Simulation** as the primary genre. This is the most accurate
+single-word description of what the app does: it simulates conversations.
+
+### Secondary genre
+
+Select **Casual** as the secondary genre. The app is approachable, non-violent,
+and requires no prior gaming skill.
+
+### Steam store tags
+
+Apply the following tags in the Steamworks partner portal. Tags are listed
+in priority order — apply the first ten if Valve's tag picker limits the
+count.
+
+| Priority | Tag | Rationale |
+|----------|-----|-----------|
+| 1 | Singleplayer | All scenarios are single-player. |
+| 2 | Simulation | Core mechanic: simulated conversation. |
+| 3 | Education | Explicit skill-building goal in every scenario. |
+| 4 | Indie | Outright Mental is an independent studio. |
+| 5 | Casual | No combat, no violence, low barrier to entry. |
+| 6 | Text-Based | Text is the primary interaction mode. |
+| 7 | Life Sim | Simulates real-life social situations. |
+| 8 | Social Sim | Specifically simulates social interactions. |
+| 9 | Artificial Intelligence | Local AI inference is a core component. |
+| 10 | Interactive Fiction | Player choices drive the narrative state. |
+| 11 | Language Learning | Language Café pack targets language practice. |
+| 12 | Choices Matter | NPC state evolves based on player responses. |
+| 13 | Relaxing | Low-stakes, no time pressure, no fail state. |
+
+**Tags to avoid:** Action, Adventure, RPG, Strategy, Horror, Puzzle, Sports,
+Racing, Multiplayer. None of these accurately describe the app, and
+misapplied tags generate negative reviews from players with wrong expectations.
+
+---
+
+## Age and content disclosures
+
+### IARC / Steam content questionnaire answers
+
+Complete the Steamworks IARC questionnaire with the following answers.
+These reflect the built-in safety policy (see
+[`publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md`](STEAM_COMPLIANCE_AND_RISK_REGISTER.md)
+— MVP content boundaries).
+
+| Question | Answer |
+|----------|--------|
+| Does the game contain violence? | No |
+| Does the game contain sexual content? | No |
+| Does the game contain nudity? | No |
+| Does the game contain drug references? | No |
+| Does the game contain gambling? | No |
+| Does the game contain horror content? | No |
+| Does the game contain strong language? | Mild — language appropriate to workplace and social conflict scenarios |
+| Does the game involve online interaction with other players? | No |
+| Is the game intended only for adults? | No |
+| Does the game involve real-money purchases? | No |
+
+**Expected rating outcome:**
+
+| Rating body | Expected rating | Notes |
+|-------------|----------------|-------|
+| ESRB | E10+ or T | Mild interpersonal conflict language |
+| PEGI | 7 or 12 | Social conflict, no violence or sexual content |
+| USK | 0 or 6 | |
+| ACB | G or PG | |
+| CERO | A | All ages |
+
+If Valve assigns a rating higher than PEGI 12 / ESRB T, review the store copy
+and content questionnaire before accepting the rating — an unexpectedly high
+rating may indicate that copy language needs clarification.
+
+### Steam age gate
+
+An 18+ age gate is **not** expected and should **not** be requested. All
+built-in content is PG to PG-13. If Valve requires an age gate for any
+reason, accept it rather than weakening the content policies — see risk SP-03
+in the compliance register.
+
+### Steam content descriptors
+
+Apply the following content descriptors in the Steamworks partner portal:
+
+- **Mild Language** — workplace and social conflict scenarios may contain
+  language appropriate to those contexts (frustration, assertiveness, candid
+  professional feedback).
+
+Do **not** apply:
+- Violence
+- Sexual content
+- Nudity
+- Drug references
+- Gambling
+
+---
+
+## Store page review checklist
+
+Complete this checklist before submitting the store page for Valve review.
+This is a supplement to the compliance checklist (SR-07) in
+[`publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md`](STEAM_COMPLIANCE_AND_RISK_REGISTER.md).
+
+### Copy accuracy
+
+- [ ] Short description is ≤ 300 characters and accurately describes the app.
+- [ ] Long description contains no claim of AI therapy, diagnosis, or clinical
+      authority.
+- [ ] Long description contains no implication of a paid marketplace, premium
+      tier, or microtransactions.
+- [ ] Local-first privacy copy is consistent with [`docs/privacy.md`](../docs/privacy.md)
+      and the runtime behaviour confirmed in SR-01 and SR-02.
+- [ ] Content-boundaries list matches the safety policy schema
+      ([`schemas/safety.schema.json`](../schemas/safety.schema.json)).
+- [ ] Free edition wording accurately states that the app is free forever with
+      no time limit or demo restriction.
+- [ ] System requirements have been verified against actual test results from
+      the platform smoke matrix ([`docs/release-checklist.md`](../docs/release-checklist.md)).
+- [ ] Steam Deck notes accurately reflect the text-mode fallback (AU-03) and
+      the external-microphone requirement for voice.
+
+### Genres and tags
+
+- [ ] Primary genre is set to **Simulation**.
+- [ ] Secondary genre is set to **Casual**.
+- [ ] At least five tags from the priority list above are applied.
+- [ ] No misleading tags (Action, RPG, Multiplayer, Horror, etc.) are applied.
+
+### Age and content
+
+- [ ] IARC questionnaire is completed with the answers in the table above.
+- [ ] Content descriptors applied match the list above (Mild Language only).
+- [ ] No 18+ age gate is requested or accepted without Outright Mental approval.
+- [ ] IARC rating received is PEGI 12 / ESRB T or lower; if higher, escalate
+      for review before accepting.
+
+### Assets
+
+- [ ] Header capsule (460 × 215 px) uploaded and approved.
+- [ ] Small capsule (231 × 87 px) uploaded and approved.
+- [ ] Main capsule / library header (3840 × 1240 px) uploaded and approved.
+- [ ] At least five screenshots (1280 × 720 px minimum) uploaded; at least
+      three show actual in-app gameplay (conversation, debrief, scenario
+      library).
+- [ ] Trailer (30–120 seconds) uploaded showing actual scenario flow and
+      debrief screen.
+- [ ] All assets reviewed: no real faces, no real voices, no sensitive data,
+      all fictional NPCs only.
+- [ ] All assets reviewed for accuracy: UI shown in assets matches the current
+      release build.
+
+### Final approval
+
+- [ ] Publishing owner (Outright Mental) has read and approved all copy.
+- [ ] Platform team has verified technical claims (system requirements,
+      local-first guarantee, microphone handling).
+- [ ] Content team has verified pack descriptions and content-boundary
+      statements.
+- [ ] Legal has confirmed no claims of clinical authority or regulated
+      professional advice.
+
+---
+
+## Sign-off
+
+| Section | Reviewer | Date | Notes |
+|---------|----------|------|-------|
+| Short description | | | |
+| Long description | | | |
+| Feature bullets | | | |
+| Privacy copy | | | |
+| Content boundaries | | | |
+| Free edition wording | | | |
+| System requirements | | | |
+| Genres and tags | | | |
+| Age disclosures | | | |
+| Store review checklist | | | |
+
+All sections must be signed off before the store page is submitted to Valve
+for review.
+
+---
+
+## Links
+
+- [`publishing/STEAM_APP_REGISTRATION.md`](STEAM_APP_REGISTRATION.md) — app identity, depot layout, and CI credentials
+- [`publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md`](STEAM_COMPLIANCE_AND_RISK_REGISTER.md) — risk register, MVP content boundaries, and compliance checklists SR-01 through SR-09
+- [`publishing/STEAM_ASSETS_SPEC.md`](STEAM_ASSETS_SPEC.md) — capsule art, screenshot, and trailer production briefs
+- [`docs/STEAM_ROADMAP.md`](../docs/STEAM_ROADMAP.md) — release principles and release train
+- [`docs/steam-mvp-scope.md`](../docs/steam-mvp-scope.md) — Stage 4 gate G4-04 (store page accuracy)
+- [`docs/privacy.md`](../docs/privacy.md) — local-first data handling reference
+- [`schemas/safety.schema.json`](../schemas/safety.schema.json) — safety policy schema (content boundaries source of truth)
+- [`docs/screenshots.md`](../docs/screenshots.md) — existing screenshot and demo asset inventory

--- a/publishing/STEAM_STORE_PAGE.md
+++ b/publishing/STEAM_STORE_PAGE.md
@@ -38,7 +38,7 @@ difficult talks, and language skills with AI characters that run entirely on
 your computer. No internet needed during play. Free forever.
 ```
 
-Character count: 213. Within the 300-character limit.
+Character count: 212. Within the 300-character limit.
 
 ---
 
@@ -244,8 +244,8 @@ any server. This includes:
   - Usage events and analytics
 
 All processing happens on your computer. Conversation history is stored in
-a local SQLite database at ~/.convsim/db/sessions.db (Windows: %APPDATA%\
-convsim\). You can view, export, or permanently delete your session history
+a local SQLite database at ~/.convsim/db/sessions.db (Windows:
+%USERPROFILE%\.convsim\db\sessions.db). You can view, export, or permanently delete your session history
 from the Settings screen at any time.
 
 The release build contains no crash reporter, telemetry SDK, or background


### PR DESCRIPTION
## What changed

Delivers the four publishing artefacts required by issue #231:

### `publishing/STEAM_STORE_PAGE.md` (new)
Canonical source of truth for all Steamworks store text:
- **Short description** (212 chars, within the 300-char Steam limit)
- **Long description** (HTML, ready to paste into the Steamworks rich-text editor) covering the core loop, four built-in packs, key features, the local-first privacy guarantee, content boundaries, Steam Deck notes, and the free-forever statement
- **Feature bullets** (five, for the Steam sidebar)
- **Local-first privacy copy** (authoritative statement consistent with `docs/privacy.md`)
- **Content boundaries** — what the app contains and what it explicitly does not contain, aligned with the safety policy schema
- **Free edition wording** (usable in FAQ, press kit, and store page)
- **System requirements** for Windows 10/11, macOS 13+, Linux (Ubuntu 22.04 / Fedora 40), and SteamOS / Steam Deck (with text-mode fallback and external-microphone note)
- **Steam genres and tags** — Simulation (primary), Casual (secondary), 13 prioritised tags (Singleplayer, Simulation, Education, Indie, Casual, Text-Based, Life Sim, Social Sim, Artificial Intelligence, Interactive Fiction, Language Learning, Choices Matter, Relaxing) with a rationale column and an explicit avoid-list
- **IARC age-disclosure answers** and expected rating outcomes (PEGI 7–12, ESRB E10+–T); no 18+ age gate expected
- **Steam content descriptors** (Mild Language only)
- **Store page review checklist** covering copy accuracy, genres/tags, age/content, and assets — supplements SR-07 in the compliance register
- **Sign-off table** for publishing, platform, content, and legal reviewers

### `publishing/STEAM_ASSETS_SPEC.md` (new)
Production brief for every visual and video asset Steamworks requires:
- **Capsule art brief** — design language, prohibited content, file specs for all five capsule/background sizes (460 × 215 px header, 231 × 87 px small, 3840 × 1240 px library hero, 600 × 900 px library, 1438 × 810 px background)
- **Six screenshot briefs** with Steam-ready captions, exact content requirements, and production rules (resolution, format, content safety)
- **Gameplay trailer brief** — 30–120 second target, timestamped content structure (title card → scenario selection → core loop → debrief → close), narration and music guidance, content safety rules, and technical delivery spec (MP4/H.264, thumbnail frame)
- **Placeholder asset status table** cross-referencing the existing SVGs in `docs/assets/screenshots/`

### `publishing/STEAM_APP_REGISTRATION.md` (updated)
Added links to both new publishing documents.

### `publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md` (updated)
Expanded SR-07 (Steam platform requirements) with specific checklist items linking to the store page review checklist and the assets spec; added links to both new documents in the Links section.

## Why

Issue #231 requires all store copy, asset specs, system requirements, genre/tag selection, age disclosures, and a review checklist to be committed before the app can be submitted to Valve for private beta review (Stage 3 gate). These documents are prerequisites for G4-04 (store page accuracy gate) and the expanded SR-07 compliance checklist.

## How it was tested

- All copy reviewed against the hard constraints in the issue and the existing compliance register: no therapy/diagnosis/legal-advice claims, no implied marketplace, local-first statements factually accurate and consistent with `docs/privacy.md`.
- Content boundaries verified against the safety policy schema (`schemas/safety.schema.json`) and the MVP content boundaries table in `publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md`.
- System requirements cross-checked against platform targets in `docs/STEAM_ROADMAP.md` and `publishing/STEAM_APP_REGISTRATION.md`.
- Short description character count confirmed at 212 (under the 300-char Steam limit).
- All cross-references between the three publishing documents and the docs directory verified for consistency.

Closes #231