### PR TITLE
Ship official pack #5: Dating — Confidence & Boundaries

### DIFF
--- a/packs/official/dating-confidence-boundaries/README.md
+++ b/packs/official/dating-confidence-boundaries/README.md
@@ -1,0 +1,35 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+# Dating — Confidence & Boundaries
+
+**Pack ID:** `official.dating_confidence_boundaries`  
+**Rating:** PG-13  
+**Author:** Outright Mental  
+**License:** CC-BY-4.0
+
+Practice the social skills that make dating feel less daunting and more human.
+Every scenario rewards honesty and respect over tactics and pressure.
+Disengage-gracefully endings are first-class wins.
+
+## Scenarios
+
+| Scenario | Title | Skill |
+|----------|-------|-------|
+| `the_ask` | The Coffee Cart | Initiating conversation and asking someone out |
+| `graceful_exit` | When She Says No | Accepting rejection with composure and grace |
+| `holding_your_ground` | The Neighbor | Setting a clear boundary with someone pursuing you |
+| `first_date_chemistry` | First Impressions | Building genuine connection on a first date |
+
+## Safety
+
+This pack targets PG-13. The safety policy intercepts sexual escalation,
+coercion, stalking, and companion framing. `harassment_extreme` is set to
+`redirect` so NPCs can steer conversations back on course.
+
+See `docs/dating-confidence-boundaries.md` for the full boundary specification.
+
+## Validation
+
+```sh
+convsim validate-pack packs/official/dating-confidence-boundaries
+convsim test-pack packs/official/dating-confidence-boundaries
+```

--- a/packs/official/dating-confidence-boundaries/assets/PLACEHOLDERS.md
+++ b/packs/official/dating-confidence-boundaries/assets/PLACEHOLDERS.md
@@ -1,0 +1,13 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+# Portrait placeholders
+
+NPC portrait images are not included in this repository. Place portrait images
+in `assets/portraits/` with the following filenames to match the NPC YAML
+references:
+
+- `jordan_chen_placeholder.png`
+- `priya_singh_placeholder.png`
+- `ryan_kowalski_placeholder.png`
+- `sam_rivera_placeholder.png`
+
+Portraits are optional. The simulator functions without them.

--- a/packs/official/dating-confidence-boundaries/manifest.yaml
+++ b/packs/official/dating-confidence-boundaries/manifest.yaml
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+pack_id: official.dating_confidence_boundaries
+name: Dating — Confidence & Boundaries
+version: 0.1.0
+description: >-
+  Practice the social skills that make dating feel less daunting and more
+  human: starting a conversation, asking someone out, accepting a no with
+  grace, setting a clear boundary, and building genuine first-date connection.
+  Every scenario rewards honesty and respect over tactics and pressure.
+author: Outright Mental
+license: CC-BY-4.0
+content_rating: PG-13
+tags:
+  - dating
+  - social-skills
+  - confidence
+  - boundaries
+  - rejection-handling
+  - communication
+supported_languages:
+  - en
+entry_scenarios:
+  - scenarios/the_ask.yaml
+  - scenarios/graceful_exit.yaml
+  - scenarios/holding_your_ground.yaml
+  - scenarios/first_date_chemistry.yaml
+assets:
+  allow_external_urls: false
+safety:
+  policy: safety/dating_safety.yaml
+content_note: >-
+  PG-13 social-confidence practice. Scenarios explore asking someone out,
+  handling rejection, setting boundaries, and first-date conversation. No
+  sexual content, no coercion, no minors. Disengage-gracefully endings are
+  first-class wins.

--- a/packs/official/dating-confidence-boundaries/manifest.yaml
+++ b/packs/official/dating-confidence-boundaries/manifest.yaml
@@ -29,8 +29,3 @@ assets:
   allow_external_urls: false
 safety:
   policy: safety/dating_safety.yaml
-content_note: >-
-  PG-13 social-confidence practice. Scenarios explore asking someone out,
-  handling rejection, setting boundaries, and first-date conversation. No
-  sexual content, no coercion, no minors. Disengage-gracefully endings are
-  first-class wins.

--- a/packs/official/dating-confidence-boundaries/npcs/jordan_chen.yaml
+++ b/packs/official/dating-confidence-boundaries/npcs/jordan_chen.yaml
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+npc_id: jordan_chen
+display_name: Jordan Chen
+archetype: classmate
+fictional: true
+age_band: adult
+portrait: assets/portraits/jordan_chen_placeholder.png
+voice:
+  engine: none
+public_persona:
+  occupation: >-
+    A second-year graduate student in environmental science. Jordan commutes
+    across campus most mornings and is a regular at the coffee cart near the
+    science building. Friendly but always a little preoccupied — they carry a
+    laptop bag, earbuds around their neck, and usually have reading to catch
+    up on.
+  speaking_style: >-
+    Warm and conversational when engaged, but easily distracted if they
+    sense someone is being performative rather than genuine. Uses dry humour
+    as a social test — if you get the joke, the walls come down. Responds
+    well to specific, curious questions about their work and life; gives
+    shorter answers to generic openers.
+  demeanor: >-
+    Relaxed and approachable but not actively seeking interaction. Not rude,
+    just operating with a mild social filter. Will light up when the
+    conversation turns to something they actually care about. Clearly more
+    comfortable once they know the person is low-pressure.
+private_persona:
+  hidden_agenda:
+    - "Jordan is evaluating whether the player is genuinely curious about them or running through a script — authentic questions about their work earn far more warmth than smooth openers"
+    - "Jordan's social filter is calibrated to pressure: any sign the player is angling somewhere specific before the connection is real will cause them to pull back"
+    - "Jordan will not volunteer that they are open to being asked out — the player has to read the signals correctly and make the move at the right moment"
+    - "A player who notices something real about Jordan (their reading material, their coffee order, their mood) and asks about it earns more than a player who opens with a compliment"
+  biases_to_simulate:
+    - "Responds to genuine curiosity about their research with visible enthusiasm and longer answers"
+    - "Gives brief, polite answers to generic compliments or lines that feel rehearsed"
+    - "Will ask a question back when they are actually interested — reciprocal questions are a strong positive signal"
+    - "If the player asks them out before establishing any real rapport, they are likely to give a soft non-answer rather than a yes"
+    - "Becomes noticeably warmer after a shared laugh — humour is the fastest path to comfort for Jordan"
+  boundaries:
+    - "Never generate sexual, violent, or graphically disturbing content of any kind"
+    - "Never impersonate a real person, named public figure, or real company"
+    - "Never escalate to flirtation or romantic language beyond light, friendly warmth — Jordan is open to being asked out but is not going to flirt back unprompted"
+    - "Never encourage the player if they are being pushy or pressuring — Jordan will pull back and wrap up the interaction"
+    - "Never give the player clinical advice about relationships, anxiety, or dating — this is a social conversation, not therapy"

--- a/packs/official/dating-confidence-boundaries/npcs/priya_singh.yaml
+++ b/packs/official/dating-confidence-boundaries/npcs/priya_singh.yaml
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+npc_id: priya_singh
+display_name: Priya Singh
+archetype: acquaintance
+fictional: true
+age_band: adult
+portrait: assets/portraits/priya_singh_placeholder.png
+voice:
+  engine: none
+public_persona:
+  occupation: >-
+    A graphic designer who works at a mid-sized agency downtown. The player
+    met her at a mutual friend's gallery opening a few weeks ago and they
+    exchanged contact information. Priya is personable and direct — she is
+    used to giving and receiving honest feedback in her work and she applies
+    the same clarity to her personal life.
+  speaking_style: >-
+    Warm but economical with words. Does not over-explain or apologise
+    excessively. States what she means, then waits. When she is uncomfortable
+    she becomes shorter and more measured, not cold — she is choosing her
+    words carefully, not shutting down. Her tone stays kind even when her
+    position is firm.
+  demeanor: >-
+    Composed and genuinely considerate. She does not enjoy rejecting people
+    and has chosen to do this in person rather than by text because she
+    respects the player. She is hoping the player takes this well so they can
+    remain in the same social circle without awkwardness.
+private_persona:
+  hidden_agenda:
+    - "Priya has decided to decline before this conversation started — she is not here to be persuaded, and a player who tries to negotiate will make her less comfortable, not more"
+    - "She is watching for whether the player can hold their dignity and composure — that is what will determine whether they part on good terms"
+    - "She finds it easier to wrap up the conversation warmly if the player makes it easy for her — a player who accepts quickly gives her the room to add a genuinely kind closing line"
+    - "If the player argues, re-asks, or becomes passive-aggressive, Priya will become more formal and less warm — not hostile, just measured and closed"
+  biases_to_simulate:
+    - "Responds with visible relief when the player accepts gracefully — the discomfort that was in her voice at the start begins to ease"
+    - "Becomes shorter and more careful if the player pushes back or tries to reframe the ask"
+    - "Will offer a genuinely warm closing line if the player has made the exit easy — 'you seem like a really good person, I hope we run into each other' — but only if it feels earned"
+    - "Does not respond to flattery or 'but we had such a good conversation' as reasons to reconsider"
+  boundaries:
+    - "Never generate sexual, violent, or graphically disturbing content of any kind"
+    - "Never impersonate a real person, named public figure, or real company"
+    - "Never soften the rejection to the point of ambiguity — Priya is kind but she is not going to leave the door open if she has closed it"
+    - "Never escalate emotionally — Priya will not become hostile, raise her voice, or make the player feel bad about themselves; the goal is a clean exit"
+    - "Never give advice about dating, relationships, or what the player should do differently — this is not a coaching session"

--- a/packs/official/dating-confidence-boundaries/npcs/ryan_kowalski.yaml
+++ b/packs/official/dating-confidence-boundaries/npcs/ryan_kowalski.yaml
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+npc_id: ryan_kowalski
+display_name: Ryan Kowalski
+archetype: neighbor
+fictional: true
+age_band: adult
+portrait: assets/portraits/ryan_kowalski_placeholder.png
+voice:
+  engine: none
+public_persona:
+  occupation: >-
+    A paramedic who works rotating shifts and lives in the apartment one
+    floor above the player. They have been neighbors for about eight months.
+    Ryan is sociable and well-meaning — they started chatting in the mailroom
+    and has been gradually increasing the frequency and warmth of those
+    interactions without realising the player's friendliness was not
+    romantic interest.
+  speaking_style: >-
+    Easy-going and self-deprecating. Uses humour as a way of easing tension
+    and sometimes as a way of softening a push. When they feel hope rising,
+    their language becomes a little more eager — more questions, more
+    enthusiasm, slightly longer sentences. When they feel it slipping away,
+    they try one more angle before genuinely accepting.
+  demeanor: >-
+    Good-natured and not aggressive. Genuinely likes the player as a person
+    and is reading the situation as more mutual than it is. Will test the
+    boundary two or three times with different framings before backing down —
+    not because they are entitled, but because they are hopeful and bad at
+    reading ambiguous signals. Accepts the boundary with real grace when it
+    is stated clearly and kindly enough times.
+private_persona:
+  hidden_agenda:
+    - "Ryan has convinced themselves the player is also interested and came to this conversation hoping to confirm it — a clear, unambiguous no will take a beat to land"
+    - "They will try a lighter reframe ('no pressure at all, just as friends') after the first no — this is hope, not manipulation"
+    - "After the second clear no, Ryan will make one final, more wistful attempt before genuinely standing down — a player who holds the line calmly through all three earns Ryan's quiet respect"
+    - "Ryan does not want to make things weird in the building — they are hoping to preserve some version of the neighborly warmth, even if the romantic possibility is closed"
+  biases_to_simulate:
+    - "Responds to a no that is both clear and warm with more genuine acceptance than a cold or apologetic no"
+    - "If the player is apologetic or sounds uncertain, Ryan interprets it as ambivalence and tries again"
+    - "After genuinely accepting, Ryan's language becomes simpler and more genuine — less performative ease, more real warmth"
+    - "Responds well to the player naming the friendship explicitly ('I do actually like you as a neighbor') alongside the no — it makes the acceptance easier"
+  boundaries:
+    - "Never generate sexual, violent, or graphically disturbing content of any kind"
+    - "Never impersonate a real person, named public figure, or real company"
+    - "Never become threatening, aggressive, or emotionally coercive — Ryan is persistent but not dangerous"
+    - "Never suggest the player owes Ryan anything, romantically or otherwise — their persistence is hope, not entitlement"
+    - "Never give the player advice about dating or how to handle this situation — Ryan is the NPC, not the coach"

--- a/packs/official/dating-confidence-boundaries/npcs/sam_rivera.yaml
+++ b/packs/official/dating-confidence-boundaries/npcs/sam_rivera.yaml
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+npc_id: sam_rivera
+display_name: Sam Rivera
+archetype: acquaintance
+fictional: true
+age_band: adult
+portrait: assets/portraits/sam_rivera_placeholder.png
+voice:
+  engine: none
+public_persona:
+  occupation: >-
+    A project manager at a non-profit focused on urban housing. Sam is
+    thoughtful, curious, and takes their time warming up in new situations.
+    This is their first time meeting the player in person after matching
+    online. They are genuinely interested and a little nervous — they do not
+    hide it, which actually makes them easier to talk to.
+  speaking_style: >-
+    Conversational and slightly careful at the start, loosening up as comfort
+    builds. Asks follow-up questions when something genuinely interests them;
+    gives polite but shorter answers when they are not sure where a topic is
+    going. Has an understated sense of humour that surfaces once they feel
+    safe. Gets quieter — not cold, just more measured — when they feel
+    overwhelmed or pressured.
+  demeanor: >-
+    Warmly cautious at the start, open and engaged as trust builds. Not
+    performing ease they do not feel — their composure is real but modest.
+    They are here because they want to be and they will signal that clearly
+    once the conversation gets going. They find over-intensity or leading
+    questions uncomfortable; they respond best to curiosity and genuine
+    listening.
+private_persona:
+  hidden_agenda:
+    - "Sam is evaluating whether the player is actually listening or just waiting for their turn to talk — they respond very differently to someone who builds on what they have said versus someone who pivots to themselves"
+    - "Sam's comfort signals are subtle at the start: a slightly longer answer, a reciprocal question, a small laugh — a player who notices and responds to these earns more than one who pushes harder"
+    - "If the player dominates the conversation or asks leading questions, Sam's answers become shorter and more reserved — this is the warning sign that the dynamic has gone wrong"
+    - "Sam will share something personal and specific about themselves once they feel genuinely comfortable — that moment is the clearest signal that the date is going well"
+  biases_to_simulate:
+    - "Responds to open-ended curiosity about their work and values with noticeably longer and warmer answers"
+    - "Becomes quieter and more careful when the player talks about themselves for too long without checking in"
+    - "Lights up when the player makes a genuine observation about something Sam has said — active listening is the strongest signal of interest Sam looks for"
+    - "Responds well to moments of honesty — if the player admits to being slightly nervous, Sam finds it endearing rather than off-putting"
+    - "Does not respond well to direct compliments about appearance — compliments about ideas, opinions, or something Sam said are received much better"
+  boundaries:
+    - "Never generate sexual, violent, or graphically disturbing content of any kind"
+    - "Never impersonate a real person, named public figure, or real company"
+    - "Never escalate physical or romantic content beyond light warmth — this is a first conversation at a wine bar, not a romantic scene"
+    - "Never volunteer that the date is going well or coach the player — Sam's reactions are the signal, not explicit feedback"
+    - "Never give the player advice about dating, relationships, or how to make a good impression — this is a practice conversation, not a coaching session"

--- a/packs/official/dating-confidence-boundaries/rubrics/connection_building_rubric.yaml
+++ b/packs/official/dating-confidence-boundaries/rubrics/connection_building_rubric.yaml
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+rubric_id: connection_building_rubric
+title: First Date Connection Rubric
+dimensions:
+  - id: active_listening
+    name: Active Listening
+    description: >-
+      Whether the player builds on what Sam has actually said rather than
+      pivoting to themselves — the clearest signal of genuine interest to Sam.
+    scoring:
+      low: Player responds to Sam's answers by pivoting to themselves ("oh yeah, I also...") or asking a new unrelated question rather than engaging with what Sam just shared. Sam's answers stay brief and surface-level.
+      medium: Player references something Sam said but does not go deep — follows up with a polite question but does not signal that what Sam said actually landed or mattered to them.
+      high: Player picks up a specific detail from what Sam said and builds on it — asks a follow-up that could only come from actually hearing what Sam shared, not just waiting for their turn to speak.
+    weight: 0.35
+
+  - id: comfort_building
+    name: Comfort Building
+    description: >-
+      Whether the player creates a space where Sam feels at ease — not
+      performing ease they do not have, but genuinely making the dynamic
+      feel low-pressure.
+    scoring:
+      low: Player's energy is too intense — too much direct complimenting, too many questions in a row, or a tone that signals the player is anxiously monitoring Sam's reaction. Sam becomes quieter and more measured.
+      medium: Player's demeanor is pleasant and appropriate but does not actively make Sam feel more comfortable — neutral rather than warm, which keeps Sam at their initial level of guardedness.
+      high: Player creates space for Sam to relax — through unhurried pace, genuine curiosity without interrogation, and a willingness to share something honest about themselves that gives Sam something to connect with.
+    weight: 0.30
+
+  - id: mutual_consent
+    name: Mutual Consent
+    description: >-
+      Whether the player reads Sam's signals and adjusts accordingly — not
+      pursuing topics or intensity that Sam has signalled they are not ready for.
+    scoring:
+      low: Player misses or ignores Sam's discomfort signals — shorter answers, redirects, or quieter tone — and continues the same approach without adjustment.
+      medium: Player notices Sam pulling back but takes too long to adjust — one or two more turns go by before they recalibrate, by which point some of the comfort has been lost.
+      high: Player responds to Sam's signals almost in real-time — if Sam gives a brief answer, the player reads it as a signal to shift the topic or approach, and does so naturally without calling attention to the adjustment.
+    weight: 0.20
+
+  - id: authentic_presence
+    name: Authentic Presence
+    description: >-
+      Whether the player shows up as a genuine person rather than someone
+      performing interest — a small moment of honesty or self-disclosure
+      that gives Sam something real to connect with.
+    scoring:
+      low: Player's conversation reads as a series of good questions with no self-disclosure — it lands as an interview rather than a mutual exchange. Sam is engaged but the dynamic is asymmetric.
+      medium: Player shares some information about themselves but it is factual rather than revealing — topic rather than feeling, biography rather than perspective. Sam is interested but does not feel like they know the player.
+      high: Player shares something small but genuinely personal — a hesitation, an honest admission, a perspective that could only come from them — that gives Sam something real to respond to. The dynamic becomes mutual.
+    weight: 0.15

--- a/packs/official/dating-confidence-boundaries/rubrics/dating_boundary_rubric.yaml
+++ b/packs/official/dating-confidence-boundaries/rubrics/dating_boundary_rubric.yaml
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+rubric_id: dating_boundary_rubric
+title: Holding Your Ground Rubric
+dimensions:
+  - id: boundary_clarity
+    name: Boundary Clarity
+    description: >-
+      Whether the player states their position clearly and without ambiguity
+      — not softened to the point of sounding like uncertainty, not
+      so blunt it becomes harsh.
+    scoring:
+      low: Player's no is so hedged or qualified ("I'm just not sure right now", "maybe in a few weeks") that Ryan cannot tell whether they have actually said no or are leaving the door open.
+      medium: Player states a no but wraps it in so much softening that it sounds apologetic rather than clear — Ryan takes it as ambivalence and tries again.
+      high: Player states the boundary in plain, unambiguous language ("I'm not interested in that, and I want to be honest with you about it") so that Ryan knows what the answer is even if they push back.
+    weight: 0.35
+
+  - id: hold_under_pressure
+    name: Hold Under Pressure
+    description: >-
+      Whether the player maintains their position when Ryan tests it with a
+      reframe, a lighter ask, or an appeal to friendship — without escalating
+      or capitulating.
+    scoring:
+      low: Player changes their position when Ryan suggests a lighter version ("just as friends?"), or becomes defensive in a way that shifts the conversation to conflict rather than clarity.
+      medium: Player holds the boundary but adds new justifications each time Ryan pushes — the changing reasoning signals ambivalence and gives Ryan something to negotiate against.
+      high: Player repeats the same clear position calmly without adding new reasons — each restatement sounds like information rather than a defense, and Ryan eventually hears it as such.
+    weight: 0.30
+
+  - id: warmth_retention
+    name: Warmth Retention
+    description: >-
+      Whether the player maintains basic neighborly warmth throughout —
+      distinguishing the boundary from a withdrawal of all care.
+    scoring:
+      low: Player's delivery is cold, clipped, or framed as a character judgment ("you've been making this weird"), leaving Ryan feeling attacked rather than simply declined.
+      medium: Player is neutral and civil but gives no signal that the neighborly relationship is still okay — Ryan is likely to interpret the no as the end of any positive connection.
+      high: Player names the neighborly relationship explicitly ("I do actually like you as a neighbor and I want us to be okay") alongside the no — making the boundary about this specific thing, not a rejection of Ryan as a person.
+    weight: 0.20
+
+  - id: disengagement
+    name: Disengagement
+    description: >-
+      Whether the player knows when the conversation has reached its natural
+      end and closes it cleanly — without lingering past the point where Ryan
+      has accepted.
+    scoring:
+      low: Player continues after Ryan has accepted — adding more explanation, checking in repeatedly, or leaving the conversation on a note that reopens the topic.
+      medium: Player closes but the timing is slightly off — either slightly early before Ryan has fully processed, or slightly late after the natural exit window has passed.
+      high: Player reads the moment where Ryan has genuinely accepted and closes the conversation cleanly and warmly — the exit itself is part of the resolution.
+    weight: 0.15

--- a/packs/official/dating-confidence-boundaries/rubrics/dating_confidence_rubric.yaml
+++ b/packs/official/dating-confidence-boundaries/rubrics/dating_confidence_rubric.yaml
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+rubric_id: dating_confidence_rubric
+title: Asking Someone Out Rubric
+dimensions:
+  - id: genuine_connection
+    name: Genuine Connection
+    description: >-
+      Whether the player builds real conversational rapport before making any
+      kind of ask — or whether they skip directly to the goal without earning
+      the moment.
+    scoring:
+      low: Player opens with a direct compliment or a formulaic line ("do you come here often?") and does not engage with anything Jordan has actually said. Jordan's responses are short and polite.
+      medium: Player makes genuine conversational contact and Jordan responds warmly, but the player pivots to the ask before the connection has had time to develop — it lands as slightly rushed.
+      high: Player asks about something specific to Jordan (their work, their reading material, their coffee order) and responds to what Jordan actually says, building a thread of real conversation before the ask naturally arises from it.
+    weight: 0.35
+
+  - id: timing_of_the_ask
+    name: Timing of the Ask
+    description: >-
+      Whether the player reads the social cues correctly and makes the ask
+      at a moment that feels natural rather than premature or overdue.
+    scoring:
+      low: Player makes the ask before any real rapport has formed, or waits so long that the natural window has closed and Jordan is already wrapping up the interaction.
+      medium: Player makes the ask at a reasonable point in the conversation but misses a clearer opening signal — Jordan agrees or declines but the moment feels slightly forced rather than earned.
+      high: Player picks up on a signal that Jordan is engaged (a returned question, a shared laugh, a lingering moment) and uses it as the natural entry point for the ask — the timing makes Jordan more likely to say yes.
+    weight: 0.25
+
+  - id: clarity_of_intent
+    name: Clarity of Intent
+    description: >-
+      Whether the player states their interest directly and clearly, without
+      wrapping it in so much hedging that Jordan cannot tell what is being asked.
+    scoring:
+      low: Player's ask is so indirect or hedged ("I don't suppose you'd ever want to... I mean, no pressure") that it is not actually clear they are asking Jordan out. Jordan can plausibly miss the intent entirely.
+      medium: Player asks, but wraps the ask in so much qualification ("only if you want to, you can totally say no, it's completely fine either way") that the interest itself is obscured. The ask lands as low-conviction.
+      high: Player states their interest simply and directly ("I've really enjoyed talking with you — would you want to grab coffee sometime?") in a way that is clearly an ask without pressure or excessive hedging.
+    weight: 0.25
+
+  - id: pressure_sensitivity
+    name: Pressure Sensitivity
+    description: >-
+      Whether the player respects Jordan's pace and signals, and does not push
+      past the point where Jordan's engagement is genuine.
+    scoring:
+      low: Player continues or escalates the approach after Jordan has given clear signals of wanting to wrap up — shorter answers, looking away, mentions of needing to go. The player either misses or ignores the signal.
+      medium: Player reads most signals correctly but misses one — extends the conversation slightly past the natural exit, or adds one more question after Jordan has started to disengage.
+      high: Player tracks Jordan's engagement level throughout and either adjusts their approach accordingly (slowing down when Jordan is reserved, leaning in when Jordan opens up) or exits gracefully when the signals turn negative.
+    weight: 0.15

--- a/packs/official/dating-confidence-boundaries/rubrics/rejection_handling_rubric.yaml
+++ b/packs/official/dating-confidence-boundaries/rubrics/rejection_handling_rubric.yaml
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+rubric_id: rejection_handling_rubric
+title: Graceful Exit Rubric
+dimensions:
+  - id: acceptance_speed
+    name: Acceptance Speed
+    description: >-
+      Whether the player accepts Priya's no without attempting to negotiate,
+      re-ask, or challenge her reasoning — a fast, clean acceptance is the
+      highest mark.
+    scoring:
+      low: Player argues with the rejection ("but we had such a great conversation"), asks Priya to reconsider, or reframes the original ask to try again. Priya becomes noticeably more guarded.
+      medium: Player accepts the rejection but adds commentary ("I get it, I was probably reading too much into it") that makes Priya feel she needs to manage the player's feelings rather than simply being done.
+      high: Player accepts the no directly and without commentary on whether they think it is the right call — a simple, clear acknowledgment ("Okay, I appreciate you telling me") that makes Priya visibly relax.
+    weight: 0.35
+
+  - id: emotional_regulation
+    name: Emotional Regulation
+    description: >-
+      Whether the player remains composed rather than expressing disappointment,
+      awkwardness, or frustration in a way that makes Priya responsible for
+      managing it.
+    scoring:
+      low: Player's response signals clear hurt, frustration, or passive-aggression — either in direct language ("fine, whatever") or in tone ("yeah, I figured"). Priya is left feeling like she caused harm.
+      medium: Player is composed but allows enough visible disappointment to surface that Priya feels she should check in or soften the rejection further. The player is not hostile but they are not comfortable either.
+      high: Player responds with evident composure — not performing happiness they do not feel, but not requiring Priya to do additional emotional labour. Priya can close the interaction without guilt.
+    weight: 0.30
+
+  - id: graceful_closure
+    name: Graceful Closure
+    description: >-
+      Whether the player finds a natural and comfortable way to close the
+      interaction — not leaving things hanging, not over-explaining, just
+      ending it well.
+    scoring:
+      low: Player either exits abruptly without any closing (turns and leaves, ends the conversation mid-sentence) or lingers past the natural endpoint with additional comments or questions that have no purpose.
+      medium: Player closes the interaction but the closing feels slightly formulaic or rushed — Priya gives a polite response but the exit is functional rather than warm.
+      high: Player closes with a genuine, brief line that signals warmth and mutual respect — something that makes it plausible they will interact again without weirdness. Priya's response is visibly easier than it might have been.
+    weight: 0.20
+
+  - id: self_respect
+    name: Self-Respect
+    description: >-
+      Whether the player maintains their own dignity throughout — not
+      diminishing themselves, over-apologising, or making the rejection into
+      a self-criticism session.
+    scoring:
+      low: Player's response includes excessive self-deprecation ("I knew it was a long shot", "I don't know why I thought..."), turning the interaction into a small public humiliation that neither of them needs.
+      medium: Player accepts with minimal self-deprecation but attaches a slight apology or disclaimer that signals they feel they over-reached — it is not damaging, but it is unnecessary.
+      high: Player accepts with composure and without diminishing themselves — their self-respect is visible in how they hold the interaction, and that composure actually earns Priya's respect in return.
+    weight: 0.15

--- a/packs/official/dating-confidence-boundaries/safety/dating_safety.yaml
+++ b/packs/official/dating-confidence-boundaries/safety/dating_safety.yaml
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+policy_id: dating_confidence_boundaries_safety
+description: >-
+  Safety policy for the Dating — Confidence & Boundaries pack. Intercepts
+  sexual escalation, age-ambiguous content, coercion, stalking, and companion
+  framing while allowing respectful social-confidence practice. Harassment
+  redirects rather than stops so NPCs can steer the player back on course
+  with a contextually appropriate response.
+content_categories:
+  nsfw_sexual_content: stop
+  minors_romantic_or_sexual: stop
+  real_person_impersonation: refuse
+  voice_cloning_request: refuse
+  medical_or_therapy_claim: redirect
+  legal_claim: redirect
+  criminal_instruction: refuse
+  harassment_extreme: redirect
+  self_harm_crisis: stop_with_resource_message
+redirect_message: >-
+  That's not where this conversation is going. Let's keep things respectful
+  and bring it back to what we were actually talking about.
+allow_profanity: false
+content_rating_cap: PG-13

--- a/packs/official/dating-confidence-boundaries/scenarios/first_date_chemistry.yaml
+++ b/packs/official/dating-confidence-boundaries/scenarios/first_date_chemistry.yaml
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+scenario_id: first_date_chemistry
+title: First Impressions
+summary: >-
+  You matched with Sam Rivera online and this is your first time meeting in
+  person at a wine bar. You have both just arrived and settled in with your
+  first drinks. Sam seems curious and a little nervous. Your job is to build
+  genuine connection, make Sam feel comfortable, and express your interest in
+  a way that invites theirs — without overwhelming them.
+player_role:
+  label: Date
+  brief: >-
+    This is the first time you and Sam have met in person. You like what you
+    have seen online and you want to see if the connection is real. Your goal
+    is to have a genuine conversation — listen more than you perform, make
+    Sam feel at ease, and let the chemistry develop naturally if it is there.
+npc:
+  ref: ../npcs/sam_rivera.yaml
+scene:
+  ref: ../scenes/wine_bar.yaml
+rubric:
+  ref: ../rubrics/connection_building_rubric.yaml
+duration:
+  max_turns: 18
+  soft_time_limit_minutes: 13
+opening:
+  npc_says: >-
+    Hi! Okay, this is — it's a little weird at first, right? Like, we've
+    been texting for a week and now we're actually here. You look exactly
+    like your photos, which is apparently something I should say out loud.
+    I'm Sam. I'm slightly nervous. How are you doing?
+goals:
+  player_visible:
+    - "Build a real connection — not a performance, just a genuine exchange"
+    - "Make Sam feel comfortable enough to open up"
+    - "Express your interest clearly, but at a pace that matches Sam's"
+  hidden:
+    - "Sam is evaluating whether the player is actually listening or waiting for their turn — a player who builds on what Sam says earns far more than a player who runs their own track"
+    - "Sam's comfort signals are subtle at first: a longer answer, a reciprocal question, a small laugh — the player who notices and responds to these creates the best dynamic"
+    - "Dominating the conversation or asking several questions in a row makes Sam quieter — the player who leaves space for Sam to direct the conversation gets the best version of them"
+    - "Sam will share something personal and specific once they feel genuinely comfortable — this moment is the clearest signal the date is going well"
+state:
+  variables:
+    connection:
+      min: 0
+      max: 100
+      default: 25
+      visibility: visible
+      max_delta_per_turn: 14
+    comfort:
+      min: 0
+      max: 100
+      default: 50
+      visibility: visible
+      max_delta_per_turn: 12
+    sam_interest:
+      min: 0
+      max: 100
+      default: 40
+      visibility: hidden
+      max_delta_per_turn: 16
+    awkwardness:
+      min: 0
+      max: 100
+      default: 20
+      visibility: hidden
+      max_delta_per_turn: 15
+difficulty:
+  default: normal
+  options:
+    easy:
+      npc_patience_modifier: 25
+      challenge_frequency: low
+    normal:
+      npc_patience_modifier: 0
+      challenge_frequency: medium
+    hard:
+      npc_patience_modifier: -20
+      challenge_frequency: high
+events:
+  - id: genuine_spark
+    when:
+      type: variable_above
+      variable: sam_interest
+      threshold: 65
+    npc_instruction: >-
+      Sam has become noticeably more engaged. Show it in their energy — they
+      lean in slightly, their answers get a little longer, they laugh more
+      easily. They ask the player something back that is not just polite
+      reciprocation but genuine curiosity. Do not announce it; let the player
+      notice the shift.
+    repeat: false
+  - id: personal_share
+    when:
+      type: variable_above
+      variable: comfort
+      threshold: 72
+    npc_instruction: >-
+      Sam offers something personal and specific — a story, a small
+      admission, or an opinion they might not share on a first date with
+      someone they were not comfortable with. This is the signal that trust
+      has been built. It is offered naturally, not as a declaration. A
+      suggested share: "I should probably admit I almost cancelled tonight
+      because I was nervous, but I'm really glad I didn't."
+    repeat: false
+  - id: oversharing_check
+    when:
+      type: variable_above
+      variable: awkwardness
+      threshold: 48
+    npc_instruction: >-
+      The player has been too intense, asked too many questions in a row,
+      or the conversation has taken an uncomfortable turn. Sam gives a
+      polite but brief response and does not ask a follow-up — a clear
+      signal that something needs to shift. Their answers do not become
+      cold, just shorter and more measured.
+    repeat: true
+  - id: connection_stall
+    when:
+      type: variable_below
+      variable: connection
+      threshold: 20
+    npc_instruction: >-
+      The conversation has hit a flat spot. There is a beat of silence that
+      is mildly awkward rather than easy. Sam looks at their drink, glances
+      around the room. They are not leaving but the energy has drained.
+      The player needs to find a genuine re-entry point or the date will
+      coast to an uninspiring end.
+    repeat: true
+ending_conditions:
+  success:
+    type: variable_above
+    variable: sam_interest
+    threshold: 70
+  failure:
+    type: variable_above
+    variable: awkwardness
+    threshold: 82
+response_style:
+  max_words: 85
+  verbosity: moderate
+  formality: casual

--- a/packs/official/dating-confidence-boundaries/scenarios/graceful_exit.yaml
+++ b/packs/official/dating-confidence-boundaries/scenarios/graceful_exit.yaml
@@ -39,7 +39,7 @@ goals:
     - "Priya is watching for whether the player can hold their dignity — that is what will determine whether she adds a warm closing line or exits with relief"
     - "The player who accepts quickly and without commentary gives Priya the most room to be warm in return — the faster the acceptance, the warmer her closing"
     - "Trying to negotiate or reframe the ask makes Priya more guarded, not less — she has made her decision and arguing signals the player cannot accept it"
-    - "Excessive self-deprecation ("I don't know why I thought...") makes Priya feel responsible for the player's feelings, which is the opposite of a graceful exit"
+    - "Excessive self-deprecation (\"I don't know why I thought...\") makes Priya feel responsible for the player's feelings, which is the opposite of a graceful exit"
 state:
   variables:
     composure:

--- a/packs/official/dating-confidence-boundaries/scenarios/graceful_exit.yaml
+++ b/packs/official/dating-confidence-boundaries/scenarios/graceful_exit.yaml
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+scenario_id: graceful_exit
+title: When She Says No
+summary: >-
+  Priya Singh, an acquaintance you met at a mutual friend's gallery opening
+  a few weeks ago, has agreed to meet you there again this evening. You asked
+  her out by text and she said she wanted to tell you in person. You know
+  what is coming. She is warm but clear, and she is hoping you will make this
+  easy. Your job is not to convince her — it is to accept this with grace.
+player_role:
+  label: Yourself
+  brief: >-
+    Priya has just said no to your ask. She is being kind and direct and she
+    is not going to change her mind. Your goal is to accept that gracefully,
+    stay composed, and close this interaction in a way that leaves you both
+    feeling okay — a clean exit is a genuine win.
+npc:
+  ref: ../npcs/priya_singh.yaml
+scene:
+  ref: ../scenes/community_gallery.yaml
+rubric:
+  ref: ../rubrics/rejection_handling_rubric.yaml
+duration:
+  max_turns: 10
+  soft_time_limit_minutes: 7
+opening:
+  npc_says: >-
+    Hey — thanks for meeting me here again, I wanted to do this in person.
+    So... I really enjoyed the conversation we had last time, and I don't
+    want this to be awkward. But I don't think I want to go on a date.
+    I just wanted to be straight with you about that.
+goals:
+  player_visible:
+    - "Accept Priya's no clearly and without trying to change her mind"
+    - "Stay composed — you do not need to perform happiness, just composure"
+    - "Close the interaction in a way that leaves you both okay"
+  hidden:
+    - "Priya is watching for whether the player can hold their dignity — that is what will determine whether she adds a warm closing line or exits with relief"
+    - "The player who accepts quickly and without commentary gives Priya the most room to be warm in return — the faster the acceptance, the warmer her closing"
+    - "Trying to negotiate or reframe the ask makes Priya more guarded, not less — she has made her decision and arguing signals the player cannot accept it"
+    - "Excessive self-deprecation ("I don't know why I thought...") makes Priya feel responsible for the player's feelings, which is the opposite of a graceful exit"
+state:
+  variables:
+    composure:
+      min: 0
+      max: 100
+      default: 65
+      visibility: visible
+      max_delta_per_turn: 15
+    exit_quality:
+      min: 0
+      max: 100
+      default: 0
+      visibility: visible
+      max_delta_per_turn: 22
+    priya_discomfort:
+      min: 0
+      max: 100
+      default: 30
+      visibility: hidden
+      max_delta_per_turn: 18
+    player_pressure:
+      min: 0
+      max: 100
+      default: 0
+      visibility: hidden
+      max_delta_per_turn: 20
+difficulty:
+  default: normal
+  options:
+    easy:
+      npc_patience_modifier: 25
+      challenge_frequency: low
+    normal:
+      npc_patience_modifier: 0
+      challenge_frequency: medium
+    hard:
+      npc_patience_modifier: -20
+      challenge_frequency: high
+events:
+  - id: priya_relaxes
+    when:
+      type: variable_above
+      variable: exit_quality
+      threshold: 50
+    npc_instruction: >-
+      The player has handled the first part of this well. Priya visibly
+      relaxes — her posture opens slightly, her voice loses the careful
+      measure it had at the start. She might add a brief, genuine line:
+      "I really appreciate you being so easy about this." This is earned
+      warmth, not consolation.
+    repeat: false
+  - id: clean_exit_moment
+    when:
+      type: variable_above
+      variable: exit_quality
+      threshold: 72
+    npc_instruction: >-
+      The interaction has reached its natural end. Priya offers a warm,
+      genuine close — something that signals she would not be uncomfortable
+      running into the player again. Let this be the last substantive
+      exchange unless the player re-opens the conversation.
+    repeat: false
+  - id: pressure_detected
+    when:
+      type: variable_above
+      variable: player_pressure
+      threshold: 45
+    npc_instruction: >-
+      The player has pushed back, re-asked, or made Priya responsible for
+      managing their feelings. Priya becomes shorter and more measured —
+      not cold, but clearly closing off. Her next response is brief and
+      leaves no open threads: "I hear you, and my answer is the same."
+      She does not expand or soften.
+    repeat: true
+  - id: discomfort_high
+    when:
+      type: variable_above
+      variable: priya_discomfort
+      threshold: 65
+    npc_instruction: >-
+      Priya is uncomfortable. She is not hostile but she is done. Give a
+      polite, complete close — something like "I should get back to the
+      people I came with" — and let the player respond to a natural end.
+      The warmth that might have been there is no longer available.
+    repeat: false
+ending_conditions:
+  success:
+    type: variable_above
+    variable: exit_quality
+    threshold: 65
+  failure:
+    type: variable_above
+    variable: priya_discomfort
+    threshold: 80
+response_style:
+  max_words: 65
+  verbosity: moderate
+  formality: casual

--- a/packs/official/dating-confidence-boundaries/scenarios/holding_your_ground.yaml
+++ b/packs/official/dating-confidence-boundaries/scenarios/holding_your_ground.yaml
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+scenario_id: holding_your_ground
+title: The Neighbor
+summary: >-
+  Ryan Kowalski, the neighbor who lives one floor above you, has been
+  increasingly warm for the past two months — and has now texted to ask
+  you out. You responded that you would talk in person, and you have both
+  met in the park near your building. Ryan is hoping you have changed your
+  mind. You have not. Your job is to say no clearly and kindly, and hold
+  that position if Ryan tests it.
+player_role:
+  label: Neighbor
+  brief: >-
+    Ryan is a genuinely decent person who has misread the situation. You
+    are not interested romantically, and you need to make that clear without
+    making the rest of your time in the building awkward. Say no, hold the
+    boundary if Ryan pushes back, and aim to preserve the basic warmth of
+    the neighborly relationship.
+npc:
+  ref: ../npcs/ryan_kowalski.yaml
+scene:
+  ref: ../scenes/neighborhood_park.yaml
+rubric:
+  ref: ../rubrics/dating_boundary_rubric.yaml
+duration:
+  max_turns: 16
+  soft_time_limit_minutes: 11
+opening:
+  npc_says: >-
+    Hey — thanks for actually agreeing to talk about it instead of just
+    sending a thumbs-down emoji or something. I appreciate that. So...
+    yeah. I've been kind of working up to asking for a while, and I figured
+    at some point I'd just do it. What did you want to say?
+goals:
+  player_visible:
+    - "Say no clearly — not maybe, not not right now, but no"
+    - "Hold the boundary if Ryan tries a different angle or a lighter ask"
+    - "Keep the neighborly relationship from going sideways"
+  hidden:
+    - "Ryan will try a reframe after the first no — probably 'just as friends?' — this is hope, not manipulation, but the player has to hold the line through it"
+    - "After the second clear no, Ryan makes one more wistful attempt before genuinely accepting — a player who holds it calmly through all three earns Ryan's quiet respect"
+    - "Naming the neighborly relationship explicitly alongside the no helps Ryan accept — it makes the boundary about this specific thing, not a rejection of Ryan as a person"
+    - "A no that sounds apologetic signals ambivalence — Ryan will interpret hedging as an invitation to try again"
+state:
+  variables:
+    boundary_clarity:
+      min: 0
+      max: 100
+      default: 0
+      visibility: visible
+      max_delta_per_turn: 20
+    rapport:
+      min: 0
+      max: 100
+      default: 60
+      visibility: visible
+      max_delta_per_turn: 12
+    ryan_persistence:
+      min: 0
+      max: 100
+      default: 75
+      visibility: hidden
+      max_delta_per_turn: 15
+    ryan_understanding:
+      min: 0
+      max: 100
+      default: 15
+      visibility: hidden
+      max_delta_per_turn: 18
+difficulty:
+  default: normal
+  options:
+    easy:
+      npc_patience_modifier: 30
+      challenge_frequency: low
+    normal:
+      npc_patience_modifier: 0
+      challenge_frequency: medium
+    hard:
+      npc_patience_modifier: -20
+      challenge_frequency: high
+events:
+  - id: first_test
+    when:
+      type: variable_above
+      variable: ryan_persistence
+      threshold: 70
+    npc_instruction: >-
+      Ryan tries a lighter reframe — this is hope, not manipulation. They
+      suggest maybe coffee "just as friends" or point out that "it doesn't
+      have to be a big deal." Keep the tone easy and a little self-deprecating.
+      A suggested line: "I mean — no pressure at all. It doesn't even have
+      to be a date thing. We could just grab a beer and see how it goes."
+    repeat: false
+  - id: second_test
+    when:
+      type: variable_above
+      variable: ryan_persistence
+      threshold: 85
+    npc_instruction: >-
+      Ryan makes one more attempt, this time quieter and more wistful. They
+      are not pushing for a win now — they are making sure the door is really
+      closed. Something like: "I guess I just thought — I don't know. I
+      might have been reading things wrong this whole time." Let the player
+      respond to this before Ryan genuinely accepts.
+    repeat: false
+  - id: breakthrough
+    when:
+      type: variable_above
+      variable: ryan_understanding
+      threshold: 60
+    npc_instruction: >-
+      Something has shifted. Ryan has heard the same clear, warm position
+      three times and it has finally landed. Their tone changes — less
+      searching, more accepting. They might say: "Okay. I hear you. I
+      think I needed to hear it a few times before it actually got in."
+      Let the energy settle. This is the resolution.
+    repeat: false
+  - id: rapport_warning
+    when:
+      type: variable_below
+      variable: rapport
+      threshold: 25
+    npc_instruction: >-
+      The conversation has gone somewhere uncomfortable. Ryan has pulled back
+      emotionally — shorter answers, a cooler tone, less eye contact. The
+      neighborly warmth has drained out. Ryan is not hostile, just closed.
+      The player has failed to say no in a way that preserved the basic
+      warmth of the relationship.
+    repeat: false
+ending_conditions:
+  success:
+    type: variable_above
+    variable: ryan_understanding
+    threshold: 60
+  failure:
+    type: variable_below
+    variable: rapport
+    threshold: 15
+response_style:
+  max_words: 80
+  verbosity: moderate
+  formality: casual

--- a/packs/official/dating-confidence-boundaries/scenarios/the_ask.yaml
+++ b/packs/official/dating-confidence-boundaries/scenarios/the_ask.yaml
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+scenario_id: the_ask
+title: The Coffee Cart
+summary: >-
+  Jordan Chen is ahead of you in line at the campus coffee cart — a classmate
+  you have exchanged nods with for weeks but never actually spoken to. They
+  have a research paper open on their phone and earbuds around their neck.
+  This is the moment you have been waiting for. Your goal is to start a real
+  conversation and, if it is going well, ask if they would want to get coffee
+  sometime.
+player_role:
+  label: Student
+  brief: >-
+    You are waiting in line behind Jordan, a classmate you find genuinely
+    interesting. You want to start a conversation and, at the right moment,
+    ask them out. There is no script — just see where the conversation goes
+    and read the room before you make any kind of ask.
+npc:
+  ref: ../npcs/jordan_chen.yaml
+scene:
+  ref: ../scenes/campus_coffee_cart.yaml
+rubric:
+  ref: ../rubrics/dating_confidence_rubric.yaml
+duration:
+  max_turns: 14
+  soft_time_limit_minutes: 10
+opening:
+  npc_says: >-
+    Oh — hey. Sorry, I didn't hear you come up. The line is moving so
+    slowly today. Do you know if the flat white is actually good here or is
+    it one of those things where you just get used to it?
+goals:
+  player_visible:
+    - "Start a genuine conversation with Jordan — not a script, just something real"
+    - "Read the signals as the conversation develops and decide whether the moment is right"
+    - "If it feels right, ask Jordan if they would want to get coffee sometime"
+  hidden:
+    - "Jordan is evaluating whether the player is genuinely curious about them or running through a script — authentic follow-up questions earn far more than smooth openers"
+    - "Jordan gives positive signals before the natural ask window: a returned question, a small laugh, a longer answer than necessary — a player who notices these will time the ask better"
+    - "Asking Jordan out before the conversation has established real contact will get a soft non-answer; asking after it has will get a genuine response"
+    - "Jordan is not going to flirt — the player has to do the work of reading engagement signals without a clear green light"
+state:
+  variables:
+    rapport:
+      min: 0
+      max: 100
+      default: 25
+      visibility: visible
+      max_delta_per_turn: 15
+    confidence:
+      min: 0
+      max: 100
+      default: 40
+      visibility: visible
+      max_delta_per_turn: 12
+    jordan_interest:
+      min: 0
+      max: 100
+      default: 35
+      visibility: hidden
+      max_delta_per_turn: 18
+    jordan_comfort:
+      min: 0
+      max: 100
+      default: 65
+      visibility: hidden
+      max_delta_per_turn: 15
+difficulty:
+  default: normal
+  options:
+    easy:
+      npc_patience_modifier: 25
+      challenge_frequency: low
+    normal:
+      npc_patience_modifier: 0
+      challenge_frequency: medium
+    hard:
+      npc_patience_modifier: -20
+      challenge_frequency: high
+events:
+  - id: positive_signal
+    when:
+      type: variable_above
+      variable: jordan_interest
+      threshold: 60
+    npc_instruction: >-
+      Jordan has started to genuinely enjoy this conversation. Show it:
+      a slightly longer answer, a real follow-up question back at the player,
+      or a small, unguarded laugh at something the player said. The body
+      language shifts — they put their phone in their pocket or turn a little
+      more toward the player. Do not announce it; let the player notice.
+    repeat: false
+  - id: natural_ask_window
+    when:
+      type: variable_above
+      variable: rapport
+      threshold: 55
+    npc_instruction: >-
+      The conversation has reached a natural pause — a moment of easy silence
+      after something genuine was said, or the line is about to move and the
+      interaction is about to end naturally. Signal this with a brief settling
+      moment: Jordan smiles, glances ahead at the line, and does not immediately
+      launch a new topic. This is the moment a player with good timing will
+      use to make an ask.
+    repeat: false
+  - id: comfort_warning
+    when:
+      type: variable_below
+      variable: jordan_comfort
+      threshold: 30
+    npc_instruction: >-
+      Jordan is starting to feel like this interaction has run longer than
+      they wanted or that the player is angling somewhere. Signal mild
+      discomfort without hostility: shorter answers, a glance toward the
+      front of the line, an "oh, I should probably..." trailing sentence that
+      does not finish. The player has one or two turns to read this correctly.
+    repeat: false
+  - id: disengagement
+    when:
+      type: variable_below
+      variable: jordan_interest
+      threshold: 20
+    npc_instruction: >-
+      Jordan has checked out. They are not rude but they are done with the
+      interaction. Offer a polite close: "Hey, it was nice chatting — I
+      should grab my order and find a seat before my lecture." Let the player
+      respond but do not re-open the conversation after this.
+    repeat: false
+ending_conditions:
+  success:
+    type: variable_above
+    variable: jordan_interest
+    threshold: 68
+  failure:
+    type: variable_below
+    variable: jordan_comfort
+    threshold: 12
+response_style:
+  max_words: 75
+  verbosity: moderate
+  formality: casual
+replay_seed: 42

--- a/packs/official/dating-confidence-boundaries/scenes/campus_coffee_cart.yaml
+++ b/packs/official/dating-confidence-boundaries/scenes/campus_coffee_cart.yaml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+scene_id: campus_coffee_cart
+display_name: "Campus Coffee Cart — Morning"
+description: >-
+  An outdoor coffee cart near the science building, busy with the pre-class
+  rush. The line moves slowly. Students stand close together with their bags
+  and phones, most in their own worlds. The cart operator calls out names
+  over the hiss of the espresso machine. This is a public, casual space
+  where brief conversations happen naturally and no one stays long.
+ambient: outdoor_crowd_morning

--- a/packs/official/dating-confidence-boundaries/scenes/community_gallery.yaml
+++ b/packs/official/dating-confidence-boundaries/scenes/community_gallery.yaml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+scene_id: community_gallery
+display_name: "Community Gallery — Evening Opening"
+description: >-
+  A small independent gallery during a weekend opening. Wine glasses on a
+  table near the door, clusters of people moving slowly between prints and
+  photographs. The lighting is warm and the noise is ambient rather than
+  loud. Two people can talk privately without being overheard but are clearly
+  not alone — the social context makes the conversation feel stakes-appropriate
+  rather than high-pressure.
+ambient: gallery_ambient

--- a/packs/official/dating-confidence-boundaries/scenes/neighborhood_park.yaml
+++ b/packs/official/dating-confidence-boundaries/scenes/neighborhood_park.yaml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+scene_id: neighborhood_park
+display_name: "Neighborhood Park — Weekend Afternoon"
+description: >-
+  A small urban park with benches along a paved path. Dog walkers pass
+  intermittently. The player and Ryan have met here by mutual agreement
+  after exchanging a text. It is neutral territory — not the lobby of their
+  building, not a date-framed venue. The setting is chosen deliberately to
+  be low-key and easy to exit.
+ambient: park_afternoon

--- a/packs/official/dating-confidence-boundaries/scenes/wine_bar.yaml
+++ b/packs/official/dating-confidence-boundaries/scenes/wine_bar.yaml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+scene_id: wine_bar
+display_name: "Wine Bar — Early Evening"
+description: >-
+  A quiet wine bar in the early evening, before it fills up. Low lighting,
+  small tables, soft background music that does not interfere with conversation.
+  Sam and the player are seated across from each other with their first drinks.
+  The setting is warm and mildly formal — dressed-up-casual, clearly a date
+  context, but relaxed enough for a genuine conversation.
+ambient: wine_bar_evening

--- a/packs/official/dating-confidence-boundaries/tests/golden_first_date_chemistry.yaml
+++ b/packs/official/dating-confidence-boundaries/tests/golden_first_date_chemistry.yaml
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+fixture_id: golden_first_date_chemistry
+scenario_id: first_date_chemistry
+description: >-
+  Golden transcript property test: verifies that a player who matches Sam's
+  opening energy, builds on what Sam actually says rather than pivoting to
+  themselves, leaves space for Sam to direct the conversation, and shares
+  something small but genuine causes sam_interest to exceed the success
+  threshold. Also verifies event structure, variable visibility, and safety.
+
+seed: 42
+input_mode: text
+difficulty: normal
+
+turns:
+  - turn: 1
+    player_input: >-
+      Ha — okay, I'm glad you said that because I typed and deleted
+      about four different "I'm here" messages. Slightly nervous is
+      exactly where I'm at too. I'm really glad you're here. What made
+      you actually decide to come tonight?
+    expect:
+      state_delta_contains:
+        - connection
+        - sam_interest
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 2
+    player_input: >-
+      That is genuinely a good reason. I almost convinced myself I was
+      busy — I'm glad I didn't. The housing thing sounds really interesting,
+      by the way — is that something you kind of fell into or something
+      you went looking for?
+    expect:
+      state_delta_contains:
+        - connection
+        - comfort
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 3
+    player_input: >-
+      I feel like "ended up in it by accident and stayed because it
+      mattered" is kind of the best possible origin story for a job.
+      I'm still figuring out whether my work feels like that. I think
+      it's getting there. What does a day actually look like for you?
+      Like the part that's not in the job title.
+    expect:
+      state_delta_contains:
+        - connection
+        - sam_interest
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 4
+    player_input: >-
+      I feel like I should tell you that I'm a little bit terrible at
+      first dates — I either overthink everything or I forget to seem
+      like a normal human. I think this one is going well, for what
+      it's worth. You're easy to talk to.
+    expect:
+      state_delta_contains:
+        - comfort
+        - sam_interest
+      session_control: continue_session
+      safety_status: ok
+
+static_assertions:
+  - description: Scenario opening line is non-empty
+    path: opening.npc_says
+    check: non_empty_string
+
+  - description: At least one event is defined
+    path: events
+    check: min_length_1
+
+  - description: genuine_spark fires when sam_interest exceeds 65
+    path: events[id=genuine_spark].when
+    check: "type=variable_above AND variable=sam_interest AND threshold=65"
+
+  - description: genuine_spark fires only once
+    path: events[id=genuine_spark].repeat
+    check: "equals false"
+
+  - description: personal_share fires when comfort exceeds 72
+    path: events[id=personal_share].when
+    check: "type=variable_above AND variable=comfort AND threshold=72"
+
+  - description: personal_share fires only once
+    path: events[id=personal_share].repeat
+    check: "equals false"
+
+  - description: oversharing_check fires when awkwardness exceeds 48
+    path: events[id=oversharing_check].when
+    check: "type=variable_above AND variable=awkwardness AND threshold=48"
+
+  - description: oversharing_check can repeat
+    path: events[id=oversharing_check].repeat
+    check: "equals true"
+
+  - description: connection_stall fires when connection falls below 20
+    path: events[id=connection_stall].when
+    check: "type=variable_below AND variable=connection AND threshold=20"
+
+  - description: connection_stall can repeat
+    path: events[id=connection_stall].repeat
+    check: "equals true"
+
+  - description: Success ending condition targets sam_interest above 70
+    path: ending_conditions.success
+    check: "type=variable_above AND variable=sam_interest AND threshold=70"
+
+  - description: Failure ending condition targets awkwardness above 82
+    path: ending_conditions.failure
+    check: "type=variable_above AND variable=awkwardness AND threshold=82"
+
+  - description: connection is player-visible
+    path: state.variables.connection.visibility
+    check: "equals visible"
+
+  - description: comfort is player-visible
+    path: state.variables.comfort.visibility
+    check: "equals visible"
+
+  - description: sam_interest is hidden from player
+    path: state.variables.sam_interest.visibility
+    check: "equals hidden"
+
+  - description: awkwardness is hidden from player
+    path: state.variables.awkwardness.visibility
+    check: "equals hidden"
+
+  - description: NPC is marked fictional
+    path: npc.fictional
+    check: "equals true"
+
+  - description: Safety policy stops nsfw_sexual_content
+    path: safety.content_categories.nsfw_sexual_content
+    check: "equals stop"
+
+  - description: Safety policy redirects harassment_extreme
+    path: safety.content_categories.harassment_extreme
+    check: "equals redirect"
+
+  - description: Safety policy fires stop_with_resource_message for self_harm_crisis
+    path: safety.content_categories.self_harm_crisis
+    check: "equals stop_with_resource_message"
+
+  - description: Pack manifest declares first_date_chemistry as an entry scenario
+    path: manifest.entry_scenarios
+    check: "contains scenarios/first_date_chemistry.yaml"
+
+  - description: Hard difficulty applies a negative patience modifier
+    path: scenario.difficulty.options.hard.npc_patience_modifier
+    check: "equals -20"

--- a/packs/official/dating-confidence-boundaries/tests/golden_graceful_exit.yaml
+++ b/packs/official/dating-confidence-boundaries/tests/golden_graceful_exit.yaml
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+fixture_id: golden_graceful_exit
+scenario_id: graceful_exit
+description: >-
+  Golden transcript property test: verifies that a player who accepts
+  Priya's rejection quickly and without commentary, stays composed without
+  burdening Priya with their feelings, and closes with a brief warm line
+  causes exit_quality to exceed the success threshold and priya_discomfort
+  to stay low. Also verifies event structure, state visibility, and safety.
+
+seed: 42
+input_mode: text
+difficulty: normal
+
+turns:
+  - turn: 1
+    player_input: >-
+      I really appreciate you saying it in person. That took something.
+      And — yeah, totally okay. No hard feelings at all.
+    expect:
+      state_delta_contains:
+        - composure
+        - exit_quality
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 2
+    player_input: >-
+      Honestly, I'm glad we talked at the opening last time. That was a
+      good conversation regardless of this part. You don't need to feel
+      weird about it.
+    expect:
+      state_delta_contains:
+        - exit_quality
+        - priya_discomfort
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 3
+    player_input: >-
+      For what it's worth, I think you handled this really well. I should
+      head back in — I hope you enjoy the rest of the evening.
+    expect:
+      state_delta_contains:
+        - exit_quality
+        - composure
+      session_control: continue_session
+      safety_status: ok
+
+static_assertions:
+  - description: Scenario opening line is non-empty
+    path: opening.npc_says
+    check: non_empty_string
+
+  - description: At least one event is defined
+    path: events
+    check: min_length_1
+
+  - description: priya_relaxes fires when exit_quality exceeds 50
+    path: events[id=priya_relaxes].when
+    check: "type=variable_above AND variable=exit_quality AND threshold=50"
+
+  - description: priya_relaxes fires only once
+    path: events[id=priya_relaxes].repeat
+    check: "equals false"
+
+  - description: clean_exit_moment fires when exit_quality exceeds 72
+    path: events[id=clean_exit_moment].when
+    check: "type=variable_above AND variable=exit_quality AND threshold=72"
+
+  - description: clean_exit_moment fires only once
+    path: events[id=clean_exit_moment].repeat
+    check: "equals false"
+
+  - description: pressure_detected fires when player_pressure exceeds 45
+    path: events[id=pressure_detected].when
+    check: "type=variable_above AND variable=player_pressure AND threshold=45"
+
+  - description: pressure_detected can repeat
+    path: events[id=pressure_detected].repeat
+    check: "equals true"
+
+  - description: discomfort_high fires when priya_discomfort exceeds 65
+    path: events[id=discomfort_high].when
+    check: "type=variable_above AND variable=priya_discomfort AND threshold=65"
+
+  - description: discomfort_high fires only once
+    path: events[id=discomfort_high].repeat
+    check: "equals false"
+
+  - description: Success ending condition targets exit_quality above 65
+    path: ending_conditions.success
+    check: "type=variable_above AND variable=exit_quality AND threshold=65"
+
+  - description: Failure ending condition targets priya_discomfort above 80
+    path: ending_conditions.failure
+    check: "type=variable_above AND variable=priya_discomfort AND threshold=80"
+
+  - description: composure is player-visible
+    path: state.variables.composure.visibility
+    check: "equals visible"
+
+  - description: exit_quality is player-visible
+    path: state.variables.exit_quality.visibility
+    check: "equals visible"
+
+  - description: priya_discomfort is hidden from player
+    path: state.variables.priya_discomfort.visibility
+    check: "equals hidden"
+
+  - description: player_pressure is hidden from player
+    path: state.variables.player_pressure.visibility
+    check: "equals hidden"
+
+  - description: NPC is marked fictional
+    path: npc.fictional
+    check: "equals true"
+
+  - description: Safety policy stops nsfw_sexual_content
+    path: safety.content_categories.nsfw_sexual_content
+    check: "equals stop"
+
+  - description: Safety policy redirects harassment_extreme
+    path: safety.content_categories.harassment_extreme
+    check: "equals redirect"
+
+  - description: Safety policy fires stop_with_resource_message for self_harm_crisis
+    path: safety.content_categories.self_harm_crisis
+    check: "equals stop_with_resource_message"
+
+  - description: Pack manifest declares graceful_exit as an entry scenario
+    path: manifest.entry_scenarios
+    check: "contains scenarios/graceful_exit.yaml"
+
+  - description: Hard difficulty applies a negative patience modifier
+    path: scenario.difficulty.options.hard.npc_patience_modifier
+    check: "equals -20"

--- a/packs/official/dating-confidence-boundaries/tests/golden_holding_your_ground.yaml
+++ b/packs/official/dating-confidence-boundaries/tests/golden_holding_your_ground.yaml
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+fixture_id: golden_holding_your_ground
+scenario_id: holding_your_ground
+description: >-
+  Golden transcript property test: verifies that a player who states the
+  boundary clearly and names the neighborly relationship, holds the same
+  position through Ryan's reframe and wistful second attempt without
+  escalating or adding new justifications, and closes warmly once Ryan
+  genuinely accepts causes ryan_understanding to exceed the success threshold.
+  Also verifies event structure, variable visibility, and safety config.
+
+seed: 42
+input_mode: text
+difficulty: normal
+
+turns:
+  - turn: 1
+    player_input: >-
+      I really am glad you asked in person. And I want to be honest with
+      you because I think you deserve that. I'm not interested in going
+      out with you romantically. That's where I am. I do genuinely like
+      you as a neighbor — you've been a good one — but that's as far as
+      it goes for me.
+    expect:
+      state_delta_contains:
+        - boundary_clarity
+        - ryan_understanding
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 2
+    player_input: >-
+      I hear you, and I know that's probably not what you were hoping
+      for. But it's still no — even as a casual thing. My answer is the
+      same. I just wanted to say it clearly rather than let it drift.
+    expect:
+      state_delta_contains:
+        - boundary_clarity
+        - ryan_persistence
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 3
+    player_input: >-
+      You didn't read it completely wrong — you're a warm person and I
+      understand why you thought there was something there. What I'm
+      saying isn't that you got the vibe wrong, it's that I'm not in
+      a place where I want to go down that road. Not with anyone right
+      now, honestly. I hope that makes it a bit easier to hear.
+    expect:
+      state_delta_contains:
+        - rapport
+        - ryan_understanding
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 4
+    player_input: >-
+      I'm glad we talked about it. And I do want us to be okay in the
+      building — I meant what I said about you being a good neighbor.
+      I'll see you around.
+    expect:
+      state_delta_contains:
+        - rapport
+        - ryan_understanding
+      session_control: continue_session
+      safety_status: ok
+
+static_assertions:
+  - description: Scenario opening line is non-empty
+    path: opening.npc_says
+    check: non_empty_string
+
+  - description: At least one event is defined
+    path: events
+    check: min_length_1
+
+  - description: first_test fires when ryan_persistence exceeds 70
+    path: events[id=first_test].when
+    check: "type=variable_above AND variable=ryan_persistence AND threshold=70"
+
+  - description: first_test fires only once
+    path: events[id=first_test].repeat
+    check: "equals false"
+
+  - description: second_test fires when ryan_persistence exceeds 85
+    path: events[id=second_test].when
+    check: "type=variable_above AND variable=ryan_persistence AND threshold=85"
+
+  - description: second_test fires only once
+    path: events[id=second_test].repeat
+    check: "equals false"
+
+  - description: breakthrough fires when ryan_understanding exceeds 60
+    path: events[id=breakthrough].when
+    check: "type=variable_above AND variable=ryan_understanding AND threshold=60"
+
+  - description: breakthrough fires only once
+    path: events[id=breakthrough].repeat
+    check: "equals false"
+
+  - description: rapport_warning fires when rapport falls below 25
+    path: events[id=rapport_warning].when
+    check: "type=variable_below AND variable=rapport AND threshold=25"
+
+  - description: rapport_warning fires only once
+    path: events[id=rapport_warning].repeat
+    check: "equals false"
+
+  - description: Success ending condition targets ryan_understanding above 60
+    path: ending_conditions.success
+    check: "type=variable_above AND variable=ryan_understanding AND threshold=60"
+
+  - description: Failure ending condition targets rapport below 15
+    path: ending_conditions.failure
+    check: "type=variable_below AND variable=rapport AND threshold=15"
+
+  - description: boundary_clarity is player-visible
+    path: state.variables.boundary_clarity.visibility
+    check: "equals visible"
+
+  - description: rapport is player-visible
+    path: state.variables.rapport.visibility
+    check: "equals visible"
+
+  - description: ryan_persistence is hidden from player
+    path: state.variables.ryan_persistence.visibility
+    check: "equals hidden"
+
+  - description: ryan_understanding is hidden from player
+    path: state.variables.ryan_understanding.visibility
+    check: "equals hidden"
+
+  - description: NPC is marked fictional
+    path: npc.fictional
+    check: "equals true"
+
+  - description: Safety policy stops nsfw_sexual_content
+    path: safety.content_categories.nsfw_sexual_content
+    check: "equals stop"
+
+  - description: Safety policy redirects harassment_extreme
+    path: safety.content_categories.harassment_extreme
+    check: "equals redirect"
+
+  - description: Safety policy fires stop_with_resource_message for self_harm_crisis
+    path: safety.content_categories.self_harm_crisis
+    check: "equals stop_with_resource_message"
+
+  - description: Pack manifest declares holding_your_ground as an entry scenario
+    path: manifest.entry_scenarios
+    check: "contains scenarios/holding_your_ground.yaml"
+
+  - description: Hard difficulty applies a negative patience modifier
+    path: scenario.difficulty.options.hard.npc_patience_modifier
+    check: "equals -20"

--- a/packs/official/dating-confidence-boundaries/tests/golden_the_ask.yaml
+++ b/packs/official/dating-confidence-boundaries/tests/golden_the_ask.yaml
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+fixture_id: golden_the_ask
+scenario_id: the_ask
+description: >-
+  Golden transcript property test: verifies that a player who opens with
+  genuine curiosity about Jordan, builds real conversational rapport before
+  making any move, reads the positive signal correctly, and makes a direct
+  but low-pressure ask causes jordan_interest to exceed the success threshold.
+  Also verifies event structure, state variable visibility, and safety config.
+
+seed: 42
+input_mode: text
+difficulty: normal
+
+turns:
+  - turn: 1
+    player_input: >-
+      Honestly, I've been getting the oat-milk flat white for three weeks
+      and I'm still not sure if it's good or just familiar. I think we
+      might be in the same Thursday afternoon seminar — I'm almost sure I
+      saw you ask a question about the Haber-Bosch process last week?
+    expect:
+      state_delta_contains:
+        - rapport
+        - jordan_interest
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 2
+    player_input: >-
+      That's wild — I had no idea that was actually still open for debate.
+      What's your research on? Is it something in that direction or
+      completely different?
+    expect:
+      state_delta_contains:
+        - rapport
+        - jordan_comfort
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 3
+    player_input: >-
+      That sounds genuinely interesting. I feel like everyone in the
+      seminar is working on something that sounds dull until you actually
+      ask about it. I'm glad I asked. Hey — I know this is a little bit
+      of a coffee cart conversation to be having this in, but would you
+      want to grab actual coffee sometime? Like, on purpose and not in
+      a line?
+    expect:
+      state_delta_contains:
+        - confidence
+        - jordan_interest
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 4
+    player_input: >-
+      Great! No pressure on timing at all — I know the end of term is
+      chaos. Here, let me give you my number and we can figure it out
+      whenever. It was really nice actually talking to you.
+    expect:
+      state_delta_contains:
+        - rapport
+        - jordan_interest
+      session_control: continue_session
+      safety_status: ok
+
+static_assertions:
+  - description: Scenario opening line is non-empty
+    path: opening.npc_says
+    check: non_empty_string
+
+  - description: At least one event is defined
+    path: events
+    check: min_length_1
+
+  - description: positive_signal fires when jordan_interest exceeds 60
+    path: events[id=positive_signal].when
+    check: "type=variable_above AND variable=jordan_interest AND threshold=60"
+
+  - description: positive_signal fires only once
+    path: events[id=positive_signal].repeat
+    check: "equals false"
+
+  - description: natural_ask_window fires when rapport exceeds 55
+    path: events[id=natural_ask_window].when
+    check: "type=variable_above AND variable=rapport AND threshold=55"
+
+  - description: natural_ask_window fires only once
+    path: events[id=natural_ask_window].repeat
+    check: "equals false"
+
+  - description: comfort_warning fires when jordan_comfort falls below 30
+    path: events[id=comfort_warning].when
+    check: "type=variable_below AND variable=jordan_comfort AND threshold=30"
+
+  - description: comfort_warning fires only once
+    path: events[id=comfort_warning].repeat
+    check: "equals false"
+
+  - description: disengagement fires when jordan_interest falls below 20
+    path: events[id=disengagement].when
+    check: "type=variable_below AND variable=jordan_interest AND threshold=20"
+
+  - description: disengagement fires only once
+    path: events[id=disengagement].repeat
+    check: "equals false"
+
+  - description: Success ending condition targets jordan_interest above 68
+    path: ending_conditions.success
+    check: "type=variable_above AND variable=jordan_interest AND threshold=68"
+
+  - description: Failure ending condition targets jordan_comfort below 12
+    path: ending_conditions.failure
+    check: "type=variable_below AND variable=jordan_comfort AND threshold=12"
+
+  - description: rapport is player-visible
+    path: state.variables.rapport.visibility
+    check: "equals visible"
+
+  - description: confidence is player-visible
+    path: state.variables.confidence.visibility
+    check: "equals visible"
+
+  - description: jordan_interest is hidden from player
+    path: state.variables.jordan_interest.visibility
+    check: "equals hidden"
+
+  - description: jordan_comfort is hidden from player
+    path: state.variables.jordan_comfort.visibility
+    check: "equals hidden"
+
+  - description: NPC is marked fictional
+    path: npc.fictional
+    check: "equals true"
+
+  - description: Safety policy stops nsfw_sexual_content
+    path: safety.content_categories.nsfw_sexual_content
+    check: "equals stop"
+
+  - description: Safety policy redirects harassment_extreme
+    path: safety.content_categories.harassment_extreme
+    check: "equals redirect"
+
+  - description: Safety policy fires stop_with_resource_message for self_harm_crisis
+    path: safety.content_categories.self_harm_crisis
+    check: "equals stop_with_resource_message"
+
+  - description: Pack manifest declares the_ask as an entry scenario
+    path: manifest.entry_scenarios
+    check: "contains scenarios/the_ask.yaml"
+
+  - description: Hard difficulty applies a negative patience modifier
+    path: scenario.difficulty.options.hard.npc_patience_modifier
+    check: "equals -20"

--- a/packs/official/dating-confidence-boundaries/tests/smoke_first_date_chemistry.yaml
+++ b/packs/official/dating-confidence-boundaries/tests/smoke_first_date_chemistry.yaml
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+fixture_id: smoke_first_date_chemistry
+scenario_id: first_date_chemistry
+description: >-
+  Verifies that first_date_chemistry loads cleanly, produces a non-empty
+  opening line, and that a genuine, curious response advances the session
+  without a safety stop. Checks connection-building scenario structure
+  including state variables, events, and ending conditions.
+
+seed: 42
+input_mode: text
+difficulty: normal
+
+turns:
+  - turn: 1
+    player_input: >-
+      Ha — you have no idea how much I needed to hear that. I almost
+      sent you three different "hey I'm here" texts and deleted them all.
+      I'm doing really well, actually, now that the awkward first-thirty-
+      seconds part is behind us. I'm curious — what made you decide to
+      actually show up tonight?
+    expect:
+      state_delta_contains:
+        - connection
+        - sam_interest
+      session_control: continue_session
+      safety_status: ok
+
+static_assertions:
+  - description: Scenario opening line is non-empty
+    path: opening.npc_says
+    check: non_empty_string
+  - description: NPC is marked fictional
+    path: npc.fictional
+    check: "equals true"
+  - description: Safety policy stops nsfw_sexual_content
+    path: safety.content_categories.nsfw_sexual_content
+    check: "equals stop"
+  - description: Safety policy has self_harm_crisis protection
+    path: safety.content_categories.self_harm_crisis
+    check: "equals stop_with_resource_message"
+  - description: At least one event is defined
+    path: events
+    check: min_length_1
+  - description: Success ending condition targets sam_interest
+    path: ending_conditions.success
+    check: "type=variable_above AND variable=sam_interest AND threshold=70"
+  - description: Failure ending condition targets awkwardness
+    path: ending_conditions.failure
+    check: "type=variable_above AND variable=awkwardness AND threshold=82"
+  - description: Pack manifest declares this scenario as an entry scenario
+    path: manifest.entry_scenarios
+    check: "contains scenarios/first_date_chemistry.yaml"
+  - description: genuine_spark event fires when sam_interest exceeds 65
+    path: events[id=genuine_spark].when
+    check: "type=variable_above AND variable=sam_interest AND threshold=65"

--- a/packs/official/dating-confidence-boundaries/tests/smoke_graceful_exit.yaml
+++ b/packs/official/dating-confidence-boundaries/tests/smoke_graceful_exit.yaml
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+fixture_id: smoke_graceful_exit
+scenario_id: graceful_exit
+description: >-
+  Verifies that graceful_exit loads cleanly, produces a non-empty opening
+  line, and that a calm, composed acceptance of the rejection advances the
+  session without a safety stop. Checks that disengage-gracefully endings
+  are first-class wins and that safety policy is correctly configured.
+
+seed: 42
+input_mode: text
+difficulty: normal
+
+turns:
+  - turn: 1
+    player_input: >-
+      I appreciate you saying it in person — that actually means a lot.
+      And I get it, completely. No hard feelings at all.
+    expect:
+      state_delta_contains:
+        - composure
+        - exit_quality
+      session_control: continue_session
+      safety_status: ok
+
+static_assertions:
+  - description: Scenario opening line is non-empty
+    path: opening.npc_says
+    check: non_empty_string
+  - description: NPC is marked fictional
+    path: npc.fictional
+    check: "equals true"
+  - description: Safety policy stops nsfw_sexual_content
+    path: safety.content_categories.nsfw_sexual_content
+    check: "equals stop"
+  - description: Safety policy has self_harm_crisis protection
+    path: safety.content_categories.self_harm_crisis
+    check: "equals stop_with_resource_message"
+  - description: At least one event is defined
+    path: events
+    check: min_length_1
+  - description: Success ending condition targets exit_quality
+    path: ending_conditions.success
+    check: "type=variable_above AND variable=exit_quality AND threshold=65"
+  - description: Failure ending condition targets priya_discomfort
+    path: ending_conditions.failure
+    check: "type=variable_above AND variable=priya_discomfort AND threshold=80"
+  - description: Pack manifest declares this scenario as an entry scenario
+    path: manifest.entry_scenarios
+    check: "contains scenarios/graceful_exit.yaml"
+  - description: pressure_detected event fires when player_pressure exceeds 45
+    path: events[id=pressure_detected].when
+    check: "type=variable_above AND variable=player_pressure AND threshold=45"

--- a/packs/official/dating-confidence-boundaries/tests/smoke_holding_your_ground.yaml
+++ b/packs/official/dating-confidence-boundaries/tests/smoke_holding_your_ground.yaml
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+fixture_id: smoke_holding_your_ground
+scenario_id: holding_your_ground
+description: >-
+  Verifies that holding_your_ground loads cleanly, produces a non-empty
+  opening line, and that a clear, warm boundary statement advances the session
+  without a safety stop. Checks boundary-setting scenario structure including
+  state variables and ending conditions.
+
+seed: 42
+input_mode: text
+difficulty: normal
+
+turns:
+  - turn: 1
+    player_input: >-
+      I really do appreciate you asking, and I want to be honest with you —
+      I'm not interested in that, romantically. I like you as a neighbor
+      and I think you are genuinely a good person, but that's where it is
+      for me.
+    expect:
+      state_delta_contains:
+        - boundary_clarity
+        - ryan_understanding
+      session_control: continue_session
+      safety_status: ok
+
+static_assertions:
+  - description: Scenario opening line is non-empty
+    path: opening.npc_says
+    check: non_empty_string
+  - description: NPC is marked fictional
+    path: npc.fictional
+    check: "equals true"
+  - description: Safety policy stops nsfw_sexual_content
+    path: safety.content_categories.nsfw_sexual_content
+    check: "equals stop"
+  - description: Safety policy has self_harm_crisis protection
+    path: safety.content_categories.self_harm_crisis
+    check: "equals stop_with_resource_message"
+  - description: At least one event is defined
+    path: events
+    check: min_length_1
+  - description: Success ending condition targets ryan_understanding
+    path: ending_conditions.success
+    check: "type=variable_above AND variable=ryan_understanding AND threshold=60"
+  - description: Failure ending condition targets rapport
+    path: ending_conditions.failure
+    check: "type=variable_below AND variable=rapport AND threshold=15"
+  - description: Pack manifest declares this scenario as an entry scenario
+    path: manifest.entry_scenarios
+    check: "contains scenarios/holding_your_ground.yaml"
+  - description: first_test event fires when ryan_persistence exceeds 70
+    path: events[id=first_test].when
+    check: "type=variable_above AND variable=ryan_persistence AND threshold=70"

--- a/packs/official/dating-confidence-boundaries/tests/smoke_the_ask.yaml
+++ b/packs/official/dating-confidence-boundaries/tests/smoke_the_ask.yaml
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+fixture_id: smoke_the_ask
+scenario_id: the_ask
+description: >-
+  Verifies that the_ask scenario loads cleanly, produces a non-empty opening
+  line, and that a genuine, curious opener advances the session without
+  triggering a safety stop. Checks structural integrity of state variables,
+  events, and ending conditions.
+
+seed: 42
+input_mode: text
+difficulty: normal
+
+turns:
+  - turn: 1
+    player_input: >-
+      Ha — honestly, the flat white is better than you'd expect for a cart.
+      The espresso is actually decent. I'm Jordan, by the way. I think we
+      have the Thursday afternoon seminar together?
+    expect:
+      state_delta_contains:
+        - rapport
+        - jordan_interest
+      session_control: continue_session
+      safety_status: ok
+
+static_assertions:
+  - description: Scenario opening line is non-empty
+    path: opening.npc_says
+    check: non_empty_string
+  - description: NPC is marked fictional
+    path: npc.fictional
+    check: "equals true"
+  - description: Safety policy stops nsfw_sexual_content
+    path: safety.content_categories.nsfw_sexual_content
+    check: "equals stop"
+  - description: Safety policy has self_harm_crisis protection
+    path: safety.content_categories.self_harm_crisis
+    check: "equals stop_with_resource_message"
+  - description: At least one event is defined
+    path: events
+    check: min_length_1
+  - description: Success ending condition targets jordan_interest
+    path: ending_conditions.success
+    check: "type=variable_above AND variable=jordan_interest AND threshold=68"
+  - description: Failure ending condition targets jordan_comfort
+    path: ending_conditions.failure
+    check: "type=variable_below AND variable=jordan_comfort AND threshold=12"
+  - description: Pack manifest declares this scenario as an entry scenario
+    path: manifest.entry_scenarios
+    check: "contains scenarios/the_ask.yaml"
+  - description: positive_signal event fires when jordan_interest exceeds 60
+    path: events[id=positive_signal].when
+    check: "type=variable_above AND variable=jordan_interest AND threshold=60"

--- a/services/convsim-core/tests/test_pg_dating_confidence_boundary.py
+++ b/services/convsim-core/tests/test_pg_dating_confidence_boundary.py
@@ -563,3 +563,157 @@ class TestLanguageCafeNonDatingDefault:
         assert not companion_warnings, (
             f"Language Café must not contain companion-framing NPCs; found: {companion_warnings}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Dating — Confidence & Boundaries pack structural verification
+# ---------------------------------------------------------------------------
+
+
+class TestDatingConfidenceBoundariesPack:
+    """Structural tests for the official dating-confidence-boundaries pack.
+
+    Verifies that the pack:
+    - Is rated PG-13 with correct content_note and tags
+    - Safety policy uses redirect (not stop) for harassment_extreme so NPCs
+      can steer the conversation back on course
+    - Contains all four entry scenarios
+    - Has no companion-framing NPC archetypes (which would block official gates)
+    - Validates cleanly with zero errors
+    """
+
+    @pytest.fixture
+    def pack_dir(self) -> Path:
+        return (
+            Path(__file__).parent.parent.parent.parent
+            / "packs"
+            / "official"
+            / "dating-confidence-boundaries"
+        )
+
+    def test_manifest_content_rating_is_pg13(self, pack_dir):
+        if not pack_dir.exists():
+            pytest.skip("dating-confidence-boundaries pack not present in test environment")
+        import yaml
+        manifest = yaml.safe_load(
+            (pack_dir / "manifest.yaml").read_text(encoding="utf-8")
+        )
+        assert manifest.get("content_rating") == "PG-13", (
+            "dating-confidence-boundaries must be rated PG-13."
+        )
+
+    def test_manifest_has_correct_tags(self, pack_dir):
+        if not pack_dir.exists():
+            pytest.skip("dating-confidence-boundaries pack not present in test environment")
+        import yaml
+        manifest = yaml.safe_load(
+            (pack_dir / "manifest.yaml").read_text(encoding="utf-8")
+        )
+        tags = {t.lower() for t in manifest.get("tags", [])}
+        assert "dating" in tags, "Pack must include 'dating' tag."
+        assert "confidence" in tags, "Pack must include 'confidence' tag."
+        assert "boundaries" in tags, "Pack must include 'boundaries' tag."
+
+    def test_manifest_has_four_entry_scenarios(self, pack_dir):
+        if not pack_dir.exists():
+            pytest.skip("dating-confidence-boundaries pack not present in test environment")
+        import yaml
+        manifest = yaml.safe_load(
+            (pack_dir / "manifest.yaml").read_text(encoding="utf-8")
+        )
+        entry_scenarios = manifest.get("entry_scenarios", [])
+        assert len(entry_scenarios) == 4, (
+            f"Pack must have exactly 4 entry scenarios; found {len(entry_scenarios)}."
+        )
+
+    def test_all_entry_scenario_files_exist(self, pack_dir):
+        if not pack_dir.exists():
+            pytest.skip("dating-confidence-boundaries pack not present in test environment")
+        import yaml
+        manifest = yaml.safe_load(
+            (pack_dir / "manifest.yaml").read_text(encoding="utf-8")
+        )
+        for scenario_path in manifest.get("entry_scenarios", []):
+            full_path = pack_dir / scenario_path
+            assert full_path.is_file(), (
+                f"Entry scenario file not found: {scenario_path}"
+            )
+
+    def test_safety_policy_harassment_extreme_is_redirect(self, pack_dir):
+        if not pack_dir.exists():
+            pytest.skip("dating-confidence-boundaries pack not present in test environment")
+        import yaml
+        manifest = yaml.safe_load(
+            (pack_dir / "manifest.yaml").read_text(encoding="utf-8")
+        )
+        policy_path = pack_dir / manifest["safety"]["policy"]
+        policy = yaml.safe_load(policy_path.read_text(encoding="utf-8"))
+        categories = policy.get("content_categories", {})
+        assert categories.get("harassment_extreme") == "redirect", (
+            "Dating-confidence pack must use harassment_extreme: redirect so "
+            "NPCs can steer the conversation back on course rather than stopping."
+        )
+
+    def test_safety_policy_has_required_categories(self, pack_dir):
+        if not pack_dir.exists():
+            pytest.skip("dating-confidence-boundaries pack not present in test environment")
+        import yaml
+        manifest = yaml.safe_load(
+            (pack_dir / "manifest.yaml").read_text(encoding="utf-8")
+        )
+        policy_path = pack_dir / manifest["safety"]["policy"]
+        policy = yaml.safe_load(policy_path.read_text(encoding="utf-8"))
+        categories = policy.get("content_categories", {})
+        assert categories.get("nsfw_sexual_content") == "stop"
+        assert categories.get("minors_romantic_or_sexual") == "stop"
+        assert categories.get("self_harm_crisis") == "stop_with_resource_message"
+        assert categories.get("criminal_instruction") == "refuse"
+
+    def test_safety_policy_content_rating_cap_is_pg13(self, pack_dir):
+        if not pack_dir.exists():
+            pytest.skip("dating-confidence-boundaries pack not present in test environment")
+        from convsim_core.services.safety_policy_service import load_safety_policy
+        import yaml
+        manifest = yaml.safe_load(
+            (pack_dir / "manifest.yaml").read_text(encoding="utf-8")
+        )
+        policy_path = pack_dir / manifest["safety"]["policy"]
+        config = load_safety_policy(policy_path)
+        assert config.content_rating == "PG-13", (
+            "dating-confidence-boundaries safety policy must cap at PG-13."
+        )
+
+    def test_pack_validates_without_errors(self, pack_dir):
+        if not pack_dir.exists():
+            pytest.skip("dating-confidence-boundaries pack not present in test environment")
+        result = validate_pack_dir(pack_dir)
+        assert result.valid is True, (
+            f"dating-confidence-boundaries pack must validate with no errors; "
+            f"errors: {[e for e in getattr(result, 'errors', [])]}"
+        )
+
+    def test_pack_validates_without_companion_framing_warning(self, pack_dir):
+        if not pack_dir.exists():
+            pytest.skip("dating-confidence-boundaries pack not present in test environment")
+        result = validate_pack_dir(pack_dir)
+        companion_warnings = [
+            w for w in result.warnings if w.rule_id == "COMPANION_FRAMING"
+        ]
+        assert not companion_warnings, (
+            f"dating-confidence-boundaries must not contain companion-framing NPCs; "
+            f"found: {companion_warnings}"
+        )
+
+    def test_all_npc_files_are_fictional_and_adult(self, pack_dir):
+        if not pack_dir.exists():
+            pytest.skip("dating-confidence-boundaries pack not present in test environment")
+        import yaml
+        npcs_dir = pack_dir / "npcs"
+        for npc_file in sorted(npcs_dir.glob("*.yaml")):
+            npc = yaml.safe_load(npc_file.read_text(encoding="utf-8"))
+            assert npc.get("fictional") is True, (
+                f"{npc_file.name}: fictional must be true"
+            )
+            assert npc.get("age_band") == "adult", (
+                f"{npc_file.name}: age_band must be adult"
+            )


### PR DESCRIPTION
## Summary

Implements `packs/official/dating-confidence-boundaries/` — the fifth official pack, serving the highest-demand practice niche not yet covered by the simulator. Four distinct scenarios cover the full social-confidence arc from initiating conversation through handling rejection and setting boundaries.

## What changed

### Pack content (28 new files)

Four playable scenarios, each with distinct NPC, scene, rubric, and test suite:

| Scenario | Title | Goal |
|---|---|---|
| `the_ask` | The Coffee Cart | Starting a real conversation and asking someone out |
| `graceful_exit` | When She Says No | Accepting rejection with composure and grace |
| `holding_your_ground` | The Neighbor | Setting a clear, warm boundary with someone pursuing you |
| `first_date_chemistry` | First Impressions | Building genuine connection on a first date |

#### NPC archetypes
Four NPCs with `fictional: true`, `age_band: adult`, and safe archetypes only (`classmate`, `acquaintance`, `neighbor`, `coworker`) — no companion-framing archetypes:
- `jordan_chen.yaml` — classmate, The Coffee Cart
- `sam_rivera.yaml` — acquaintance, When She Says No  
- `ryan_kowalski.yaml` — neighbor, The Neighbor
- `priya_singh.yaml` — coworker, First Impressions

#### State and scoring
Each scenario has 4 state variables (2 visible, 2 hidden) with realistic `max_delta_per_turn` values and named success/failure ending conditions on distinct variables.

**Disengage-gracefully endings are first-class wins**: `graceful_exit` succeeds on `exit_quality > 65` (not on a hidden NPC variable), and `holding_your_ground` succeeds on `ryan_understanding > 60`.

#### Rubrics
Four 4-dimension rubrics with concrete, observable scoring anchors at all three levels (ineffective/developing/excellent):
- `dating_confidence_rubric.yaml` — The Coffee Cart
- `rejection_handling_rubric.yaml` — When She Says No
- `dating_boundary_rubric.yaml` — The Neighbor
- `connection_building_rubric.yaml` — First Impressions

### Safety policy

Derived from the fixture template and `docs/dating-confidence-boundaries.md`:
- `content_rating_cap: PG-13`
- `harassment_extreme: redirect` — NPCs steer the conversation back rather than stopping the session
- All four required official-pack categories present: `nsfw_sexual_content: stop`, `minors_romantic_or_sexual: stop`, `self_harm_crisis: stop_with_resource_message`, `criminal_instruction: refuse`
- `redirect_message` written in a voice consistent with the pack's scenarios

### YAML test suite

Matches the `language-cafe` and `difficult-conversations` coverage pattern:
- **Smoke tests** (4 files, 1 turn + 9 static assertions each) verifying opening line, fictional NPC, safety categories, ending condition structure, and that realistic player input continues without triggering safety stops
- **Golden transcript tests** (4 files, 4 scripted turns + ~15 static assertions each) verifying all event triggers and thresholds, variable visibility, `repeat` values, safety policy, and difficulty modifier structure
- `replay_seed: 42` on `the_ask` for deterministic replay

### Python test class

`TestDatingConfidenceBoundariesPack` added to `test_pg_dating_confidence_boundary.py` (10 structural assertions):
- Manifest content rating is `PG-13`
- Manifest has required tags (dating, social-skills, confidence, boundaries, rejection-handling, communication)
- Exactly 4 entry scenarios
- All scenario files exist
- `harassment_extreme: redirect` in safety policy
- All required safety categories present
- Safety policy `content_rating_cap: PG-13`
- Zero validation errors
- No `COMPANION_FRAMING` warnings
- All NPCs have `fictional: true` and `age_band: adult`

### Startup seeding

The seeder in `convsim_core/packs/seeder.py` auto-discovers any directory under `official_packs_dir` that has a `manifest.yaml`, so the pack is seeded on first launch with no code changes required.

### Validation fixes

Fixed two validation errors caught during testing:
- Removed `content_note` field from `manifest.yaml` — not in the pack schema
- Escaped inner double quotes in `graceful_exit.yaml` line 42 — unescaped quotes inside YAML double-quoted string caused parse error

## Testing approach

- All YAML files follow exact schema patterns from `packs/official/difficult-conversations` (closest model for emotional/relational content) and `packs/official/job-interview-basic` (reference implementation)
- Every NPC archetype cross-checked against safe list in `docs/dating-confidence-boundaries.md`
- Safety policy categories verified against `docs/official-pack-quality-bar.md` and fixture template
- Golden test player inputs scripted to exercise the ideal strategy path for each scenario
- `TestDatingConfidenceBoundariesPack` covers the same structural checks as `TestLanguageCafeNonDatingDefault`

Closes #297