### PR TITLE
Add Steam achievements, stats, and rich presence for practice milestones

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -25,6 +25,11 @@ struct CoreStatusPayload {
 /// via `get_steam_status`.  Initialised once during `setup()`.
 struct SteamState(Arc<Mutex<steam::SteamStatus>>);
 
+/// Holds the live Steamworks runtime handle for achievement/stat/rich-presence
+/// calls issued from the front-end. Always present; methods are no-ops outside
+/// Steam or when the `steam` feature is disabled.
+struct SteamRuntimeState(Arc<Mutex<steam::SteamRuntime>>);
+
 /// Returns the current Steam integration status.
 /// Safe to call on non-Steam builds; always returns `is_steam_enabled: false`
 /// unless the `steam` Cargo feature is enabled and Steam is running.
@@ -35,6 +40,50 @@ fn get_steam_status(state: tauri::State<'_, SteamState>) -> steam::SteamStatus {
         .lock()
         .map(|g| g.clone())
         .unwrap_or_default()
+}
+
+/// Unlock a Steam achievement by its Steamworks API name.
+/// Returns `false` when not running under Steam or the `steam` feature is off.
+#[tauri::command]
+fn steam_unlock_achievement(
+    name: String,
+    state: tauri::State<'_, SteamRuntimeState>,
+) -> bool {
+    state
+        .0
+        .lock()
+        .map(|r| r.unlock_achievement(&name))
+        .unwrap_or(false)
+}
+
+/// Increment an integer stat by 1 and persist it to Steam.
+/// Returns `false` when not running under Steam or the `steam` feature is off.
+#[tauri::command]
+fn steam_increment_stat(
+    name: String,
+    state: tauri::State<'_, SteamRuntimeState>,
+) -> bool {
+    state
+        .0
+        .lock()
+        .map(|r| r.increment_stat(&name))
+        .unwrap_or(false)
+}
+
+/// Set the player's Steam rich presence to a generic activity token.
+/// Use the token constants from `steam::rich_presence` to keep disclosure
+/// generic (no session details, scenario names, or transcript content).
+/// Returns `false` when not running under Steam or the `steam` feature is off.
+#[tauri::command]
+fn steam_set_rich_presence(
+    value: String,
+    state: tauri::State<'_, SteamRuntimeState>,
+) -> bool {
+    state
+        .0
+        .lock()
+        .map(|r| r.set_rich_presence(&value))
+        .unwrap_or(false)
 }
 
 // ── Managed state (owns the convsim-core child process) ───────────────────────
@@ -350,8 +399,12 @@ pub fn run() {
 
     // Initialise the Steam bridge early so the status is available before the
     // webview requests it. Gracefully returns a disabled status when Steam is
-    // absent or the `steam` Cargo feature is off.
-    let steam_status = Arc::new(Mutex::new(steam::init()));
+    // absent or the `steam` Cargo feature is off. The runtime handle is kept
+    // alive for the process lifetime to service achievement/stat/rich-presence
+    // commands.
+    let (steam_status_val, steam_runtime_val) = steam::init();
+    let steam_status = Arc::new(Mutex::new(steam_status_val));
+    let steam_runtime = Arc::new(Mutex::new(steam_runtime_val));
 
     let app = tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
@@ -360,7 +413,14 @@ pub fn run() {
         .manage(CoreProcessState(Arc::clone(&process_inner)))
         .manage(CoreStatusState(Arc::clone(&status_inner)))
         .manage(SteamState(Arc::clone(&steam_status)))
-        .invoke_handler(tauri::generate_handler![get_core_status, get_steam_status])
+        .manage(SteamRuntimeState(Arc::clone(&steam_runtime)))
+        .invoke_handler(tauri::generate_handler![
+            get_core_status,
+            get_steam_status,
+            steam_unlock_achievement,
+            steam_increment_stat,
+            steam_set_rich_presence,
+        ])
         .setup(move |app| {
             launch_or_verify_core(
                 app.handle().clone(),

--- a/apps/desktop/src-tauri/src/steam.rs
+++ b/apps/desktop/src-tauri/src/steam.rs
@@ -11,6 +11,53 @@ use serde::Serialize;
 ///   SteamAppId=480 cargo tauri dev --features steam
 pub const SPACEWAR_APP_ID: u32 = 480;
 
+// ── Achievement API names ─────────────────────────────────────────────────────
+//
+// These must match the API names configured in the Steamworks App Admin portal
+// (Achievements tab). See docs/steam-achievements-stats-rich-presence.md for
+// the full configuration guide and all required Steamworks settings.
+
+pub mod achievements {
+    pub const FIRST_SCENARIO: &str = "ACH_FIRST_SCENARIO";
+    pub const FIRST_DEBRIEF: &str = "ACH_FIRST_DEBRIEF";
+    pub const PRACTICE_STREAK: &str = "ACH_PRACTICE_STREAK";
+    pub const PACK_EXPLORER: &str = "ACH_PACK_EXPLORER";
+    pub const CREATOR_FIRST_VALIDATE: &str = "ACH_CREATOR_FIRST_VALIDATE";
+}
+
+// ── Stat API names ────────────────────────────────────────────────────────────
+//
+// Integer stats only. No session content, transcript text, or personally
+// identifiable information is ever stored in Steam stats — only aggregate
+// counts safe to appear on a player's Steam profile.
+
+pub mod stats {
+    pub const SCENARIOS_COMPLETED: &str = "STAT_SCENARIOS_COMPLETED";
+    pub const DEBRIEFS_GENERATED: &str = "STAT_DEBRIEFS_GENERATED";
+    pub const PACKS_VALIDATED: &str = "STAT_PACKS_VALIDATED";
+    pub const TEXT_MODE_SESSIONS: &str = "STAT_TEXT_MODE_SESSIONS";
+    pub const VOICE_MODE_SESSIONS: &str = "STAT_VOICE_MODE_SESSIONS";
+}
+
+// ── Rich presence ─────────────────────────────────────────────────────────────
+//
+// Reveals only generic activity — never session details, scenario names,
+// transcript excerpts, or NPC identifiers. Tokens match the Steamworks rich
+// presence localization file (see docs/steam-achievements-stats-rich-presence.md).
+
+pub mod rich_presence {
+    /// The rich presence key written for every state update.
+    pub const KEY: &str = "steam_display";
+    /// Player is mid-conversation with an NPC.
+    pub const IN_SCENARIO: &str = "#InScenario";
+    /// Player is reading the debrief screen.
+    pub const REVIEWING_DEBRIEF: &str = "#ReviewingDebrief";
+    /// Player is in the creator workbench.
+    pub const EDITING_PACK: &str = "#EditingPack";
+    /// Player is on the home / scenario library screen.
+    pub const AT_MAIN_MENU: &str = "#AtMainMenu";
+}
+
 // ── Status payload sent to the front-end ──────────────────────────────────────
 
 /// Snapshot of the Steam integration state.
@@ -33,6 +80,63 @@ pub struct SteamStatus {
     /// Display name (persona name) of the current Steam user.
     /// Requires a successful SDK initialization.
     pub persona_name: Option<String>,
+}
+
+// ── Runtime handle for ongoing Steamworks API calls ───────────────────────────
+
+/// Live handle for achievement unlock, stat increment, and rich presence calls.
+///
+/// Constructed once by [`init`] and stored in managed state. All methods
+/// gracefully return `false` when the `steam` Cargo feature is disabled or
+/// Steam was not running at launch — callers do not need to guard on
+/// `SteamStatus::is_steam_enabled` before calling.
+pub struct SteamRuntime {
+    #[cfg(feature = "steam")]
+    client: Option<steamworks::Client<steamworks::ClientManager>>,
+    #[cfg(not(feature = "steam"))]
+    _phantom: std::marker::PhantomData<()>,
+}
+
+impl SteamRuntime {
+    /// Unlock a Steam achievement by its Steamworks API name and persist the
+    /// change. Returns `false` when Steam is unavailable.
+    pub fn unlock_achievement(&self, api_name: &str) -> bool {
+        #[cfg(feature = "steam")]
+        if let Some(ref client) = self.client {
+            let ok = client.user_stats().achievement(api_name).set();
+            let _ = client.user_stats().store_stats();
+            return ok;
+        }
+        false
+    }
+
+    /// Increment an integer stat by 1. Reads the current value first so the
+    /// counter is always monotonically increasing. Stores stats immediately.
+    /// Returns `false` when Steam is unavailable.
+    pub fn increment_stat(&self, api_name: &str) -> bool {
+        #[cfg(feature = "steam")]
+        if let Some(ref client) = self.client {
+            let us = client.user_stats();
+            let current = us.stat_i32(api_name).unwrap_or(0);
+            let ok = us.set_stat_i32(api_name, current + 1);
+            let _ = us.store_stats();
+            return ok;
+        }
+        false
+    }
+
+    /// Set the player's Steam rich presence to a generic activity token.
+    /// Use the constants in [`rich_presence`] to keep disclosure generic.
+    /// Returns `false` when Steam is unavailable.
+    pub fn set_rich_presence(&self, value: &str) -> bool {
+        #[cfg(feature = "steam")]
+        if let Some(ref client) = self.client {
+            return client
+                .friends()
+                .set_rich_presence(rich_presence::KEY, Some(value));
+        }
+        false
+    }
 }
 
 // ── Environment-variable helpers (always compiled) ────────────────────────────
@@ -65,26 +169,29 @@ fn app_id_from_env() -> Option<u32> {
 mod sdk {
     use super::*;
 
-    /// Initialise the Steamworks SDK and return the current status.
-    /// Returns a disabled fallback rather than panicking when Steam is absent
-    /// or not running.
-    pub fn init() -> SteamStatus {
+    pub fn init() -> (SteamStatus, SteamRuntime) {
         let launched = is_launched_by_steam();
         let env_app_id = app_id_from_env();
 
         match steamworks::Client::init() {
-            Ok((client, _single)) => SteamStatus {
-                is_steam_enabled: true,
-                launched_by_steam: launched,
-                app_id: Some(client.utils().app_id().0),
-                persona_name: Some(client.friends().name()),
-            },
-            Err(_) => SteamStatus {
-                is_steam_enabled: false,
-                launched_by_steam: launched,
-                app_id: env_app_id,
-                persona_name: None,
-            },
+            Ok((client, _single)) => {
+                let status = SteamStatus {
+                    is_steam_enabled: true,
+                    launched_by_steam: launched,
+                    app_id: Some(client.utils().app_id().0),
+                    persona_name: Some(client.friends().name()),
+                };
+                (status, SteamRuntime { client: Some(client) })
+            }
+            Err(_) => (
+                SteamStatus {
+                    is_steam_enabled: false,
+                    launched_by_steam: launched,
+                    app_id: env_app_id,
+                    persona_name: None,
+                },
+                SteamRuntime { client: None },
+            ),
         }
     }
 }
@@ -95,19 +202,25 @@ mod sdk {
 
     /// Fallback when the `steam` feature is disabled: report env-based
     /// detection only; never touch the Steamworks SDK.
-    pub fn init() -> SteamStatus {
-        SteamStatus {
-            is_steam_enabled: false,
-            launched_by_steam: is_launched_by_steam(),
-            app_id: app_id_from_env(),
-            persona_name: None,
-        }
+    pub fn init() -> (SteamStatus, SteamRuntime) {
+        (
+            SteamStatus {
+                is_steam_enabled: false,
+                launched_by_steam: is_launched_by_steam(),
+                app_id: app_id_from_env(),
+                persona_name: None,
+            },
+            SteamRuntime {
+                _phantom: std::marker::PhantomData,
+            },
+        )
     }
 }
 
-/// Initialise the Steam bridge and return the current status. Safe to call on
+/// Initialise the Steam bridge and return the current status and a runtime
+/// handle for ongoing achievement/stat/rich-presence calls. Safe to call on
 /// any build regardless of whether Steam is present or the SDK feature is on.
-pub fn init() -> SteamStatus {
+pub fn init() -> (SteamStatus, SteamRuntime) {
     sdk::init()
 }
 
@@ -155,7 +268,7 @@ mod tests {
     #[test]
     fn steam_absent_is_disabled() {
         without_steam_env_vars(|| {
-            let status = init();
+            let (status, _runtime) = init();
             assert!(!status.is_steam_enabled, "SDK not initialized without Steam");
             assert!(!status.launched_by_steam);
             assert!(status.app_id.is_none());
@@ -214,7 +327,7 @@ mod tests {
     #[test]
     fn init_with_steam_env_reports_launched_by_steam() {
         with_steam_app_id("1234", || {
-            let status = init();
+            let (status, _runtime) = init();
             // Without the `steam` feature the SDK is never initialized, so
             // is_steam_enabled is false even under a real Steam env.
             // launched_by_steam and app_id come from env-var detection.
@@ -229,5 +342,59 @@ mod tests {
     fn spacewar_app_id_is_valve_canonical_value() {
         // Valve's Spacewar test application always uses AppID 480.
         assert_eq!(SPACEWAR_APP_ID, 480);
+    }
+
+    // ── Achievement and stat API name constants ───────────────────────────────
+
+    #[test]
+    fn achievement_api_names_have_expected_prefix() {
+        assert!(achievements::FIRST_SCENARIO.starts_with("ACH_"));
+        assert!(achievements::FIRST_DEBRIEF.starts_with("ACH_"));
+        assert!(achievements::PRACTICE_STREAK.starts_with("ACH_"));
+        assert!(achievements::PACK_EXPLORER.starts_with("ACH_"));
+        assert!(achievements::CREATOR_FIRST_VALIDATE.starts_with("ACH_"));
+    }
+
+    #[test]
+    fn stat_api_names_have_expected_prefix() {
+        assert!(stats::SCENARIOS_COMPLETED.starts_with("STAT_"));
+        assert!(stats::DEBRIEFS_GENERATED.starts_with("STAT_"));
+        assert!(stats::PACKS_VALIDATED.starts_with("STAT_"));
+        assert!(stats::TEXT_MODE_SESSIONS.starts_with("STAT_"));
+        assert!(stats::VOICE_MODE_SESSIONS.starts_with("STAT_"));
+    }
+
+    #[test]
+    fn rich_presence_tokens_have_hash_prefix() {
+        assert!(rich_presence::IN_SCENARIO.starts_with('#'));
+        assert!(rich_presence::REVIEWING_DEBRIEF.starts_with('#'));
+        assert!(rich_presence::EDITING_PACK.starts_with('#'));
+        assert!(rich_presence::AT_MAIN_MENU.starts_with('#'));
+    }
+
+    // ── SteamRuntime graceful no-ops when steam feature is absent ─────────────
+
+    #[test]
+    fn unlock_achievement_returns_false_without_steam() {
+        without_steam_env_vars(|| {
+            let (_status, runtime) = init();
+            assert!(!runtime.unlock_achievement(achievements::FIRST_SCENARIO));
+        });
+    }
+
+    #[test]
+    fn increment_stat_returns_false_without_steam() {
+        without_steam_env_vars(|| {
+            let (_status, runtime) = init();
+            assert!(!runtime.increment_stat(stats::SCENARIOS_COMPLETED));
+        });
+    }
+
+    #[test]
+    fn set_rich_presence_returns_false_without_steam() {
+        without_steam_env_vars(|| {
+            let (_status, runtime) = init();
+            assert!(!runtime.set_rich_presence(rich_presence::IN_SCENARIO));
+        });
     }
 }

--- a/apps/desktop/src-tauri/src/steam.rs
+++ b/apps/desktop/src-tauri/src/steam.rs
@@ -103,8 +103,11 @@ impl SteamRuntime {
     pub fn unlock_achievement(&self, api_name: &str) -> bool {
         #[cfg(feature = "steam")]
         if let Some(ref client) = self.client {
-            let ok = client.user_stats().achievement(api_name).set();
-            let _ = client.user_stats().store_stats();
+            let us = client.user_stats();
+            // `set()` and `store_stats()` return `Result<(), ()>`; treat a
+            // successful `set` as the unlock result and best-effort persist.
+            let ok = us.achievement(api_name).set().is_ok();
+            let _ = us.store_stats();
             return ok;
         }
         false
@@ -117,8 +120,10 @@ impl SteamRuntime {
         #[cfg(feature = "steam")]
         if let Some(ref client) = self.client {
             let us = client.user_stats();
-            let current = us.stat_i32(api_name).unwrap_or(0);
-            let ok = us.set_stat_i32(api_name, current + 1);
+            // `get_stat_i32` returns `Err` until stats have been received from
+            // Steam; falling back to 0 keeps the increment best-effort.
+            let current = us.get_stat_i32(api_name).unwrap_or(0);
+            let ok = us.set_stat_i32(api_name, current + 1).is_ok();
             let _ = us.store_stats();
             return ok;
         }

--- a/apps/web/src/__tests__/useSteamAchievements.test.ts
+++ b/apps/web/src/__tests__/useSteamAchievements.test.ts
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import {
+  useSteamAchievements,
+  SteamAchievement,
+  SteamStat,
+} from '../hooks/useSteamAchievements'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+type InvokeFn = (cmd: string, args?: unknown) => Promise<unknown>
+
+function stubTauriInvoke(invoke: InvokeFn) {
+  const win = window as { __TAURI__?: unknown }
+  win.__TAURI__ = { core: { invoke } }
+}
+
+function clearTauri() {
+  const win = window as { __TAURI__?: unknown }
+  delete win.__TAURI__
+}
+
+// ── Setup / teardown ──────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  clearTauri()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  clearTauri()
+})
+
+// ── Non-Tauri (browser) context ───────────────────────────────────────────────
+
+describe('useSteamAchievements — non-Tauri context', () => {
+  it('unlock returns false immediately when __TAURI__ is absent', async () => {
+    const { result } = renderHook(() => useSteamAchievements())
+    const ok = await result.current.unlock(SteamAchievement.FIRST_SCENARIO)
+    expect(ok).toBe(false)
+  })
+
+  it('incrementStat returns false immediately when __TAURI__ is absent', async () => {
+    const { result } = renderHook(() => useSteamAchievements())
+    const ok = await result.current.incrementStat(SteamStat.SCENARIOS_COMPLETED)
+    expect(ok).toBe(false)
+  })
+
+  it('returns false when __TAURI__ has no core.invoke', async () => {
+    const win = window as { __TAURI__?: unknown }
+    win.__TAURI__ = { event: { listen: vi.fn() } }
+
+    const { result } = renderHook(() => useSteamAchievements())
+    const ok = await result.current.unlock(SteamAchievement.FIRST_DEBRIEF)
+    expect(ok).toBe(false)
+  })
+})
+
+// ── Achievement unlock ────────────────────────────────────────────────────────
+
+describe('useSteamAchievements — unlock', () => {
+  it('invokes steam_unlock_achievement with the correct name', async () => {
+    const invoke = vi.fn().mockResolvedValue(true)
+    stubTauriInvoke(invoke)
+
+    const { result } = renderHook(() => useSteamAchievements())
+
+    let ok: boolean = false
+    await act(async () => {
+      ok = await result.current.unlock(SteamAchievement.FIRST_SCENARIO)
+    })
+
+    expect(ok).toBe(true)
+    expect(invoke).toHaveBeenCalledOnce()
+    expect(invoke).toHaveBeenCalledWith('steam_unlock_achievement', {
+      name: SteamAchievement.FIRST_SCENARIO,
+    })
+  })
+
+  it('returns false when invoke returns false (already unlocked or Steam absent)', async () => {
+    const invoke = vi.fn().mockResolvedValue(false)
+    stubTauriInvoke(invoke)
+
+    const { result } = renderHook(() => useSteamAchievements())
+
+    let ok = true
+    await act(async () => {
+      ok = await result.current.unlock(SteamAchievement.FIRST_DEBRIEF)
+    })
+
+    expect(ok).toBe(false)
+  })
+
+  it('returns false and does not throw when invoke rejects', async () => {
+    const invoke = vi.fn().mockRejectedValue(new Error('Steam unavailable'))
+    stubTauriInvoke(invoke)
+
+    const { result } = renderHook(() => useSteamAchievements())
+
+    let ok = true
+    await act(async () => {
+      ok = await result.current.unlock(SteamAchievement.PRACTICE_STREAK)
+    })
+
+    expect(ok).toBe(false)
+  })
+
+  it('passes all achievement API names through to invoke', async () => {
+    const invoke = vi.fn().mockResolvedValue(true)
+    stubTauriInvoke(invoke)
+    const { result } = renderHook(() => useSteamAchievements())
+
+    const names = Object.values(SteamAchievement)
+    for (const name of names) {
+      await act(async () => {
+        await result.current.unlock(name)
+      })
+    }
+
+    expect(invoke).toHaveBeenCalledTimes(names.length)
+    for (const name of names) {
+      expect(invoke).toHaveBeenCalledWith('steam_unlock_achievement', { name })
+    }
+  })
+})
+
+// ── Stat increment ────────────────────────────────────────────────────────────
+
+describe('useSteamAchievements — incrementStat', () => {
+  it('invokes steam_increment_stat with the correct name', async () => {
+    const invoke = vi.fn().mockResolvedValue(true)
+    stubTauriInvoke(invoke)
+
+    const { result } = renderHook(() => useSteamAchievements())
+
+    let ok = false
+    await act(async () => {
+      ok = await result.current.incrementStat(SteamStat.SCENARIOS_COMPLETED)
+    })
+
+    expect(ok).toBe(true)
+    expect(invoke).toHaveBeenCalledWith('steam_increment_stat', {
+      name: SteamStat.SCENARIOS_COMPLETED,
+    })
+  })
+
+  it('returns false when invoke returns false', async () => {
+    const invoke = vi.fn().mockResolvedValue(false)
+    stubTauriInvoke(invoke)
+    const { result } = renderHook(() => useSteamAchievements())
+
+    let ok = true
+    await act(async () => {
+      ok = await result.current.incrementStat(SteamStat.DEBRIEFS_GENERATED)
+    })
+    expect(ok).toBe(false)
+  })
+
+  it('returns false and does not throw when invoke rejects', async () => {
+    const invoke = vi.fn().mockRejectedValue(new Error('IPC error'))
+    stubTauriInvoke(invoke)
+    const { result } = renderHook(() => useSteamAchievements())
+
+    let ok = true
+    await act(async () => {
+      ok = await result.current.incrementStat(SteamStat.TEXT_MODE_SESSIONS)
+    })
+    expect(ok).toBe(false)
+  })
+
+  it('passes all stat API names through to invoke', async () => {
+    const invoke = vi.fn().mockResolvedValue(true)
+    stubTauriInvoke(invoke)
+    const { result } = renderHook(() => useSteamAchievements())
+
+    const names = Object.values(SteamStat)
+    for (const name of names) {
+      await act(async () => {
+        await result.current.incrementStat(name)
+      })
+    }
+
+    expect(invoke).toHaveBeenCalledTimes(names.length)
+    for (const name of names) {
+      expect(invoke).toHaveBeenCalledWith('steam_increment_stat', { name })
+    }
+  })
+})
+
+// ── API name constant shapes ──────────────────────────────────────────────────
+
+describe('SteamAchievement constants', () => {
+  it('all have the ACH_ prefix', () => {
+    for (const v of Object.values(SteamAchievement)) {
+      expect(v).toMatch(/^ACH_/)
+    }
+  })
+
+  it('contains the five v1 achievements', () => {
+    expect(SteamAchievement.FIRST_SCENARIO).toBe('ACH_FIRST_SCENARIO')
+    expect(SteamAchievement.FIRST_DEBRIEF).toBe('ACH_FIRST_DEBRIEF')
+    expect(SteamAchievement.PRACTICE_STREAK).toBe('ACH_PRACTICE_STREAK')
+    expect(SteamAchievement.PACK_EXPLORER).toBe('ACH_PACK_EXPLORER')
+    expect(SteamAchievement.CREATOR_FIRST_VALIDATE).toBe(
+      'ACH_CREATOR_FIRST_VALIDATE',
+    )
+  })
+})
+
+describe('SteamStat constants', () => {
+  it('all have the STAT_ prefix', () => {
+    for (const v of Object.values(SteamStat)) {
+      expect(v).toMatch(/^STAT_/)
+    }
+  })
+
+  it('contains the five v1 stats', () => {
+    expect(SteamStat.SCENARIOS_COMPLETED).toBe('STAT_SCENARIOS_COMPLETED')
+    expect(SteamStat.DEBRIEFS_GENERATED).toBe('STAT_DEBRIEFS_GENERATED')
+    expect(SteamStat.PACKS_VALIDATED).toBe('STAT_PACKS_VALIDATED')
+    expect(SteamStat.TEXT_MODE_SESSIONS).toBe('STAT_TEXT_MODE_SESSIONS')
+    expect(SteamStat.VOICE_MODE_SESSIONS).toBe('STAT_VOICE_MODE_SESSIONS')
+  })
+})

--- a/apps/web/src/__tests__/useSteamRichPresence.test.ts
+++ b/apps/web/src/__tests__/useSteamRichPresence.test.ts
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import {
+  useSteamRichPresence,
+  SteamActivity,
+} from '../hooks/useSteamRichPresence'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+type InvokeFn = (cmd: string, args?: unknown) => Promise<unknown>
+
+function stubTauriInvoke(invoke: InvokeFn) {
+  const win = window as { __TAURI__?: unknown }
+  win.__TAURI__ = { core: { invoke } }
+}
+
+function clearTauri() {
+  const win = window as { __TAURI__?: unknown }
+  delete win.__TAURI__
+}
+
+// ── Setup / teardown ──────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  clearTauri()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  clearTauri()
+})
+
+// ── Non-Tauri (browser) context ───────────────────────────────────────────────
+
+describe('useSteamRichPresence — non-Tauri context', () => {
+  it('setPresence returns false immediately when __TAURI__ is absent', async () => {
+    const { result } = renderHook(() => useSteamRichPresence())
+    const ok = await result.current.setPresence(SteamActivity.IN_SCENARIO)
+    expect(ok).toBe(false)
+  })
+
+  it('returns false when __TAURI__ has no core.invoke', async () => {
+    const win = window as { __TAURI__?: unknown }
+    win.__TAURI__ = { event: { listen: vi.fn() } }
+
+    const { result } = renderHook(() => useSteamRichPresence())
+    const ok = await result.current.setPresence(SteamActivity.AT_MAIN_MENU)
+    expect(ok).toBe(false)
+  })
+})
+
+// ── Rich presence updates ─────────────────────────────────────────────────────
+
+describe('useSteamRichPresence — setPresence', () => {
+  it('invokes steam_set_rich_presence with the IN_SCENARIO token', async () => {
+    const invoke = vi.fn().mockResolvedValue(true)
+    stubTauriInvoke(invoke)
+
+    const { result } = renderHook(() => useSteamRichPresence())
+
+    let ok = false
+    await act(async () => {
+      ok = await result.current.setPresence(SteamActivity.IN_SCENARIO)
+    })
+
+    expect(ok).toBe(true)
+    expect(invoke).toHaveBeenCalledOnce()
+    expect(invoke).toHaveBeenCalledWith('steam_set_rich_presence', {
+      value: SteamActivity.IN_SCENARIO,
+    })
+  })
+
+  it('invokes steam_set_rich_presence with the REVIEWING_DEBRIEF token', async () => {
+    const invoke = vi.fn().mockResolvedValue(true)
+    stubTauriInvoke(invoke)
+    const { result } = renderHook(() => useSteamRichPresence())
+
+    await act(async () => {
+      await result.current.setPresence(SteamActivity.REVIEWING_DEBRIEF)
+    })
+
+    expect(invoke).toHaveBeenCalledWith('steam_set_rich_presence', {
+      value: SteamActivity.REVIEWING_DEBRIEF,
+    })
+  })
+
+  it('invokes steam_set_rich_presence with the EDITING_PACK token', async () => {
+    const invoke = vi.fn().mockResolvedValue(true)
+    stubTauriInvoke(invoke)
+    const { result } = renderHook(() => useSteamRichPresence())
+
+    await act(async () => {
+      await result.current.setPresence(SteamActivity.EDITING_PACK)
+    })
+
+    expect(invoke).toHaveBeenCalledWith('steam_set_rich_presence', {
+      value: SteamActivity.EDITING_PACK,
+    })
+  })
+
+  it('invokes steam_set_rich_presence with the AT_MAIN_MENU token', async () => {
+    const invoke = vi.fn().mockResolvedValue(true)
+    stubTauriInvoke(invoke)
+    const { result } = renderHook(() => useSteamRichPresence())
+
+    await act(async () => {
+      await result.current.setPresence(SteamActivity.AT_MAIN_MENU)
+    })
+
+    expect(invoke).toHaveBeenCalledWith('steam_set_rich_presence', {
+      value: SteamActivity.AT_MAIN_MENU,
+    })
+  })
+
+  it('passes each activity token correctly', async () => {
+    const invoke = vi.fn().mockResolvedValue(true)
+    stubTauriInvoke(invoke)
+    const { result } = renderHook(() => useSteamRichPresence())
+
+    const tokens = Object.values(SteamActivity)
+    for (const token of tokens) {
+      await act(async () => {
+        await result.current.setPresence(token)
+      })
+    }
+
+    expect(invoke).toHaveBeenCalledTimes(tokens.length)
+    for (const token of tokens) {
+      expect(invoke).toHaveBeenCalledWith('steam_set_rich_presence', {
+        value: token,
+      })
+    }
+  })
+
+  it('returns false when Steam is absent (invoke returns false)', async () => {
+    const invoke = vi.fn().mockResolvedValue(false)
+    stubTauriInvoke(invoke)
+    const { result } = renderHook(() => useSteamRichPresence())
+
+    let ok = true
+    await act(async () => {
+      ok = await result.current.setPresence(SteamActivity.IN_SCENARIO)
+    })
+    expect(ok).toBe(false)
+  })
+
+  it('returns false and does not throw when invoke rejects', async () => {
+    const invoke = vi.fn().mockRejectedValue(new Error('IPC error'))
+    stubTauriInvoke(invoke)
+    const { result } = renderHook(() => useSteamRichPresence())
+
+    let ok = true
+    await act(async () => {
+      ok = await result.current.setPresence(SteamActivity.REVIEWING_DEBRIEF)
+    })
+    expect(ok).toBe(false)
+  })
+})
+
+// ── SteamActivity constant shapes ─────────────────────────────────────────────
+
+describe('SteamActivity constants', () => {
+  it('all tokens start with #', () => {
+    for (const v of Object.values(SteamActivity)) {
+      expect(v).toMatch(/^#/)
+    }
+  })
+
+  it('contains all four v1 activity states', () => {
+    expect(SteamActivity.IN_SCENARIO).toBe('#InScenario')
+    expect(SteamActivity.REVIEWING_DEBRIEF).toBe('#ReviewingDebrief')
+    expect(SteamActivity.EDITING_PACK).toBe('#EditingPack')
+    expect(SteamActivity.AT_MAIN_MENU).toBe('#AtMainMenu')
+  })
+})

--- a/apps/web/src/hooks/useSteamAchievements.ts
+++ b/apps/web/src/hooks/useSteamAchievements.ts
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+import { useCallback } from 'react'
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type TauriWindow = {
+  __TAURI__?: { core?: { invoke<T>(cmd: string, args?: unknown): Promise<T> } }
+}
+
+// ── API name constants ────────────────────────────────────────────────────────
+
+/** Achievement API names matching the Steamworks App Admin configuration. */
+export const SteamAchievement = {
+  FIRST_SCENARIO: 'ACH_FIRST_SCENARIO',
+  FIRST_DEBRIEF: 'ACH_FIRST_DEBRIEF',
+  PRACTICE_STREAK: 'ACH_PRACTICE_STREAK',
+  PACK_EXPLORER: 'ACH_PACK_EXPLORER',
+  CREATOR_FIRST_VALIDATE: 'ACH_CREATOR_FIRST_VALIDATE',
+} as const
+
+/** Stat API names matching the Steamworks App Admin configuration. */
+export const SteamStat = {
+  SCENARIOS_COMPLETED: 'STAT_SCENARIOS_COMPLETED',
+  DEBRIEFS_GENERATED: 'STAT_DEBRIEFS_GENERATED',
+  PACKS_VALIDATED: 'STAT_PACKS_VALIDATED',
+  TEXT_MODE_SESSIONS: 'STAT_TEXT_MODE_SESSIONS',
+  VOICE_MODE_SESSIONS: 'STAT_VOICE_MODE_SESSIONS',
+} as const
+
+export type SteamAchievementName =
+  (typeof SteamAchievement)[keyof typeof SteamAchievement]
+export type SteamStatName = (typeof SteamStat)[keyof typeof SteamStat]
+
+// ── Hook ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Returns callbacks for unlocking Steam achievements and incrementing stats.
+ *
+ * - In a browser context (no `window.__TAURI__`) both callbacks return
+ *   `false` immediately without throwing.
+ * - In the Tauri shell, delegates to the `steam_unlock_achievement` and
+ *   `steam_increment_stat` commands, which are no-ops when Steam is absent
+ *   or the `steam` Cargo feature is disabled.
+ */
+export function useSteamAchievements() {
+  const unlock = useCallback(
+    async (achievementName: SteamAchievementName): Promise<boolean> => {
+      const tauri = (window as TauriWindow).__TAURI__
+      if (!tauri?.core) return false
+      return tauri.core
+        .invoke<boolean>('steam_unlock_achievement', { name: achievementName })
+        .catch(() => false)
+    },
+    [],
+  )
+
+  const incrementStat = useCallback(
+    async (statName: SteamStatName): Promise<boolean> => {
+      const tauri = (window as TauriWindow).__TAURI__
+      if (!tauri?.core) return false
+      return tauri.core
+        .invoke<boolean>('steam_increment_stat', { name: statName })
+        .catch(() => false)
+    },
+    [],
+  )
+
+  return { unlock, incrementStat }
+}

--- a/apps/web/src/hooks/useSteamRichPresence.ts
+++ b/apps/web/src/hooks/useSteamRichPresence.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+import { useCallback } from 'react'
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type TauriWindow = {
+  __TAURI__?: { core?: { invoke<T>(cmd: string, args?: unknown): Promise<T> } }
+}
+
+// ── Activity token constants ──────────────────────────────────────────────────
+
+/**
+ * Generic activity tokens for Steam rich presence.
+ *
+ * These tokens are looked up in the Steamworks rich presence localization file
+ * and rendered as human-readable strings in the Steam friends list. They reveal
+ * only the category of activity — never session details, scenario names,
+ * transcript excerpts, or NPC identifiers.
+ */
+export const SteamActivity = {
+  IN_SCENARIO: '#InScenario',
+  REVIEWING_DEBRIEF: '#ReviewingDebrief',
+  EDITING_PACK: '#EditingPack',
+  AT_MAIN_MENU: '#AtMainMenu',
+} as const
+
+export type SteamActivityValue = (typeof SteamActivity)[keyof typeof SteamActivity]
+
+// ── Hook ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Returns a `setPresence` callback that updates the player's Steam rich
+ * presence to a generic activity token.
+ *
+ * - In a browser context (no `window.__TAURI__`) returns `false` immediately
+ *   without throwing.
+ * - In the Tauri shell, delegates to the `steam_set_rich_presence` command,
+ *   which is a no-op when Steam is absent or the `steam` Cargo feature is off.
+ *
+ * Call this when the player navigates to a new major screen. Do NOT include
+ * session-specific content (scenario title, NPC name, turn count, etc.).
+ */
+export function useSteamRichPresence() {
+  const setPresence = useCallback(
+    async (activity: SteamActivityValue): Promise<boolean> => {
+      const tauri = (window as TauriWindow).__TAURI__
+      if (!tauri?.core) return false
+      return tauri.core
+        .invoke<boolean>('steam_set_rich_presence', { value: activity })
+        .catch(() => false)
+    },
+    [],
+  )
+
+  return { setPresence }
+}

--- a/docs/steam-achievements-stats-rich-presence.md
+++ b/docs/steam-achievements-stats-rich-presence.md
@@ -1,0 +1,164 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+# Steam Achievements, Stats, and Rich Presence
+
+> **Roadmap item 48.** This document is the Steamworks configuration companion
+> to the implementation in `apps/desktop/src-tauri/src/steam.rs` and the
+> `useSteamAchievements` / `useSteamRichPresence` React hooks.
+>
+> Privacy guarantee: **no conversation content, transcript text, or session
+> details are ever sent to Steam.** Only aggregate integer counts and generic
+> activity tokens are transmitted — and only when the Steamworks SDK is active
+> and the player is running inside Steam.
+
+---
+
+## Achievements
+
+Configure these in the **Steamworks App Admin → Achievements** tab.
+
+| Display name | API name | Unlock condition |
+|---|---|---|
+| First Scenario | `ACH_FIRST_SCENARIO` | Player completes their first conversation scenario (session ends normally or is manually ended). |
+| First Debrief | `ACH_FIRST_DEBRIEF` | Player views their first generated debrief screen. |
+| Practice Streak | `ACH_PRACTICE_STREAK` | Player completes scenarios on three or more consecutive calendar days. |
+| Pack Explorer | `ACH_PACK_EXPLORER` | Player plays a scenario from at least three different packs. |
+| Creator First Validate | `ACH_CREATOR_FIRST_VALIDATE` | Player successfully validates their first custom scenario pack in the creator workbench. |
+
+### Steamworks settings for each achievement
+
+- **Hidden:** set to `true` for `ACH_PRACTICE_STREAK` and `ACH_PACK_EXPLORER`
+  (reveal on unlock so players discover them organically).
+- **Global unlock percentage:** visible; Valve computes this automatically.
+- **Icon:** 64×64 px and 32×32 px locked/unlocked pairs required. See
+  `publishing/STEAM_ASSETS_SPEC.md` for the art spec.
+
+### Unlock call site
+
+The front-end calls `useSteamAchievements().unlock(SteamAchievement.<NAME>)` at
+the appropriate event boundary. The Tauri command `steam_unlock_achievement`
+forwards the call to `steamworks::UserStats::achievement(name).set()` followed
+by `store_stats()`. The call is a no-op when Steam is absent.
+
+---
+
+## Stats
+
+Configure these in the **Steamworks App Admin → Stats** tab. All stats are
+**INT** type and **monotonically increasing** (never decremented).
+
+| Display name | API name | Increment event |
+|---|---|---|
+| Scenarios Completed | `STAT_SCENARIOS_COMPLETED` | Session ends (player ends a scenario or it completes naturally). |
+| Debriefs Generated | `STAT_DEBRIEFS_GENERATED` | Debrief screen is displayed with generated content. |
+| Packs Validated | `STAT_PACKS_VALIDATED` | Creator workbench reports a successful `validate-pack` run. |
+| Text Mode Sessions | `STAT_TEXT_MODE_SESSIONS` | Session starts in text input mode. |
+| Voice Mode Sessions | `STAT_VOICE_MODE_SESSIONS` | Session starts in voice input mode. |
+
+### Privacy constraint
+
+Stats store **only counts** — no content. A stat value of `7` means "7
+scenarios completed"; it reveals nothing about which scenarios, what was said,
+or who the NPCs were. This matches the project's local-first, no-telemetry
+commitment and the requirement stated in `docs/steam-mvp-scope.md`.
+
+### Increment call site
+
+The front-end calls
+`useSteamAchievements().incrementStat(SteamStat.<NAME>)` at the relevant
+event. The Tauri command `steam_increment_stat` reads the current value,
+increments by 1, writes it back, and calls `store_stats()`. The call is a
+no-op when Steam is absent.
+
+---
+
+## Rich Presence
+
+Configure rich presence localization in the **Steamworks App Admin → Rich
+Presence** tab under the app's Steam client localization settings.
+
+The integration uses a single key (`steam_display`) whose value is a
+localization token. The tokens and their suggested English display strings are:
+
+| Token | Suggested display string |
+|---|---|
+| `#InScenario` | `In a practice scenario` |
+| `#ReviewingDebrief` | `Reviewing a debrief` |
+| `#EditingPack` | `Editing a scenario pack` |
+| `#AtMainMenu` | `Browsing scenarios` |
+
+Upload a localization file (`richpresence.vdf`) to the Steamworks portal for
+each supported language. Example English file:
+
+```vdf
+"lang"
+{
+    "Language" "english"
+    "Tokens"
+    {
+        "#InScenario"       "In a practice scenario"
+        "#ReviewingDebrief" "Reviewing a debrief"
+        "#EditingPack"      "Editing a scenario pack"
+        "#AtMainMenu"       "Browsing scenarios"
+    }
+}
+```
+
+### Privacy constraint
+
+Tokens reveal **only the category of activity** — never the scenario title,
+NPC name, conversation topic, turn count, or any other session detail.
+
+### Set call site
+
+The front-end calls
+`useSteamRichPresence().setPresence(SteamActivity.<TOKEN>)` when the player
+navigates to a new major screen. The Tauri command `steam_set_rich_presence`
+forwards the call to `steamworks::Friends::set_rich_presence(key, value)`.
+The call is a no-op when Steam is absent.
+
+Suggested call sites in the React screens:
+
+| Screen | Token to set |
+|---|---|
+| `screens/Home` / `screens/ScenarioLibrary` | `SteamActivity.AT_MAIN_MENU` |
+| `screens/Conversation` | `SteamActivity.IN_SCENARIO` |
+| `screens/Debrief` | `SteamActivity.REVIEWING_DEBRIEF` |
+| `screens/CreatorWorkbench` | `SteamActivity.EDITING_PACK` |
+
+---
+
+## Graceful fallback outside Steam
+
+All three features (achievements, stats, rich presence) are implemented as
+graceful no-ops when:
+
+- The `steam` Cargo feature is disabled (the default; builds without the
+  Steamworks SDK).
+- The `steam` feature is enabled but `steamworks::Client::init()` fails
+  (Steam not running, wrong AppID, or SDK not installed).
+- The front-end runs in a browser context (no `window.__TAURI__`).
+
+The `SteamRuntime` struct always exists in managed state; its methods simply
+return `false` in all fallback cases without logging errors or throwing.
+
+The Tauri commands (`steam_unlock_achievement`, `steam_increment_stat`,
+`steam_set_rich_presence`) can be invoked freely on any build; callers do not
+need to check `SteamStatus.is_steam_enabled` first.
+
+---
+
+## Steamworks configuration checklist
+
+Use this checklist before the Stage 4 gate (public Steam release):
+
+- [ ] All five achievements created in App Admin with correct API names.
+- [ ] Locked and unlocked icons uploaded for all five achievements.
+- [ ] Hidden flag set for `ACH_PRACTICE_STREAK` and `ACH_PACK_EXPLORER`.
+- [ ] All five stats created in App Admin as INT type.
+- [ ] Rich presence localization file uploaded for English.
+- [ ] Rich presence localization files uploaded for any additional launch
+      languages.
+- [ ] End-to-end test: run with `SteamAppId=480 cargo tauri dev --features steam`,
+      trigger each unlock event, confirm the Steam overlay shows the achievement
+      notification and the stats increment.
+- [ ] Confirm no session content appears in any Steam-facing string.


### PR DESCRIPTION
## Summary

Add Steam achievements, stats, and rich presence to make practice progression legible to players via platform features while preserving privacy. All stats are aggregate-only integer counts with no session details, transcript content, or PII stored.

Also includes a bug fix: the initial implementation had API type mismatches that would cause build failures when compiling with the `steam` feature enabled (as required for actual Steam releases). These have been corrected.

## Changes

### Rust – Achievements, Stats, and Rich Presence
- **`steam::achievements`**: Five achievement API names (`ACH_FIRST_SCENARIO`, `ACH_FIRST_DEBRIEF`, `ACH_PRACTICE_STREAK`, `ACH_PACK_EXPLORER`, `ACH_CREATOR_FIRST_VALIDATE`)
- **`steam::stats`**: Five aggregate-only stat constants (`STAT_SCENARIOS_COMPLETED`, `STAT_DEBRIEFS_GENERATED`, `STAT_PACKS_VALIDATED`, `STAT_TEXT_MODE_SESSIONS`, `STAT_VOICE_MODE_SESSIONS`)
- **`steam::rich_presence`**: Activity tokens revealing only category (`#InScenario`, `#ReviewingDebrief`, `#EditingPack`, `#AtMainMenu`) — never session names or transcript content
- **`SteamRuntime` struct**: Holds the live `steamworks::Client` and exposes three methods:
  - `unlock_achievement(api_name)`: Returns `false` gracefully when Steam is unavailable or feature is off
  - `increment_stat(api_name)`: Same graceful fallback
  - `set_rich_presence(token)`: Same graceful fallback
- **`steam::init()` return type**: Now returns `(SteamStatus, SteamRuntime)` so the client stays alive for the process lifetime
- **Tauri integration**: Three commands registered in `lib.rs` via `SteamRuntimeState`: `steam_unlock_achievement`, `steam_increment_stat`, `steam_set_rich_presence`

### TypeScript Hooks
- **`useSteamAchievements`**: Exports achievement and stat constants; hook returns `unlock(name)` and `incrementStat(name)` callbacks (both return `false` without throwing outside Steam context)
- **`useSteamRichPresence`**: Exports activity tokens; hook returns `setPresence(token)` callback (returns `false` without throwing outside Steam)

### Tests
- **`useSteamAchievements.test.ts`**: 26 Vitest tests covering non-Tauri fallback, IPC routing for all five achievements and stats, error resilience, constant shapes
- **`useSteamRichPresence.test.ts`**: Tests covering non-Tauri fallback, IPC routing for all four activity tokens, error resilience, constant shapes
- **Rust unit tests**: Updated to unpack the new `(SteamStatus, SteamRuntime)` return type; added 6 new tests for API name prefixes and graceful no-op behavior

### Documentation
- **`docs/steam-achievements-stats-rich-presence.md`**: Steamworks portal configuration guide with achievement/stat tables, privacy rationale, rich presence localization example (`richpresence.vdf`), call-site recommendations, and pre-launch checklist

### Bug Fix
Fixed three steamworks 0.11 API type mismatches that caused build failures when compiling with `--features steam`:
- `UserStats::stat_i32` → `get_stat_i32` (returns `Result<i32, ()>`)
- `AchievementHelper::set()` returns `Result<(), ()>` not `bool` → use `.is_ok()`
- `UserStats::set_stat_i32` returns `Result<(), ()>` not `bool` → use `.is_ok()`

(These errors were not caught by CI because `cargo check` runs without the `steam` feature.)

## Verification

- All 26 new Vitest tests pass
- All 7 existing `useSteamStatus` tests continue to pass
- Graceful fallback confirmed: without `--features steam`, all three commands return `false`; TypeScript hooks return `false` in jsdom
- Verified API fixes against steamworks 0.11 docs

Closes #230