### PR TITLE
QA accessibility and onboarding pass: first-run wizard focus management and copy improvements

### DIFF
--- a/apps/web/src/__tests__/accessibility.test.tsx
+++ b/apps/web/src/__tests__/accessibility.test.tsx
@@ -94,6 +94,7 @@ import ScenarioLibrary from '../screens/ScenarioLibrary'
 import Settings from '../screens/Settings'
 import Debrief from '../screens/Debrief'
 import CreatorWorkbench from '../screens/CreatorWorkbench'
+import FirstRunWizard from '../screens/FirstRunWizard'
 import AppLayout from '../layout/AppLayout'
 import MicButton from '../components/MicButton'
 import VadStatusIndicator from '../components/VadStatusIndicator'
@@ -381,5 +382,121 @@ describe('Accessibility: TranscriptReviewPanel', () => {
     )
     const textarea = container.querySelector('textarea')
     expect(document.activeElement).toBe(textarea)
+  })
+})
+
+describe('Accessibility: FirstRunWizard', () => {
+  beforeEach(() => {
+    // Prevent a previous test's localStorage state from triggering the "already complete" redirect.
+    localStorage.clear()
+  })
+
+  it('welcome step has no axe violations', async () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={['/first-run']}>
+        <Routes>
+          <Route path="/first-run" element={<FirstRunWizard />} />
+          <Route path="/" element={<div data-testid="home" />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+    const violations = await runAxe(container)
+    expect(violations, formatViolations(violations)).toHaveLength(0)
+  })
+
+  it('does not steal focus on initial welcome-step mount', () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={['/first-run']}>
+        <Routes>
+          <Route path="/first-run" element={<FirstRunWizard />} />
+          <Route path="/" element={<div />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+    const h1 = container.querySelector('h1')
+    expect(document.activeElement).not.toBe(h1)
+  })
+
+  it('moves focus to the step heading when the step advances', () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={['/first-run']}>
+        <Routes>
+          <Route path="/first-run" element={<FirstRunWizard />} />
+          <Route path="/" element={<div />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+    // Clicking "Get started" transitions from welcome → loading; getModels is a pending
+    // promise in this test suite so the wizard stays on the loading step.
+    fireEvent.click(container.querySelector('button')!)
+    const newH1 = container.querySelector('h1')
+    expect(document.activeElement).toBe(newH1)
+  })
+
+  it('loading step announces busy state', () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={['/first-run']}>
+        <Routes>
+          <Route path="/first-run" element={<FirstRunWizard />} />
+          <Route path="/" element={<div />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+    fireEvent.click(container.querySelector('button')!)
+    const busyEl = container.querySelector('[aria-busy="true"]')
+    expect(busyEl).not.toBeNull()
+  })
+
+  it('welcome step has a privacy and offline-play guarantee note', () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={['/first-run']}>
+        <Routes>
+          <Route path="/first-run" element={<FirstRunWizard />} />
+          <Route path="/" element={<div />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+    expect(container.querySelector('[role="note"][aria-label*="privacy"]')).not.toBeNull()
+  })
+
+  it('choose step option cards are presented as a list', async () => {
+    // Override getModels to resolve immediately so the wizard reaches the choose step.
+    const { api: mockApi } = await import('../api/client')
+    vi.mocked(mockApi.getModels).mockResolvedValueOnce({
+      registry: [],
+      installed: [],
+      ollama_models: [],
+      active: { runtime_id: null, model_id: null },
+      runtime_health: {
+        runtime_id: 'none',
+        runtime_name: 'llama.cpp',
+        status: 'unavailable',
+        model_id: null,
+        latency_ms: null,
+        message: 'No model configured',
+        checked_at: '2026-01-01T00:00:00.000Z',
+      },
+      total: 0,
+      last_benchmark: null,
+    })
+
+    const { container } = render(
+      <MemoryRouter initialEntries={['/first-run']}>
+        <Routes>
+          <Route path="/first-run" element={<FirstRunWizard />} />
+          <Route path="/" element={<div />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    fireEvent.click(container.querySelector('button')!)
+
+    // Wait for the choose step to appear.
+    await vi.waitFor(() => {
+      expect(container.querySelector('h1')?.textContent).toMatch(/choose how to get started/i)
+    })
+
+    // Option cards must be rendered as a list so assistive technologies can count them.
+    expect(container.querySelector('ul[role="list"]')).not.toBeNull()
   })
 })

--- a/apps/web/src/screens/FirstRunWizard.tsx
+++ b/apps/web/src/screens/FirstRunWizard.tsx
@@ -165,6 +165,18 @@ export default function FirstRunWizard() {
   const [benchmarkRunning, setBenchmarkRunning] = useState(false)
   const [benchmarkResult, setBenchmarkResult] = useState<BenchmarkResponse | null>(null)
   const [benchmarkError, setBenchmarkError] = useState<string | null>(null)
+
+  // Focus management: move focus to each step's heading on step change so that keyboard
+  // and screen-reader users are announced the new context without a full page reload.
+  const stepHeadingRef = useRef<HTMLHeadingElement>(null)
+  const isInitialStep = useRef(true)
+  useEffect(() => {
+    if (isInitialStep.current) {
+      isInitialStep.current = false
+      return
+    }
+    stepHeadingRef.current?.focus()
+  }, [step])
   const benchmarkStartedRef = useRef(false)
   // Capture the "already done" state once at mount so that calling markFirstRunComplete()
   // mid-wizard (before the navigate() fires) doesn't cause a spurious redirect to "/".
@@ -258,7 +270,7 @@ export default function FirstRunWizard() {
   if (step === 'welcome') {
     return (
       <div style={{ maxWidth: '640px', margin: '2rem auto', padding: '0 1rem' }}>
-        <h1>Welcome to Conversation Simulator</h1>
+        <h1 ref={stepHeadingRef} tabIndex={-1} style={{ outline: 'none' }}>Welcome to Conversation Simulator</h1>
         <p style={{ fontSize: '1rem', lineHeight: 1.6, color: '#d4d4d8' }}>
           Conversation Simulator is a flight simulator for real-life conversations — a private,
           local-first tool for practising difficult discussions at your own pace.
@@ -367,8 +379,8 @@ export default function FirstRunWizard() {
   if (step === 'loading') {
     return (
       <div style={{ maxWidth: '640px', margin: '2rem auto', padding: '0 1rem' }}>
-        <h1>Model Setup</h1>
-        <p>Loading model information…</p>
+        <h1 ref={stepHeadingRef} tabIndex={-1} style={{ outline: 'none' }}>Model Setup</h1>
+        <p aria-live="polite" aria-busy="true">Loading model information…</p>
       </div>
     )
   }
@@ -378,7 +390,7 @@ export default function FirstRunWizard() {
   if (step === 'load-error') {
     return (
       <div style={{ maxWidth: '640px', margin: '2rem auto', padding: '0 1rem' }}>
-        <h1>Model Setup</h1>
+        <h1 ref={stepHeadingRef} tabIndex={-1} style={{ outline: 'none' }}>Model Setup</h1>
         <p role="alert" style={{ color: '#f87171' }}>
           {loadError ?? 'Something went wrong loading model information. Please try again.'}
         </p>
@@ -428,78 +440,98 @@ export default function FirstRunWizard() {
   if (step === 'choose') {
     return (
       <div style={{ maxWidth: '640px', margin: '2rem auto', padding: '0 1rem' }}>
-        <h1>Choose how to get started</h1>
+        <h1 ref={stepHeadingRef} tabIndex={-1} style={{ outline: 'none' }}>Choose how to get started</h1>
         <p style={{ color: '#a1a1aa', fontSize: '0.9rem' }}>
           Pick an option below. You can change it later in Settings.
         </p>
 
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem', marginTop: '1.5rem' }}>
+        <ul
+          role="list"
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '1rem',
+            marginTop: '1.5rem',
+            listStyle: 'none',
+            padding: 0,
+            margin: '1.5rem 0 0',
+          }}
+        >
           {recommendedModel && (
+            <li>
+              <SectionCard>
+                <CardHeading>Install recommended model</CardHeading>
+                <CardDescription>
+                  {recommendedModel.name} · {recommendedModel.size_gb} GB ·{' '}
+                  {recommendedModel.license_spdx} · Requires {recommendedModel.min_vram_gb} GB VRAM
+                </CardDescription>
+                <ActionButton
+                  onClick={() => {
+                    setSelectedModel(recommendedModel)
+                    resetAction()
+                    setStep('confirm-install')
+                  }}
+                >
+                  Install {recommendedModel.name}
+                </ActionButton>
+              </SectionCard>
+            </li>
+          )}
+
+          <li>
             <SectionCard>
-              <CardHeading>Install recommended model</CardHeading>
+              <CardHeading>Use existing Ollama model</CardHeading>
               <CardDescription>
-                {recommendedModel.name} · {recommendedModel.size_gb} GB ·{' '}
-                {recommendedModel.license_spdx} · Requires {recommendedModel.min_vram_gb} GB VRAM
+                Select from models already installed in your local Ollama instance.
               </CardDescription>
               <ActionButton
                 onClick={() => {
-                  setSelectedModel(recommendedModel)
                   resetAction()
-                  setStep('confirm-install')
+                  setStep('ollama-select')
                 }}
               >
-                Install {recommendedModel.name}
+                Browse Ollama models
               </ActionButton>
             </SectionCard>
-          )}
+          </li>
 
-          <SectionCard>
-            <CardHeading>Use existing Ollama model</CardHeading>
-            <CardDescription>
-              Select from models already installed in your local Ollama instance.
-            </CardDescription>
-            <ActionButton
-              onClick={() => {
-                resetAction()
-                setStep('ollama-select')
-              }}
-            >
-              Browse Ollama models
-            </ActionButton>
-          </SectionCard>
+          <li>
+            <SectionCard>
+              <CardHeading>Use a local GGUF file</CardHeading>
+              <CardDescription>
+                Point to a GGUF model file already on your machine. Compatible with llama.cpp.
+              </CardDescription>
+              <ActionButton
+                onClick={() => {
+                  setGgufPath('')
+                  setGgufPathError(null)
+                  resetAction()
+                  setStep('gguf-path')
+                }}
+              >
+                Use a GGUF file
+              </ActionButton>
+            </SectionCard>
+          </li>
 
-          <SectionCard>
-            <CardHeading>Use a local GGUF file</CardHeading>
-            <CardDescription>
-              Point to a GGUF model file already on your machine. Compatible with llama.cpp.
-            </CardDescription>
-            <ActionButton
-              onClick={() => {
-                setGgufPath('')
-                setGgufPathError(null)
-                resetAction()
-                setStep('gguf-path')
-              }}
-            >
-              Use a GGUF file
-            </ActionButton>
-          </SectionCard>
-
-          <SectionCard>
-            <CardHeading>Continue without a model</CardHeading>
-            <CardDescription>
-              Try the interface without a model. NPC responses are scripted — not real AI quality.
-            </CardDescription>
-            <ActionButton
-              onClick={() => {
-                resetAction()
-                setStep('demo-warning')
-              }}
-            >
-              Continue in text-only demo
-            </ActionButton>
-          </SectionCard>
-        </div>
+          <li>
+            <SectionCard>
+              <CardHeading>Continue without a model</CardHeading>
+              <CardDescription>
+                Try the interface without a model. NPC responses will be scripted — not AI-generated.
+                Response quality is limited compared to a real local model.
+              </CardDescription>
+              <ActionButton
+                onClick={() => {
+                  resetAction()
+                  setStep('demo-warning')
+                }}
+              >
+                Continue in text-only demo
+              </ActionButton>
+            </SectionCard>
+          </li>
+        </ul>
       </div>
     )
   }
@@ -513,13 +545,24 @@ export default function FirstRunWizard() {
 
     return (
       <div style={{ maxWidth: '640px', margin: '2rem auto', padding: '0 1rem' }}>
-        <h1>Confirm model install</h1>
+        <h1 ref={stepHeadingRef} tabIndex={-1} style={{ outline: 'none' }}>Confirm model install</h1>
         <p style={{ color: '#a1a1aa', fontSize: '0.9rem' }}>
           Review the details below before starting the download. No download begins until you click{' '}
           <strong>Confirm &amp; install</strong>.
         </p>
 
         <table style={{ marginTop: '1rem', borderCollapse: 'collapse', width: '100%' }}>
+          <caption
+            style={{
+              textAlign: 'left',
+              fontSize: '0.8rem',
+              color: '#71717a',
+              paddingBottom: '0.4rem',
+              captionSide: 'top',
+            }}
+          >
+            Model details
+          </caption>
           <tbody>
             <DetailRow label="Model">{selectedModel.name}</DetailRow>
             <DetailRow label="Size">
@@ -542,7 +585,7 @@ export default function FirstRunWizard() {
                 ? `${selectedModel.recommended_vram_gb} GB`
                 : 'Unknown'}
             </DetailRow>
-            <DetailRow label="SHA-256 checksum">
+            <DetailRow label="Integrity checksum">
               <span
                 style={{
                   fontFamily: 'monospace',
@@ -553,7 +596,7 @@ export default function FirstRunWizard() {
               >
                 {sha256Display}
               </span>
-              {sha256IsPending && (
+              {sha256IsPending ? (
                 <span
                   style={{
                     display: 'block',
@@ -562,11 +605,22 @@ export default function FirstRunWizard() {
                     marginTop: '0.2rem',
                   }}
                 >
-                  Checksum not yet confirmed — install may be rejected by the runtime.
+                  Checksum not yet confirmed — the download will be rejected if verification fails.
+                </span>
+              ) : (
+                <span
+                  style={{
+                    display: 'block',
+                    fontSize: '0.75rem',
+                    color: '#71717a',
+                    marginTop: '0.2rem',
+                  }}
+                >
+                  SHA-256 — the app checks this after download to confirm the file was not corrupted.
                 </span>
               )}
             </DetailRow>
-            <DetailRow label="Saved to">
+            <DetailRow label="Saves to">
               <code style={{ fontSize: '0.8rem' }}>
                 ~/.convsim/models/llm/{selectedModel.id}.gguf
               </code>
@@ -675,7 +729,7 @@ export default function FirstRunWizard() {
 
       return (
         <div style={{ maxWidth: '640px', margin: '2rem auto', padding: '0 1rem' }}>
-          <h1>Installing model</h1>
+          <h1 ref={stepHeadingRef} tabIndex={-1} style={{ outline: 'none' }}>Installing model</h1>
 
           {isNetworkError && (
             <div
@@ -821,9 +875,10 @@ export default function FirstRunWizard() {
 
     return (
       <div style={{ maxWidth: '640px', margin: '2rem auto', padding: '0 1rem' }}>
-        <h1>Installing model</h1>
+        <h1 ref={stepHeadingRef} tabIndex={-1} style={{ outline: 'none' }}>Installing model</h1>
         <p style={{ color: '#a1a1aa', fontSize: '0.9rem' }}>
-          {statusLabel[status] ?? 'Downloading…'} Download time depends on your connection speed.
+          {statusLabel[status] ?? 'Downloading…'} Download time depends on your internet speed.
+          The app will be ready as soon as the download completes.
         </p>
 
         <div
@@ -851,7 +906,7 @@ export default function FirstRunWizard() {
           />
         </div>
 
-        <p style={{ fontSize: '0.8rem', color: '#71717a', marginTop: '0.4rem' }}>
+        <p aria-live="polite" style={{ fontSize: '0.8rem', color: '#71717a', marginTop: '0.4rem' }}>
           {pct != null
             ? `${pct}% — ${(progressBytes / 1_073_741_824).toFixed(2)} GB`
             : 'Waiting for progress data…'}
@@ -898,7 +953,7 @@ export default function FirstRunWizard() {
 
     return (
       <div style={{ maxWidth: '640px', margin: '2rem auto', padding: '0 1rem' }}>
-        <h1>Use Ollama model</h1>
+        <h1 ref={stepHeadingRef} tabIndex={-1} style={{ outline: 'none' }}>Use Ollama model</h1>
 
         {ollamaModels.length === 0 ? (
           <div>
@@ -1013,7 +1068,7 @@ export default function FirstRunWizard() {
 
     return (
       <div style={{ maxWidth: '640px', margin: '2rem auto', padding: '0 1rem' }}>
-        <h1>Use a GGUF file</h1>
+        <h1 ref={stepHeadingRef} tabIndex={-1} style={{ outline: 'none' }}>Use a GGUF file</h1>
 
         <div
           role="note"
@@ -1072,7 +1127,9 @@ export default function FirstRunWizard() {
             id="gguf-path-hint"
             style={{ fontSize: '0.8rem', color: '#71717a', marginTop: '0.3rem' }}
           >
-            Absolute path to a GGUF model file compatible with llama.cpp.
+            Full file path including the filename, e.g.{' '}
+            <code style={{ fontFamily: 'monospace' }}>/home/you/Downloads/model.gguf</code> —
+            must be compatible with llama.cpp.
           </p>
           {ggufPathError && (
             <p
@@ -1128,7 +1185,7 @@ export default function FirstRunWizard() {
 
     return (
       <div style={{ maxWidth: '640px', margin: '2rem auto', padding: '0 1rem' }}>
-        <h1>Text-only demo</h1>
+        <h1 ref={stepHeadingRef} tabIndex={-1} style={{ outline: 'none' }}>Text-only demo</h1>
 
         <div
           role="note"
@@ -1178,7 +1235,7 @@ export default function FirstRunWizard() {
   if (step === 'benchmark') {
     return (
       <div style={{ maxWidth: '640px', margin: '2rem auto', padding: '0 1rem' }}>
-        <h1>Model benchmark</h1>
+        <h1 ref={stepHeadingRef} tabIndex={-1} style={{ outline: 'none' }}>Model benchmark</h1>
         <p style={{ color: '#a1a1aa', fontSize: '0.9rem' }}>
           Running a short benchmark to measure generation speed and check hardware compatibility.
         </p>


### PR DESCRIPTION
## Summary

This PR completes the [QA] accessibility and non-technical user onboarding pass (issue #240). A keyboard-only navigation audit of the first-run wizard revealed one structural gap — advancing from one step to the next left focus on the button the user had just clicked, giving screen-reader users no indication that the page had changed. The following improvements address that and several related issues found during the playtest.

### Accessibility fixes (`FirstRunWizard.tsx`)

- **Step-change focus management**: A `useRef` on each step's `<h1>` is focused after every wizard step transition (skipping the initial mount so the welcome screen does not steal focus on load). This mirrors the pattern used in `AppLayout` for route changes and ensures assistive technologies announce the new step heading.
- **`tabIndex={-1}` on headings**: Enables programmatic focus without inserting headings into the Tab order.
- **`aria-live="polite" aria-busy="true"`** on the loading-step container: screen readers now announce that model information is being fetched.
- **`aria-live="polite"`** on the download-progress percentage paragraph: progress updates are announced as they arrive.
- **`<caption>` on the confirm-install detail table**: gives the table an accessible label independent of surrounding prose.
- **List structure on the choose step**: option cards were bare `<div>` elements; converted to `<ul role="list"><li>` so assistive technologies can count the available options.

### Copy improvements (`FirstRunWizard.tsx`)

- **Integrity checksum field**: renamed from "SHA-256 checksum" to "Integrity checksum" with a plain-language note ("SHA-256 — the app checks this after download to confirm the file was not corrupted") so non-technical users understand why it is shown.
- **GGUF path hint**: now includes a concrete example path (`/home/you/Downloads/model.gguf`).
- **Demo-mode card**: clarifies that responses are scripted, not AI-generated, and quality is limited compared to a real model.
- **Installing step**: now states "The app will be ready as soon as the download completes" to reduce uncertainty during long downloads.
- **SHA-256 PENDING path**: message updated to "the download will be rejected if verification fails" (more precise than the previous wording).

### New tests (`accessibility.test.tsx`)

Added a `FirstRunWizard` describe block with six tests:
1. Welcome step has no axe-core violations.
2. Initial mount does not steal focus.
3. Advancing to the next step moves focus to the new heading.
4. Loading step exposes `aria-busy="true"`.
5. Welcome step contains the privacy-and-offline-play guarantee note.
6. Choose step renders its option cards inside a list element.

## Test plan

- [ ] All 836 existing tests pass (`pnpm test` in `apps/web`).
- [ ] TypeScript type-check passes (`pnpm typecheck` in `apps/web`).
- [ ] Manual keyboard-only walk-through of the first-run wizard: Tab from "Get started", confirm focus moves to the "Model Setup" heading on the loading step, confirm each subsequent step heading receives focus.
- [ ] Screen-reader spot-check: NVDA/VoiceOver announces step names on advance.

Closes #240