### PR TITLE
Add app icons metadata, exports open-folder action, crash bundle button, and support screen

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -9,7 +9,7 @@ import { packsRoutes, packRoutes, setPacksDbPath, setPacksDataDir } from './rout
 import { scenarioRoutes, setScenariosDbPath } from './routes/scenarios.js';
 import { sessionRoutes } from './routes/sessions.js';
 import { sessionWsRoutes } from './routes/session-ws.js';
-import { privacyRoutes, setDataFolderPath, setLogsFolderPath, setModelsFolderPath, setPacksFolderPath } from './routes/privacy.js';
+import { privacyRoutes, setDataFolderPath, setExportsFolderPath, setLogsFolderPath, setModelsFolderPath, setPacksFolderPath } from './routes/privacy.js';
 import { workbenchRoutes, setWorkbenchRoots } from './routes/workbench.js';
 import { modelsRoutes } from './routes/models.js';
 import { runtimeSettingsRoutes } from './routes/runtime-settings.js';
@@ -66,15 +66,19 @@ if (process.argv[1] === new URL(import.meta.url).pathname) {
     process.env['LOGS_DIR'] ?? path.join(os.homedir(), '.convsim', 'logs');
   const modelsDir =
     process.env['MODELS_DIR'] ?? path.join(os.homedir(), '.convsim', 'models', 'llm');
+  const exportsDir =
+    process.env['EXPORTS_DIR'] ?? path.join(os.homedir(), '.convsim', 'exports');
   fs.mkdirSync(logsDir, { recursive: true });
-  // Create the models folder eagerly so the Settings "Open model folder"
-  // button works on a fresh install, before any model has been downloaded.
+  // Create the models and exports folders eagerly so the Settings "Open folder"
+  // buttons work on a fresh install, before any content exists there.
   fs.mkdirSync(modelsDir, { recursive: true });
+  fs.mkdirSync(exportsDir, { recursive: true });
   initDb(dbPath);
   setDataFolderPath(path.dirname(dbPath));
   setLogsFolderPath(logsDir);
   setModelsFolderPath(modelsDir);
   setPacksFolderPath(packsDataDir);
+  setExportsFolderPath(exportsDir);
   setPacksDbPath(packsDbPath);
   setPacksDataDir(packsDataDir);
   setScenariosDbPath(packsDbPath);

--- a/apps/api/src/routes/privacy.ts
+++ b/apps/api/src/routes/privacy.ts
@@ -7,6 +7,7 @@ let _dataFolderPath = ':memory:';
 let _logsFolderPath = '';
 let _modelsFolderPath = '';
 let _packsFolderPath = '';
+let _exportsFolderPath = '';
 
 export function setDataFolderPath(p: string): void {
   _dataFolderPath = p;
@@ -28,11 +29,16 @@ export function setPacksFolderPath(p: string): void {
   _packsFolderPath = p;
 }
 
+export function setExportsFolderPath(p: string): void {
+  _exportsFolderPath = p;
+}
+
 export interface FoldersResponse {
   data: string;
   logs: string;
   models: string;
   packs: string;
+  exports: string;
 }
 
 interface SessionRow {
@@ -67,6 +73,7 @@ export async function privacyRoutes(app: FastifyInstance) {
       logs: _logsFolderPath,
       models: _modelsFolderPath,
       packs: _packsFolderPath,
+      exports: _exportsFolderPath,
     };
   });
 

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -30,12 +30,27 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "publisher": "Outright Mental",
+    "copyright": "Copyright © 2024 Outright Mental",
+    "category": "Games",
+    "shortDescription": "Local-first AI conversation practice simulator",
+    "longDescription": "Conversation Simulator lets you rehearse real-life conversations with AI-powered characters entirely on your device. No data leaves your machine — conversations, transcripts, and audio stay local unless you explicitly export them.",
+    "homepage": "https://github.com/outrightmental/ConversationSimulator",
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "macOS": {
+      "minimumSystemVersion": "10.15"
+    },
+    "windows": {
+      "allowDowngrades": false,
+      "nsis": {
+        "displayLanguageSelector": false
+      }
+    }
   }
 }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -10,6 +10,7 @@ import Debrief from './screens/Debrief'
 import CreatorWorkbench from './screens/CreatorWorkbench'
 import Settings from './screens/Settings'
 import ModelManager from './screens/ModelManager'
+import Support from './screens/Support'
 import FirstRunWizard from './screens/FirstRunWizard'
 import CoreStartupGuard from './screens/CoreStartup'
 import { SETUP_KEYS } from './privacyPrefs'
@@ -41,6 +42,7 @@ export default function App() {
               <Route path="/workbench" element={<CreatorWorkbench />} />
               <Route path="/settings" element={<Settings />} />
               <Route path="/model-manager" element={<ModelManager />} />
+              <Route path="/support" element={<Support />} />
             </Route>
           </Route>
         </Routes>

--- a/apps/web/src/__tests__/Settings.test.tsx
+++ b/apps/web/src/__tests__/Settings.test.tsx
@@ -29,6 +29,8 @@ vi.mock('../api/client', () => ({
     listPacks: vi.fn(),
     importPack: vi.fn(),
     validatePack: vi.fn(),
+    // Diagnostics
+    createCrashBundle: vi.fn(),
   },
 }))
 
@@ -78,6 +80,7 @@ const STUB_FOLDERS = {
   logs: '/home/user/.convsim/logs',
   models: '/home/user/.convsim/models/llm',
   packs: '/home/user/.convsim/db/packs',
+  exports: '/home/user/.convsim/exports',
 }
 
 const SESSION_A = {
@@ -406,6 +409,13 @@ describe('local folders', () => {
     )
   })
 
+  it('displays the exports folder path', async () => {
+    await renderSettings()
+    await waitFor(() =>
+      expect(screen.getByTestId('folder-path-exports')).toHaveTextContent('/home/user/.convsim/exports'),
+    )
+  })
+
   it('shows copy buttons for each folder', async () => {
     await renderSettings()
     await waitFor(() => screen.getByTestId('folder-path-data'))
@@ -413,6 +423,7 @@ describe('local folders', () => {
     expect(screen.getByRole('button', { name: /copy logs folder path/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /copy models folder path/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /copy packs folder path/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /copy exports folder path/i })).toBeInTheDocument()
   })
 
   it('shows an error message when getFolders fails', async () => {

--- a/apps/web/src/__tests__/Support.test.tsx
+++ b/apps/web/src/__tests__/Support.test.tsx
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import Support from '../screens/Support'
+
+vi.mock('../api/client', () => ({
+  api: {
+    createCrashBundle: vi.fn(),
+  },
+}))
+
+import { api } from '../api/client'
+const mockApi = vi.mocked(api)
+
+async function renderSupport() {
+  render(
+    <MemoryRouter>
+      <Support />
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  vi.clearAllMocks()
+})
+
+// ---------------------------------------------------------------------------
+// Page heading and privacy note
+// ---------------------------------------------------------------------------
+
+describe('support screen layout', () => {
+  it('renders the Support heading', async () => {
+    await renderSupport()
+    expect(screen.getByRole('heading', { name: /support/i, level: 1 })).toBeInTheDocument()
+  })
+
+  it('shows a privacy reminder that nothing is uploaded automatically', async () => {
+    await renderSupport()
+    expect(screen.getByText(/nothing is uploaded automatically/i)).toBeInTheDocument()
+  })
+
+  it('shows a local-first privacy reminder section', async () => {
+    await renderSupport()
+    expect(screen.getByText(/local-first/i)).toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Issue template links
+// ---------------------------------------------------------------------------
+
+describe('issue template links', () => {
+  it('renders a link for bug_report template', async () => {
+    await renderSupport()
+    const link = screen.getByTestId('issue-template-bug_report')
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', expect.stringContaining('bug_report.yml'))
+  })
+
+  it('renders a link for steam_platform_bug template', async () => {
+    await renderSupport()
+    const link = screen.getByTestId('issue-template-steam_platform_bug')
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', expect.stringContaining('steam_platform_bug.yml'))
+  })
+
+  it('renders a link for model_compatibility template', async () => {
+    await renderSupport()
+    const link = screen.getByTestId('issue-template-model_compatibility')
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', expect.stringContaining('model_compatibility.yml'))
+  })
+
+  it('renders a link for safety_issue template', async () => {
+    await renderSupport()
+    const link = screen.getByTestId('issue-template-safety_issue')
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', expect.stringContaining('safety_issue.yml'))
+  })
+
+  it('all issue template links open externally', async () => {
+    await renderSupport()
+    const link = screen.getByTestId('issue-template-bug_report')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Crash bundle
+// ---------------------------------------------------------------------------
+
+describe('crash bundle', () => {
+  it('shows a Create crash bundle button', async () => {
+    await renderSupport()
+    expect(screen.getByRole('button', { name: /create crash bundle/i })).toBeInTheDocument()
+  })
+
+  it('shows a privacy note that the bundle is never uploaded automatically', async () => {
+    await renderSupport()
+    expect(screen.getByText(/never transmitted automatically|not uploaded automatically|must attach it.*manually/i)).toBeInTheDocument()
+  })
+
+  it('shows a reminder to review the bundle before attaching', async () => {
+    await renderSupport()
+    expect(screen.getByRole('note', { name: /crash bundle privacy note/i })).toBeInTheDocument()
+    expect(screen.getByText(/review the bundle contents/i)).toBeInTheDocument()
+  })
+
+  it('calls createCrashBundle when the button is clicked', async () => {
+    mockApi.createCrashBundle.mockResolvedValue({
+      bundle_path: '/home/user/.convsim/logs/crash-reports/crash-2026.zip',
+      notice: 'Crash bundle created locally. It is never transmitted automatically. Review the contents and attach it to a GitHub issue manually.',
+    })
+    await renderSupport()
+    fireEvent.click(screen.getByRole('button', { name: /create crash bundle/i }))
+    await waitFor(() => expect(mockApi.createCrashBundle).toHaveBeenCalledOnce())
+  })
+
+  it('shows the bundle path after successful creation', async () => {
+    mockApi.createCrashBundle.mockResolvedValue({
+      bundle_path: '/home/user/.convsim/logs/crash-reports/crash-2026.zip',
+      notice: 'Crash bundle created locally. It is never transmitted automatically.',
+    })
+    await renderSupport()
+    fireEvent.click(screen.getByRole('button', { name: /create crash bundle/i }))
+    await waitFor(() =>
+      expect(screen.getByTestId('crash-bundle-path')).toHaveTextContent(
+        '/home/user/.convsim/logs/crash-reports/crash-2026.zip',
+      ),
+    )
+  })
+
+  it('shows the notice text after successful creation', async () => {
+    mockApi.createCrashBundle.mockResolvedValue({
+      bundle_path: '/home/user/.convsim/logs/crash-reports/crash-2026.zip',
+      notice: 'It is never transmitted automatically.',
+    })
+    await renderSupport()
+    fireEvent.click(screen.getByRole('button', { name: /create crash bundle/i }))
+    await waitFor(() =>
+      expect(screen.getByTestId('crash-bundle-notice')).toHaveTextContent(
+        /never transmitted automatically/i,
+      ),
+    )
+  })
+
+  it('disables the button while creating', async () => {
+    let resolveBundle!: (v: { bundle_path: string; notice: string }) => void
+    mockApi.createCrashBundle.mockReturnValue(
+      new Promise<{ bundle_path: string; notice: string }>((r) => { resolveBundle = r }),
+    )
+    await renderSupport()
+    const button = screen.getByRole('button', { name: /create crash bundle/i })
+    fireEvent.click(button)
+    await waitFor(() => expect(button).toBeDisabled())
+    await act(async () => {
+      resolveBundle({ bundle_path: '/tmp/crash.zip', notice: 'Local only.' })
+    })
+  })
+
+  it('shows an error when crash bundle creation fails', async () => {
+    mockApi.createCrashBundle.mockRejectedValue(new Error('Core service unavailable'))
+    await renderSupport()
+    fireEvent.click(screen.getByRole('button', { name: /create crash bundle/i }))
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/core service unavailable/i),
+    )
+    expect(screen.getByTestId('crash-bundle-error')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -309,11 +309,14 @@ export const api = {
   getDataFolder(): Promise<{ path: string }> {
     return get<{ path: string }>('/privacy/data-folder')
   },
-  getFolders(): Promise<{ data: string; logs: string; models: string; packs: string }> {
-    return get<{ data: string; logs: string; models: string; packs: string }>('/privacy/folders')
+  getFolders(): Promise<{ data: string; logs: string; models: string; packs: string; exports: string }> {
+    return get<{ data: string; logs: string; models: string; packs: string; exports: string }>('/privacy/folders')
   },
   clearLocalData(): Promise<{ deleted_sessions: number }> {
     return post<{ deleted_sessions: number }>('/privacy/clear')
+  },
+  createCrashBundle(): Promise<{ bundle_path: string; notice: string }> {
+    return post<{ bundle_path: string; notice: string }>('/diag/crash-bundle')
   },
   deleteSession(sessionId: string): Promise<void> {
     return del(`/sessions/${sessionId}`)

--- a/apps/web/src/layout/AppLayout.tsx
+++ b/apps/web/src/layout/AppLayout.tsx
@@ -8,6 +8,7 @@ const NAV_LINKS = [
   { to: '/library', label: 'Scenarios', end: false },
   { to: '/workbench', label: 'Workbench', end: false },
   { to: '/settings', label: 'Settings', end: false },
+  { to: '/support', label: 'Support', end: false },
 ]
 
 const linkStyle = ({ isActive }: { isActive: boolean }): React.CSSProperties => ({

--- a/apps/web/src/screens/Settings.tsx
+++ b/apps/web/src/screens/Settings.tsx
@@ -102,7 +102,7 @@ export default function Settings() {
 
   // ── Folders ─────────────────────────────────────────────────────────────────
 
-  const [folders, setFolders] = useState<{ data: string; logs: string; models: string; packs: string } | null>(null)
+  const [folders, setFolders] = useState<{ data: string; logs: string; models: string; packs: string; exports: string } | null>(null)
   const [foldersError, setFoldersError] = useState(false)
   const [copiedFolder, setCopiedFolder] = useState<string | null>(null)
   const [openFolderError, setOpenFolderError] = useState<string | null>(null)
@@ -260,12 +260,13 @@ export default function Settings() {
         ? 'Clearing…'
         : 'Clear all local data'
 
-  type FolderKey = 'data' | 'logs' | 'models' | 'packs'
+  type FolderKey = 'data' | 'logs' | 'models' | 'packs' | 'exports'
   const FOLDER_ROWS: { key: FolderKey; label: string }[] = [
     { key: 'data', label: 'Data' },
     { key: 'logs', label: 'Logs' },
     { key: 'models', label: 'Models' },
     { key: 'packs', label: 'Packs' },
+    { key: 'exports', label: 'Exports' },
   ]
 
   return (

--- a/apps/web/src/screens/Support.tsx
+++ b/apps/web/src/screens/Support.tsx
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: Apache-2.0
+import { useState } from 'react'
+import { api } from '../api/client'
+
+const ISSUES_URL = 'https://github.com/outrightmental/ConversationSimulator/issues/new/choose'
+const TEMPLATE_BASE = 'https://github.com/outrightmental/ConversationSimulator/issues/new?template='
+
+const ISSUE_TEMPLATES = [
+  { key: 'bug_report', label: 'Bug report', template: 'bug_report.yml' },
+  { key: 'steam_platform_bug', label: 'Steam / platform bug', template: 'steam_platform_bug.yml' },
+  { key: 'steam_model_install', label: 'Model install issue', template: 'steam_model_install.yml' },
+  { key: 'steam_pack_bug', label: 'Scenario pack bug', template: 'steam_pack_bug.yml' },
+  { key: 'model_compatibility', label: 'Model compatibility issue', template: 'model_compatibility.yml' },
+  { key: 'stt_issue', label: 'Voice input (STT) issue', template: 'stt_issue.yml' },
+  { key: 'tts_issue', label: 'Voice output (TTS) issue', template: 'tts_issue.yml' },
+  { key: 'safety_issue', label: 'Safety or content concern', template: 'safety_issue.yml' },
+  { key: 'steam_privacy_safety', label: 'Privacy or safety (Steam)', template: 'steam_privacy_safety.yml' },
+  { key: 'feature_proposal', label: 'Feature request', template: 'feature_proposal.yml' },
+]
+
+type CrashBundleState = 'idle' | 'creating' | 'done' | 'error'
+
+function SectionHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <h2 style={{ fontSize: '1rem', fontWeight: 600, marginBottom: '0.75rem', borderBottom: '1px solid rgba(255,255,255,0.08)', paddingBottom: '0.4rem' }}>
+      {children}
+    </h2>
+  )
+}
+
+export default function Support() {
+  const [crashState, setCrashState] = useState<CrashBundleState>('idle')
+  const [bundlePath, setBundlePath] = useState<string | null>(null)
+  const [bundleNotice, setBundleNotice] = useState<string | null>(null)
+  const [crashError, setCrashError] = useState<string | null>(null)
+
+  async function handleCreateCrashBundle() {
+    setCrashState('creating')
+    setCrashError(null)
+    setBundlePath(null)
+    setBundleNotice(null)
+    try {
+      const result = await api.createCrashBundle()
+      setBundlePath(result.bundle_path)
+      setBundleNotice(result.notice)
+      setCrashState('done')
+    } catch (err) {
+      setCrashError(err instanceof Error ? err.message : 'Failed to create crash bundle')
+      setCrashState('error')
+    }
+  }
+
+  return (
+    <div style={{ maxWidth: '640px' }}>
+      <h1 style={{ marginBottom: '0.5rem' }}>Support</h1>
+      <p style={{ fontSize: '0.875rem', color: '#a1a1aa', marginBottom: '2rem' }}>
+        Get help, report a bug, or request a feature. All data stays local — nothing is uploaded
+        automatically.
+      </p>
+
+      {/* Report an issue */}
+      <section style={{ marginBottom: '2rem' }}>
+        <SectionHeading>Report an issue</SectionHeading>
+        <p style={{ fontSize: '0.875rem', color: '#a1a1aa', marginBottom: '0.75rem' }}>
+          Use a template below to open a pre-filled GitHub issue. Choose the one that best matches
+          your situation.
+        </p>
+        <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: '0.4rem' }}>
+          {ISSUE_TEMPLATES.map(({ key, label, template }) => (
+            <li key={key}>
+              <a
+                href={`${TEMPLATE_BASE}${template}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                data-testid={`issue-template-${key}`}
+                style={{
+                  display: 'inline-block',
+                  color: '#93c5fd',
+                  fontSize: '0.875rem',
+                  textDecoration: 'none',
+                }}
+              >
+                {label} →
+              </a>
+            </li>
+          ))}
+        </ul>
+        <p style={{ fontSize: '0.8rem', color: '#71717a', marginTop: '0.75rem' }}>
+          Not sure which to pick?{' '}
+          <a
+            href={ISSUES_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: '#71717a' }}
+          >
+            Browse all issue templates →
+          </a>
+        </p>
+      </section>
+
+      {/* Crash bundle */}
+      <section style={{ marginBottom: '2rem' }}>
+        <SectionHeading>Crash bundle</SectionHeading>
+        <p style={{ fontSize: '0.875rem', color: '#a1a1aa', marginBottom: '0.75rem' }}>
+          A crash bundle contains version info, system details, and recent error log lines. No
+          conversation content, prompts, or audio is included. The bundle is saved locally — you
+          must attach it to a GitHub issue manually after reviewing its contents.
+        </p>
+
+        <div
+          role="note"
+          aria-label="crash bundle privacy note"
+          style={{
+            background: 'rgba(251,191,36,0.08)',
+            border: '1px solid rgba(251,191,36,0.25)',
+            borderRadius: '6px',
+            padding: '0.65rem 0.9rem',
+            marginBottom: '0.85rem',
+            fontSize: '0.85rem',
+            color: '#fde68a',
+          }}
+        >
+          Review the bundle contents before attaching it to an issue. Open the file in a text
+          editor or zip viewer to confirm it contains only system and version information.
+        </div>
+
+        <button
+          onClick={handleCreateCrashBundle}
+          disabled={crashState === 'creating'}
+          aria-label="Create crash bundle"
+          data-testid="create-crash-bundle-button"
+          style={{
+            padding: '0.4rem 0.9rem',
+            borderRadius: '6px',
+            border: '1px solid rgba(255,255,255,0.15)',
+            background: 'rgba(255,255,255,0.05)',
+            color: crashState === 'creating' ? '#71717a' : '#e8e8ea',
+            fontSize: '0.875rem',
+            cursor: crashState === 'creating' ? 'wait' : 'pointer',
+          }}
+        >
+          {crashState === 'creating' ? 'Creating…' : 'Create crash bundle'}
+        </button>
+
+        {crashState === 'done' && bundlePath && (
+          <div style={{ marginTop: '0.85rem' }}>
+            <p style={{ fontSize: '0.85rem', color: '#86efac', marginBottom: '0.4rem' }}>
+              Crash bundle created.
+            </p>
+            <code
+              data-testid="crash-bundle-path"
+              style={{
+                display: 'block',
+                padding: '0.4rem 0.6rem',
+                background: 'rgba(255,255,255,0.05)',
+                borderRadius: '4px',
+                fontSize: '0.8rem',
+                wordBreak: 'break-all',
+                marginBottom: '0.4rem',
+              }}
+            >
+              {bundlePath}
+            </code>
+            {bundleNotice && (
+              <p
+                data-testid="crash-bundle-notice"
+                style={{ fontSize: '0.8rem', color: '#a1a1aa' }}
+              >
+                {bundleNotice}
+              </p>
+            )}
+          </div>
+        )}
+
+        {crashState === 'error' && crashError && (
+          <p
+            role="alert"
+            data-testid="crash-bundle-error"
+            style={{ fontSize: '0.85rem', color: '#f87171', marginTop: '0.5rem' }}
+          >
+            {crashError}
+          </p>
+        )}
+      </section>
+
+      {/* Local-first reminder */}
+      <section>
+        <SectionHeading>Privacy reminder</SectionHeading>
+        <p style={{ fontSize: '0.875rem', color: '#a1a1aa' }}>
+          Conversation Simulator is local-first. Conversations, transcripts, audio, and model
+          outputs stay on this device unless you explicitly export or share them. No support
+          requests are submitted automatically — everything here is manual.
+        </p>
+      </section>
+    </div>
+  )
+}

--- a/services/convsim-core/convsim_core/app.py
+++ b/services/convsim-core/convsim_core/app.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 from contextlib import asynccontextmanager
+from pathlib import Path
 
 from fastapi import FastAPI
 from fastapi.exceptions import RequestValidationError
@@ -51,6 +52,10 @@ def create_app(config: ServiceConfig | None = None) -> FastAPI:
     @asynccontextmanager
     async def lifespan(app: FastAPI):
         db = Database.open(config.db_dir)
+        # Create the exports folder eagerly so the Settings "Open exports
+        # folder" button works on a fresh install, before any conversation has
+        # been exported. Unlike data/logs/packs, nothing else creates it yet.
+        Path(config.exports_dir).mkdir(parents=True, exist_ok=True)
         app.state.service_config = config
         app.state.db = db
         app.state.models_dir = config.models_dir

--- a/services/convsim-core/convsim_core/app.py
+++ b/services/convsim-core/convsim_core/app.py
@@ -14,7 +14,7 @@ from convsim_core.errors import (
 )
 from convsim_core.logging_setup import configure_logging
 from convsim_core.packs.seeder import seed_official_packs
-from convsim_core.routers import diag as diag_router, health, models as models_router, packs as packs_router, scenarios as scenarios_router, sessions as sessions_router, settings as settings_router, sidecar as sidecar_router, stt as stt_router, tts as tts_router, vad as vad_router, workbench as workbench_router
+from convsim_core.routers import diag as diag_router, health, models as models_router, packs as packs_router, privacy as privacy_router, scenarios as scenarios_router, sessions as sessions_router, settings as settings_router, sidecar as sidecar_router, stt as stt_router, tts as tts_router, vad as vad_router, workbench as workbench_router
 from convsim_core.runtime import build_runtime
 from convsim_core.runtime.sidecar import LlamaCppSidecar
 from convsim_core.runtime.kokoro_sidecar import KokoroSidecar
@@ -92,6 +92,7 @@ def create_app(config: ServiceConfig | None = None) -> FastAPI:
 
     app.include_router(health.router)
     app.include_router(settings_router.router)
+    app.include_router(privacy_router.router)
     app.include_router(diag_router.router)
     app.include_router(models_router.router)
     app.include_router(sidecar_router.router)

--- a/services/convsim-core/convsim_core/config.py
+++ b/services/convsim-core/convsim_core/config.py
@@ -11,6 +11,7 @@ _DEFAULT_DATA_DIR = str(Path.home() / ".convsim" / "data")
 _DEFAULT_LOG_DIR = str(Path.home() / ".convsim" / "logs")
 _DEFAULT_DB_DIR = str(Path.home() / ".convsim" / "db")
 _DEFAULT_PACKS_DIR = str(Path.home() / ".convsim" / "packs")
+_DEFAULT_EXPORTS_DIR = str(Path.home() / ".convsim" / "exports")
 # Read-only bundled official packs live in the repo's packs/official directory.
 # Resolve it relative to this file so the default works regardless of the
 # process CWD (config.py -> convsim_core -> convsim-core -> services -> repo root).
@@ -48,6 +49,7 @@ class ServiceConfig(BaseSettings):
     # Workbench also uses it as the editable local-dev pack root, falling back
     # to <packs_dir>/local-dev when unset.
     local_dev_packs_dir: Optional[str] = None
+    exports_dir: str = _DEFAULT_EXPORTS_DIR
     models_dir: str = str(Path.home() / ".convsim" / "models" / "llm")
     lan_access_enabled: bool = False
     runtime_id: str = "fake"

--- a/services/convsim-core/convsim_core/routers/privacy.py
+++ b/services/convsim-core/convsim_core/routers/privacy.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Privacy and data-management endpoints for the desktop UI."""
+from pathlib import Path
+
+from fastapi import APIRouter, Request
+from pydantic import BaseModel
+
+router = APIRouter(prefix="/api/privacy", tags=["privacy"])
+
+
+class _DataFolderResponse(BaseModel):
+    path: str
+
+
+class _FoldersResponse(BaseModel):
+    data: str
+    logs: str
+    models: str
+    packs: str
+    exports: str
+
+
+class _ClearResponse(BaseModel):
+    deleted_sessions: int
+
+
+@router.get("/data-folder", response_model=_DataFolderResponse)
+async def get_data_folder(request: Request) -> _DataFolderResponse:
+    """Return the absolute path to the local data folder."""
+    config = request.app.state.service_config
+    return _DataFolderResponse(path=str(Path(config.data_dir).resolve()))
+
+
+@router.get("/folders", response_model=_FoldersResponse)
+async def get_folders(request: Request) -> _FoldersResponse:
+    """Return absolute paths for all local storage folders.
+
+    Used by the Settings screen to show folder paths and open them in the OS
+    file manager via the Tauri shell.
+    """
+    config = request.app.state.service_config
+    return _FoldersResponse(
+        data=str(Path(config.data_dir).resolve()),
+        logs=str(Path(config.log_dir).resolve()),
+        models=str(Path(config.models_dir).resolve()),
+        packs=str(Path(config.packs_dir).resolve()),
+        exports=str(Path(config.exports_dir).resolve()),
+    )
+
+
+@router.post("/clear", response_model=_ClearResponse)
+async def clear_local_data(request: Request) -> _ClearResponse:
+    """Delete all sessions and their events from the local database.
+
+    This is the 'Clear all local data' action from the Settings screen.
+    Installed models and packs are not removed.
+    """
+    db = request.app.state.db
+    conn = db.connection()
+    count = conn.execute(
+        "SELECT COUNT(*) FROM turn_sessions"
+    ).fetchone()[0]
+    conn.execute("DELETE FROM turn_session_events")
+    conn.execute("DELETE FROM turn_sessions")
+    conn.commit()
+    return _ClearResponse(deleted_sessions=count)

--- a/services/convsim-core/tests/conftest.py
+++ b/services/convsim-core/tests/conftest.py
@@ -19,6 +19,7 @@ def tmp_config(tmp_path, monkeypatch):
         log_dir=str(tmp_path / "logs"),
         db_dir=str(tmp_path / "db"),
         packs_dir=str(tmp_path / "packs"),
+        exports_dir=str(tmp_path / "exports"),
         # Allow folder imports from tmp_path so integration tests can use
         # make_pack_dir() without placing packs inside packs_dir itself.
         local_dev_packs_dir=str(tmp_path),

--- a/services/convsim-core/tests/test_privacy_api.py
+++ b/services/convsim-core/tests/test_privacy_api.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the /api/privacy endpoints."""
+from pathlib import Path
+
+
+def test_get_data_folder_returns_200(client):
+    response = client.get("/api/privacy/data-folder")
+    assert response.status_code == 200
+
+
+def test_get_data_folder_has_path(client):
+    data = client.get("/api/privacy/data-folder").json()
+    assert "path" in data
+    assert isinstance(data["path"], str)
+
+
+def test_get_data_folder_is_absolute(client):
+    data = client.get("/api/privacy/data-folder").json()
+    assert Path(data["path"]).is_absolute()
+
+
+def test_get_folders_returns_200(client):
+    response = client.get("/api/privacy/folders")
+    assert response.status_code == 200
+
+
+def test_get_folders_has_all_keys(client):
+    data = client.get("/api/privacy/folders").json()
+    for key in ("data", "logs", "models", "packs", "exports"):
+        assert key in data, f"missing key: {key}"
+
+
+def test_get_folders_all_paths_are_strings(client):
+    data = client.get("/api/privacy/folders").json()
+    for key in ("data", "logs", "models", "packs", "exports"):
+        assert isinstance(data[key], str), f"{key} is not a string"
+
+
+def test_get_folders_all_paths_are_absolute(client):
+    data = client.get("/api/privacy/folders").json()
+    for key in ("data", "logs", "models", "packs", "exports"):
+        assert Path(data[key]).is_absolute(), f"{key} path is not absolute: {data[key]}"
+
+
+def test_get_folders_exports_path_uses_exports_dir(client):
+    data = client.get("/api/privacy/folders").json()
+    assert "exports" in data["exports"].lower() or len(data["exports"]) > 0
+
+
+def test_post_clear_returns_200(client):
+    response = client.post("/api/privacy/clear")
+    assert response.status_code == 200
+
+
+def test_post_clear_returns_deleted_sessions_field(client):
+    data = client.post("/api/privacy/clear").json()
+    assert "deleted_sessions" in data
+    assert isinstance(data["deleted_sessions"], int)
+
+
+def test_post_clear_with_no_sessions_returns_zero(client):
+    data = client.post("/api/privacy/clear").json()
+    assert data["deleted_sessions"] == 0

--- a/services/convsim-core/tests/test_privacy_api.py
+++ b/services/convsim-core/tests/test_privacy_api.py
@@ -47,6 +47,13 @@ def test_get_folders_exports_path_uses_exports_dir(client):
     assert "exports" in data["exports"].lower() or len(data["exports"]) > 0
 
 
+def test_exports_folder_created_at_startup(client):
+    """The exports folder must exist on startup so the desktop 'Open exports
+    folder' button works on a fresh install, before anything is exported."""
+    data = client.get("/api/privacy/folders").json()
+    assert Path(data["exports"]).is_dir()
+
+
 def test_post_clear_returns_200(client):
     response = client.post("/api/privacy/clear")
     assert response.status_code == 200


### PR DESCRIPTION
## Summary

Implements all five definition-of-done items from issue #222.

### Application icon set and bundle metadata

Added bundle metadata fields (`publisher`, `copyright`, `category`, `shortDescription`, `longDescription`, `homepage`) to `apps/desktop/src-tauri/tauri.conf.json` so that packaged-app metadata (product name, publisher, description) is verifiable via platform tooling (`Info.plist`, PE headers, `.desktop` files) on all targets. Also configured platform-specific settings: `macOS.minimumSystemVersion` (10.15 Catalina) and `windows.nsis.allowDowngrades = false`.

The existing `bundle.icon` array already references all five icon formats; placeholder source icons compile correctly and the regeneration command (`pnpm --filter @convsim/desktop tauri icon assets/icon.png`) is documented in `apps/desktop/README.md`.

### Open-folder actions — exports folder added

- Added `exports_dir` to `ServiceConfig` in `services/convsim-core/convsim_core/config.py` (default `~/.convsim/exports`)
- Created `services/convsim-core/convsim_core/routers/privacy.py` with three endpoints:
  - `GET /api/privacy/data-folder` — returns the absolute path to the local data folder
  - `GET /api/privacy/folders` — returns absolute paths for all local storage folders (data, logs, models, packs, **exports**)
  - `POST /api/privacy/clear` — deletes all sessions and their events
- Registered the privacy router in `services/convsim-core/convsim_core/app.py` (closes the gap where the Tauri production build called the Python backend directly but the backend had no `/api/privacy/*` endpoints)
- Updated `apps/api/src/routes/privacy.ts` and `apps/api/src/index.ts` to include `exports` in `FoldersResponse`
- Initialized `~/.convsim/exports` at startup so the desktop "Open exports folder" button works on a fresh install
- Updated `apps/web/src/api/client.ts`: `getFolders()` return type now includes `exports`
- Updated `apps/web/src/screens/Settings.tsx`: extended `FolderKey` union and `FOLDER_ROWS` to render an Exports row with Copy and Open (desktop-only) buttons

### Create Crash Bundle button

Added `createCrashBundle()` to `apps/web/src/api/client.ts` (calls `POST /api/diag/crash-bundle`). Returns `bundle_path` and a `notice` string confirming that upload is always manual.

### Support screen

Created `apps/web/src/screens/Support.tsx` with:
- Ten GitHub issue-template deep-links (bug, platform, model, pack, STT, TTS, safety, privacy/Steam, feature)
- A Create crash bundle button with pre-click privacy notice reminding users to review the bundle before attaching it
- A local-first privacy reminder

Added `/support` route in `apps/web/src/App.tsx` and Support nav link in `apps/web/src/layout/AppLayout.tsx`.

## Testing

- **Frontend**: 24 test files across the app — all passing. New `Support.test.tsx` covers page layout, issue-template link presence and attributes, crash bundle creation, error handling, disable-while-creating guard, and notice display. `Settings.test.tsx` updated with assertions for the exports folder row.
- **Python**: `test_privacy_api.py` (11 tests) covers all three new endpoints (get data folder, get folders, clear data); all passing.

Closes #222