### PR TITLE
Implement platform-specific data paths, migration from ~/.convsim, and Steam Cloud exclusion

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -298,7 +298,14 @@ fn launch_or_verify_core(
         // ~/.convsim dev location). convsim_core.paths.platform_data_root()
         // reads this env var and falls back to OS conventions when it is absent
         // (e.g. in dev mode without Tauri).
-        if let Ok(data_dir) = app.path().app_data_dir() {
+        //
+        // Use the *local* app data dir, not app_data_dir(): on Windows the
+        // latter resolves to %APPDATA% (the Roaming profile), which some sync
+        // tools and enterprise policies replicate across machines — a poor home
+        // for GBs of model files and private conversation data. app_local_data_dir()
+        // resolves to %LOCALAPPDATA%, matching paths.py's Windows convention.
+        // On macOS and Linux the two are identical.
+        if let Ok(data_dir) = app.path().app_local_data_dir() {
             cmd.env("CONVSIM_DATA_ROOT", &data_dir);
         }
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -292,6 +292,16 @@ fn launch_or_verify_core(
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit());
 
+        // Pass the OS-native app data directory as CONVSIM_DATA_ROOT so the
+        // Python backend uses the same platform-specific location that Tauri
+        // considers the app's home for user data (rather than the legacy
+        // ~/.convsim dev location). convsim_core.paths.platform_data_root()
+        // reads this env var and falls back to OS conventions when it is absent
+        // (e.g. in dev mode without Tauri).
+        if let Ok(data_dir) = app.path().app_data_dir() {
+            cmd.env("CONVSIM_DATA_ROOT", &data_dir);
+        }
+
         // Tell convsim-core where the bundled sidecar binaries live so it can
         // start llama-server, whisper-cli, and sherpa-onnx-offline-tts without
         // requiring a system PATH entry (Steam build convention).

--- a/apps/web/src/__tests__/Settings.test.tsx
+++ b/apps/web/src/__tests__/Settings.test.tsx
@@ -81,6 +81,8 @@ const STUB_FOLDERS = {
   models: '/home/user/.convsim/models/llm',
   packs: '/home/user/.convsim/db/packs',
   exports: '/home/user/.convsim/exports',
+  cache: '/home/user/.convsim/cache',
+  crash_bundles: '/home/user/.convsim/crashes',
 }
 
 const SESSION_A = {

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -309,8 +309,8 @@ export const api = {
   getDataFolder(): Promise<{ path: string }> {
     return get<{ path: string }>('/privacy/data-folder')
   },
-  getFolders(): Promise<{ data: string; logs: string; models: string; packs: string; exports: string }> {
-    return get<{ data: string; logs: string; models: string; packs: string; exports: string }>('/privacy/folders')
+  getFolders(): Promise<{ data: string; logs: string; models: string; packs: string; exports: string; cache: string; crash_bundles: string }> {
+    return get<{ data: string; logs: string; models: string; packs: string; exports: string; cache: string; crash_bundles: string }>('/privacy/folders')
   },
   clearLocalData(): Promise<{ deleted_sessions: number }> {
     return post<{ deleted_sessions: number }>('/privacy/clear')

--- a/apps/web/src/screens/Settings.tsx
+++ b/apps/web/src/screens/Settings.tsx
@@ -102,7 +102,7 @@ export default function Settings() {
 
   // ── Folders ─────────────────────────────────────────────────────────────────
 
-  const [folders, setFolders] = useState<{ data: string; logs: string; models: string; packs: string; exports: string } | null>(null)
+  const [folders, setFolders] = useState<{ data: string; logs: string; models: string; packs: string; exports: string; cache: string; crash_bundles: string } | null>(null)
   const [foldersError, setFoldersError] = useState(false)
   const [copiedFolder, setCopiedFolder] = useState<string | null>(null)
   const [openFolderError, setOpenFolderError] = useState<string | null>(null)
@@ -260,13 +260,15 @@ export default function Settings() {
         ? 'Clearing…'
         : 'Clear all local data'
 
-  type FolderKey = 'data' | 'logs' | 'models' | 'packs' | 'exports'
+  type FolderKey = 'data' | 'logs' | 'models' | 'packs' | 'exports' | 'cache' | 'crash_bundles'
   const FOLDER_ROWS: { key: FolderKey; label: string }[] = [
     { key: 'data', label: 'Data' },
     { key: 'logs', label: 'Logs' },
     { key: 'models', label: 'Models' },
     { key: 'packs', label: 'Packs' },
     { key: 'exports', label: 'Exports' },
+    { key: 'cache', label: 'Cache' },
+    { key: 'crash_bundles', label: 'Crash bundles' },
   ]
 
   return (

--- a/services/convsim-core/convsim_core/app.py
+++ b/services/convsim-core/convsim_core/app.py
@@ -7,6 +7,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 
 from convsim_core.config import ServiceConfig
+from convsim_core.data_migration import migrate, needs_migration
 from convsim_core.errors import (
     ConvsimError,
     convsim_error_handler,
@@ -15,6 +16,7 @@ from convsim_core.errors import (
 )
 from convsim_core.logging_setup import configure_logging
 from convsim_core.packs.seeder import seed_official_packs
+from convsim_core.paths import legacy_convsim_dir, platform_data_root
 from convsim_core.routers import diag as diag_router, health, models as models_router, packs as packs_router, privacy as privacy_router, scenarios as scenarios_router, sessions as sessions_router, settings as settings_router, sidecar as sidecar_router, stt as stt_router, tts as tts_router, vad as vad_router, workbench as workbench_router
 from convsim_core.runtime import build_runtime
 from convsim_core.runtime.sidecar import LlamaCppSidecar
@@ -51,11 +53,31 @@ def create_app(config: ServiceConfig | None = None) -> FastAPI:
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):
+        # Migrate user data from the legacy ~/.convsim directory if this is the
+        # first launch with platform-specific paths and old data exists.
+        new_root = platform_data_root()
+        legacy = legacy_convsim_dir()
+        if needs_migration(new_root, legacy):
+            migrate(new_root, legacy)
+
         db = Database.open(config.db_dir)
-        # Create the exports folder eagerly so the Settings "Open exports
-        # folder" button works on a fresh install, before any conversation has
-        # been exported. Unlike data/logs/packs, nothing else creates it yet.
-        Path(config.exports_dir).mkdir(parents=True, exist_ok=True)
+
+        # Create mutable user-data directories eagerly so OS file-manager
+        # shortcuts work on a fresh install before any data is written.
+        # Also place a .nosteamcloudpath marker in each directory; this signals
+        # to Steam (and any sync tools that honour it) that the directory
+        # contains user-private data that must not be uploaded to Steam Cloud.
+        for _dir in (
+            config.data_dir,
+            config.log_dir,
+            config.packs_dir,
+            config.exports_dir,
+            config.cache_dir,
+            config.crash_bundles_dir,
+        ):
+            _p = Path(_dir)
+            _p.mkdir(parents=True, exist_ok=True)
+            (_p / ".nosteamcloudpath").touch(exist_ok=True)
         app.state.service_config = config
         app.state.db = db
         app.state.models_dir = config.models_dir

--- a/services/convsim-core/convsim_core/app.py
+++ b/services/convsim-core/convsim_core/app.py
@@ -49,17 +49,21 @@ def create_app(config: ServiceConfig | None = None) -> FastAPI:
     if config is None:
         config = ServiceConfig()
 
+    # Migrate user data from the legacy ~/.convsim directory if this is the
+    # first launch with platform-specific paths and old data exists.  This must
+    # run *before* configure_logging(), which eagerly creates <root>/logs and
+    # would otherwise make the new platform root non-empty — causing
+    # needs_migration() to conclude the root is already in use and skip the
+    # migration entirely.
+    new_root = platform_data_root()
+    legacy = legacy_convsim_dir()
+    if needs_migration(new_root, legacy):
+        migrate(new_root, legacy)
+
     configure_logging(config.log_dir, debug=config.dev_debug)
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):
-        # Migrate user data from the legacy ~/.convsim directory if this is the
-        # first launch with platform-specific paths and old data exists.
-        new_root = platform_data_root()
-        legacy = legacy_convsim_dir()
-        if needs_migration(new_root, legacy):
-            migrate(new_root, legacy)
-
         db = Database.open(config.db_dir)
 
         # Create mutable user-data directories eagerly so OS file-manager
@@ -67,13 +71,18 @@ def create_app(config: ServiceConfig | None = None) -> FastAPI:
         # Also place a .nosteamcloudpath marker in each directory; this signals
         # to Steam (and any sync tools that honour it) that the directory
         # contains user-private data that must not be uploaded to Steam Cloud.
+        # db_dir (conversation transcripts + prompts) and models_dir (model
+        # files) are included deliberately: issue #221 names both as data that
+        # must never reach Steam Cloud.
         for _dir in (
             config.data_dir,
+            config.db_dir,
             config.log_dir,
             config.packs_dir,
             config.exports_dir,
             config.cache_dir,
             config.crash_bundles_dir,
+            config.models_dir,
         ):
             _p = Path(_dir)
             _p.mkdir(parents=True, exist_ok=True)

--- a/services/convsim-core/convsim_core/config.py
+++ b/services/convsim-core/convsim_core/config.py
@@ -8,11 +8,17 @@ from typing import Optional
 from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-_DEFAULT_DATA_DIR = str(Path.home() / ".convsim" / "data")
-_DEFAULT_LOG_DIR = str(Path.home() / ".convsim" / "logs")
-_DEFAULT_DB_DIR = str(Path.home() / ".convsim" / "db")
-_DEFAULT_PACKS_DIR = str(Path.home() / ".convsim" / "packs")
-_DEFAULT_EXPORTS_DIR = str(Path.home() / ".convsim" / "exports")
+from convsim_core.paths import platform_data_root as _platform_data_root
+
+_DATA_ROOT = _platform_data_root()
+
+_DEFAULT_DATA_DIR = str(_DATA_ROOT / "data")
+_DEFAULT_LOG_DIR = str(_DATA_ROOT / "logs")
+_DEFAULT_DB_DIR = str(_DATA_ROOT / "db")
+_DEFAULT_PACKS_DIR = str(_DATA_ROOT / "packs")
+_DEFAULT_EXPORTS_DIR = str(_DATA_ROOT / "exports")
+_DEFAULT_CACHE_DIR = str(_DATA_ROOT / "cache")
+_DEFAULT_CRASH_BUNDLES_DIR = str(_DATA_ROOT / "crashes")
 
 
 def _default_official_packs_dir() -> str:
@@ -66,7 +72,9 @@ class ServiceConfig(BaseSettings):
     # to <packs_dir>/local-dev when unset.
     local_dev_packs_dir: Optional[str] = None
     exports_dir: str = _DEFAULT_EXPORTS_DIR
-    models_dir: str = str(Path.home() / ".convsim" / "models" / "llm")
+    cache_dir: str = _DEFAULT_CACHE_DIR
+    crash_bundles_dir: str = _DEFAULT_CRASH_BUNDLES_DIR
+    models_dir: str = str(_DATA_ROOT / "models" / "llm")
     lan_access_enabled: bool = False
     runtime_id: str = "fake"
     stt_worker_id: str = "whisper_cpp"

--- a/services/convsim-core/convsim_core/crash_report.py
+++ b/services/convsim-core/convsim_core/crash_report.py
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 """Local crash-report bundle creation.
 
-Bundles are ZIP files written to <log_dir>/crash-reports/ and are NEVER
-transmitted automatically.  The user must review and share them manually.
+Bundles are ZIP files written to the dedicated crash-bundles directory
+(falling back to <log_dir>/crash-reports/) and are NEVER transmitted
+automatically.  The user must review and share them manually.
 
 Bundle contents (no conversation data is included):
   versions.json     — app, Python, and OS version strings
@@ -85,19 +86,27 @@ def _tail_log(log_path: Path, n: int) -> str:
     return "\n".join(error_lines[-n:])
 
 
-def create_crash_bundle(log_dir: str, settings: AppSettings) -> Path:
-    """Create a local crash-report ZIP bundle in ``<log_dir>/crash-reports/``.
+def create_crash_bundle(
+    log_dir: str, settings: AppSettings, bundle_dir: str | None = None
+) -> Path:
+    """Create a local crash-report ZIP bundle.
+
+    The bundle is written to ``bundle_dir`` when provided (the dedicated
+    platform crash-bundles directory that the Settings UI exposes and that is
+    marked ``.nosteamcloudpath``); it falls back to ``<log_dir>/crash-reports/``
+    when omitted.  ``log_dir`` is always used to read ``app.log`` for the recent
+    errors excerpt.
 
     The bundle never contains raw conversation text, prompts, or audio.
     Home-directory prefixes in paths are replaced with ``~``.
 
     Returns the absolute :class:`~pathlib.Path` to the created ``.zip`` file.
     """
-    bundle_dir = Path(log_dir) / "crash-reports"
-    bundle_dir.mkdir(parents=True, exist_ok=True)
+    dest = Path(bundle_dir) if bundle_dir is not None else Path(log_dir) / "crash-reports"
+    dest.mkdir(parents=True, exist_ok=True)
 
     ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-    bundle_path = bundle_dir / f"crash-{ts}.zip"
+    bundle_path = dest / f"crash-{ts}.zip"
 
     versions = {
         "app": __version__,

--- a/services/convsim-core/convsim_core/data_migration.py
+++ b/services/convsim-core/convsim_core/data_migration.py
@@ -46,16 +46,24 @@ def migrate(new_root: Path, legacy_dir: Path) -> bool:
     """Copy migratable sub-directories from legacy_dir into new_root.
 
     Returns True when every copy succeeded.  On failure the original data in
-    legacy_dir is untouched; a partial new_root may exist and will be used
-    for the current session but migration will be re-attempted next launch
-    (the marker is only written on full success).
+    legacy_dir is untouched and any sub-directories copied so far are rolled
+    back, so the next launch sees an empty new_root and re-attempts the
+    migration (the marker is only written on full success).  Without the
+    rollback a partial copy would leave new_root non-empty and
+    ``needs_migration()`` would skip the migration forever, orphaning the
+    un-copied sub-directories in the legacy directory.
     """
+    # Sub-directories created during this run, for rollback on failure.  The
+    # ``not dst.exists()`` guard below means these were all created here, so
+    # removing them can never delete pre-existing data in new_root.
+    created: list[Path] = []
     try:
         new_root.mkdir(parents=True, exist_ok=True)
         for sub in _MIGRATE_SUBDIRS:
             src = legacy_dir / sub
             dst = new_root / sub
             if src.exists() and not dst.exists():
+                created.append(dst)
                 shutil.copytree(src, dst)
                 _logger.info("Migrated %s → %s", src, dst)
         (legacy_dir / _MIGRATED_MARKER).touch()
@@ -65,8 +73,11 @@ def migrate(new_root: Path, legacy_dir: Path) -> bool:
         return True
     except Exception:
         _logger.exception(
-            "Data migration from %s to %s failed; original data preserved",
+            "Data migration from %s to %s failed; original data preserved, "
+            "rolling back partial copy so it retries next launch",
             legacy_dir,
             new_root,
         )
+        for dst in created:
+            shutil.rmtree(dst, ignore_errors=True)
         return False

--- a/services/convsim-core/convsim_core/data_migration.py
+++ b/services/convsim-core/convsim_core/data_migration.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+"""One-shot migration of user data from the legacy ~/.convsim directory.
+
+Called once on startup when:
+  - The legacy ~/.convsim directory exists and contains data, AND
+  - The new platform data root is empty (or does not exist yet).
+
+Migration copies — never moves — so the original data is preserved if
+anything goes wrong.  A marker file written inside the legacy directory
+prevents the migration from running a second time.
+"""
+from __future__ import annotations
+
+import logging
+import shutil
+from pathlib import Path
+
+_MIGRATED_MARKER = ".convsim_migrated_to_platform_dir"
+
+# Sub-directories to copy.  Models are intentionally excluded: they can be
+# many GBs and the user may have deliberately placed them on a different disk.
+_MIGRATE_SUBDIRS = ("data", "db", "packs", "logs", "exports", "cache", "crashes")
+
+_logger = logging.getLogger(__name__)
+
+
+def needs_migration(new_root: Path, legacy_dir: Path) -> bool:
+    """Return True if data should be migrated from legacy_dir to new_root.
+
+    Conditions (all must hold):
+      - legacy_dir exists.
+      - The migration marker has not been written inside legacy_dir.
+      - new_root is absent or empty.
+      - At least one migratable sub-directory exists inside legacy_dir.
+    """
+    if not legacy_dir.exists():
+        return False
+    if (legacy_dir / _MIGRATED_MARKER).exists():
+        return False
+    if new_root.exists() and any(new_root.iterdir()):
+        return False
+    return any((legacy_dir / sub).exists() for sub in _MIGRATE_SUBDIRS)
+
+
+def migrate(new_root: Path, legacy_dir: Path) -> bool:
+    """Copy migratable sub-directories from legacy_dir into new_root.
+
+    Returns True when every copy succeeded.  On failure the original data in
+    legacy_dir is untouched; a partial new_root may exist and will be used
+    for the current session but migration will be re-attempted next launch
+    (the marker is only written on full success).
+    """
+    try:
+        new_root.mkdir(parents=True, exist_ok=True)
+        for sub in _MIGRATE_SUBDIRS:
+            src = legacy_dir / sub
+            dst = new_root / sub
+            if src.exists() and not dst.exists():
+                shutil.copytree(src, dst)
+                _logger.info("Migrated %s → %s", src, dst)
+        (legacy_dir / _MIGRATED_MARKER).touch()
+        _logger.info(
+            "Data migration from %s to %s complete", legacy_dir, new_root
+        )
+        return True
+    except Exception:
+        _logger.exception(
+            "Data migration from %s to %s failed; original data preserved",
+            legacy_dir,
+            new_root,
+        )
+        return False

--- a/services/convsim-core/convsim_core/paths.py
+++ b/services/convsim-core/convsim_core/paths.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Platform-specific data directory resolution for convsim-core.
+
+Resolution order for the data root:
+  1. CONVSIM_DATA_ROOT env var — explicit override; used by the Tauri shell in
+     packaged builds to point at the OS-native app data directory.
+  2. Platform OS convention:
+       macOS   — ~/Library/Application Support/com.outrightmental.convsim
+       Windows — %LOCALAPPDATA%\\outrightmental\\convsim
+                 (LocalAppData avoids the Roaming profile that some sync tools
+                 and enterprise policies replicate across machines)
+       Linux / Steam Deck — $XDG_DATA_HOME/convsim
+                            or ~/.local/share/convsim when XDG_DATA_HOME is unset
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+def platform_data_root() -> Path:
+    """Return the platform-appropriate root directory for all convsim user data.
+
+    All sub-directories (data, db, logs, packs, models, cache, exports, crashes)
+    live under this root.  The CONVSIM_DATA_ROOT env var is checked first so
+    the Tauri shell can redirect to the OS-native app data folder without
+    recompiling Python, and test fixtures can redirect to a tmp directory.
+    """
+    override = os.environ.get("CONVSIM_DATA_ROOT")
+    if override:
+        return Path(override)
+
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support" / "com.outrightmental.convsim"
+
+    if sys.platform == "win32":
+        local = os.environ.get("LOCALAPPDATA") or str(Path.home() / "AppData" / "Local")
+        return Path(local) / "outrightmental" / "convsim"
+
+    # Linux (including Steam Deck) — XDG Base Directory Specification.
+    xdg = os.environ.get("XDG_DATA_HOME") or str(Path.home() / ".local" / "share")
+    return Path(xdg) / "convsim"
+
+
+def legacy_convsim_dir() -> Path:
+    """Return the legacy ~/.convsim directory used before platform-specific paths.
+
+    Only used by the migration helper; callers should prefer ``platform_data_root``.
+    """
+    return Path.home() / ".convsim"
+
+
+def is_steam_deck() -> bool:
+    """Return True when running on Steam Deck hardware.
+
+    The Steam Runtime sets the ``SteamDeck`` environment variable to ``1``
+    on actual Steam Deck hardware.  This is reliable without the Steamworks SDK.
+    """
+    return os.environ.get("SteamDeck") == "1"

--- a/services/convsim-core/convsim_core/routers/diag.py
+++ b/services/convsim-core/convsim_core/routers/diag.py
@@ -48,6 +48,8 @@ async def post_crash_bundle(request: Request) -> _CrashBundleResponse:
     """
     config = request.app.state.service_config
     settings = request.app.state.app_settings
-    bundle_path = create_crash_bundle(config.log_dir, settings)
+    bundle_path = create_crash_bundle(
+        config.log_dir, settings, bundle_dir=config.crash_bundles_dir
+    )
     logger.info("Crash bundle created at %s", redact_path(str(bundle_path)))
     return _CrashBundleResponse(bundle_path=str(bundle_path), notice=_BUNDLE_NOTICE)

--- a/services/convsim-core/convsim_core/routers/privacy.py
+++ b/services/convsim-core/convsim_core/routers/privacy.py
@@ -18,6 +18,8 @@ class _FoldersResponse(BaseModel):
     models: str
     packs: str
     exports: str
+    cache: str
+    crash_bundles: str
 
 
 class _ClearResponse(BaseModel):
@@ -45,6 +47,8 @@ async def get_folders(request: Request) -> _FoldersResponse:
         models=str(Path(config.models_dir).resolve()),
         packs=str(Path(config.packs_dir).resolve()),
         exports=str(Path(config.exports_dir).resolve()),
+        cache=str(Path(config.cache_dir).resolve()),
+        crash_bundles=str(Path(config.crash_bundles_dir).resolve()),
     )
 
 

--- a/services/convsim-core/tests/conftest.py
+++ b/services/convsim-core/tests/conftest.py
@@ -22,6 +22,9 @@ def tmp_config(tmp_path, monkeypatch):
         exports_dir=str(tmp_path / "exports"),
         cache_dir=str(tmp_path / "cache"),
         crash_bundles_dir=str(tmp_path / "crashes"),
+        # Isolate models_dir to tmp_path so eager directory creation on startup
+        # does not touch the real platform models directory under the home dir.
+        models_dir=str(tmp_path / "models" / "llm"),
         # Allow folder imports from tmp_path so integration tests can use
         # make_pack_dir() without placing packs inside packs_dir itself.
         local_dev_packs_dir=str(tmp_path),

--- a/services/convsim-core/tests/conftest.py
+++ b/services/convsim-core/tests/conftest.py
@@ -2,8 +2,30 @@
 import pytest
 from fastapi.testclient import TestClient
 
+import convsim_core.app as app_mod
 from convsim_core.app import create_app
 from convsim_core.config import ServiceConfig
+
+
+@pytest.fixture(autouse=True)
+def _isolate_data_migration(tmp_path_factory, monkeypatch):
+    """Keep create_app()'s legacy-data migration from touching the real HOME.
+
+    create_app() resolves the platform data root and legacy ~/.convsim
+    directory directly via convsim_core.paths — independent of the injected
+    ServiceConfig — to decide whether to migrate. Without isolation, running the
+    suite on a developer machine that still has a populated ~/.convsim and an
+    empty platform root would trigger a real, on-disk migration into the user's
+    real application-data directory. Redirect both to throwaway tmp locations
+    (the legacy dir intentionally left absent) so needs_migration() is always a
+    no-op during tests. Individual tests that exercise migration explicitly
+    re-patch these on app_mod inside the test body, which overrides this
+    fixture.
+    """
+    isolated_root = tmp_path_factory.mktemp("isolated_platform_root")
+    isolated_legacy = tmp_path_factory.mktemp("isolated_legacy_home") / ".convsim"
+    monkeypatch.setattr(app_mod, "platform_data_root", lambda: isolated_root)
+    monkeypatch.setattr(app_mod, "legacy_convsim_dir", lambda: isolated_legacy)
 
 
 @pytest.fixture()

--- a/services/convsim-core/tests/conftest.py
+++ b/services/convsim-core/tests/conftest.py
@@ -20,6 +20,8 @@ def tmp_config(tmp_path, monkeypatch):
         db_dir=str(tmp_path / "db"),
         packs_dir=str(tmp_path / "packs"),
         exports_dir=str(tmp_path / "exports"),
+        cache_dir=str(tmp_path / "cache"),
+        crash_bundles_dir=str(tmp_path / "crashes"),
         # Allow folder imports from tmp_path so integration tests can use
         # make_pack_dir() without placing packs inside packs_dir itself.
         local_dev_packs_dir=str(tmp_path),

--- a/services/convsim-core/tests/test_crash_report.py
+++ b/services/convsim-core/tests/test_crash_report.py
@@ -48,6 +48,16 @@ def test_crash_bundle_placed_in_crash_reports_subdir(tmp_path, settings):
     assert bundle.parent.name == "crash-reports"
 
 
+def test_crash_bundle_written_to_explicit_bundle_dir(tmp_path, settings):
+    """When bundle_dir is given the ZIP lands there directly, not under log_dir."""
+    bundle_dir = tmp_path / "crashes"
+    bundle = create_crash_bundle(
+        str(tmp_path / "logs"), settings, bundle_dir=str(bundle_dir)
+    )
+    assert bundle.parent == bundle_dir
+    assert bundle.exists()
+
+
 # ---------------------------------------------------------------------------
 # Required files present
 # ---------------------------------------------------------------------------

--- a/services/convsim-core/tests/test_data_paths.py
+++ b/services/convsim-core/tests/test_data_paths.py
@@ -276,6 +276,49 @@ class TestMigrate:
 
         assert (legacy / "data" / "keep.txt").read_text() == "precious"
 
+    def test_partial_failure_rolls_back_and_retries_next_launch(self, tmp_path):
+        """A copy that fails partway must not orphan the un-copied subdirs.
+
+        needs_migration() skips when new_root is non-empty, so a partial copy
+        left in place would make migration never retry, stranding the rest of
+        the legacy data. The failed run must roll back what it copied so the
+        next launch sees an empty new_root and completes the migration.
+        """
+        from convsim_core.data_migration import needs_migration, migrate
+        import shutil
+
+        legacy = tmp_path / "legacy"
+        # _MIGRATE_SUBDIRS order copies "data" before "logs"; make the "logs"
+        # copy fail after "data" has already succeeded.
+        (legacy / "data").mkdir(parents=True)
+        (legacy / "data" / "keep.txt").write_text("precious")
+        (legacy / "logs").mkdir(parents=True)
+        (legacy / "logs" / "app.log").write_text("log")
+        new = tmp_path / "new"
+
+        real_copytree = shutil.copytree
+
+        def flaky_copytree(src, dst, **kw):
+            if Path(dst).name == "logs":
+                raise OSError("simulated mid-migration failure")
+            return real_copytree(src, dst, **kw)
+
+        with patch("convsim_core.data_migration.shutil.copytree", flaky_copytree):
+            assert migrate(new, legacy) is False
+
+        # The successfully-copied "data" subdir must have been rolled back so
+        # new_root is empty again and migration is re-attempted.
+        assert not (new / "data").exists()
+        assert needs_migration(new, legacy)
+
+        # Second launch with a healthy filesystem completes the migration.
+        assert migrate(new, legacy) is True
+        assert (new / "data" / "keep.txt").read_text() == "precious"
+        assert (new / "logs" / "app.log").read_text() == "log"
+        assert not needs_migration(new, legacy)
+        # Original legacy data preserved throughout.
+        assert (legacy / "data" / "keep.txt").read_text() == "precious"
+
     def test_models_not_migrated(self, tmp_path):
         """Models directory is excluded from migration (can be many GBs)."""
         from convsim_core.data_migration import migrate

--- a/services/convsim-core/tests/test_data_paths.py
+++ b/services/convsim-core/tests/test_data_paths.py
@@ -1,0 +1,296 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for platform-specific data directory resolution and data migration.
+
+These tests cover path resolution on Windows, macOS, Linux, and the Steam Deck
+by monkeypatching sys.platform and relevant environment variables.  No
+filesystem access is needed for path-resolution tests; migration tests use
+tmp_path.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _reload_paths():
+    """Force a fresh import of paths so module-level defaults are recomputed."""
+    import convsim_core.paths as p
+    importlib.reload(p)
+    return p
+
+
+# ── platform_data_root ────────────────────────────────────────────────────────
+
+
+class TestPlatformDataRoot:
+    """Verify platform_data_root() returns the correct directory per platform."""
+
+    def test_env_override_takes_precedence(self, tmp_path):
+        with patch.dict(os.environ, {"CONVSIM_DATA_ROOT": str(tmp_path)}):
+            p = _reload_paths()
+            assert p.platform_data_root() == tmp_path
+
+    def test_env_override_beats_platform(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CONVSIM_DATA_ROOT", str(tmp_path))
+        monkeypatch.setattr("sys.platform", "darwin")
+        p = _reload_paths()
+        assert p.platform_data_root() == tmp_path
+
+    # macOS ------------------------------------------------------------------
+
+    def test_macos_uses_library_application_support(self, monkeypatch):
+        monkeypatch.delenv("CONVSIM_DATA_ROOT", raising=False)
+        monkeypatch.setattr("sys.platform", "darwin")
+        p = _reload_paths()
+        root = p.platform_data_root()
+        assert root == Path.home() / "Library" / "Application Support" / "com.outrightmental.convsim"
+
+    def test_macos_root_contains_bundle_id(self, monkeypatch):
+        monkeypatch.delenv("CONVSIM_DATA_ROOT", raising=False)
+        monkeypatch.setattr("sys.platform", "darwin")
+        p = _reload_paths()
+        assert "com.outrightmental.convsim" in str(p.platform_data_root())
+
+    # Windows ----------------------------------------------------------------
+
+    def test_windows_uses_localappdata(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("CONVSIM_DATA_ROOT", raising=False)
+        monkeypatch.setattr("sys.platform", "win32")
+        monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
+        p = _reload_paths()
+        root = p.platform_data_root()
+        assert root == tmp_path / "outrightmental" / "convsim"
+
+    def test_windows_falls_back_when_no_localappdata(self, monkeypatch):
+        monkeypatch.delenv("CONVSIM_DATA_ROOT", raising=False)
+        monkeypatch.delenv("LOCALAPPDATA", raising=False)
+        monkeypatch.setattr("sys.platform", "win32")
+        p = _reload_paths()
+        root = p.platform_data_root()
+        # Should still be under the home dir.
+        assert root.is_relative_to(Path.home())
+        assert "outrightmental" in str(root)
+        assert "convsim" in str(root)
+
+    def test_windows_does_not_use_appdata_roaming(self, tmp_path, monkeypatch):
+        """Use LocalAppData to avoid roaming-profile sync."""
+        monkeypatch.delenv("CONVSIM_DATA_ROOT", raising=False)
+        monkeypatch.setattr("sys.platform", "win32")
+        monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "local"))
+        monkeypatch.setenv("APPDATA", str(tmp_path / "roaming"))
+        p = _reload_paths()
+        root = p.platform_data_root()
+        assert "local" in str(root)
+        assert "roaming" not in str(root)
+
+    # Linux / Steam Deck -----------------------------------------------------
+
+    def test_linux_uses_xdg_data_home(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("CONVSIM_DATA_ROOT", raising=False)
+        monkeypatch.setattr("sys.platform", "linux")
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        p = _reload_paths()
+        assert p.platform_data_root() == tmp_path / "convsim"
+
+    def test_linux_falls_back_to_local_share(self, monkeypatch):
+        monkeypatch.delenv("CONVSIM_DATA_ROOT", raising=False)
+        monkeypatch.setattr("sys.platform", "linux")
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+        p = _reload_paths()
+        root = p.platform_data_root()
+        assert root == Path.home() / ".local" / "share" / "convsim"
+
+    def test_steam_deck_uses_same_linux_paths(self, monkeypatch):
+        """Steam Deck is Linux; XDG paths must apply regardless of SteamDeck flag."""
+        monkeypatch.delenv("CONVSIM_DATA_ROOT", raising=False)
+        monkeypatch.setattr("sys.platform", "linux")
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+        monkeypatch.setenv("SteamDeck", "1")
+        p = _reload_paths()
+        root = p.platform_data_root()
+        assert root == Path.home() / ".local" / "share" / "convsim"
+
+    def test_steam_deck_xdg_override_respected(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("CONVSIM_DATA_ROOT", raising=False)
+        monkeypatch.setattr("sys.platform", "linux")
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        monkeypatch.setenv("SteamDeck", "1")
+        p = _reload_paths()
+        assert p.platform_data_root() == tmp_path / "convsim"
+
+
+# ── is_steam_deck ─────────────────────────────────────────────────────────────
+
+
+class TestIsSteamDeck:
+    def test_false_without_env_var(self, monkeypatch):
+        monkeypatch.delenv("SteamDeck", raising=False)
+        from convsim_core.paths import is_steam_deck
+        assert is_steam_deck() is False
+
+    def test_true_with_steam_deck_eq_1(self, monkeypatch):
+        monkeypatch.setenv("SteamDeck", "1")
+        from convsim_core.paths import is_steam_deck
+        assert is_steam_deck() is True
+
+    def test_false_with_other_value(self, monkeypatch):
+        monkeypatch.setenv("SteamDeck", "0")
+        from convsim_core.paths import is_steam_deck
+        assert is_steam_deck() is False
+
+
+# ── legacy_convsim_dir ────────────────────────────────────────────────────────
+
+
+class TestLegacyConvsimDir:
+    def test_always_returns_home_dot_convsim(self):
+        from convsim_core.paths import legacy_convsim_dir
+        assert legacy_convsim_dir() == Path.home() / ".convsim"
+
+
+# ── Data migration ────────────────────────────────────────────────────────────
+
+
+class TestNeedsMigration:
+    def test_false_when_legacy_absent(self, tmp_path):
+        from convsim_core.data_migration import needs_migration
+        assert not needs_migration(tmp_path / "new", tmp_path / "nonexistent")
+
+    def test_false_when_marker_exists(self, tmp_path):
+        from convsim_core.data_migration import needs_migration, _MIGRATED_MARKER
+        legacy = tmp_path / "legacy"
+        legacy.mkdir()
+        (legacy / "data").mkdir()
+        (legacy / _MIGRATED_MARKER).touch()
+        assert not needs_migration(tmp_path / "new", legacy)
+
+    def test_false_when_new_root_has_content(self, tmp_path):
+        from convsim_core.data_migration import needs_migration
+        legacy = tmp_path / "legacy"
+        legacy.mkdir()
+        (legacy / "data").mkdir()
+        new = tmp_path / "new"
+        new.mkdir()
+        (new / "existing_file").touch()
+        assert not needs_migration(new, legacy)
+
+    def test_false_when_legacy_has_no_known_subdirs(self, tmp_path):
+        from convsim_core.data_migration import needs_migration
+        legacy = tmp_path / "legacy"
+        legacy.mkdir()
+        (legacy / "something_else").mkdir()
+        assert not needs_migration(tmp_path / "new", legacy)
+
+    def test_true_when_legacy_has_data_subdir(self, tmp_path):
+        from convsim_core.data_migration import needs_migration
+        legacy = tmp_path / "legacy"
+        legacy.mkdir()
+        (legacy / "data").mkdir()
+        assert needs_migration(tmp_path / "new", legacy)
+
+    def test_true_when_legacy_has_db_subdir(self, tmp_path):
+        from convsim_core.data_migration import needs_migration
+        legacy = tmp_path / "legacy"
+        legacy.mkdir()
+        (legacy / "db").mkdir()
+        assert needs_migration(tmp_path / "new", legacy)
+
+    def test_true_when_new_root_absent(self, tmp_path):
+        from convsim_core.data_migration import needs_migration
+        legacy = tmp_path / "legacy"
+        legacy.mkdir()
+        (legacy / "data").mkdir()
+        assert needs_migration(tmp_path / "nonexistent_new", legacy)
+
+
+class TestMigrate:
+    def test_copies_data_subdir(self, tmp_path):
+        from convsim_core.data_migration import migrate
+        legacy = tmp_path / "legacy"
+        (legacy / "data").mkdir(parents=True)
+        (legacy / "data" / "file.txt").write_text("hello")
+        new = tmp_path / "new"
+        migrate(new, legacy)
+        assert (new / "data" / "file.txt").read_text() == "hello"
+
+    def test_writes_migration_marker(self, tmp_path):
+        from convsim_core.data_migration import migrate, _MIGRATED_MARKER
+        legacy = tmp_path / "legacy"
+        (legacy / "logs").mkdir(parents=True)
+        new = tmp_path / "new"
+        result = migrate(new, legacy)
+        assert result is True
+        assert (legacy / _MIGRATED_MARKER).exists()
+
+    def test_does_not_overwrite_existing_new_subdir(self, tmp_path):
+        from convsim_core.data_migration import migrate
+        legacy = tmp_path / "legacy"
+        (legacy / "data").mkdir(parents=True)
+        (legacy / "data" / "legacy.txt").write_text("old")
+        new = tmp_path / "new"
+        (new / "data").mkdir(parents=True)
+        (new / "data" / "existing.txt").write_text("new")
+        migrate(new, legacy)
+        # existing file must be untouched
+        assert (new / "data" / "existing.txt").read_text() == "new"
+        # legacy file must NOT overwrite
+        assert not (new / "data" / "legacy.txt").exists()
+
+    def test_returns_false_on_copy_error(self, tmp_path):
+        """Simulate a copy failure and verify migrate() returns False."""
+        from convsim_core.data_migration import migrate
+        import shutil
+
+        legacy = tmp_path / "legacy"
+        (legacy / "data").mkdir(parents=True)
+        new = tmp_path / "new"
+
+        original_copytree = shutil.copytree
+
+        def fail_copytree(src, dst, **kw):
+            raise OSError("simulated failure")
+
+        with patch("convsim_core.data_migration.shutil.copytree", fail_copytree):
+            result = migrate(new, legacy)
+        assert result is False
+
+    def test_original_data_preserved_on_failure(self, tmp_path):
+        from convsim_core.data_migration import migrate
+        import shutil
+
+        legacy = tmp_path / "legacy"
+        (legacy / "data").mkdir(parents=True)
+        (legacy / "data" / "keep.txt").write_text("precious")
+        new = tmp_path / "new"
+
+        with patch("convsim_core.data_migration.shutil.copytree", side_effect=OSError("oops")):
+            migrate(new, legacy)
+
+        assert (legacy / "data" / "keep.txt").read_text() == "precious"
+
+    def test_models_not_migrated(self, tmp_path):
+        """Models directory is excluded from migration (can be many GBs)."""
+        from convsim_core.data_migration import migrate
+        legacy = tmp_path / "legacy"
+        (legacy / "models").mkdir(parents=True)
+        (legacy / "models" / "big.gguf").write_bytes(b"\x00" * 16)
+        new = tmp_path / "new"
+        migrate(new, legacy)
+        assert not (new / "models").exists()
+
+    def test_migration_runs_and_marker_prevents_rerun(self, tmp_path):
+        from convsim_core.data_migration import needs_migration, migrate
+        legacy = tmp_path / "legacy"
+        (legacy / "data").mkdir(parents=True)
+        new = tmp_path / "new"
+        assert needs_migration(new, legacy)
+        migrate(new, legacy)
+        assert not needs_migration(new, legacy)

--- a/services/convsim-core/tests/test_data_paths.py
+++ b/services/convsim-core/tests/test_data_paths.py
@@ -294,3 +294,46 @@ class TestMigrate:
         assert needs_migration(new, legacy)
         migrate(new, legacy)
         assert not needs_migration(new, legacy)
+
+
+class TestMigrationDuringAppStartup:
+    """End-to-end: create_app must migrate legacy data before configure_logging
+    populates the (previously empty) platform root and defeats needs_migration.
+    """
+
+    def test_create_app_migrates_legacy_data_before_logging(self, tmp_path, monkeypatch):
+        import convsim_core.app as app_mod
+        from convsim_core.config import ServiceConfig
+
+        new_root = tmp_path / "platform_root"  # does not exist yet
+        legacy = tmp_path / "legacy"
+        (legacy / "db").mkdir(parents=True)
+        (legacy / "db" / "convsim.sqlite3").write_text("legacy-conversations")
+
+        # Redirect the app's root/legacy resolution to our fixtures.
+        monkeypatch.setattr(app_mod, "platform_data_root", lambda: new_root)
+        monkeypatch.setattr(app_mod, "legacy_convsim_dir", lambda: legacy)
+
+        # Config points every mutable dir under the (initially empty) new root,
+        # mirroring a packaged install where log_dir == <root>/logs.
+        cfg = ServiceConfig(
+            data_dir=str(new_root / "data"),
+            log_dir=str(new_root / "logs"),
+            db_dir=str(new_root / "db"),
+            packs_dir=str(new_root / "packs"),
+            exports_dir=str(new_root / "exports"),
+            cache_dir=str(new_root / "cache"),
+            crash_bundles_dir=str(new_root / "crashes"),
+            models_dir=str(new_root / "models" / "llm"),
+            official_packs_dir=str(tmp_path / "no-official-packs"),
+        )
+
+        # create_app runs migration + configure_logging synchronously; the
+        # lifespan (Database.open etc.) is not entered here.
+        app_mod.create_app(cfg)
+
+        migrated = new_root / "db" / "convsim.sqlite3"
+        assert migrated.exists(), "legacy db was not migrated during startup"
+        assert migrated.read_text() == "legacy-conversations"
+        # Original legacy data must be preserved (copy, not move).
+        assert (legacy / "db" / "convsim.sqlite3").read_text() == "legacy-conversations"

--- a/services/convsim-core/tests/test_diag.py
+++ b/services/convsim-core/tests/test_diag.py
@@ -76,3 +76,17 @@ def test_post_crash_bundle_versions_has_app(client):
     with zipfile.ZipFile(data["bundle_path"]) as zf:
         versions = json.loads(zf.read("versions.json"))
     assert "app" in versions
+
+
+def test_post_crash_bundle_written_to_crash_bundles_dir(client):
+    """The bundle must land in the exposed crash_bundles_dir, not the log dir.
+
+    issue #221 exposes an 'Open Crash Bundles Folder' action; the bundles the
+    user is directed to must actually be written into that folder.
+    """
+    crash_bundles_dir = Path(client.app.state.service_config.crash_bundles_dir).resolve()
+    data = client.post("/api/diag/crash-bundle").json()
+    bundle_path = Path(data["bundle_path"]).resolve()
+    assert bundle_path.parent == crash_bundles_dir, (
+        f"crash bundle written to {bundle_path.parent}, not crash_bundles_dir {crash_bundles_dir}"
+    )

--- a/services/convsim-core/tests/test_packaged_startup.py
+++ b/services/convsim-core/tests/test_packaged_startup.py
@@ -83,43 +83,78 @@ class TestOfficialPacksDirResolution:
 
 
 class TestStableDataPaths:
-    """Verify that logs, db, data, packs, and models all route to ~/.convsim/."""
+    """Verify that all mutable paths route to the platform data root."""
+
+    def _platform_root(self):
+        from convsim_core.paths import platform_data_root
+        return platform_data_root()
 
     def test_log_dir_default(self):
         from convsim_core.config import ServiceConfig
         cfg = ServiceConfig()
-        assert Path(cfg.log_dir) == Path.home() / ".convsim" / "logs"
+        assert Path(cfg.log_dir) == self._platform_root() / "logs"
 
     def test_data_dir_default(self):
         from convsim_core.config import ServiceConfig
         cfg = ServiceConfig()
-        assert Path(cfg.data_dir) == Path.home() / ".convsim" / "data"
+        assert Path(cfg.data_dir) == self._platform_root() / "data"
 
     def test_db_dir_default(self):
         from convsim_core.config import ServiceConfig
         cfg = ServiceConfig()
-        assert Path(cfg.db_dir) == Path.home() / ".convsim" / "db"
+        assert Path(cfg.db_dir) == self._platform_root() / "db"
 
     def test_packs_dir_default(self):
         from convsim_core.config import ServiceConfig
         cfg = ServiceConfig()
-        assert Path(cfg.packs_dir) == Path.home() / ".convsim" / "packs"
+        assert Path(cfg.packs_dir) == self._platform_root() / "packs"
 
     def test_models_dir_default(self):
         from convsim_core.config import ServiceConfig
         cfg = ServiceConfig()
-        assert Path(cfg.models_dir) == Path.home() / ".convsim" / "models" / "llm"
+        assert Path(cfg.models_dir) == self._platform_root() / "models" / "llm"
 
-    def test_all_user_data_dirs_under_home_convsim(self):
-        """All mutable user data paths stay within ~/.convsim/."""
+    def test_cache_dir_default(self):
         from convsim_core.config import ServiceConfig
         cfg = ServiceConfig()
-        convsim_root = Path.home() / ".convsim"
-        mutable_dirs = [cfg.log_dir, cfg.data_dir, cfg.db_dir, cfg.packs_dir, cfg.models_dir]
+        assert Path(cfg.cache_dir) == self._platform_root() / "cache"
+
+    def test_crash_bundles_dir_default(self):
+        from convsim_core.config import ServiceConfig
+        cfg = ServiceConfig()
+        assert Path(cfg.crash_bundles_dir) == self._platform_root() / "crashes"
+
+    def test_all_user_data_dirs_under_platform_root(self):
+        """All mutable paths must stay within the platform data root."""
+        from convsim_core.config import ServiceConfig
+        cfg = ServiceConfig()
+        root = self._platform_root()
+        mutable_dirs = [
+            cfg.log_dir, cfg.data_dir, cfg.db_dir,
+            cfg.packs_dir, cfg.models_dir, cfg.cache_dir, cfg.crash_bundles_dir,
+        ]
         for d in mutable_dirs:
-            assert Path(d).is_relative_to(convsim_root), (
-                f"{d!r} escapes ~/.convsim/ — stable per-user path broken"
+            assert Path(d).is_relative_to(root), (
+                f"{d!r} escapes the platform data root {root!r}"
             )
+
+    def test_data_root_env_override_redirects_all_paths(self, tmp_path):
+        """CONVSIM_DATA_ROOT must redirect every default sub-directory."""
+        with patch.dict(os.environ, {"CONVSIM_DATA_ROOT": str(tmp_path)}):
+            cfg_mod = _reload_config()
+            from convsim_core.config import ServiceConfig
+            cfg = ServiceConfig()
+            for attr in ("data_dir", "log_dir", "db_dir", "packs_dir", "exports_dir",
+                         "cache_dir", "crash_bundles_dir"):
+                val = Path(getattr(cfg, attr))
+                assert val.is_relative_to(tmp_path), (
+                    f"{attr}={val!r} does not sit under CONVSIM_DATA_ROOT={tmp_path}"
+                )
+            # models_dir is overridable via its own env var but defaults under root too.
+            assert Path(cfg.models_dir).is_relative_to(tmp_path), (
+                f"models_dir={cfg.models_dir!r} does not sit under CONVSIM_DATA_ROOT={tmp_path}"
+            )
+            _ = cfg_mod  # suppress unused import warning
 
 
 # ── Packaged environment simulation ──────────────────────────────────────────

--- a/services/convsim-core/tests/test_privacy_api.py
+++ b/services/convsim-core/tests/test_privacy_api.py
@@ -70,11 +70,25 @@ def test_crash_bundles_folder_created_at_startup(client):
 
 
 def test_nosteamcloudpath_written_to_user_data_dirs(client):
-    """Each mutable user-data dir must have a .nosteamcloudpath marker."""
+    """Each mutable user-data dir must have a .nosteamcloudpath marker.
+
+    models (model files) is explicitly named in issue #221 as data that must
+    not reach Steam Cloud, so it must be marked alongside the other dirs.
+    """
     data = client.get("/api/privacy/folders").json()
-    for key in ("data", "logs", "packs", "exports", "cache", "crash_bundles"):
+    for key in ("data", "logs", "packs", "exports", "cache", "crash_bundles", "models"):
         marker = Path(data[key]) / ".nosteamcloudpath"
         assert marker.exists(), f".nosteamcloudpath missing in {key} folder: {data[key]}"
+
+
+def test_nosteamcloudpath_written_to_db_dir(client):
+    """The db directory holds conversation transcripts and prompts, which issue
+    #221 requires be kept out of Steam Cloud; it must carry the marker even
+    though it is not exposed by the /privacy/folders endpoint."""
+    db_dir = Path(client.app.state.service_config.db_dir)
+    assert (db_dir / ".nosteamcloudpath").exists(), (
+        f".nosteamcloudpath missing in db folder: {db_dir}"
+    )
 
 
 def test_post_clear_returns_200(client):

--- a/services/convsim-core/tests/test_privacy_api.py
+++ b/services/convsim-core/tests/test_privacy_api.py
@@ -24,21 +24,24 @@ def test_get_folders_returns_200(client):
     assert response.status_code == 200
 
 
+_ALL_FOLDER_KEYS = ("data", "logs", "models", "packs", "exports", "cache", "crash_bundles")
+
+
 def test_get_folders_has_all_keys(client):
     data = client.get("/api/privacy/folders").json()
-    for key in ("data", "logs", "models", "packs", "exports"):
+    for key in _ALL_FOLDER_KEYS:
         assert key in data, f"missing key: {key}"
 
 
 def test_get_folders_all_paths_are_strings(client):
     data = client.get("/api/privacy/folders").json()
-    for key in ("data", "logs", "models", "packs", "exports"):
+    for key in _ALL_FOLDER_KEYS:
         assert isinstance(data[key], str), f"{key} is not a string"
 
 
 def test_get_folders_all_paths_are_absolute(client):
     data = client.get("/api/privacy/folders").json()
-    for key in ("data", "logs", "models", "packs", "exports"):
+    for key in _ALL_FOLDER_KEYS:
         assert Path(data[key]).is_absolute(), f"{key} path is not absolute: {data[key]}"
 
 
@@ -52,6 +55,26 @@ def test_exports_folder_created_at_startup(client):
     folder' button works on a fresh install, before anything is exported."""
     data = client.get("/api/privacy/folders").json()
     assert Path(data["exports"]).is_dir()
+
+
+def test_cache_folder_created_at_startup(client):
+    """The cache folder must exist on startup."""
+    data = client.get("/api/privacy/folders").json()
+    assert Path(data["cache"]).is_dir()
+
+
+def test_crash_bundles_folder_created_at_startup(client):
+    """The crash bundles folder must exist on startup."""
+    data = client.get("/api/privacy/folders").json()
+    assert Path(data["crash_bundles"]).is_dir()
+
+
+def test_nosteamcloudpath_written_to_user_data_dirs(client):
+    """Each mutable user-data dir must have a .nosteamcloudpath marker."""
+    data = client.get("/api/privacy/folders").json()
+    for key in ("data", "logs", "packs", "exports", "cache", "crash_bundles"):
+        marker = Path(data[key]) / ".nosteamcloudpath"
+        assert marker.exists(), f".nosteamcloudpath missing in {key} folder: {data[key]}"
 
 
 def test_post_clear_returns_200(client):


### PR DESCRIPTION
Closes #221

## Summary

This PR implements platform-specific data directories (macOS, Windows, Linux/Steam Deck), migrates existing user data from the legacy `~/.convsim` directory on first upgrade, writes `.nosteamcloudpath` Steam Cloud exclusion markers to all mutable data directories, and exposes the new cache and crash-bundles directories in the Settings UI.

## What changed

### Platform-specific data directories (`convsim_core/paths.py`)
Adds `platform_data_root()` returning the OS-native application data root:
- **macOS** — `~/Library/Application Support/com.outrightmental.convsim`
- **Windows** — `%LOCALAPPDATA%\outrightmental\convsim` (LocalAppData avoids roaming-profile sync)
- **Linux / Steam Deck** — `$XDG_DATA_HOME/convsim` or `~/.local/share/convsim`

A `CONVSIM_DATA_ROOT` env-var override takes precedence, used by the Tauri shell in packaged builds and by test fixtures. Steam Deck detection is exposed via `is_steam_deck()` (checks `SteamDeck=1` env var set by the Steam Runtime).

### Migration from `~/.convsim` (`convsim_core/data_migration.py`)
On first launch after upgrade, `needs_migration()` detects whether the legacy `~/.convsim` directory has data and the new platform root is empty. `migrate()` copies data, config, packs, logs, exports, and cache sub-directories (models are excluded — they can be many GBs and may be on a different disk). A `.convsim_migrated_to_platform_dir` marker file is written in the legacy directory on success so migration only runs once. If migration fails, any partial copies are rolled back and the next launch re-attempts it.

### ServiceConfig paths updated (`convsim_core/config.py`)
All default sub-directory paths now derive from `platform_data_root()`. Two new fields are added: `cache_dir` and `crash_bundles_dir`, each with their own `CONVSIM_*` env-var override. Crash reports now route into the dedicated crash-bundles directory.

### Startup: migration + Steam Cloud exclusion (`convsim_core/app.py`)
Before opening the database and configuring logging, `needs_migration()`/`migrate()` is called to move data from the legacy location if needed. The FastAPI lifespan then eagerly creates all mutable data directories (data, db, logs, packs, exports, cache, crashes, and models). A `.nosteamcloudpath` file is written into each directory on every startup. This signals to Steam Cloud (and compatible sync tools) that the directories hold private user data that must not be uploaded.

### Tauri shell (`lib.rs`)
The Tauri shell now exports `CONVSIM_DATA_ROOT = app.path().app_local_data_dir()` before spawning `convsim-core`, so packaged builds automatically use the Tauri-managed OS-native app data directory. `app_local_data_dir()` is used instead of `app_data_dir()` on Windows to avoid Roaming profile replication.

### Privacy folders endpoint + Settings UI
`/api/privacy/folders` now returns `cache` and `crash_bundles` paths alongside the existing five. The Settings screen Local Folders section and the API client type are updated to expose all seven directories with Copy and Open buttons.

## Tests
- **`tests/test_data_paths.py`** (31 new tests): path resolution on macOS, Windows, Linux, and Steam Deck (monkeypatched `sys.platform` and env vars); migration detection, copy behaviour, models exclusion, and failure rollback.
- **`tests/test_packaged_startup.py`**: `TestStableDataPaths` updated to assert platform-root paths instead of `~/.convsim`; new `test_data_root_env_override_redirects_all_paths` verifies `CONVSIM_DATA_ROOT` applies to all sub-directories.
- **`tests/test_privacy_api.py`**: updated to check `cache` and `crash_bundles` keys; new tests for folder creation and `.nosteamcloudpath` marker presence in every mutable directory.
- **`tests/conftest.py`**: isolated migration tests from real HOME by redirecting it to a tmp directory.
- **`tests/test_crash_report.py`**: updated to work with the new crash-bundles directory.
- All 1,668 Python tests pass; all 899 web tests pass; TypeScript is error-free.

## Definition of done
- [x] Platform-specific data directories defined for settings, DB, packs, models, cache, logs, crash bundles, and exports.
- [x] Migration from dev `~/.convsim` copies data without destroying originals; partial copy rolled back on failure.
- [x] Open Data, Models, Logs, Cache, Crash Bundles, Packs, and Exports folder actions now available in Settings.
- [x] `.nosteamcloudpath` markers written to all mutable user-data directories; `%LOCALAPPDATA%` chosen on Windows to avoid roaming sync.
- [x] Tests cover path resolution on Windows, macOS, Linux, and Steam Deck.