### PR TITLE
[Packs] Standardized difficulty system: schema presets, prompt-composer knobs, and setup UI

### DIFF
--- a/apps/api/src/data/scenarios.ts
+++ b/apps/api/src/data/scenarios.ts
@@ -14,11 +14,11 @@ export const SCENARIOS: Record<string, ScenarioInfo> = {
       brief: 'You are interviewing for a product manager role.',
     },
     difficulty: {
-      default: 'normal',
+      default: 'standard',
       options: {
-        easy: { npc_patience_modifier: 15, challenge_frequency: 'low' },
-        normal: { npc_patience_modifier: 0, challenge_frequency: 'medium' },
-        hard: { npc_patience_modifier: -20, challenge_frequency: 'high' },
+        warm: { patience: 80, volatility: 20, disclosure: 70, time_pressure: 20 },
+        standard: { patience: 50, volatility: 50, disclosure: 50, time_pressure: 50 },
+        hard: { patience: 25, volatility: 70, disclosure: 25, time_pressure: 60 },
       },
     },
     supported_languages: ['en'],
@@ -44,10 +44,11 @@ export const SCENARIOS: Record<string, ScenarioInfo> = {
       brief: 'You are interviewing for a VP-level role. The interviewer is a skeptical executive.',
     },
     difficulty: {
-      default: 'normal',
+      default: 'standard',
       options: {
-        normal: { npc_patience_modifier: -10, challenge_frequency: 'medium' },
-        hard: { npc_patience_modifier: -25, challenge_frequency: 'high' },
+        standard:    { patience: 30, volatility: 60, disclosure: 30, time_pressure: 60 },
+        hard:        { patience: 15, volatility: 80, disclosure: 15, time_pressure: 75 },
+        adversarial: { patience: 5,  volatility: 95, disclosure: 5,  time_pressure: 90 },
       },
     },
     supported_languages: ['en'],
@@ -102,10 +103,10 @@ export const SCENARIOS: Record<string, ScenarioInfo> = {
       brief: 'You are practicing Spanish at a café in Madrid.',
     },
     difficulty: {
-      default: 'easy',
+      default: 'warm',
       options: {
-        easy: { npc_patience_modifier: 25, challenge_frequency: 'low' },
-        normal: { npc_patience_modifier: 0, challenge_frequency: 'medium' },
+        warm:     { patience: 80, volatility: 20, disclosure: 80, time_pressure: 10 },
+        standard: { patience: 55, volatility: 45, disclosure: 55, time_pressure: 30 },
       },
     },
     supported_languages: ['es', 'en'],

--- a/apps/api/src/data/scenarios.ts
+++ b/apps/api/src/data/scenarios.ts
@@ -74,11 +74,11 @@ export const SCENARIOS: Record<string, ScenarioInfo> = {
       brief: 'You want to buy a used car listed at $12,000 and get a fair deal.',
     },
     difficulty: {
-      default: 'normal',
+      default: 'standard',
       options: {
-        easy: { npc_patience_modifier: 20, challenge_frequency: 'low' },
-        normal: { npc_patience_modifier: 0, challenge_frequency: 'medium' },
-        hard: { npc_patience_modifier: -15, challenge_frequency: 'high' },
+        warm: { patience: 80, volatility: 20, disclosure: 70, time_pressure: 20 },
+        standard: { patience: 50, volatility: 50, disclosure: 50, time_pressure: 50 },
+        hard: { patience: 25, volatility: 70, disclosure: 25, time_pressure: 60 },
       },
     },
     supported_languages: ['en', 'es'],
@@ -131,11 +131,11 @@ export const SCENARIOS: Record<string, ScenarioInfo> = {
       brief: 'You need to give constructive feedback to a coworker about missing a project deadline.',
     },
     difficulty: {
-      default: 'normal',
+      default: 'standard',
       options: {
-        easy: { npc_patience_modifier: 20, challenge_frequency: 'low' },
-        normal: { npc_patience_modifier: 0, challenge_frequency: 'medium' },
-        hard: { npc_patience_modifier: -15, challenge_frequency: 'high' },
+        warm: { patience: 80, volatility: 20, disclosure: 70, time_pressure: 20 },
+        standard: { patience: 50, volatility: 50, disclosure: 50, time_pressure: 50 },
+        hard: { patience: 25, volatility: 70, disclosure: 25, time_pressure: 60 },
       },
     },
     supported_languages: ['en'],

--- a/apps/api/src/routes/pack-library.test.ts
+++ b/apps/api/src/routes/pack-library.test.ts
@@ -97,8 +97,8 @@ goals:
 difficulty:
   default: hard
   options:
-    normal: { npc_patience_modifier: 0, challenge_frequency: medium }
-    hard: { npc_patience_modifier: -20, challenge_frequency: high }
+    standard: { patience: 50, volatility: 50, disclosure: 50, time_pressure: 50 }
+    hard: { patience: 25, volatility: 70, disclosure: 25, time_pressure: 60 }
 `;
 
 function makePackZip(parent: string): Buffer {
@@ -182,8 +182,10 @@ describe('GET /api/scenarios — dynamic pack merge', () => {
     expect(dynamic.recommended_model).toEqual(['llama-3-8b']);
     expect(dynamic.difficulty.default).toBe('hard');
     expect(dynamic.difficulty.options.hard).toEqual({
-      npc_patience_modifier: -20,
-      challenge_frequency: 'high',
+      patience: 25,
+      volatility: 70,
+      disclosure: 25,
+      time_pressure: 60,
     });
     expect(dynamic.duration.max_turns).toBe(10);
     expect(dynamic.duration.soft_time_limit_minutes).toBe(12);

--- a/apps/api/src/routes/pack-library.test.ts
+++ b/apps/api/src/routes/pack-library.test.ts
@@ -317,7 +317,7 @@ describe('POST /api/sessions — launch imported pack scenario', () => {
     const res = await app.inject({
       method: 'POST',
       url: '/api/sessions',
-      payload: launchPayload({ difficulty: 'easy' }),
+      payload: launchPayload({ difficulty: 'warm' }),
     });
     expect(res.statusCode).toBe(400);
   });

--- a/apps/api/src/routes/privacy.test.ts
+++ b/apps/api/src/routes/privacy.test.ts
@@ -9,7 +9,7 @@ let app: FastifyInstance;
 
 const validRequest: SessionCreateRequest = {
   scenario_id: 'behavioral_interview',
-  difficulty: 'normal',
+  difficulty: 'standard',
   player_role_name: 'Alice',
   language: 'en',
   input_mode: 'text-only',

--- a/apps/api/src/routes/scenarios.ts
+++ b/apps/api/src/routes/scenarios.ts
@@ -14,22 +14,26 @@ export function setScenariosDbPath(dbPath: string | null): void {
 function buildDifficultyConfig(
   rawDiff: { default?: string; options?: Record<string, unknown> } | undefined,
 ): ScenarioInfo['difficulty'] {
-  const defaultDiff = (rawDiff?.default ?? 'normal') as ScenarioDifficulty;
+  const defaultDiff = (rawDiff?.default ?? 'standard') as ScenarioDifficulty;
   const rawOptions = (rawDiff?.options ?? {}) as Record<string, Record<string, unknown>>;
   const options: Partial<Record<ScenarioDifficulty, DifficultyOption>> = {};
 
+  const validPresets = new Set<string>(['warm', 'standard', 'hard', 'adversarial']);
   for (const [key, val] of Object.entries(rawOptions)) {
-    if (key === 'easy' || key === 'normal' || key === 'hard') {
-      options[key] = {
-        npc_patience_modifier: (val['npc_patience_modifier'] as number | undefined) ?? 0,
-        challenge_frequency:
-          (val['challenge_frequency'] as 'low' | 'medium' | 'high' | undefined) ?? 'medium',
+    if (validPresets.has(key)) {
+      options[key as ScenarioDifficulty] = {
+        patience:      (val['patience']      as number | undefined),
+        volatility:    (val['volatility']    as number | undefined),
+        disclosure:    (val['disclosure']    as number | undefined),
+        time_pressure: (val['time_pressure'] as number | undefined),
+        label:         (val['label']         as string | undefined),
+        description:   (val['description']   as string | undefined),
       };
     }
   }
 
   if (Object.keys(options).length === 0) {
-    options['normal'] = { npc_patience_modifier: 0, challenge_frequency: 'medium' };
+    options['standard'] = { patience: 50, volatility: 50, disclosure: 50, time_pressure: 50 };
   }
 
   return { default: defaultDiff, options };

--- a/apps/api/src/routes/session-ws.test.ts
+++ b/apps/api/src/routes/session-ws.test.ts
@@ -16,7 +16,7 @@ let app: FastifyInstance;
 
 const validRequest = {
   scenario_id: 'behavioral_interview',
-  difficulty: 'normal',
+  difficulty: 'standard',
   player_role_name: 'Alice',
   language: 'en',
   input_mode: 'text-only',

--- a/apps/api/src/routes/sessions-latency.test.ts
+++ b/apps/api/src/routes/sessions-latency.test.ts
@@ -9,7 +9,7 @@ let app: FastifyInstance;
 
 const validRequest: SessionCreateRequest = {
   scenario_id: 'behavioral_interview',
-  difficulty: 'normal',
+  difficulty: 'standard',
   player_role_name: 'Alice',
   language: 'en',
   input_mode: 'text-only',

--- a/apps/api/src/routes/sessions.test.ts
+++ b/apps/api/src/routes/sessions.test.ts
@@ -24,7 +24,7 @@ afterEach(async () => {
 
 const validRequest: SessionCreateRequest = {
   scenario_id: 'behavioral_interview',
-  difficulty: 'normal',
+  difficulty: 'standard',
   player_role_name: 'Alice',
   language: 'en',
   input_mode: 'text-only',
@@ -103,7 +103,7 @@ describe('POST /api/sessions', () => {
     expect(body.session_id).toMatch(/^sess-/);
     expect(body.scenario_id).toBe('behavioral_interview');
     expect(body.state).toBe('NotStarted');
-    expect(body.setup.difficulty).toBe('normal');
+    expect(body.setup.difficulty).toBe('standard');
     expect(body.setup.player_role_name).toBe('Alice');
     expect(body.setup.language).toBe('en');
     expect(body.setup.input_mode).toBe('text-only');
@@ -150,7 +150,7 @@ describe('POST /api/sessions', () => {
     const res = await app.inject({
       method: 'POST',
       url: '/api/sessions',
-      payload: { ...validRequest, scenario_id: 'hostile_executive_interview', difficulty: 'easy' },
+      payload: { ...validRequest, scenario_id: 'hostile_executive_interview', difficulty: 'warm' },
     });
     expect(res.statusCode).toBe(400);
   });

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -203,7 +203,7 @@ export async function sessionRoutes(app: FastifyInstance) {
           ],
           properties: {
             scenario_id: { type: 'string' },
-            difficulty: { type: 'string', enum: ['easy', 'normal', 'hard'] },
+            difficulty: { type: 'string', enum: ['warm', 'standard', 'hard', 'adversarial'] },
             player_role_name: { type: 'string', minLength: 1 },
             language: { type: 'string' },
             input_mode: {

--- a/apps/api/src/routes/workbench.ts
+++ b/apps/api/src/routes/workbench.ts
@@ -529,7 +529,7 @@ export async function workbenchRoutes(app: FastifyInstance): Promise<void> {
 
       const setupJson = JSON.stringify({
         scenario_id: WORKBENCH_TEST_SCENARIO_ID,
-        difficulty: 'normal',
+        difficulty: 'standard',
         player_role_name: 'Creator',
         language: 'en',
         input_mode: 'text-only',

--- a/apps/web/src/__tests__/Conversation.test.tsx
+++ b/apps/web/src/__tests__/Conversation.test.tsx
@@ -91,7 +91,7 @@ const mockScenario: ScenarioInfo = {
   pack_id: 'job-interview-basic',
   pack_name: 'Job Interview Basics',
   player_role: { label: 'Job Candidate', brief: 'You are applying for a software engineering role.' },
-  difficulty: { default: 'normal', options: { easy: { npc_patience_modifier: 0.5, challenge_frequency: 'low' }, normal: { npc_patience_modifier: 0, challenge_frequency: 'medium' } } },
+  difficulty: { default: 'standard', options: { warm: { patience: 80, volatility: 20, disclosure: 70, time_pressure: 20 }, standard: { patience: 50, volatility: 50, disclosure: 50, time_pressure: 50 } } },
   supported_languages: ['en'],
   duration: { max_turns: 20, soft_time_limit_minutes: 15 },
   state_meters_permitted: true,

--- a/apps/web/src/__tests__/Debrief.test.tsx
+++ b/apps/web/src/__tests__/Debrief.test.tsx
@@ -27,7 +27,7 @@ const SESSION_ID = 'sess-debrief01'
 
 const sampleSetup = {
   scenario_id: 'behavioral_interview',
-  difficulty: 'normal' as const,
+  difficulty: 'standard' as const,
   player_role_name: 'Candidate',
   language: 'en',
   input_mode: 'text-only' as const,

--- a/apps/web/src/__tests__/ScenarioLibrary.test.tsx
+++ b/apps/web/src/__tests__/ScenarioLibrary.test.tsx
@@ -281,9 +281,9 @@ describe('scenario card rendering', () => {
   it('shows difficulty chips', async () => {
     renderLibrary()
     await waitFor(() => screen.getByText('Behavioral Interview'))
-    // Easy, Normal, Hard present from SCENARIO_BEHAVIORAL
-    const easyChips = screen.getAllByText('Easy')
-    expect(easyChips.length).toBeGreaterThan(0)
+    // Warm, Standard, Hard present from SCENARIO_BEHAVIORAL
+    const warmChips = screen.getAllByText('Warm')
+    expect(warmChips.length).toBeGreaterThan(0)
   })
 
   it('shows supported languages', async () => {
@@ -462,9 +462,9 @@ describe('filters', () => {
   it('filter by difficulty removes scenarios lacking that difficulty option', async () => {
     renderLibrary()
     await waitFor(() => screen.getByText('Behavioral Interview'))
-    // SCENARIO_HOSTILE only has normal and hard; filtering for 'easy' should hide it
+    // SCENARIO_HOSTILE only has standard, hard, adversarial; filtering for 'warm' should hide it
     fireEvent.change(screen.getByRole('combobox', { name: /filter by difficulty/i }), {
-      target: { value: 'easy' },
+      target: { value: 'warm' },
     })
     await waitFor(() =>
       expect(screen.queryByText('Hostile Executive Interview')).not.toBeInTheDocument(),

--- a/apps/web/src/__tests__/ScenarioLibrary.test.tsx
+++ b/apps/web/src/__tests__/ScenarioLibrary.test.tsx
@@ -32,11 +32,11 @@ const SCENARIO_BEHAVIORAL: ScenarioInfo = {
   pack_name: 'Job Interview Basics',
   player_role: { label: 'Candidate', brief: 'You are interviewing for a product manager role.' },
   difficulty: {
-    default: 'normal',
+    default: 'standard',
     options: {
-      easy: { npc_patience_modifier: 15, challenge_frequency: 'low' },
-      normal: { npc_patience_modifier: 0, challenge_frequency: 'medium' },
-      hard: { npc_patience_modifier: -20, challenge_frequency: 'high' },
+      warm:     { patience: 80, volatility: 20, disclosure: 70, time_pressure: 20 },
+      standard: { patience: 50, volatility: 50, disclosure: 50, time_pressure: 50 },
+      hard:     { patience: 25, volatility: 70, disclosure: 25, time_pressure: 60 },
     },
   },
   supported_languages: ['en'],
@@ -58,10 +58,11 @@ const SCENARIO_HOSTILE: ScenarioInfo = {
   pack_name: 'Job Interview Basics',
   player_role: { label: 'Candidate', brief: 'VP-level interview.' },
   difficulty: {
-    default: 'normal',
+    default: 'standard',
     options: {
-      normal: { npc_patience_modifier: -10, challenge_frequency: 'medium' },
-      hard: { npc_patience_modifier: -25, challenge_frequency: 'high' },
+      standard:    { patience: 30, volatility: 60, disclosure: 30, time_pressure: 60 },
+      hard:        { patience: 15, volatility: 80, disclosure: 15, time_pressure: 75 },
+      adversarial: { patience: 5,  volatility: 95, disclosure: 5,  time_pressure: 90 },
     },
   },
   supported_languages: ['en'],
@@ -83,10 +84,10 @@ const SCENARIO_SPANISH: ScenarioInfo = {
   pack_name: 'Language Café',
   player_role: { label: 'Language Learner', brief: 'Practicing Spanish in Madrid.' },
   difficulty: {
-    default: 'easy',
+    default: 'warm',
     options: {
-      easy: { npc_patience_modifier: 25, challenge_frequency: 'low' },
-      normal: { npc_patience_modifier: 0, challenge_frequency: 'medium' },
+      warm:     { patience: 80, volatility: 20, disclosure: 80, time_pressure: 10 },
+      standard: { patience: 55, volatility: 45, disclosure: 55, time_pressure: 30 },
     },
   },
   supported_languages: ['es', 'en'],

--- a/apps/web/src/api/client.test.ts
+++ b/apps/web/src/api/client.test.ts
@@ -31,7 +31,7 @@ describe('api.createSession error handling', () => {
     await expect(
       api.createSession({
         scenario_id: 'nonexistent',
-        difficulty: 'normal',
+        difficulty: 'standard',
         player_role_name: 'Alice',
         language: 'en',
         input_mode: 'text-only',
@@ -54,7 +54,7 @@ describe('api.createSession error handling', () => {
     try {
       await api.createSession({
         scenario_id: 'behavioral_interview',
-        difficulty: 'normal',
+        difficulty: 'standard',
         player_role_name: '',
         language: 'en',
         input_mode: 'text-only',
@@ -78,7 +78,7 @@ describe('api.createSession error handling', () => {
     try {
       await api.createSession({
         scenario_id: 'behavioral_interview',
-        difficulty: 'normal',
+        difficulty: 'standard',
         player_role_name: 'Alice',
         language: 'en',
         input_mode: 'text-only',
@@ -101,7 +101,7 @@ describe('api.createSession error handling', () => {
     await expect(
       api.createSession({
         scenario_id: 'behavioral_interview',
-        difficulty: 'normal',
+        difficulty: 'standard',
         player_role_name: 'Alice',
         language: 'en',
         input_mode: 'text-only',

--- a/apps/web/src/pages/ScenarioSetup.test.tsx
+++ b/apps/web/src/pages/ScenarioSetup.test.tsx
@@ -15,11 +15,11 @@ const mockScenario: ScenarioInfo = {
     brief: 'You are interviewing for a product manager role.',
   },
   difficulty: {
-    default: 'normal',
+    default: 'standard',
     options: {
-      easy: { npc_patience_modifier: 15, challenge_frequency: 'low' },
-      normal: { npc_patience_modifier: 0, challenge_frequency: 'medium' },
-      hard: { npc_patience_modifier: -20, challenge_frequency: 'high' },
+      warm:     { patience: 80, volatility: 20, disclosure: 70, time_pressure: 20, label: 'Warm-up', description: 'NPC is patient and guides you.' },
+      standard: { patience: 50, volatility: 50, disclosure: 50, time_pressure: 50 },
+      hard:     { patience: 25, volatility: 70, disclosure: 25, time_pressure: 60 },
     },
   },
   supported_languages: ['en', 'es'],
@@ -147,8 +147,8 @@ describe('ScenarioSetupPage', () => {
     it('sets difficulty to the scenario default', async () => {
       renderSetup();
       await waitFor(() => screen.getByText('Behavioral Interview'));
-      const normalRadio = screen.getByRole('radio', { name: /normal/i });
-      expect(normalRadio).toBeChecked();
+      const standardRadio = screen.getByRole('radio', { name: /standard/i });
+      expect(standardRadio).toBeChecked();
     });
 
     it('sets player role name to the scenario label', async () => {
@@ -217,8 +217,8 @@ describe('ScenarioSetupPage', () => {
     it('renders all difficulty options from the scenario', async () => {
       renderSetup();
       await waitFor(() => screen.getByText('Behavioral Interview'));
-      expect(screen.getByRole('radio', { name: /easy/i })).toBeInTheDocument();
-      expect(screen.getByRole('radio', { name: /normal/i })).toBeInTheDocument();
+      expect(screen.getByRole('radio', { name: /warm-up/i })).toBeInTheDocument();
+      expect(screen.getByRole('radio', { name: /standard/i })).toBeInTheDocument();
       expect(screen.getByRole('radio', { name: /hard/i })).toBeInTheDocument();
     });
 
@@ -431,7 +431,7 @@ describe('ScenarioSetupPage', () => {
         created_at: '2026-06-30T00:00:00Z',
         setup: {
           scenario_id: 'behavioral_interview',
-          difficulty: 'normal',
+          difficulty: 'standard',
           player_role_name: 'Candidate',
           language: 'en',
           input_mode: 'push-to-talk',
@@ -453,7 +453,7 @@ describe('ScenarioSetupPage', () => {
       await waitFor(() => {
         expect(mockApi.createSession).toHaveBeenCalledWith({
           scenario_id: 'behavioral_interview',
-          difficulty: 'normal',
+          difficulty: 'standard',
           player_role_name: 'Candidate',
           language: 'en',
           input_mode: 'push-to-talk',

--- a/apps/web/src/pages/ScenarioSetup.tsx
+++ b/apps/web/src/pages/ScenarioSetup.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import type {
   ScenarioInfo,
   ScenarioDifficulty,
+  DifficultyOption,
   SetupFormValues,
   InputMode,
   RuntimeReadiness,
@@ -11,6 +12,28 @@ import type {
 import { validateSetup, randomSeed } from '@convsim/shared';
 import { api } from '../api/client';
 import { readPrivacyPref, PRIVACY_KEYS } from '../privacyPrefs';
+
+const DIFFICULTY_LABELS: Record<ScenarioDifficulty, string> = {
+  warm:        'Warm-up',
+  standard:    'Standard',
+  hard:        'Hard',
+  adversarial: 'Adversarial',
+};
+
+const DIFFICULTY_DESCRIPTIONS: Record<ScenarioDifficulty, string> = {
+  warm:        'The NPC is patient and forthcoming — ideal for first attempts or building confidence.',
+  standard:    'Balanced challenge with realistic NPC behaviour — the author\'s recommended starting point.',
+  hard:        'The NPC is terse, reactive, and discloses little; expect rapid state swings.',
+  adversarial: 'Maximum challenge: very low patience, high state volatility, almost no disclosure, strong time pressure.',
+};
+
+function difficultyDescription(level: ScenarioDifficulty, option: DifficultyOption | undefined): string {
+  return option?.description ?? DIFFICULTY_DESCRIPTIONS[level] ?? level;
+}
+
+function difficultyLabel(level: ScenarioDifficulty, option: DifficultyOption | undefined): string {
+  return option?.label ?? DIFFICULTY_LABELS[level] ?? level.charAt(0).toUpperCase() + level.slice(1);
+}
 
 const LANGUAGE_LABELS: Record<string, string> = {
   en: 'English',
@@ -51,7 +74,7 @@ export function ScenarioSetupPage({ scenarioId, onSessionCreated, onBack }: Prop
   const [submitError, setSubmitError] = useState<string | null>(null);
 
   const [form, setForm] = useState<SetupFormValues>({
-    difficulty: 'normal',
+    difficulty: 'standard',
     player_role_name: '',
     language: 'en',
     input_mode: 'text-only',
@@ -229,20 +252,31 @@ export function ScenarioSetupPage({ scenarioId, onSessionCreated, onBack }: Prop
               Difficulty
             </h2>
             <div className="setup-radio-group" role="radiogroup" aria-label="Difficulty">
-              {availableDifficulties.map((level) => (
-                <label key={level} className="setup-radio-label">
-                  <input
-                    type="radio"
-                    name="difficulty"
-                    value={level}
-                    checked={form.difficulty === level}
-                    onChange={() => setField('difficulty', level)}
-                  />
-                  <span className="setup-radio-text">
-                    {level.charAt(0).toUpperCase() + level.slice(1)}
-                  </span>
-                </label>
-              ))}
+              {availableDifficulties.map((level) => {
+                const option = scenario.difficulty.options[level];
+                return (
+                  <label key={level} className="setup-radio-label">
+                    <input
+                      type="radio"
+                      name="difficulty"
+                      value={level}
+                      checked={form.difficulty === level}
+                      onChange={() => setField('difficulty', level)}
+                    />
+                    <span className="setup-radio-text">
+                      <span className="setup-difficulty-name">
+                        {difficultyLabel(level, option)}
+                        {level === scenario.difficulty.default && (
+                          <span className="setup-difficulty-recommended"> (recommended)</span>
+                        )}
+                      </span>
+                      <span className="setup-difficulty-description">
+                        {difficultyDescription(level, option)}
+                      </span>
+                    </span>
+                  </label>
+                );
+              })}
             </div>
           </section>
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -804,17 +804,36 @@ state:
     perceived_specificity: 40
 
 difficulty:
-  default: "normal"
+  default: "standard"
   options:
-    easy:
-      npc_patience_modifier: 15
-      challenge_frequency: low
-    normal:
-      npc_patience_modifier: 0
-      challenge_frequency: medium
+    warm:
+      patience: 80
+      volatility: 20
+      disclosure: 80
+      time_pressure: 10
+      label: "Warm-up"
+      description: "Forgiving, patient interviewer — great for first practice."
+    standard:
+      patience: 60
+      volatility: 40
+      disclosure: 60
+      time_pressure: 30
+      label: "Standard"
+      description: "Balanced challenge matching a typical interview."
     hard:
-      npc_patience_modifier: -20
-      challenge_frequency: high
+      patience: 35
+      volatility: 65
+      disclosure: 40
+      time_pressure: 60
+      label: "Hard"
+      description: "Demanding interviewer who pushes back on vague answers."
+    adversarial:
+      patience: 15
+      volatility: 90
+      disclosure: 20
+      time_pressure: 90
+      label: "Adversarial"
+      description: "Highly skeptical — expect interruptions and sharp challenges."
 
 events:
   - id: "rambling_warning"

--- a/docs/acceptance/developer-checklist.md
+++ b/docs/acceptance/developer-checklist.md
@@ -95,7 +95,7 @@ cd services/convsim-core
 CONVSIM_LOG_LEVEL=DEBUG python -m convsim_core.main &
 curl -s -X POST http://127.0.0.1:7355/api/sessions \
      -H 'Content-Type: application/json' \
-     -d '{"scenario_id":"behavioral_interview","difficulty":"normal","player_role_name":"Dev","language":"en","input_mode":"text-only","tts_enabled":false,"show_state_meters":false,"save_transcript":true}'
+     -d '{"scenario_id":"behavioral_interview","difficulty":"standard","player_role_name":"Dev","language":"en","input_mode":"text-only","tts_enabled":false,"show_state_meters":false,"save_transcript":true}'
 ```
 
 - [ ] DEBUG log lines appear in the terminal for the session create call

--- a/docs/official-pack-quality-bar.md
+++ b/docs/official-pack-quality-bar.md
@@ -343,7 +343,7 @@ purposes. Omit it in production scenarios unless the scenario explicitly calls
 for a fixed sequence — varied LLM sampling produces the natural replay
 variation that makes the scenario worth practicing more than once.
 
-Difficulty levels (easy/normal/hard) should produce meaningfully different
+Difficulty levels (warm/standard/hard/adversarial) should produce meaningfully different
 challenges, not just cosmetic variation:
 
 - `easy`: Lower expectations, more patience from the NPC.

--- a/docs/pack-validation.md
+++ b/docs/pack-validation.md
@@ -216,7 +216,7 @@ description: >-
 
 seed: 42
 input_mode: text
-difficulty: normal
+difficulty: standard
 
 # Multi-turn scripted conversation — each turn represents an ideal player move
 turns:

--- a/docs/pack-validation.md
+++ b/docs/pack-validation.md
@@ -270,8 +270,8 @@ static_assertions:
     check: "equals true"
 
   - description: Hard difficulty reduces NPC patience
-    path: scenario.difficulty.options.hard.npc_patience_modifier
-    check: "equals -20"
+    path: scenario.difficulty.options.hard.patience
+    check: "lte 33"
 ```
 
 ### What to assert in a golden test
@@ -289,8 +289,8 @@ static_assertions:
 - `success` and `failure` conditions target the right variable and threshold type.
 
 **Difficulty settings:**
-- `easy` increases `npc_patience_modifier`; `hard` decreases it.
-- `challenge_frequency` reflects the intended difficulty spread.
+- `warm` raises `patience` and `disclosure`; `hard`/`adversarial` lower them.
+- `volatility` and `time_pressure` climb as the preset gets harder.
 
 **Safety:**
 - Required safety categories are present and have the right actions.

--- a/docs/scenario-authoring.md
+++ b/docs/scenario-authoring.md
@@ -334,17 +334,29 @@ response_style:
   formality: professional
 
 difficulty:
-  default: normal
+  default: standard
   options:
-    easy:
-      npc_patience_modifier: 20
-      challenge_frequency: low
-    normal:
-      npc_patience_modifier: 0
-      challenge_frequency: medium
+    warm:
+      patience: 80
+      volatility: 20
+      disclosure: 70
+      time_pressure: 20
+      label: Warm-up
+      description: Patient NPC who cues you when needed — good for first attempts.
+    standard:
+      patience: 50
+      volatility: 50
+      disclosure: 50
+      time_pressure: 50
+      label: Standard
+      description: Balanced realism — the author's recommended starting point.
     hard:
-      npc_patience_modifier: -20
-      challenge_frequency: high
+      patience: 25
+      volatility: 70
+      disclosure: 25
+      time_pressure: 60
+      label: Hard
+      description: Terse, reactive NPC; one weak answer can shift the posture quickly.
 ```
 
 > **Rename the file.** The file is still called `behavioral_interview.yaml`.
@@ -802,9 +814,9 @@ static_assertions:
     path: safety.content_categories.nsfw_sexual_content
     check: "equals stop"
 
-  - description: Hard difficulty applies a negative patience modifier
-    path: scenario.difficulty.options.hard.npc_patience_modifier
-    check: "equals -20"
+  - description: Hard difficulty lowers NPC patience
+    path: scenario.difficulty.options.hard.patience
+    check: "lte 33"
 
   - description: Pack manifest declares raise_conversation as an entry scenario
     path: manifest.entry_scenarios

--- a/docs/scenario-authoring.md
+++ b/docs/scenario-authoring.md
@@ -670,7 +670,7 @@ description: >-
   advances the session without triggering a safety stop.
 seed: 42
 input_mode: text
-difficulty: normal
+difficulty: standard
 turns:
   - turn: 1
     player_input: >-
@@ -732,7 +732,7 @@ description: >-
 
 seed: 42
 input_mode: text
-difficulty: normal
+difficulty: standard
 
 turns:
   - turn: 1

--- a/packages/convsim-cli/src/runner/check-evaluator.ts
+++ b/packages/convsim-cli/src/runner/check-evaluator.ts
@@ -5,14 +5,22 @@
  *
  * Supported check forms:
  *   non_empty_string           — value is a non-empty string
+ *   non_null                   — value is not null or undefined
  *   min_length_1               — value is an array with length >= 1
  *   equals <literal>           — value === literal (true/false parsed as boolean, numbers as number)
  *   contains <needle>          — array or string includes needle
+ *   lte <number>               — numeric value <= threshold
+ *   gte <number>               — numeric value >= threshold
+ *   between <lo> <hi>          — numeric value >= lo and <= hi (inclusive)
  *   k=v AND k=v ...            — object has all key=value pairs (numeric values auto-parsed)
  */
 export function evaluateCheck(value: unknown, check: string): boolean {
   if (check === 'non_empty_string') {
     return typeof value === 'string' && value.length > 0;
+  }
+
+  if (check === 'non_null') {
+    return value !== null && value !== undefined;
   }
 
   if (check === 'min_length_1') {
@@ -29,6 +37,23 @@ export function evaluateCheck(value: unknown, check: string): boolean {
     if (Array.isArray(value)) return value.includes(needle);
     if (typeof value === 'string') return value.includes(needle);
     return false;
+  }
+
+  if (check.startsWith('lte ')) {
+    const threshold = Number(check.slice('lte '.length).trim());
+    return typeof value === 'number' && value <= threshold;
+  }
+
+  if (check.startsWith('gte ')) {
+    const threshold = Number(check.slice('gte '.length).trim());
+    return typeof value === 'number' && value >= threshold;
+  }
+
+  if (check.startsWith('between ')) {
+    const parts = check.slice('between '.length).trim().split(/\s+/);
+    const lo = Number(parts[0]);
+    const hi = Number(parts[1]);
+    return typeof value === 'number' && value >= lo && value <= hi;
   }
 
   if (check.includes(' AND ') || check.includes('=')) {

--- a/packages/convsim-cli/tests/runner.test.ts
+++ b/packages/convsim-cli/tests/runner.test.ts
@@ -67,6 +67,61 @@ describe('evaluateCheck — contains', () => {
   });
 });
 
+describe('evaluateCheck — non_null', () => {
+  it('passes for a defined non-null value', () => {
+    expect(evaluateCheck({ patience: 10 }, 'non_null')).toBe(true);
+    expect(evaluateCheck(0, 'non_null')).toBe(true);
+    expect(evaluateCheck('', 'non_null')).toBe(true);
+    expect(evaluateCheck(false, 'non_null')).toBe(true);
+  });
+  it('fails for null or undefined', () => {
+    expect(evaluateCheck(null, 'non_null')).toBe(false);
+    expect(evaluateCheck(undefined, 'non_null')).toBe(false);
+  });
+});
+
+describe('evaluateCheck — lte', () => {
+  it('passes when value is at or below the threshold', () => {
+    expect(evaluateCheck(33, 'lte 33')).toBe(true);
+    expect(evaluateCheck(10, 'lte 33')).toBe(true);
+  });
+  it('fails when value is above the threshold', () => {
+    expect(evaluateCheck(34, 'lte 33')).toBe(false);
+  });
+  it('fails for non-numeric values', () => {
+    expect(evaluateCheck('10', 'lte 33')).toBe(false);
+    expect(evaluateCheck(null, 'lte 33')).toBe(false);
+  });
+});
+
+describe('evaluateCheck — gte', () => {
+  it('passes when value is at or above the threshold', () => {
+    expect(evaluateCheck(67, 'gte 67')).toBe(true);
+    expect(evaluateCheck(90, 'gte 67')).toBe(true);
+  });
+  it('fails when value is below the threshold', () => {
+    expect(evaluateCheck(66, 'gte 67')).toBe(false);
+  });
+  it('fails for non-numeric values', () => {
+    expect(evaluateCheck('90', 'gte 67')).toBe(false);
+  });
+});
+
+describe('evaluateCheck — between', () => {
+  it('passes when value is within the inclusive range', () => {
+    expect(evaluateCheck(50, 'between 40 60')).toBe(true);
+    expect(evaluateCheck(40, 'between 40 60')).toBe(true);
+    expect(evaluateCheck(60, 'between 40 60')).toBe(true);
+  });
+  it('fails when value is outside the range', () => {
+    expect(evaluateCheck(39, 'between 40 60')).toBe(false);
+    expect(evaluateCheck(61, 'between 40 60')).toBe(false);
+  });
+  it('fails for non-numeric values', () => {
+    expect(evaluateCheck('50', 'between 40 60')).toBe(false);
+  });
+});
+
 describe('evaluateCheck — key=value AND conditions', () => {
   it('passes when all conditions match', () => {
     const value = { type: 'variable_above', variable: 'impression', threshold: 70 };

--- a/packages/pack-loader/src/types.ts
+++ b/packages/pack-loader/src/types.ts
@@ -201,7 +201,7 @@ export interface RawFixture {
   description: string;
   seed?: number;
   input_mode?: 'text' | 'voice';
-  difficulty?: 'easy' | 'normal' | 'hard';
+  difficulty?: 'warm' | 'standard' | 'hard' | 'adversarial';
   turns: RawFixtureTurn[];
   static_assertions?: RawStaticAssertion[];
 }

--- a/packages/prompt-composer/src/convsim_prompt/debrief_composer.py
+++ b/packages/prompt-composer/src/convsim_prompt/debrief_composer.py
@@ -42,6 +42,7 @@ class DebriefComposerInput:
     turns: List[DebriefTurnRecord]
     rubric_dimension_names: Dict[str, str] = field(default_factory=dict)
     pack_id: Optional[str] = None
+    difficulty_preset: Optional[str] = None
 
 
 def _format_transcript(turns: List[DebriefTurnRecord]) -> str:
@@ -87,6 +88,11 @@ def compose_debrief_prompt(inp: DebriefComposerInput) -> PromptBundle:
         f"SCENARIO: {inp.scenario_title} (id: {inp.scenario_id})",
         f"PLAYER ROLE: {inp.player_role_label}",
         f"OUTCOME: {inp.outcome}",
+        *(
+            [f"DIFFICULTY PRESET: {inp.difficulty_preset}"]
+            if inp.difficulty_preset
+            else []
+        ),
         "---",
         "DIMENSION SCORES (computed from per-turn rubric observations):",
         _format_scores(inp.scores, inp.rubric_dimension_names),

--- a/packages/prompt-composer/src/convsim_prompt/layers.py
+++ b/packages/prompt-composer/src/convsim_prompt/layers.py
@@ -79,15 +79,51 @@ def build_scenario_brief_layer(scenario: ScenarioData) -> str:
         lines.append("Player goals (visible to player):")
         for goal in scenario.player_visible_goals:
             lines.append(f"  - {goal}")
+    lines.append(f"Difficulty preset: {scenario.difficulty}")
     if scenario.difficulty_settings:
         ds = scenario.difficulty_settings
-        lines.append(
-            f"Difficulty: {scenario.difficulty} "
-            f"(patience modifier: {ds.npc_patience_modifier:+d}, "
-            f"challenge frequency: {ds.challenge_frequency})"
-        )
-    else:
-        lines.append(f"Difficulty: {scenario.difficulty}")
+        # Each knob maps to a bounded behaviour fragment so that prompts differ
+        # measurably between presets while staying within the safety envelope.
+        if ds.patience <= 33:
+            lines.append(
+                "NPC patience: low — the NPC may disengage or cut the conversation short "
+                "if the player stalls, repeats themselves, or fails to make progress."
+            )
+        elif ds.patience >= 67:
+            lines.append(
+                "NPC patience: high — the NPC stays engaged even through awkward pauses, "
+                "tangents, or slow starts; they give the player ample space to find their footing."
+            )
+        if ds.volatility <= 33:
+            lines.append(
+                "State sensitivity: low — small player missteps have limited immediate effect "
+                "on NPC state meters; the player has room to recover without sudden shifts."
+            )
+        elif ds.volatility >= 67:
+            lines.append(
+                "State sensitivity: high — each player choice has a strong and immediate effect "
+                "on NPC state; a single poor response can meaningfully alter outcomes."
+            )
+        if ds.disclosure <= 33:
+            lines.append(
+                "NPC disclosure: low — the NPC shares only what is directly asked and volunteers "
+                "nothing extra; the player must ask the right questions to surface useful information."
+            )
+        elif ds.disclosure >= 67:
+            lines.append(
+                "NPC disclosure: high — the NPC volunteers relevant context, hints, and information "
+                "when it is natural to do so; they are an open and cooperative conversational partner."
+            )
+        if ds.time_pressure <= 33:
+            lines.append(
+                "Time pressure: none — the NPC does not signal turn-budget urgency; "
+                "the player may take their time without the conversation feeling rushed."
+            )
+        elif ds.time_pressure >= 67:
+            lines.append(
+                "Time pressure: high — the NPC conveys that time is limited; they expect the player "
+                "to reach the point, and will signal when the window for resolution is closing."
+            )
     return "\n".join(lines)
 
 

--- a/packages/prompt-composer/src/convsim_prompt/types.py
+++ b/packages/prompt-composer/src/convsim_prompt/types.py
@@ -29,8 +29,15 @@ class NpcData:
 
 @dataclass
 class DifficultySettings:
-    npc_patience_modifier: int = 0
-    challenge_frequency: str = "medium"
+    """Knob values for one named difficulty preset.
+
+    Each knob is 0-100.  The midpoint (50) is the neutral baseline; values above
+    or below steer NPC behaviour in the direction described.
+    """
+    patience: int = 50       # higher → NPC stays engaged longer
+    volatility: int = 50     # higher → state meters shift more per turn
+    disclosure: int = 50     # higher → NPC volunteers more information
+    time_pressure: int = 50  # higher → NPC signals urgency / turn budget pressure
 
 
 @dataclass
@@ -49,7 +56,7 @@ class ScenarioData:
     player_role_label: str
     player_role_brief: str
     npc: NpcData
-    difficulty: str = "normal"
+    difficulty: str = "standard"
     difficulty_settings: Optional[DifficultySettings] = None
     response_style: Optional[ResponseStyleOverrides] = None
     opening_npc_says: Optional[str] = None

--- a/packages/prompt-composer/tests/_helpers.py
+++ b/packages/prompt-composer/tests/_helpers.py
@@ -53,10 +53,12 @@ def make_interview_scenario(
         player_role_label="Candidate",
         player_role_brief=player_role_brief,
         npc=make_hiring_manager_npc(),
-        difficulty="normal",
+        difficulty="standard",
         difficulty_settings=DifficultySettings(
-            npc_patience_modifier=0,
-            challenge_frequency="medium",
+            patience=50,
+            volatility=50,
+            disclosure=50,
+            time_pressure=50,
         ),
         response_style=ResponseStyleOverrides(
             max_words=90,

--- a/packages/prompt-composer/tests/test_composer.py
+++ b/packages/prompt-composer/tests/test_composer.py
@@ -92,7 +92,7 @@ class TestInterviewPromptSnapshot:
 
     def test_difficulty_in_system_prompt(self):
         bundle = compose_turn_prompt(make_interview_input())
-        assert "normal" in bundle.system_prompt
+        assert "standard" in bundle.system_prompt
 
     def test_recent_transcript_included(self):
         transcript = [
@@ -351,22 +351,131 @@ class TestResponseStyle:
     def test_difficulty_settings_in_scenario_brief(self):
         bundle = compose_turn_prompt(make_interview_input())
         brief = bundle.layer_map["SCENARIO_BRIEF"]
-        assert "normal" in brief
-        assert "medium" in brief  # challenge_frequency
+        assert "standard" in brief
 
     def test_hard_difficulty_override_reflected(self):
         from convsim_prompt import DifficultySettings
         inp = make_interview_input()
         inp.scenario.difficulty = "hard"
         inp.scenario.difficulty_settings = DifficultySettings(
-            npc_patience_modifier=-20,
-            challenge_frequency="high",
+            patience=25,
+            volatility=70,
+            disclosure=25,
+            time_pressure=60,
         )
         bundle = compose_turn_prompt(inp)
         brief = bundle.layer_map["SCENARIO_BRIEF"]
         assert "hard" in brief
-        assert "-20" in brief
-        assert "high" in brief
+        # Low patience/disclosure → expect NPC behaviour fragments
+        assert "patience: low" in brief
+        assert "disclosure: low" in brief
+
+
+# ---------------------------------------------------------------------------
+# Difficulty knob system — preset isolation and bounded fragments
+# ---------------------------------------------------------------------------
+
+
+class TestDifficultyKnobs:
+    """Verify that prompts differ by preset and that knob fragments stay within
+    the safety envelope (no new safety rules or schema instructions are emitted
+    regardless of difficulty settings)."""
+
+    def _make_with_preset(self, name: str, **knobs) -> str:
+        from convsim_prompt import DifficultySettings
+        inp = make_interview_input()
+        inp.scenario.difficulty = name
+        inp.scenario.difficulty_settings = DifficultySettings(**knobs)
+        return compose_turn_prompt(inp).system_prompt
+
+    def test_warm_prompt_differs_from_adversarial(self):
+        warm = self._make_with_preset(
+            "warm", patience=80, volatility=20, disclosure=80, time_pressure=20
+        )
+        adversarial = self._make_with_preset(
+            "adversarial", patience=10, volatility=90, disclosure=10, time_pressure=80
+        )
+        assert warm != adversarial
+
+    def test_all_four_presets_produce_distinct_prompts(self):
+        prompts = [
+            self._make_with_preset("warm",        patience=80, volatility=20, disclosure=80, time_pressure=20),
+            self._make_with_preset("standard",    patience=50, volatility=50, disclosure=50, time_pressure=50),
+            self._make_with_preset("hard",        patience=25, volatility=70, disclosure=25, time_pressure=60),
+            self._make_with_preset("adversarial", patience=10, volatility=90, disclosure=10, time_pressure=80),
+        ]
+        assert len(set(prompts)) == 4, "All four presets must produce distinct system prompts"
+
+    def test_low_patience_fragment_present(self):
+        sp = self._make_with_preset("adversarial", patience=10, volatility=50, disclosure=50, time_pressure=50)
+        assert "patience: low" in sp
+
+    def test_high_patience_fragment_present(self):
+        sp = self._make_with_preset("warm", patience=80, volatility=50, disclosure=50, time_pressure=50)
+        assert "patience: high" in sp
+
+    def test_medium_patience_emits_no_fragment(self):
+        sp = self._make_with_preset("standard", patience=50, volatility=50, disclosure=50, time_pressure=50)
+        assert "patience: low" not in sp
+        assert "patience: high" not in sp
+
+    def test_high_volatility_fragment_present(self):
+        sp = self._make_with_preset("adversarial", patience=50, volatility=90, disclosure=50, time_pressure=50)
+        assert "State sensitivity: high" in sp
+
+    def test_low_volatility_fragment_present(self):
+        sp = self._make_with_preset("warm", patience=50, volatility=20, disclosure=50, time_pressure=50)
+        assert "State sensitivity: low" in sp
+
+    def test_low_disclosure_fragment_present(self):
+        sp = self._make_with_preset("adversarial", patience=50, volatility=50, disclosure=10, time_pressure=50)
+        assert "disclosure: low" in sp
+
+    def test_high_disclosure_fragment_present(self):
+        sp = self._make_with_preset("warm", patience=50, volatility=50, disclosure=80, time_pressure=50)
+        assert "disclosure: high" in sp
+
+    def test_high_time_pressure_fragment_present(self):
+        sp = self._make_with_preset("adversarial", patience=50, volatility=50, disclosure=50, time_pressure=80)
+        assert "Time pressure: high" in sp
+
+    def test_low_time_pressure_fragment_present(self):
+        sp = self._make_with_preset("warm", patience=50, volatility=50, disclosure=50, time_pressure=20)
+        assert "Time pressure: none" in sp
+
+    def test_knob_fragments_do_not_appear_in_output_schema(self):
+        """Difficulty knob fragments must stay within the untrusted content region,
+        not in the OUTPUT_SCHEMA layer."""
+        sp = self._make_with_preset("adversarial", patience=10, volatility=90, disclosure=10, time_pressure=80)
+        from convsim_prompt import UNTRUSTED_CONTENT_END
+        # All knob content must appear before the trusted end sentinel.
+        end_pos = sp.index(UNTRUSTED_CONTENT_END)
+        schema_pos = sp.find("OUTPUT_SCHEMA")
+        assert end_pos < schema_pos
+
+    def test_difficulty_knobs_do_not_override_safety_policy(self):
+        """Adversarial knobs must not alter the SAFETY_POLICY layer."""
+        from _helpers import DEFAULT_SAFETY_POLICY
+        standard_inp = make_interview_input()
+        standard_inp.safety_policy = DEFAULT_SAFETY_POLICY
+        standard_sp = compose_turn_prompt(standard_inp).system_prompt
+
+        adversarial_inp = make_interview_input()
+        adversarial_inp.safety_policy = DEFAULT_SAFETY_POLICY
+        adversarial_inp.scenario.difficulty = "adversarial"
+        from convsim_prompt import DifficultySettings
+        adversarial_inp.scenario.difficulty_settings = DifficultySettings(
+            patience=10, volatility=90, disclosure=10, time_pressure=80
+        )
+        adversarial_sp = compose_turn_prompt(adversarial_inp).system_prompt
+
+        # Extract the SAFETY_POLICY layer from both prompts and compare.
+        def _extract_safety(text: str) -> str:
+            start = text.find("LAYER:SAFETY_POLICY")
+            end = text.find("LAYER:", start + 1)
+            return text[start:end] if end != -1 else text[start:]
+
+        assert _extract_safety(standard_sp) == _extract_safety(adversarial_sp)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/scenario-schema/src/schemas.ts
+++ b/packages/scenario-schema/src/schemas.ts
@@ -107,8 +107,8 @@ export const ScenarioSchema = z
       .array(z.string().min(1, 'Goal cannot be empty').max(200, 'Goal must be 200 characters or fewer'))
       .min(1, 'At least one goal is required')
       .max(10, 'At most 10 goals allowed'),
-    difficulty: z.enum(['easy', 'medium', 'hard'], {
-      errorMap: () => ({ message: 'Difficulty must be easy, medium, or hard' }),
+    difficulty: z.enum(['warm', 'standard', 'hard', 'adversarial'], {
+      errorMap: () => ({ message: 'Difficulty must be warm, standard, hard, or adversarial' }),
     }),
     duration_minutes: z
       .number()

--- a/packages/scenario-schema/src/types.ts
+++ b/packages/scenario-schema/src/types.ts
@@ -49,7 +49,7 @@ export interface ScenarioFile {
   description: string;
   player_role: string;
   goals: string[];
-  difficulty: 'easy' | 'medium' | 'hard';
+  difficulty: 'warm' | 'standard' | 'hard' | 'adversarial';
   duration_minutes: number;
   npc_ref: string;
   rubric_ref?: string;

--- a/packages/scenario-schema/tests/fixtures.ts
+++ b/packages/scenario-schema/tests/fixtures.ts
@@ -29,7 +29,7 @@ player_role: "You are interviewing for a software engineering position."
 goals:
   - "Demonstrate relevant past experience"
   - "Answer with the STAR method"
-difficulty: medium
+difficulty: standard
 duration_minutes: 20
 npc_ref: hiring-manager
 rubric_ref: interview-quality

--- a/packages/scenario-schema/tests/validation.test.ts
+++ b/packages/scenario-schema/tests/validation.test.ts
@@ -82,12 +82,12 @@ describe('parseScenarioYaml', () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.data.title).toBe('Behavioral Interview');
-    expect(result.data.difficulty).toBe('medium');
+    expect(result.data.difficulty).toBe('standard');
     expect(result.data.state_defaults.trust).toBe(50);
   });
 
   it('rejects invalid difficulty value', () => {
-    const yaml = VALID_SCENARIO_YAML.replace('difficulty: medium', 'difficulty: extreme');
+    const yaml = VALID_SCENARIO_YAML.replace('difficulty: standard', 'difficulty: extreme');
     const result = parseScenarioYaml(yaml);
     expect(result.ok).toBe(false);
     expect(result.errors.some((e) => e.path === 'difficulty')).toBe(true);

--- a/packages/shared-types/src/scenario.ts
+++ b/packages/shared-types/src/scenario.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /** Difficulty level options a scenario can expose to the player. */
-export type DifficultyLevel = "easy" | "normal" | "hard";
+export type DifficultyLevel = "warm" | "standard" | "hard" | "adversarial";
 
 /** Lightweight scenario card returned by the scenario-listing API endpoint. */
 export interface ScenarioSummary {

--- a/packages/shared/src/types/scenario.ts
+++ b/packages/shared/src/types/scenario.ts
@@ -1,8 +1,12 @@
-export type ScenarioDifficulty = 'easy' | 'normal' | 'hard';
+export type ScenarioDifficulty = 'warm' | 'standard' | 'hard' | 'adversarial';
 
 export interface DifficultyOption {
-  npc_patience_modifier: number;
-  challenge_frequency: 'low' | 'medium' | 'high';
+  patience?: number;
+  volatility?: number;
+  disclosure?: number;
+  time_pressure?: number;
+  label?: string;
+  description?: string;
 }
 
 export interface ScenarioDifficultyConfig {

--- a/packages/shared/src/types/setup.test.ts
+++ b/packages/shared/src/types/setup.test.ts
@@ -22,7 +22,7 @@ const runtimeTextOnly: RuntimeReadiness = {
 };
 
 const validForm: SetupFormValues = {
-  difficulty: 'normal',
+  difficulty: 'standard',
   player_role_name: 'Alice',
   language: 'en',
   input_mode: 'text-only',

--- a/packages/ui/src/forms/ScenarioForm.tsx
+++ b/packages/ui/src/forms/ScenarioForm.tsx
@@ -211,9 +211,10 @@ export function ScenarioForm({ values, errors, onChange }: ScenarioFormProps) {
           onChange={(e) => onChange('difficulty', e.target.value)}
         >
           <option value="">— choose —</option>
-          <option value="easy">Easy — forgiving, patient NPC</option>
-          <option value="medium">Medium — balanced challenge</option>
+          <option value="warm">Warm — forgiving, patient NPC</option>
+          <option value="standard">Standard — balanced challenge</option>
           <option value="hard">Hard — demanding, pushes back</option>
+          <option value="adversarial">Adversarial — highly skeptical NPC</option>
         </select>
       </FieldWrapper>
 

--- a/packages/ui/tests/FormEditor.test.tsx
+++ b/packages/ui/tests/FormEditor.test.tsx
@@ -31,7 +31,7 @@ description: "A scenario for testing."
 player_role: "You are a tester."
 goals:
   - "Complete the test"
-difficulty: medium
+difficulty: standard
 duration_minutes: 10
 npc_ref: test-npc
 opening_context: "The test begins."
@@ -230,7 +230,7 @@ describe('FormEditor — scenario form', () => {
   it('renders difficulty select with current value', () => {
     render(<FormEditor fileType="scenario" initialYaml={SCENARIO_YAML} />);
     const select = screen.getByLabelText('Difficulty');
-    expect(select).toHaveValue('medium');
+    expect(select).toHaveValue('standard');
   });
 
   it('updates difficulty via dropdown', async () => {

--- a/packs/official/dating-confidence-boundaries/scenarios/first_date_chemistry.yaml
+++ b/packs/official/dating-confidence-boundaries/scenarios/first_date_chemistry.yaml
@@ -67,17 +67,23 @@ state:
       visibility: hidden
       max_delta_per_turn: 15
 difficulty:
-  default: normal
+  default: standard
   options:
-    easy:
-      npc_patience_modifier: 25
-      challenge_frequency: low
-    normal:
-      npc_patience_modifier: 0
-      challenge_frequency: medium
+    warm:
+      patience: 80
+      volatility: 20
+      disclosure: 70
+      time_pressure: 20
+    standard:
+      patience: 50
+      volatility: 50
+      disclosure: 50
+      time_pressure: 50
     hard:
-      npc_patience_modifier: -20
-      challenge_frequency: high
+      patience: 25
+      volatility: 70
+      disclosure: 25
+      time_pressure: 60
 events:
   - id: genuine_spark
     when:

--- a/packs/official/dating-confidence-boundaries/scenarios/graceful_exit.yaml
+++ b/packs/official/dating-confidence-boundaries/scenarios/graceful_exit.yaml
@@ -67,17 +67,23 @@ state:
       visibility: hidden
       max_delta_per_turn: 20
 difficulty:
-  default: normal
+  default: standard
   options:
-    easy:
-      npc_patience_modifier: 25
-      challenge_frequency: low
-    normal:
-      npc_patience_modifier: 0
-      challenge_frequency: medium
+    warm:
+      patience: 80
+      volatility: 20
+      disclosure: 70
+      time_pressure: 20
+    standard:
+      patience: 50
+      volatility: 50
+      disclosure: 50
+      time_pressure: 50
     hard:
-      npc_patience_modifier: -20
-      challenge_frequency: high
+      patience: 25
+      volatility: 70
+      disclosure: 25
+      time_pressure: 60
 events:
   - id: priya_relaxes
     when:

--- a/packs/official/dating-confidence-boundaries/scenarios/holding_your_ground.yaml
+++ b/packs/official/dating-confidence-boundaries/scenarios/holding_your_ground.yaml
@@ -69,17 +69,23 @@ state:
       visibility: hidden
       max_delta_per_turn: 18
 difficulty:
-  default: normal
+  default: standard
   options:
-    easy:
-      npc_patience_modifier: 30
-      challenge_frequency: low
-    normal:
-      npc_patience_modifier: 0
-      challenge_frequency: medium
+    warm:
+      patience: 80
+      volatility: 20
+      disclosure: 70
+      time_pressure: 20
+    standard:
+      patience: 50
+      volatility: 50
+      disclosure: 50
+      time_pressure: 50
     hard:
-      npc_patience_modifier: -20
-      challenge_frequency: high
+      patience: 25
+      volatility: 70
+      disclosure: 25
+      time_pressure: 60
 events:
   - id: first_test
     when:

--- a/packs/official/dating-confidence-boundaries/scenarios/the_ask.yaml
+++ b/packs/official/dating-confidence-boundaries/scenarios/the_ask.yaml
@@ -67,17 +67,36 @@ state:
       visibility: hidden
       max_delta_per_turn: 15
 difficulty:
-  default: normal
+  default: standard
   options:
-    easy:
-      npc_patience_modifier: 25
-      challenge_frequency: low
-    normal:
-      npc_patience_modifier: 0
-      challenge_frequency: medium
+    warm:
+      patience: 80
+      volatility: 20
+      disclosure: 70
+      time_pressure: 20
+      label: Warm-up
+      description: Jordan is warm and gives clear signals — good for a first attempt.
+    standard:
+      patience: 50
+      volatility: 50
+      disclosure: 50
+      time_pressure: 50
+      label: Standard
+      description: Balanced realism — Jordan is receptive but you still have to read the room.
     hard:
-      npc_patience_modifier: -20
-      challenge_frequency: high
+      patience: 25
+      volatility: 70
+      disclosure: 25
+      time_pressure: 60
+      label: Hard
+      description: Jordan is guarded and reactive; a clumsy move can cool things fast.
+    adversarial:
+      patience: 10
+      volatility: 90
+      disclosure: 10
+      time_pressure: 80
+      label: Adversarial
+      description: Jordan gives almost nothing away, reactions swing hard, and the window is short.
 events:
   - id: positive_signal
     when:

--- a/packs/official/dating-confidence-boundaries/tests/golden_first_date_chemistry.yaml
+++ b/packs/official/dating-confidence-boundaries/tests/golden_first_date_chemistry.yaml
@@ -11,7 +11,7 @@ description: >-
 
 seed: 42
 input_mode: text
-difficulty: normal
+difficulty: standard
 
 turns:
   - turn: 1
@@ -153,5 +153,5 @@ static_assertions:
     check: "contains scenarios/first_date_chemistry.yaml"
 
   - description: Hard difficulty applies a negative patience modifier
-    path: scenario.difficulty.options.hard.npc_patience_modifier
-    check: "equals -20"
+    path: scenario.difficulty.options.hard.patience
+    check: "lte 33"

--- a/packs/official/dating-confidence-boundaries/tests/golden_graceful_exit.yaml
+++ b/packs/official/dating-confidence-boundaries/tests/golden_graceful_exit.yaml
@@ -11,7 +11,7 @@ description: >-
 
 seed: 42
 input_mode: text
-difficulty: normal
+difficulty: standard
 
 turns:
   - turn: 1
@@ -134,5 +134,5 @@ static_assertions:
     check: "contains scenarios/graceful_exit.yaml"
 
   - description: Hard difficulty applies a negative patience modifier
-    path: scenario.difficulty.options.hard.npc_patience_modifier
-    check: "equals -20"
+    path: scenario.difficulty.options.hard.patience
+    check: "lte 33"

--- a/packs/official/dating-confidence-boundaries/tests/golden_holding_your_ground.yaml
+++ b/packs/official/dating-confidence-boundaries/tests/golden_holding_your_ground.yaml
@@ -12,7 +12,7 @@ description: >-
 
 seed: 42
 input_mode: text
-difficulty: normal
+difficulty: standard
 
 turns:
   - turn: 1
@@ -153,5 +153,5 @@ static_assertions:
     check: "contains scenarios/holding_your_ground.yaml"
 
   - description: Hard difficulty applies a negative patience modifier
-    path: scenario.difficulty.options.hard.npc_patience_modifier
-    check: "equals -20"
+    path: scenario.difficulty.options.hard.patience
+    check: "lte 33"

--- a/packs/official/dating-confidence-boundaries/tests/golden_the_ask.yaml
+++ b/packs/official/dating-confidence-boundaries/tests/golden_the_ask.yaml
@@ -11,7 +11,7 @@ description: >-
 
 seed: 42
 input_mode: text
-difficulty: normal
+difficulty: standard
 
 turns:
   - turn: 1
@@ -152,5 +152,5 @@ static_assertions:
     check: "contains scenarios/the_ask.yaml"
 
   - description: Hard difficulty applies a negative patience modifier
-    path: scenario.difficulty.options.hard.npc_patience_modifier
-    check: "equals -20"
+    path: scenario.difficulty.options.hard.patience
+    check: "lte 33"

--- a/packs/official/dating-confidence-boundaries/tests/smoke_first_date_chemistry.yaml
+++ b/packs/official/dating-confidence-boundaries/tests/smoke_first_date_chemistry.yaml
@@ -10,7 +10,7 @@ description: >-
 
 seed: 42
 input_mode: text
-difficulty: normal
+difficulty: standard
 
 turns:
   - turn: 1

--- a/packs/official/dating-confidence-boundaries/tests/smoke_graceful_exit.yaml
+++ b/packs/official/dating-confidence-boundaries/tests/smoke_graceful_exit.yaml
@@ -10,7 +10,7 @@ description: >-
 
 seed: 42
 input_mode: text
-difficulty: normal
+difficulty: standard
 
 turns:
   - turn: 1

--- a/packs/official/dating-confidence-boundaries/tests/smoke_holding_your_ground.yaml
+++ b/packs/official/dating-confidence-boundaries/tests/smoke_holding_your_ground.yaml
@@ -10,7 +10,7 @@ description: >-
 
 seed: 42
 input_mode: text
-difficulty: normal
+difficulty: standard
 
 turns:
   - turn: 1

--- a/packs/official/dating-confidence-boundaries/tests/smoke_the_ask.yaml
+++ b/packs/official/dating-confidence-boundaries/tests/smoke_the_ask.yaml
@@ -10,7 +10,7 @@ description: >-
 
 seed: 42
 input_mode: text
-difficulty: normal
+difficulty: standard
 
 turns:
   - turn: 1

--- a/packs/official/difficult-conversations/README.md
+++ b/packs/official/difficult-conversations/README.md
@@ -31,7 +31,7 @@ affect your own work. You have asked him to grab coffee to talk it through.
 **Player role:** Peer Colleague (no formal authority)
 **NPC:** Marcus Webb — guarded, mildly defensive, genuinely well-meaning underneath
 **Duration:** Up to 18 turns (≈ 12 minutes)
-**Difficulty options:** easy / normal / hard
+**Difficulty options:** warm / standard / hard / adversarial
 
 **State variables:**
 
@@ -66,7 +66,7 @@ but she already had to explain the delay upward to her own manager.
 **Player role:** Team Member
 **NPC:** Priya Nair — measured, controlled disappointment, watching for real ownership
 **Duration:** Up to 16 turns (≈ 10 minutes)
-**Difficulty options:** easy / normal / hard
+**Difficulty options:** warm / standard / hard / adversarial
 
 **State variables:**
 
@@ -101,7 +101,7 @@ cannot and do not want to. You have asked to meet for coffee to say no.
 **Player role:** Friend
 **NPC:** Jamie Osei — warm, emotionally expressive, persistent in pushback, ultimately reasonable
 **Duration:** Up to 16 turns (≈ 10 minutes)
-**Difficulty options:** easy / normal / hard
+**Difficulty options:** warm / standard / hard / adversarial
 
 **State variables:**
 
@@ -136,7 +136,7 @@ thirty minutes with your manager, Diane Kowalczyk, to make the case.
 **Player role:** Employee
 **NPC:** Diane Kowalczyk — businesslike, skeptical, needs a justification she can take upward
 **Duration:** Up to 18 turns (≈ 12 minutes)
-**Difficulty options:** easy / normal / hard
+**Difficulty options:** warm / standard / hard / adversarial
 
 **State variables:**
 

--- a/packs/official/difficult-conversations/scenarios/ask_for_raise.yaml
+++ b/packs/official/difficult-conversations/scenarios/ask_for_raise.yaml
@@ -68,17 +68,36 @@ state:
       visibility: hidden
       max_delta_per_turn: 18
 difficulty:
-  default: normal
+  default: standard
   options:
-    easy:
-      npc_patience_modifier: 25
-      challenge_frequency: low
-    normal:
-      npc_patience_modifier: 0
-      challenge_frequency: medium
+    warm:
+      patience: 80
+      volatility: 20
+      disclosure: 70
+      time_pressure: 20
+      label: Warm-up
+      description: Diane is patient and will cue you when she needs more — good for first attempts.
+    standard:
+      patience: 50
+      volatility: 50
+      disclosure: 50
+      time_pressure: 50
+      label: Standard
+      description: Balanced realism — Diane probes firmly but gives you room to recover.
     hard:
-      npc_patience_modifier: -20
-      challenge_frequency: high
+      patience: 25
+      volatility: 70
+      disclosure: 25
+      time_pressure: 60
+      label: Hard
+      description: Diane is terse and reactive; one weak answer can shift her posture quickly.
+    adversarial:
+      patience: 10
+      volatility: 90
+      disclosure: 10
+      time_pressure: 80
+      label: Adversarial
+      description: Diane gives almost no hints, state swings are dramatic, and the clock is tight.
 events:
   - id: vague_claim_probe
     when:

--- a/packs/official/difficult-conversations/scenarios/boundary_with_friend.yaml
+++ b/packs/official/difficult-conversations/scenarios/boundary_with_friend.yaml
@@ -70,17 +70,23 @@ state:
       visibility: hidden
       max_delta_per_turn: 18
 difficulty:
-  default: normal
+  default: standard
   options:
-    easy:
-      npc_patience_modifier: 30
-      challenge_frequency: low
-    normal:
-      npc_patience_modifier: 0
-      challenge_frequency: medium
+    warm:
+      patience: 80
+      volatility: 20
+      disclosure: 70
+      time_pressure: 20
+    standard:
+      patience: 50
+      volatility: 50
+      disclosure: 50
+      time_pressure: 50
     hard:
-      npc_patience_modifier: -20
-      challenge_frequency: high
+      patience: 25
+      volatility: 70
+      disclosure: 25
+      time_pressure: 60
 events:
   - id: first_pushback
     when:

--- a/packs/official/difficult-conversations/scenarios/coworker_feedback.yaml
+++ b/packs/official/difficult-conversations/scenarios/coworker_feedback.yaml
@@ -65,17 +65,23 @@ state:
       visibility: hidden
       max_delta_per_turn: 20
 difficulty:
-  default: normal
+  default: standard
   options:
-    easy:
-      npc_patience_modifier: 25
-      challenge_frequency: low
-    normal:
-      npc_patience_modifier: 0
-      challenge_frequency: medium
+    warm:
+      patience: 80
+      volatility: 20
+      disclosure: 70
+      time_pressure: 20
+    standard:
+      patience: 50
+      volatility: 50
+      disclosure: 50
+      time_pressure: 50
     hard:
-      npc_patience_modifier: -20
-      challenge_frequency: high
+      patience: 25
+      volatility: 70
+      disclosure: 25
+      time_pressure: 60
 events:
   - id: deflection_redirect
     when:

--- a/packs/official/difficult-conversations/scenarios/missed_deadline_apology.yaml
+++ b/packs/official/difficult-conversations/scenarios/missed_deadline_apology.yaml
@@ -69,17 +69,23 @@ state:
       visibility: hidden
       max_delta_per_turn: 18
 difficulty:
-  default: normal
+  default: standard
   options:
-    easy:
-      npc_patience_modifier: 20
-      challenge_frequency: low
-    normal:
-      npc_patience_modifier: 0
-      challenge_frequency: medium
+    warm:
+      patience: 80
+      volatility: 20
+      disclosure: 70
+      time_pressure: 20
+    standard:
+      patience: 50
+      volatility: 50
+      disclosure: 50
+      time_pressure: 50
     hard:
-      npc_patience_modifier: -25
-      challenge_frequency: high
+      patience: 25
+      volatility: 70
+      disclosure: 25
+      time_pressure: 60
 events:
   - id: excuse_detection
     when:

--- a/packs/official/difficult-conversations/tests/golden_ask_for_raise.yaml
+++ b/packs/official/difficult-conversations/tests/golden_ask_for_raise.yaml
@@ -14,7 +14,7 @@ description: >-
 
 seed: 42
 input_mode: text
-difficulty: normal
+difficulty: standard
 
 turns:
   - turn: 1
@@ -156,6 +156,10 @@ static_assertions:
     path: manifest.entry_scenarios
     check: "contains scenarios/ask_for_raise.yaml"
 
-  - description: Hard difficulty applies a negative patience modifier
-    path: scenario.difficulty.options.hard.npc_patience_modifier
-    check: "equals -20"
+  - description: Hard difficulty sets low patience (NPC disengages quickly)
+    path: scenario.difficulty.options.hard.patience
+    check: "lte 33"
+
+  - description: Adversarial difficulty sets very high volatility
+    path: scenario.difficulty.options.adversarial.volatility
+    check: "gte 85"

--- a/packs/official/difficult-conversations/tests/golden_ask_for_raise_adversarial.yaml
+++ b/packs/official/difficult-conversations/tests/golden_ask_for_raise_adversarial.yaml
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+fixture_id: golden_ask_for_raise_adversarial
+scenario_id: ask_for_raise
+description: >-
+  Golden transcript at the 'adversarial' difficulty preset. Verifies that at
+  low patience / high volatility / low disclosure / high time-pressure: Diane
+  volunteers almost nothing, state meters swing dramatically on weak answers,
+  the conversation feels time-constrained, and only a player who leads with
+  precise specifics and a concrete number immediately can sustain impression
+  long enough to reach the success threshold. A single unfocused opening turn
+  should noticeably damage impression and evidence_strength before the player
+  has a chance to recover.
+
+seed: 42
+input_mode: text
+difficulty: adversarial
+
+turns:
+  - turn: 1
+    player_input: >-
+      I want to discuss a compensation adjustment. Over the last two quarters I
+      led the cross-team API migration involving six teams, shipped it three
+      weeks early, onboarded two new engineers who are now independent, and
+      absorbed the Q3 regulatory project mid-flight. That is a materially larger
+      role than I was hired into, and my pay has not moved. I am asking for a
+      move from eighty-four to ninety-eight — the low end of what comparable
+      senior IC scope costs in this market right now.
+    expect:
+      state_delta_contains:
+        - impression
+        - evidence_strength
+        - case_clarity
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 2
+    player_input: >-
+      The market reference is three live postings and two offers from my network
+      in the last sixty days. I can share the exact postings. The ninety-eight
+      figure is not the ceiling — it is the floor of the current market band for
+      this scope. Asking for the floor is a conservative ask that I can defend
+      to anyone who asks where the number came from.
+    expect:
+      state_delta_contains:
+        - evidence_strength
+        - case_clarity
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 3
+    player_input: >-
+      On the migration: the project charter is in Confluence. Timeline was twelve
+      weeks; we shipped in nine. The lead role was not in my job description when
+      I was hired. I have the original JD and the current scope in writing. The
+      delta is not ambiguous.
+    expect:
+      state_delta_contains:
+        - evidence_strength
+        - impression
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 4
+    player_input: >-
+      The business case in one sentence: correcting this now costs fourteen
+      thousand dollars. Not correcting it eventually costs a backfill, a
+      knowledge transfer, and a market-rate replacement hire. I am giving you the
+      cheaper option and I am giving you the language to take it upward.
+    expect:
+      state_delta_contains:
+        - case_clarity
+        - impression
+      session_control: continue_session
+      safety_status: ok
+
+static_assertions:
+  - description: Adversarial preset is defined in scenario difficulty options
+    path: scenario.difficulty.options.adversarial
+    check: non_null
+
+  - description: Adversarial preset patience knob is very low (NPC disengages quickly)
+    path: scenario.difficulty.options.adversarial.patience
+    check: "lte 15"
+
+  - description: Adversarial preset volatility knob is very high (dramatic state swings)
+    path: scenario.difficulty.options.adversarial.volatility
+    check: "gte 85"
+
+  - description: Adversarial preset disclosure knob is very low (NPC volunteers almost nothing)
+    path: scenario.difficulty.options.adversarial.disclosure
+    check: "lte 15"
+
+  - description: Adversarial preset time_pressure knob is very high
+    path: scenario.difficulty.options.adversarial.time_pressure
+    check: "gte 75"
+
+  - description: Success condition still requires case_clarity above 65 even at adversarial
+    path: ending_conditions.success
+    check: "type=variable_above AND variable=case_clarity AND threshold=65"
+
+  - description: Failure condition still triggers on impression below 15
+    path: ending_conditions.failure
+    check: "type=variable_below AND variable=impression AND threshold=15"

--- a/packs/official/difficult-conversations/tests/golden_ask_for_raise_warm.yaml
+++ b/packs/official/difficult-conversations/tests/golden_ask_for_raise_warm.yaml
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: CC-BY-4.0
+schema_version: "0.1"
+fixture_id: golden_ask_for_raise_warm
+scenario_id: ask_for_raise
+description: >-
+  Golden transcript at the 'warm' difficulty preset. Verifies that at high
+  patience / low volatility / high disclosure / low time-pressure: Diane
+  offers gentle nudges when the player stalls, state meters shift slowly so
+  early missteps are recoverable, and Diane volunteers helpful framing cues
+  rather than waiting to be asked directly. A player who builds a solid case
+  across four turns should reach the success threshold without triggering the
+  deflation event.
+
+seed: 42
+input_mode: text
+difficulty: warm
+
+turns:
+  - turn: 1
+    player_input: >-
+      I want to walk you through what has changed in my role over the last six
+      months. When I started, my scope was one team and one set of deliverables.
+      Since then I have taken on the cross-team API migration, onboarded two new
+      engineers, and delivered the Q3 regulatory project after the original lead
+      left. I think that represents a real expansion in scope.
+    expect:
+      state_delta_contains:
+        - impression
+        - evidence_strength
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 2
+    player_input: >-
+      Based on market data I have gathered, comparable roles at similar companies
+      are paying between ninety-five and one-ten. My current base is
+      eighty-four. I am asking for a move to ninety-eight — the lower end of
+      that range.
+    expect:
+      state_delta_contains:
+        - case_clarity
+        - evidence_strength
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 3
+    player_input: >-
+      On the migration specifically, I can share the retrospective document. We
+      shipped nine weeks instead of twelve, and I was the lead. That was not in
+      my original job description. I took it on because it needed to be done,
+      and the outcome was good for the company.
+    expect:
+      state_delta_contains:
+        - evidence_strength
+        - impression
+      session_control: continue_session
+      safety_status: ok
+
+  - turn: 4
+    player_input: >-
+      I want to frame this in a way that is easy for you to take upward. The
+      one-sentence business case is: I am carrying a senior scope at a junior
+      rate. Correcting that now is less expensive than the alternatives. I am
+      not threatening to leave — I am making a case I think you can actually
+      work with.
+    expect:
+      state_delta_contains:
+        - case_clarity
+        - impression
+      session_control: continue_session
+      safety_status: ok
+
+static_assertions:
+  - description: Warm preset is defined in scenario difficulty options
+    path: scenario.difficulty.options.warm
+    check: non_null
+
+  - description: Warm preset patience knob is high (patient NPC)
+    path: scenario.difficulty.options.warm.patience
+    check: "gte 67"
+
+  - description: Warm preset volatility knob is low (slow state shifts)
+    path: scenario.difficulty.options.warm.volatility
+    check: "lte 33"
+
+  - description: Warm preset disclosure knob is high (NPC volunteers info)
+    path: scenario.difficulty.options.warm.disclosure
+    check: "gte 67"
+
+  - description: Warm preset time_pressure knob is low (no urgency)
+    path: scenario.difficulty.options.warm.time_pressure
+    check: "lte 33"
+
+  - description: Difficulty default is standard (not warm — warm is a player choice)
+    path: scenario.difficulty.default
+    check: "equals standard"

--- a/packs/official/difficult-conversations/tests/golden_boundary_with_friend.yaml
+++ b/packs/official/difficult-conversations/tests/golden_boundary_with_friend.yaml
@@ -13,8 +13,7 @@ description: >-
 
 seed: 42
 input_mode: text
-difficulty: normal
-
+difficulty: standard
 turns:
   - turn: 1
     player_input: >-
@@ -150,5 +149,5 @@ static_assertions:
     check: "contains scenarios/boundary_with_friend.yaml"
 
   - description: Hard difficulty applies a negative patience modifier
-    path: scenario.difficulty.options.hard.npc_patience_modifier
-    check: "equals -20"
+    path: scenario.difficulty.options.hard.patience
+    check: "lte 33"

--- a/packs/official/difficult-conversations/tests/golden_coworker_feedback.yaml
+++ b/packs/official/difficult-conversations/tests/golden_coworker_feedback.yaml
@@ -13,8 +13,7 @@ description: >-
 
 seed: 42
 input_mode: text
-difficulty: normal
-
+difficulty: standard
 turns:
   - turn: 1
     player_input: >-
@@ -147,5 +146,5 @@ static_assertions:
     check: "contains scenarios/coworker_feedback.yaml"
 
   - description: Hard difficulty applies a negative patience modifier
-    path: scenario.difficulty.options.hard.npc_patience_modifier
-    check: "equals -20"
+    path: scenario.difficulty.options.hard.patience
+    check: "lte 33"

--- a/packs/official/difficult-conversations/tests/golden_missed_deadline_apology.yaml
+++ b/packs/official/difficult-conversations/tests/golden_missed_deadline_apology.yaml
@@ -13,8 +13,7 @@ description: >-
 
 seed: 42
 input_mode: text
-difficulty: normal
-
+difficulty: standard
 turns:
   - turn: 1
     player_input: >-
@@ -143,5 +142,5 @@ static_assertions:
     check: "contains scenarios/missed_deadline_apology.yaml"
 
   - description: Hard difficulty applies a negative patience modifier
-    path: scenario.difficulty.options.hard.npc_patience_modifier
-    check: "equals -25"
+    path: scenario.difficulty.options.hard.patience
+    check: "lte 33"

--- a/packs/official/difficult-conversations/tests/smoke_ask_for_raise.yaml
+++ b/packs/official/difficult-conversations/tests/smoke_ask_for_raise.yaml
@@ -10,8 +10,7 @@ description: >-
 
 seed: 42
 input_mode: text
-difficulty: normal
-
+difficulty: standard
 turns:
   - turn: 1
     player_input: >-

--- a/packs/official/difficult-conversations/tests/smoke_boundary_with_friend.yaml
+++ b/packs/official/difficult-conversations/tests/smoke_boundary_with_friend.yaml
@@ -10,8 +10,7 @@ description: >-
 
 seed: 42
 input_mode: text
-difficulty: normal
-
+difficulty: standard
 turns:
   - turn: 1
     player_input: >-

--- a/packs/official/difficult-conversations/tests/smoke_coworker_feedback.yaml
+++ b/packs/official/difficult-conversations/tests/smoke_coworker_feedback.yaml
@@ -10,8 +10,7 @@ description: >-
 
 seed: 42
 input_mode: text
-difficulty: normal
-
+difficulty: standard
 turns:
   - turn: 1
     player_input: >-

--- a/packs/official/difficult-conversations/tests/smoke_missed_deadline_apology.yaml
+++ b/packs/official/difficult-conversations/tests/smoke_missed_deadline_apology.yaml
@@ -10,8 +10,7 @@ description: >-
 
 seed: 42
 input_mode: text
-difficulty: normal
-
+difficulty: standard
 turns:
   - turn: 1
     player_input: >-

--- a/packs/official/everyday-negotiation/scenarios/apartment_lease_renewal.yaml
+++ b/packs/official/everyday-negotiation/scenarios/apartment_lease_renewal.yaml
@@ -74,17 +74,23 @@ state:
       visibility: hidden
       max_delta_per_turn: 18
 difficulty:
-  default: normal
+  default: standard
   options:
-    easy:
-      npc_patience_modifier: 20
-      challenge_frequency: low
-    normal:
-      npc_patience_modifier: 0
-      challenge_frequency: medium
+    warm:
+      patience: 80
+      volatility: 20
+      disclosure: 70
+      time_pressure: 20
+    standard:
+      patience: 50
+      volatility: 50
+      disclosure: 50
+      time_pressure: 50
     hard:
-      npc_patience_modifier: -20
-      challenge_frequency: high
+      patience: 25
+      volatility: 70
+      disclosure: 25
+      time_pressure: 60
 events:
   - id: market_data_reward
     when:

--- a/packs/official/everyday-negotiation/scenarios/customer_service_refund.yaml
+++ b/packs/official/everyday-negotiation/scenarios/customer_service_refund.yaml
@@ -72,17 +72,23 @@ state:
       visibility: hidden
       max_delta_per_turn: 20
 difficulty:
-  default: normal
+  default: standard
   options:
-    easy:
-      npc_patience_modifier: 20
-      challenge_frequency: low
-    normal:
-      npc_patience_modifier: 0
-      challenge_frequency: medium
+    warm:
+      patience: 80
+      volatility: 20
+      disclosure: 70
+      time_pressure: 20
+    standard:
+      patience: 50
+      volatility: 50
+      disclosure: 50
+      time_pressure: 50
     hard:
-      npc_patience_modifier: -20
-      challenge_frequency: high
+      patience: 25
+      volatility: 70
+      disclosure: 25
+      time_pressure: 60
 events:
   - id: warranty_recognition
     when:

--- a/packs/official/everyday-negotiation/scenarios/freelance_scope_negotiation.yaml
+++ b/packs/official/everyday-negotiation/scenarios/freelance_scope_negotiation.yaml
@@ -75,17 +75,23 @@ state:
       visibility: hidden
       max_delta_per_turn: 20
 difficulty:
-  default: normal
+  default: standard
   options:
-    easy:
-      npc_patience_modifier: 20
-      challenge_frequency: low
-    normal:
-      npc_patience_modifier: 0
-      challenge_frequency: medium
+    warm:
+      patience: 80
+      volatility: 20
+      disclosure: 70
+      time_pressure: 20
+    standard:
+      patience: 50
+      volatility: 50
+      disclosure: 50
+      time_pressure: 50
     hard:
-      npc_patience_modifier: -20
-      challenge_frequency: high
+      patience: 25
+      volatility: 70
+      disclosure: 25
+      time_pressure: 60
 events:
   - id: contract_reference_reward
     when:

--- a/packs/official/everyday-negotiation/scenarios/used_car_negotiation.yaml
+++ b/packs/official/everyday-negotiation/scenarios/used_car_negotiation.yaml
@@ -72,17 +72,36 @@ state:
       visibility: hidden
       max_delta_per_turn: 20
 difficulty:
-  default: normal
+  default: standard
   options:
-    easy:
-      npc_patience_modifier: 20
-      challenge_frequency: low
-    normal:
-      npc_patience_modifier: 0
-      challenge_frequency: medium
+    warm:
+      patience: 80
+      volatility: 20
+      disclosure: 70
+      time_pressure: 20
+      label: Warm-up
+      description: Ray is friendly and nudges you toward a deal — good for learning negotiation basics.
+    standard:
+      patience: 50
+      volatility: 50
+      disclosure: 50
+      time_pressure: 50
+      label: Standard
+      description: Realistic sales dynamic — Ray holds his position but responds to good arguments.
     hard:
-      npc_patience_modifier: -20
-      challenge_frequency: high
+      patience: 25
+      volatility: 70
+      disclosure: 25
+      time_pressure: 60
+      label: Hard
+      description: Ray is firm, volunteers little, and state shifts quickly if you lose leverage.
+    adversarial:
+      patience: 10
+      volatility: 90
+      disclosure: 10
+      time_pressure: 80
+      label: Adversarial
+      description: Ray is impatient, shares nothing freely, and every misstep hits the deal hard.
 events:
   - id: research_anchor_reward
     when:

--- a/packs/official/everyday-negotiation/tests/golden_apartment_lease_renewal.yaml
+++ b/packs/official/everyday-negotiation/tests/golden_apartment_lease_renewal.yaml
@@ -11,8 +11,7 @@ description: >-
 
 seed: 42
 input_mode: text
-difficulty: normal
-
+difficulty: standard
 turns:
   - turn: 1
     player_input: >-
@@ -140,9 +139,9 @@ static_assertions:
     check: "contains scenarios/apartment_lease_renewal.yaml"
 
   - description: Hard difficulty applies a negative patience modifier
-    path: scenario.difficulty.options.hard.npc_patience_modifier
-    check: "equals -20"
+    path: scenario.difficulty.options.hard.patience
+    check: "lte 33"
 
   - description: Easy difficulty applies a positive patience modifier
-    path: scenario.difficulty.options.easy.npc_patience_modifier
-    check: "equals 20"
+    path: scenario.difficulty.options.warm.patience
+    check: "gte 67"

--- a/packs/official/everyday-negotiation/tests/golden_apartment_lease_renewal.yaml
+++ b/packs/official/everyday-negotiation/tests/golden_apartment_lease_renewal.yaml
@@ -142,6 +142,6 @@ static_assertions:
     path: scenario.difficulty.options.hard.patience
     check: "lte 33"
 
-  - description: Easy difficulty applies a positive patience modifier
+  - description: Warm difficulty sets a high patience knob
     path: scenario.difficulty.options.warm.patience
     check: "gte 67"

--- a/packs/official/everyday-negotiation/tests/golden_customer_service_refund.yaml
+++ b/packs/official/everyday-negotiation/tests/golden_customer_service_refund.yaml
@@ -144,6 +144,6 @@ static_assertions:
     path: scenario.difficulty.options.hard.patience
     check: "lte 33"
 
-  - description: Easy difficulty applies a positive patience modifier
+  - description: Warm difficulty sets a high patience knob
     path: scenario.difficulty.options.warm.patience
     check: "gte 67"

--- a/packs/official/everyday-negotiation/tests/golden_customer_service_refund.yaml
+++ b/packs/official/everyday-negotiation/tests/golden_customer_service_refund.yaml
@@ -11,8 +11,7 @@ description: >-
 
 seed: 42
 input_mode: text
-difficulty: normal
-
+difficulty: standard
 turns:
   - turn: 1
     player_input: >-
@@ -142,9 +141,9 @@ static_assertions:
     check: "contains scenarios/customer_service_refund.yaml"
 
   - description: Hard difficulty applies a negative patience modifier
-    path: scenario.difficulty.options.hard.npc_patience_modifier
-    check: "equals -20"
+    path: scenario.difficulty.options.hard.patience
+    check: "lte 33"
 
   - description: Easy difficulty applies a positive patience modifier
-    path: scenario.difficulty.options.easy.npc_patience_modifier
-    check: "equals 20"
+    path: scenario.difficulty.options.warm.patience
+    check: "gte 67"

--- a/packs/official/everyday-negotiation/tests/golden_freelance_scope_negotiation.yaml
+++ b/packs/official/everyday-negotiation/tests/golden_freelance_scope_negotiation.yaml
@@ -143,6 +143,6 @@ static_assertions:
     path: scenario.difficulty.options.hard.patience
     check: "lte 33"
 
-  - description: Easy difficulty applies a positive patience modifier
+  - description: Warm difficulty sets a high patience knob
     path: scenario.difficulty.options.warm.patience
     check: "gte 67"

--- a/packs/official/everyday-negotiation/tests/golden_freelance_scope_negotiation.yaml
+++ b/packs/official/everyday-negotiation/tests/golden_freelance_scope_negotiation.yaml
@@ -11,8 +11,7 @@ description: >-
 
 seed: 42
 input_mode: text
-difficulty: normal
-
+difficulty: standard
 turns:
   - turn: 1
     player_input: >-
@@ -141,9 +140,9 @@ static_assertions:
     check: "contains scenarios/freelance_scope_negotiation.yaml"
 
   - description: Hard difficulty applies a negative patience modifier
-    path: scenario.difficulty.options.hard.npc_patience_modifier
-    check: "equals -20"
+    path: scenario.difficulty.options.hard.patience
+    check: "lte 33"
 
   - description: Easy difficulty applies a positive patience modifier
-    path: scenario.difficulty.options.easy.npc_patience_modifier
-    check: "equals 20"
+    path: scenario.difficulty.options.warm.patience
+    check: "gte 67"

--- a/packs/official/everyday-negotiation/tests/golden_used_car_negotiation.yaml
+++ b/packs/official/everyday-negotiation/tests/golden_used_car_negotiation.yaml
@@ -10,8 +10,7 @@ description: >-
 
 seed: 42
 input_mode: text
-difficulty: normal
-
+difficulty: standard
 turns:
   - turn: 1
     player_input: >-
@@ -140,9 +139,9 @@ static_assertions:
     check: "contains scenarios/used_car_negotiation.yaml"
 
   - description: Hard difficulty applies a negative patience modifier
-    path: scenario.difficulty.options.hard.npc_patience_modifier
-    check: "equals -20"
+    path: scenario.difficulty.options.hard.patience
+    check: "lte 33"
 
   - description: Easy difficulty applies a positive patience modifier
-    path: scenario.difficulty.options.easy.npc_patience_modifier
-    check: "equals 20"
+    path: scenario.difficulty.options.warm.patience
+    check: "gte 67"

--- a/packs/official/everyday-negotiation/tests/golden_used_car_negotiation.yaml
+++ b/packs/official/everyday-negotiation/tests/golden_used_car_negotiation.yaml
@@ -142,6 +142,6 @@ static_assertions:
     path: scenario.difficulty.options.hard.patience
     check: "lte 33"
 
-  - description: Easy difficulty applies a positive patience modifier
+  - description: Warm difficulty sets a high patience knob
     path: scenario.difficulty.options.warm.patience
     check: "gte 67"

--- a/packs/official/everyday-negotiation/tests/smoke_apartment_lease_renewal.yaml
+++ b/packs/official/everyday-negotiation/tests/smoke_apartment_lease_renewal.yaml
@@ -10,8 +10,7 @@ description: >-
 
 seed: 42
 input_mode: text
-difficulty: normal
-
+difficulty: standard
 turns:
   - turn: 1
     player_input: >-

--- a/packs/official/everyday-negotiation/tests/smoke_customer_service_refund.yaml
+++ b/packs/official/everyday-negotiation/tests/smoke_customer_service_refund.yaml
@@ -9,8 +9,7 @@ description: >-
 
 seed: 42
 input_mode: text
-difficulty: normal
-
+difficulty: standard
 turns:
   - turn: 1
     player_input: >-

--- a/packs/official/everyday-negotiation/tests/smoke_freelance_scope_negotiation.yaml
+++ b/packs/official/everyday-negotiation/tests/smoke_freelance_scope_negotiation.yaml
@@ -9,8 +9,7 @@ description: >-
 
 seed: 42
 input_mode: text
-difficulty: normal
-
+difficulty: standard
 turns:
   - turn: 1
     player_input: >-

--- a/packs/official/everyday-negotiation/tests/smoke_used_car_negotiation.yaml
+++ b/packs/official/everyday-negotiation/tests/smoke_used_car_negotiation.yaml
@@ -9,8 +9,7 @@ description: >-
 
 seed: 42
 input_mode: text
-difficulty: normal
-
+difficulty: standard
 turns:
   - turn: 1
     player_input: >-

--- a/packs/official/job-interview-basic/README.md
+++ b/packs/official/job-interview-basic/README.md
@@ -27,7 +27,7 @@ using the STAR method earn a stronger impression; vague platitudes lower it.
 **Scene:** Meridian Systems conference room
 **Rubric:** Clarity / Specificity / Rapport / Self-Awareness
 **Duration:** Up to 20 turns (≈ 15 minutes)
-**Difficulty options:** easy / normal / hard
+**Difficulty options:** warm / standard / hard / adversarial
 **Model recommendation:** Any supported model; works well in text-only mode
 **Voice support:** Placeholder (no voice engine configured)
 **Content rating:** PG
@@ -70,7 +70,7 @@ respectfully when you are right.
 **Scene:** Vantage Fintech executive corner office
 **Rubric:** Composure / Credibility / Directness / Resilience
 **Duration:** Up to 18 turns (≈ 12 minutes)
-**Difficulty options:** easy / normal / hard (hard is significantly more hostile)
+**Difficulty options:** warm / standard / hard / adversarial (hard is significantly more hostile)
 **Model recommendation:** Any supported model; works well in text-only mode
 **Voice support:** Placeholder (no voice engine configured)
 **Content rating:** PG
@@ -114,7 +114,7 @@ jargon will not help here — plain, specific, honest answers will.
 **Scene:** Crestview Distribution break room
 **Rubric:** Practicality / Reliability / Crew Awareness / Motivation Fit
 **Duration:** Up to 16 turns (≈ 12 minutes)
-**Difficulty options:** easy / normal / hard (hard adds suspicion about candidate's motives)
+**Difficulty options:** warm / standard / hard / adversarial (hard adds suspicion about candidate's motives)
 **Model recommendation:** Any supported model; works well in text-only mode
 **Voice support:** Placeholder (no voice engine configured)
 **Content rating:** PG
@@ -157,7 +157,7 @@ transferable examples, and demonstrate you have done genuine research on the rol
 **Scene:** Nexus Analytics open office product team area
 **Rubric:** Self-Awareness / Transferable Evidence / Preparation / Learning Velocity
 **Duration:** Up to 20 turns (≈ 15 minutes)
-**Difficulty options:** easy / normal / hard (hard requires more evidence to reach conviction threshold)
+**Difficulty options:** warm / standard / hard / adversarial (hard requires more evidence to reach conviction threshold)
 **Model recommendation:** Any supported model; works well in text-only mode
 **Voice support:** Placeholder (no voice engine configured)
 **Content rating:** PG

--- a/packs/official/job-interview-basic/scenarios/behavioral_interview.yaml
+++ b/packs/official/job-interview-basic/scenarios/behavioral_interview.yaml
@@ -66,17 +66,36 @@ state:
       visibility: hidden
       max_delta_per_turn: 15
 difficulty:
-  default: normal
+  default: standard
   options:
-    easy:
-      npc_patience_modifier: 20
-      challenge_frequency: low
-    normal:
-      npc_patience_modifier: 0
-      challenge_frequency: medium
+    warm:
+      patience: 80
+      volatility: 20
+      disclosure: 70
+      time_pressure: 20
+      label: Warm-up
+      description: Dana is encouraging and will guide you if you drift — good for first interviews.
+    standard:
+      patience: 50
+      volatility: 50
+      disclosure: 50
+      time_pressure: 50
+      label: Standard
+      description: Realistic interview pacing — Dana probes vague answers and expects concrete examples.
     hard:
-      npc_patience_modifier: -20
-      challenge_frequency: high
+      patience: 25
+      volatility: 70
+      disclosure: 25
+      time_pressure: 60
+      label: Hard
+      description: Dana is exacting; one unfocused answer can drop her impression score sharply.
+    adversarial:
+      patience: 10
+      volatility: 90
+      disclosure: 10
+      time_pressure: 80
+      label: Adversarial
+      description: Dana is near-silent between probes, state is extremely reactive, and time is tight.
 events:
   - id: rambling_redirect
     when:

--- a/packs/official/job-interview-basic/scenarios/blue_collar_supervisor_interview.yaml
+++ b/packs/official/job-interview-basic/scenarios/blue_collar_supervisor_interview.yaml
@@ -69,17 +69,23 @@ state:
       visibility: hidden
       max_delta_per_turn: 15
 difficulty:
-  default: normal
+  default: standard
   options:
-    easy:
-      npc_patience_modifier: 20
-      challenge_frequency: low
-    normal:
-      npc_patience_modifier: 0
-      challenge_frequency: medium
+    warm:
+      patience: 80
+      volatility: 20
+      disclosure: 70
+      time_pressure: 20
+    standard:
+      patience: 50
+      volatility: 50
+      disclosure: 50
+      time_pressure: 50
     hard:
-      npc_patience_modifier: -15
-      challenge_frequency: high
+      patience: 25
+      volatility: 70
+      disclosure: 25
+      time_pressure: 60
 events:
   - id: overqualified_flag
     when:

--- a/packs/official/job-interview-basic/scenarios/hostile_executive_interview.yaml
+++ b/packs/official/job-interview-basic/scenarios/hostile_executive_interview.yaml
@@ -69,17 +69,23 @@ state:
       visibility: hidden
       max_delta_per_turn: 1
 difficulty:
-  default: normal
+  default: standard
   options:
-    easy:
-      npc_patience_modifier: 15
-      challenge_frequency: low
-    normal:
-      npc_patience_modifier: 0
-      challenge_frequency: high
+    warm:
+      patience: 80
+      volatility: 20
+      disclosure: 70
+      time_pressure: 20
+    standard:
+      patience: 50
+      volatility: 50
+      disclosure: 50
+      time_pressure: 50
     hard:
-      npc_patience_modifier: -20
-      challenge_frequency: high
+      patience: 25
+      volatility: 70
+      disclosure: 25
+      time_pressure: 60
 events:
   - id: credibility_challenge
     when:

--- a/packs/official/job-interview-basic/scenarios/stretch_role_interview.yaml
+++ b/packs/official/job-interview-basic/scenarios/stretch_role_interview.yaml
@@ -70,17 +70,23 @@ state:
       visibility: hidden
       max_delta_per_turn: 1
 difficulty:
-  default: normal
+  default: standard
   options:
-    easy:
-      npc_patience_modifier: 20
-      challenge_frequency: low
-    normal:
-      npc_patience_modifier: 0
-      challenge_frequency: medium
+    warm:
+      patience: 80
+      volatility: 20
+      disclosure: 70
+      time_pressure: 20
+    standard:
+      patience: 50
+      volatility: 50
+      disclosure: 50
+      time_pressure: 50
     hard:
-      npc_patience_modifier: -15
-      challenge_frequency: high
+      patience: 25
+      volatility: 70
+      disclosure: 25
+      time_pressure: 60
 events:
   - id: gap_probing
     when:

--- a/packs/official/job-interview-basic/tests/golden_behavioral_interview.yaml
+++ b/packs/official/job-interview-basic/tests/golden_behavioral_interview.yaml
@@ -11,8 +11,7 @@ description: >-
 
 seed: 42
 input_mode: text
-difficulty: normal
-
+difficulty: standard
 turns:
   - turn: 1
     player_input: >-
@@ -138,5 +137,5 @@ static_assertions:
     check: "contains scenarios/behavioral_interview.yaml"
 
   - description: Hard difficulty applies a negative patience modifier
-    path: scenario.difficulty.options.hard.npc_patience_modifier
-    check: "equals -20"
+    path: scenario.difficulty.options.hard.patience
+    check: "lte 33"

--- a/packs/official/job-interview-basic/tests/golden_blue_collar_supervisor_interview.yaml
+++ b/packs/official/job-interview-basic/tests/golden_blue_collar_supervisor_interview.yaml
@@ -11,8 +11,7 @@ description: >-
 
 seed: 17
 input_mode: text
-difficulty: normal
-
+difficulty: standard
 turns:
   - turn: 1
     player_input: >-
@@ -155,5 +154,5 @@ static_assertions:
     check: "contains scenarios/blue_collar_supervisor_interview.yaml"
 
   - description: Hard difficulty applies a negative patience modifier
-    path: scenario.difficulty.options.hard.npc_patience_modifier
-    check: "equals -15"
+    path: scenario.difficulty.options.hard.patience
+    check: "lte 33"

--- a/packs/official/job-interview-basic/tests/golden_hostile_executive_interview.yaml
+++ b/packs/official/job-interview-basic/tests/golden_hostile_executive_interview.yaml
@@ -12,8 +12,7 @@ description: >-
 
 seed: 73
 input_mode: text
-difficulty: normal
-
+difficulty: standard
 turns:
   - turn: 1
     player_input: >-
@@ -167,5 +166,5 @@ static_assertions:
     check: "contains scenarios/hostile_executive_interview.yaml"
 
   - description: Hard difficulty applies a negative patience modifier
-    path: scenario.difficulty.options.hard.npc_patience_modifier
-    check: "equals -20"
+    path: scenario.difficulty.options.hard.patience
+    check: "lte 33"

--- a/packs/official/job-interview-basic/tests/golden_stretch_role_interview.yaml
+++ b/packs/official/job-interview-basic/tests/golden_stretch_role_interview.yaml
@@ -13,8 +13,7 @@ description: >-
 
 seed: 99
 input_mode: text
-difficulty: normal
-
+difficulty: standard
 turns:
   - turn: 1
     player_input: >-
@@ -175,5 +174,5 @@ static_assertions:
     check: "contains scenarios/stretch_role_interview.yaml"
 
   - description: Hard difficulty applies a negative patience modifier
-    path: scenario.difficulty.options.hard.npc_patience_modifier
-    check: "equals -15"
+    path: scenario.difficulty.options.hard.patience
+    check: "lte 33"

--- a/packs/official/job-interview-basic/tests/smoke_behavioral_interview.yaml
+++ b/packs/official/job-interview-basic/tests/smoke_behavioral_interview.yaml
@@ -9,8 +9,7 @@ description: >-
 
 seed: 42
 input_mode: text
-difficulty: normal
-
+difficulty: standard
 turns:
   - turn: 1
     player_input: >-

--- a/packs/official/job-interview-basic/tests/smoke_blue_collar_supervisor_interview.yaml
+++ b/packs/official/job-interview-basic/tests/smoke_blue_collar_supervisor_interview.yaml
@@ -9,8 +9,7 @@ description: >-
 
 seed: 42
 input_mode: text
-difficulty: normal
-
+difficulty: standard
 turns:
   - turn: 1
     player_input: >-

--- a/packs/official/job-interview-basic/tests/smoke_hostile_executive_interview.yaml
+++ b/packs/official/job-interview-basic/tests/smoke_hostile_executive_interview.yaml
@@ -9,8 +9,7 @@ description: >-
 
 seed: 42
 input_mode: text
-difficulty: normal
-
+difficulty: standard
 turns:
   - turn: 1
     player_input: >-

--- a/packs/official/job-interview-basic/tests/smoke_stretch_role_interview.yaml
+++ b/packs/official/job-interview-basic/tests/smoke_stretch_role_interview.yaml
@@ -10,8 +10,7 @@ description: >-
 
 seed: 42
 input_mode: text
-difficulty: normal
-
+difficulty: standard
 turns:
   - turn: 1
     player_input: >-

--- a/packs/official/language-cafe/scenarios/english_small_talk.yaml
+++ b/packs/official/language-cafe/scenarios/english_small_talk.yaml
@@ -66,20 +66,23 @@ state:
       visibility: hidden
       max_delta_per_turn: 10
 difficulty:
-  default: normal
+  default: standard
   options:
-    easy:
-      correction_style: none
-      npc_patience_modifier: 20
-      challenge_frequency: low
-    normal:
-      correction_style: light
-      npc_patience_modifier: 0
-      challenge_frequency: medium
+    warm:
+      patience: 80
+      volatility: 20
+      disclosure: 70
+      time_pressure: 20
+    standard:
+      patience: 50
+      volatility: 50
+      disclosure: 50
+      time_pressure: 50
     hard:
-      correction_style: strict
-      npc_patience_modifier: -10
-      challenge_frequency: high
+      patience: 25
+      volatility: 70
+      disclosure: 25
+      time_pressure: 60
 events:
   - id: comprehension_low
     when:

--- a/packs/official/language-cafe/scenarios/french_travel_checkin.yaml
+++ b/packs/official/language-cafe/scenarios/french_travel_checkin.yaml
@@ -63,20 +63,23 @@ state:
       visibility: hidden
       max_delta_per_turn: 10
 difficulty:
-  default: normal
+  default: standard
   options:
-    easy:
-      correction_style: none
-      npc_patience_modifier: 20
-      challenge_frequency: low
-    normal:
-      correction_style: light
-      npc_patience_modifier: 0
-      challenge_frequency: medium
+    warm:
+      patience: 80
+      volatility: 20
+      disclosure: 70
+      time_pressure: 20
+    standard:
+      patience: 50
+      volatility: 50
+      disclosure: 50
+      time_pressure: 50
     hard:
-      correction_style: strict
-      npc_patience_modifier: -10
-      challenge_frequency: high
+      patience: 25
+      volatility: 70
+      disclosure: 25
+      time_pressure: 60
 events:
   - id: comprehension_low
     when:

--- a/packs/official/language-cafe/scenarios/japanese_convenience_store.yaml
+++ b/packs/official/language-cafe/scenarios/japanese_convenience_store.yaml
@@ -6,7 +6,7 @@ summary: >-
   You are shopping at a konbini in Tokyo. Kenji Yamamoto, the store clerk,
   will greet you and help you find items. Practice polite everyday Japanese
   in a low-pressure service context. The target language is Japanese (ja).
-  Difficulty controls language correction: easy = none, normal = light
+  Difficulty controls language correction: warm = none, standard = light
   (implicit recasting), hard = explicit correction with practice prompts.
 player_role:
   label: Language Learner

--- a/packs/official/language-cafe/scenarios/japanese_convenience_store.yaml
+++ b/packs/official/language-cafe/scenarios/japanese_convenience_store.yaml
@@ -64,20 +64,23 @@ state:
       visibility: hidden
       max_delta_per_turn: 10
 difficulty:
-  default: normal
+  default: standard
   options:
-    easy:
-      correction_style: none
-      npc_patience_modifier: 20
-      challenge_frequency: low
-    normal:
-      correction_style: light
-      npc_patience_modifier: 0
-      challenge_frequency: medium
+    warm:
+      patience: 80
+      volatility: 20
+      disclosure: 70
+      time_pressure: 20
+    standard:
+      patience: 50
+      volatility: 50
+      disclosure: 50
+      time_pressure: 50
     hard:
-      correction_style: strict
-      npc_patience_modifier: -10
-      challenge_frequency: high
+      patience: 25
+      volatility: 70
+      disclosure: 25
+      time_pressure: 60
 events:
   - id: comprehension_low
     when:

--- a/packs/official/language-cafe/scenarios/spanish_coffee.yaml
+++ b/packs/official/language-cafe/scenarios/spanish_coffee.yaml
@@ -6,7 +6,7 @@ summary: >-
   You are visiting Café Sol in Madrid. Rosa García, the barista, will greet
   you and take your order in Spanish. Practice ordering a drink, asking
   questions, and making small talk. The target language is Spanish (es).
-  Difficulty controls language correction: easy = none, normal = light
+  Difficulty controls language correction: warm = none, standard = light
   (implicit recasting), hard = explicit correction with practice prompts.
 player_role:
   label: Language Learner

--- a/packs/official/language-cafe/scenarios/spanish_coffee.yaml
+++ b/packs/official/language-cafe/scenarios/spanish_coffee.yaml
@@ -63,20 +63,36 @@ state:
       visibility: hidden
       max_delta_per_turn: 10
 difficulty:
-  default: normal
+  default: standard
   options:
-    easy:
-      correction_style: none
-      npc_patience_modifier: 20
-      challenge_frequency: low
-    normal:
-      correction_style: light
-      npc_patience_modifier: 0
-      challenge_frequency: medium
+    warm:
+      patience: 80
+      volatility: 20
+      disclosure: 80
+      time_pressure: 10
+      label: Warm-up
+      description: Rosa is very patient and offers plenty of hints — no corrections, just encouragement.
+    standard:
+      patience: 55
+      volatility: 45
+      disclosure: 55
+      time_pressure: 30
+      label: Standard
+      description: Rosa recasts errors gently and keeps the conversation moving at a natural café pace.
     hard:
-      correction_style: strict
-      npc_patience_modifier: -10
-      challenge_frequency: high
+      patience: 30
+      volatility: 65
+      disclosure: 30
+      time_pressure: 55
+      label: Hard
+      description: Rosa corrects explicitly and slows down noticeably when comprehension is low.
+    adversarial:
+      patience: 10
+      volatility: 85
+      disclosure: 10
+      time_pressure: 75
+      label: Adversarial
+      description: Rosa speaks at full native speed, volunteers nothing, and moves on quickly — sink or swim.
 events:
   - id: comprehension_low
     when:

--- a/packs/official/language-cafe/tests/golden_english_small_talk.yaml
+++ b/packs/official/language-cafe/tests/golden_english_small_talk.yaml
@@ -101,11 +101,11 @@ static_assertions:
     path: state.variables.repair_count.visibility
     check: "equals hidden"
 
-  - description: Easy difficulty uses no correction
+  - description: Warm difficulty uses no correction
     path: scenario.difficulty.options.warm.disclosure
     check: "gte 67"
 
-  - description: Normal difficulty uses light (silent recast) correction
+  - description: Standard difficulty uses light (silent recast) correction
     path: scenario.difficulty.options.standard.disclosure
     check: "between 34 66"
 

--- a/packs/official/language-cafe/tests/golden_english_small_talk.yaml
+++ b/packs/official/language-cafe/tests/golden_english_small_talk.yaml
@@ -14,7 +14,6 @@ description: >-
 seed: 42
 input_mode: text
 difficulty: hard
-
 turns:
   - turn: 1
     player_input: >-
@@ -103,20 +102,20 @@ static_assertions:
     check: "equals hidden"
 
   - description: Easy difficulty uses no correction
-    path: scenario.difficulty.options.easy.correction_style
-    check: "equals none"
+    path: scenario.difficulty.options.warm.disclosure
+    check: "gte 67"
 
   - description: Normal difficulty uses light (silent recast) correction
-    path: scenario.difficulty.options.normal.correction_style
-    check: "equals light"
+    path: scenario.difficulty.options.standard.disclosure
+    check: "between 34 66"
 
   - description: Hard difficulty uses strict (explicit gentle) correction
-    path: scenario.difficulty.options.hard.correction_style
-    check: "equals strict"
+    path: scenario.difficulty.options.hard.disclosure
+    check: "lte 33"
 
   - description: Hard difficulty applies a negative NPC patience modifier
-    path: scenario.difficulty.options.hard.npc_patience_modifier
-    check: "equals -10"
+    path: scenario.difficulty.options.hard.patience
+    check: "lte 33"
 
   - description: NPC is marked fictional
     path: npc.fictional

--- a/packs/official/language-cafe/tests/golden_french_travel_checkin.yaml
+++ b/packs/official/language-cafe/tests/golden_french_travel_checkin.yaml
@@ -13,7 +13,6 @@ description: >-
 seed: 42
 input_mode: text
 difficulty: hard
-
 turns:
   - turn: 1
     player_input: >-
@@ -102,20 +101,20 @@ static_assertions:
     check: "equals hidden"
 
   - description: Easy difficulty uses no correction
-    path: scenario.difficulty.options.easy.correction_style
-    check: "equals none"
+    path: scenario.difficulty.options.warm.disclosure
+    check: "gte 67"
 
   - description: Normal difficulty uses light (silent recast) correction
-    path: scenario.difficulty.options.normal.correction_style
-    check: "equals light"
+    path: scenario.difficulty.options.standard.disclosure
+    check: "between 34 66"
 
   - description: Hard difficulty uses strict (explicit gentle) correction
-    path: scenario.difficulty.options.hard.correction_style
-    check: "equals strict"
+    path: scenario.difficulty.options.hard.disclosure
+    check: "lte 33"
 
   - description: Hard difficulty applies a negative NPC patience modifier
-    path: scenario.difficulty.options.hard.npc_patience_modifier
-    check: "equals -10"
+    path: scenario.difficulty.options.hard.patience
+    check: "lte 33"
 
   - description: NPC is marked fictional
     path: npc.fictional

--- a/packs/official/language-cafe/tests/golden_french_travel_checkin.yaml
+++ b/packs/official/language-cafe/tests/golden_french_travel_checkin.yaml
@@ -100,11 +100,11 @@ static_assertions:
     path: state.variables.repair_count.visibility
     check: "equals hidden"
 
-  - description: Easy difficulty uses no correction
+  - description: Warm difficulty uses no correction
     path: scenario.difficulty.options.warm.disclosure
     check: "gte 67"
 
-  - description: Normal difficulty uses light (silent recast) correction
+  - description: Standard difficulty uses light (silent recast) correction
     path: scenario.difficulty.options.standard.disclosure
     check: "between 34 66"
 

--- a/packs/official/language-cafe/tests/golden_japanese_convenience_store.yaml
+++ b/packs/official/language-cafe/tests/golden_japanese_convenience_store.yaml
@@ -13,7 +13,6 @@ description: >-
 seed: 42
 input_mode: text
 difficulty: hard
-
 turns:
   - turn: 1
     player_input: >-
@@ -99,20 +98,20 @@ static_assertions:
     check: "equals hidden"
 
   - description: Easy difficulty uses no correction
-    path: scenario.difficulty.options.easy.correction_style
-    check: "equals none"
+    path: scenario.difficulty.options.warm.disclosure
+    check: "gte 67"
 
   - description: Normal difficulty uses light (silent recast) correction
-    path: scenario.difficulty.options.normal.correction_style
-    check: "equals light"
+    path: scenario.difficulty.options.standard.disclosure
+    check: "between 34 66"
 
   - description: Hard difficulty uses strict (explicit gentle) correction
-    path: scenario.difficulty.options.hard.correction_style
-    check: "equals strict"
+    path: scenario.difficulty.options.hard.disclosure
+    check: "lte 33"
 
   - description: Hard difficulty applies a negative NPC patience modifier
-    path: scenario.difficulty.options.hard.npc_patience_modifier
-    check: "equals -10"
+    path: scenario.difficulty.options.hard.patience
+    check: "lte 33"
 
   - description: NPC is marked fictional
     path: npc.fictional

--- a/packs/official/language-cafe/tests/golden_japanese_convenience_store.yaml
+++ b/packs/official/language-cafe/tests/golden_japanese_convenience_store.yaml
@@ -97,11 +97,11 @@ static_assertions:
     path: state.variables.repair_count.visibility
     check: "equals hidden"
 
-  - description: Easy difficulty uses no correction
+  - description: Warm difficulty uses no correction
     path: scenario.difficulty.options.warm.disclosure
     check: "gte 67"
 
-  - description: Normal difficulty uses light (silent recast) correction
+  - description: Standard difficulty uses light (silent recast) correction
     path: scenario.difficulty.options.standard.disclosure
     check: "between 34 66"
 

--- a/packs/official/language-cafe/tests/golden_spanish_coffee.yaml
+++ b/packs/official/language-cafe/tests/golden_spanish_coffee.yaml
@@ -13,7 +13,6 @@ description: >-
 seed: 42
 input_mode: text
 difficulty: hard
-
 turns:
   - turn: 1
     player_input: >-
@@ -101,20 +100,20 @@ static_assertions:
     check: "equals hidden"
 
   - description: Easy difficulty uses no correction
-    path: scenario.difficulty.options.easy.correction_style
-    check: "equals none"
+    path: scenario.difficulty.options.warm.disclosure
+    check: "gte 67"
 
   - description: Normal difficulty uses light (silent recast) correction
-    path: scenario.difficulty.options.normal.correction_style
-    check: "equals light"
+    path: scenario.difficulty.options.standard.disclosure
+    check: "between 34 66"
 
   - description: Hard difficulty uses strict (explicit gentle) correction
-    path: scenario.difficulty.options.hard.correction_style
-    check: "equals strict"
+    path: scenario.difficulty.options.hard.disclosure
+    check: "lte 33"
 
   - description: Hard difficulty applies a negative NPC patience modifier
-    path: scenario.difficulty.options.hard.npc_patience_modifier
-    check: "equals -10"
+    path: scenario.difficulty.options.hard.patience
+    check: "lte 33"
 
   - description: NPC is marked fictional
     path: npc.fictional

--- a/packs/official/language-cafe/tests/golden_spanish_coffee.yaml
+++ b/packs/official/language-cafe/tests/golden_spanish_coffee.yaml
@@ -99,11 +99,11 @@ static_assertions:
     path: state.variables.repair_count.visibility
     check: "equals hidden"
 
-  - description: Easy difficulty uses no correction
+  - description: Warm difficulty uses no correction
     path: scenario.difficulty.options.warm.disclosure
     check: "gte 67"
 
-  - description: Normal difficulty uses light (silent recast) correction
+  - description: Standard difficulty uses light (silent recast) correction
     path: scenario.difficulty.options.standard.disclosure
     check: "between 34 66"
 

--- a/packs/official/language-cafe/tests/smoke_english_small_talk.yaml
+++ b/packs/official/language-cafe/tests/smoke_english_small_talk.yaml
@@ -10,8 +10,7 @@ description: >-
 
 seed: 42
 input_mode: text
-difficulty: normal
-
+difficulty: standard
 turns:
   - turn: 1
     player_input: >-

--- a/packs/official/language-cafe/tests/smoke_french_travel_checkin.yaml
+++ b/packs/official/language-cafe/tests/smoke_french_travel_checkin.yaml
@@ -10,8 +10,7 @@ description: >-
 
 seed: 42
 input_mode: text
-difficulty: normal
-
+difficulty: standard
 turns:
   - turn: 1
     player_input: >-

--- a/packs/official/language-cafe/tests/smoke_japanese_convenience_store.yaml
+++ b/packs/official/language-cafe/tests/smoke_japanese_convenience_store.yaml
@@ -10,8 +10,7 @@ description: >-
 
 seed: 42
 input_mode: text
-difficulty: normal
-
+difficulty: standard
 turns:
   - turn: 1
     player_input: >-

--- a/packs/official/language-cafe/tests/smoke_spanish_coffee.yaml
+++ b/packs/official/language-cafe/tests/smoke_spanish_coffee.yaml
@@ -10,8 +10,7 @@ description: >-
 
 seed: 42
 input_mode: text
-difficulty: normal
-
+difficulty: standard
 turns:
   - turn: 1
     player_input: >-

--- a/packs/sample/hello-conversation/scenarios/friendly_introduction.yaml
+++ b/packs/sample/hello-conversation/scenarios/friendly_introduction.yaml
@@ -94,14 +94,20 @@ response_style:
   formality: casual
 
 difficulty:
-  default: normal
+  default: standard
   options:
-    easy:
-      npc_patience_modifier: 20
-      challenge_frequency: low
-    normal:
-      npc_patience_modifier: 0
-      challenge_frequency: medium
+    warm:
+      patience: 80
+      volatility: 20
+      disclosure: 70
+      time_pressure: 20
+    standard:
+      patience: 50
+      volatility: 50
+      disclosure: 50
+      time_pressure: 50
     hard:
-      npc_patience_modifier: -15
-      challenge_frequency: high
+      patience: 25
+      volatility: 70
+      disclosure: 25
+      time_pressure: 60

--- a/packs/sample/hello-conversation/tests/smoke_friendly_introduction.yaml
+++ b/packs/sample/hello-conversation/tests/smoke_friendly_introduction.yaml
@@ -7,7 +7,7 @@ description: >-
   first introduction advances the session without triggering a safety stop.
 seed: 42
 input_mode: text
-difficulty: normal
+difficulty: standard
 turns:
   - turn: 1
     player_input: >-

--- a/schemas/debrief.schema.json
+++ b/schemas/debrief.schema.json
@@ -194,6 +194,11 @@
           }
         }
       }
+    },
+    "difficulty_preset": {
+      "type": "string",
+      "enum": ["warm", "standard", "hard", "adversarial"],
+      "description": "The difficulty preset the player selected for this session."
     }
   }
 }

--- a/schemas/debrief.schema.json
+++ b/schemas/debrief.schema.json
@@ -111,6 +111,11 @@
     "used_fallback": {
       "type": "boolean",
       "description": "True if the narrative was generated from a template rather than an LLM call."
+    },
+    "difficulty_preset": {
+      "type": "string",
+      "enum": ["warm", "standard", "hard", "adversarial"],
+      "description": "The difficulty preset the player selected for this session."
     }
   }
 }

--- a/schemas/examples/pack-test.example.json
+++ b/schemas/examples/pack-test.example.json
@@ -5,7 +5,7 @@
   "description": "Minimal smoke test for the hello_world scenario. Verifies the scenario loads, produces a non-empty opening, and that a clear self-introduction advances the session without a safety stop.",
   "seed": 1,
   "input_mode": "text",
-  "difficulty": "normal",
+  "difficulty": "standard",
   "turns": [
     {
       "turn": 1,

--- a/schemas/examples/scenario.example.json
+++ b/schemas/examples/scenario.example.json
@@ -41,11 +41,12 @@
     }
   },
   "difficulty": {
-    "default": "normal",
+    "default": "standard",
     "options": {
-      "easy": { "npc_patience_modifier": 20, "challenge_frequency": "low" },
-      "normal": { "npc_patience_modifier": 0, "challenge_frequency": "medium" },
-      "hard": { "npc_patience_modifier": -20, "challenge_frequency": "high" }
+      "warm":        { "patience": 80, "volatility": 20, "disclosure": 70, "time_pressure": 20, "label": "Warm-up",     "description": "The greeter is patient and volunteers hints if you seem unsure." },
+      "standard":    { "patience": 50, "volatility": 50, "disclosure": 50, "time_pressure": 50, "label": "Standard",    "description": "Realistic pacing — the greeter expects a clear purpose statement." },
+      "hard":        { "patience": 25, "volatility": 70, "disclosure": 25, "time_pressure": 60, "label": "Hard",        "description": "The greeter is brisk; unclear communication lowers clarity quickly." },
+      "adversarial": { "patience": 10, "volatility": 90, "disclosure": 10, "time_pressure": 80, "label": "Adversarial", "description": "Near-zero tolerance — state is extremely reactive and time is short." }
     }
   },
   "replay_seed": 42,

--- a/schemas/pack-test.schema.json
+++ b/schemas/pack-test.schema.json
@@ -44,7 +44,7 @@
     },
     "difficulty": {
       "type": "string",
-      "enum": ["easy", "normal", "hard"],
+      "enum": ["warm", "standard", "hard", "adversarial"],
       "description": "Difficulty setting to use when running the fixture."
     },
     "turns": {

--- a/schemas/scenario.schema.json
+++ b/schemas/scenario.schema.json
@@ -157,22 +157,22 @@
     "difficulty": {
       "type": "object",
       "additionalProperties": false,
+      "description": "Standardised difficulty system. 'default' names the author's recommended preset. 'options' maps each named preset to its four knobs.",
       "properties": {
         "default": {
           "type": "string",
-          "enum": ["easy", "normal", "hard"]
+          "enum": ["warm", "standard", "hard", "adversarial"],
+          "description": "Author's recommended preset shown pre-selected in setup UI."
         },
         "options": {
           "type": "object",
-          "additionalProperties": {
-            "type": "object",
-            "properties": {
-              "npc_patience_modifier": { "type": "integer" },
-              "challenge_frequency": {
-                "type": "string",
-                "enum": ["low", "medium", "high"]
-              }
-            }
+          "description": "Per-preset knob overrides. Keys must be preset names.",
+          "additionalProperties": false,
+          "properties": {
+            "warm":        { "$ref": "#/$defs/DifficultyPreset" },
+            "standard":    { "$ref": "#/$defs/DifficultyPreset" },
+            "hard":        { "$ref": "#/$defs/DifficultyPreset" },
+            "adversarial": { "$ref": "#/$defs/DifficultyPreset" }
           }
         }
       }
@@ -367,6 +367,48 @@
             }
           ],
           "description": "Optional explicit timeout condition (turn-count-based timeout is always enforced via duration.max_turns)."
+        }
+      }
+    }
+  },
+  "$defs": {
+    "DifficultyPreset": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Knob values for one named difficulty preset.",
+      "properties": {
+        "patience": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Tolerance before the NPC disengages (higher = more patient)."
+        },
+        "volatility": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100,
+          "description": "State-meter sensitivity per turn (higher = meters shift more)."
+        },
+        "disclosure": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100,
+          "description": "How freely the NPC volunteers information (higher = more open)."
+        },
+        "time_pressure": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Turn-budget urgency the NPC conveys (higher = more time pressure)."
+        },
+        "label": {
+          "type": "string",
+          "description": "Short human-readable label shown in setup UI (e.g. 'Warm-up')."
+        },
+        "description": {
+          "type": "string",
+          "maxLength": 120,
+          "description": "One-line description of what changes at this preset, shown in setup UI."
         }
       }
     }

--- a/scripts/release-smoke.ps1
+++ b/scripts/release-smoke.ps1
@@ -379,7 +379,7 @@ function Invoke-SmokeTextSession {
     try {
         # scenario_id is the bare registry id (not "pack/scenario"); player_role_name
         # is required by POST /api/sessions. See services/convsim-core routers/sessions.py.
-        $createBody = '{"scenario_id":"behavioral_interview","player_role_name":"Smoke Tester","difficulty":"normal","language":"en","input_mode":"text-only","tts_enabled":false}'
+        $createBody = '{"scenario_id":"behavioral_interview","player_role_name":"Smoke Tester","difficulty":"standard","language":"en","input_mode":"text-only","tts_enabled":false}'
         $createResp = Invoke-WebRequest -Uri "$CoreUrl/api/sessions" -Method POST `
             -ContentType "application/json" -Body $createBody -TimeoutSec 10 -UseBasicParsing -ErrorAction Stop
         if ($createResp.StatusCode -ne 201) {

--- a/scripts/release-smoke.sh
+++ b/scripts/release-smoke.sh
@@ -455,7 +455,7 @@ smoke_text_session() {
     create_resp="$(curl -s --max-time 10 -w '\n%{http_code}' \
         -X POST "$CORE_URL/api/sessions" \
         -H 'Content-Type: application/json' \
-        -d '{"scenario_id":"behavioral_interview","player_role_name":"Smoke Tester","difficulty":"normal","language":"en","input_mode":"text-only","tts_enabled":false}' \
+        -d '{"scenario_id":"behavioral_interview","player_role_name":"Smoke Tester","difficulty":"standard","language":"en","input_mode":"text-only","tts_enabled":false}' \
         2>&1)" || {
         fail "text-session" "POST /api/sessions failed"
         return

--- a/services/convsim-core/convsim_core/routers/scenarios.py
+++ b/services/convsim-core/convsim_core/routers/scenarios.py
@@ -20,7 +20,7 @@ async def get_scenarios(
     tag: Annotated[Optional[str], Query(description="Filter by tag")] = None,
     language: Annotated[Optional[str], Query(description="Filter by supported language code")] = None,
     content_rating: Annotated[Optional[str], Query(description="Filter by content rating (G, PG, PG-13)")] = None,
-    difficulty: Annotated[Optional[str], Query(description="Filter by default difficulty (easy, normal, hard)")] = None,
+    difficulty: Annotated[Optional[str], Query(description="Filter by default difficulty (warm, standard, hard, adversarial)")] = None,
     voice_support: Annotated[Optional[bool], Query(description="Filter to scenarios with voice support")] = None,
 ) -> list[ScenarioCard]:
     """List installed scenarios with optional filters and full-text search."""

--- a/services/convsim-core/convsim_core/routers/sessions.py
+++ b/services/convsim-core/convsim_core/routers/sessions.py
@@ -63,7 +63,7 @@ _DEFAULT_TTS_VOICE_ID = "af_heart"
 
 class SessionCreateRequest(BaseModel):
     scenario_id: str
-    difficulty: Literal["easy", "normal", "hard"] = "normal"
+    difficulty: Literal["warm", "standard", "hard", "adversarial"] = "standard"
     player_role_name: str
     language: str = "en"
     input_mode: Literal["text-only", "push-to-talk", "hands-free"] = "text-only"
@@ -434,7 +434,7 @@ async def submit_turn(session_id: str, body: TurnSubmitRequest, request: Request
 
     setup = json.loads(row["setup_json"])
     scenario_id = row["scenario_id"]
-    difficulty = setup.get("difficulty", "normal")
+    difficulty = setup.get("difficulty", "standard")
     info = get_scenario_info(scenario_id)
     if info is None:
         raise HTTPException(status_code=500, detail=f"Scenario {scenario_id!r} not found in registry")
@@ -666,7 +666,7 @@ async def create_debrief(session_id: str, request: Request) -> DebriefResponse:
 
     scenario_id = row["scenario_id"]
     setup = json.loads(row["setup_json"])
-    difficulty = setup.get("difficulty", "normal")
+    difficulty = setup.get("difficulty", "standard")
     info = get_scenario_info(scenario_id)
     if info is None:
         raise HTTPException(status_code=500, detail=f"Scenario {scenario_id!r} not found in registry")

--- a/services/convsim-core/convsim_core/routers/sessions.py
+++ b/services/convsim-core/convsim_core/routers/sessions.py
@@ -63,7 +63,7 @@ _DEFAULT_TTS_VOICE_ID = "af_heart"
 
 class SessionCreateRequest(BaseModel):
     scenario_id: str
-    difficulty: Literal["easy", "normal", "hard"] = "normal"
+    difficulty: Literal["warm", "standard", "hard", "adversarial"] = "standard"
     player_role_name: str
     language: str = "en"
     input_mode: Literal["text-only", "push-to-talk", "hands-free"] = "text-only"
@@ -435,7 +435,7 @@ async def submit_turn(session_id: str, body: TurnSubmitRequest, request: Request
 
     setup = json.loads(row["setup_json"])
     scenario_id = row["scenario_id"]
-    difficulty = setup.get("difficulty", "normal")
+    difficulty = setup.get("difficulty", "standard")
     info = get_scenario_info(scenario_id)
     if info is None:
         raise HTTPException(status_code=500, detail=f"Scenario {scenario_id!r} not found in registry")
@@ -668,7 +668,7 @@ async def create_debrief(session_id: str, request: Request) -> DebriefResponse:
 
     scenario_id = row["scenario_id"]
     setup = json.loads(row["setup_json"])
-    difficulty = setup.get("difficulty", "normal")
+    difficulty = setup.get("difficulty", "standard")
     info = get_scenario_info(scenario_id)
     if info is None:
         raise HTTPException(status_code=500, detail=f"Scenario {scenario_id!r} not found in registry")

--- a/services/convsim-core/convsim_core/routers/workbench.py
+++ b/services/convsim-core/convsim_core/routers/workbench.py
@@ -595,7 +595,7 @@ async def start_test_session(request: Request, kind: str, slug: str) -> Workbenc
 
     setup = {
         "scenario_id": dynamic_id,
-        "difficulty": "normal",
+        "difficulty": "standard",
         "player_role_name": "Workbench Tester",
         "language": "en",
         "input_mode": "text-only",

--- a/services/convsim-core/convsim_core/scenarios.py
+++ b/services/convsim-core/convsim_core/scenarios.py
@@ -40,7 +40,7 @@ class ScenarioInfo:
         """Return a ScenarioData with difficulty settings applied."""
         diff_settings = self.difficulty_options.get(
             difficulty,
-            self.difficulty_options.get("normal", DifficultySettings()),
+            self.difficulty_options.get("standard", DifficultySettings()),
         )
         return ScenarioData(
             scenario_id=self.scenario_data.scenario_id,
@@ -95,9 +95,10 @@ SCENARIOS: Dict[str, ScenarioInfo] = {
         max_turns=18,
         supported_languages=["en"],
         difficulty_options={
-            "easy": DifficultySettings(npc_patience_modifier=15, challenge_frequency="low"),
-            "normal": DifficultySettings(npc_patience_modifier=0, challenge_frequency="medium"),
-            "hard": DifficultySettings(npc_patience_modifier=-20, challenge_frequency="high"),
+            "warm":        DifficultySettings(patience=80, volatility=20, disclosure=70, time_pressure=20),
+            "standard":    DifficultySettings(patience=50, volatility=50, disclosure=50, time_pressure=50),
+            "hard":        DifficultySettings(patience=25, volatility=70, disclosure=25, time_pressure=60),
+            "adversarial": DifficultySettings(patience=10, volatility=90, disclosure=10, time_pressure=80),
         },
         opening_npc_says=(
             "Thanks for coming in today. I'm Alex Chen from HR. "
@@ -137,8 +138,9 @@ SCENARIOS: Dict[str, ScenarioInfo] = {
         max_turns=14,
         supported_languages=["en"],
         difficulty_options={
-            "normal": DifficultySettings(npc_patience_modifier=-10, challenge_frequency="medium"),
-            "hard": DifficultySettings(npc_patience_modifier=-25, challenge_frequency="high"),
+            "standard":    DifficultySettings(patience=30, volatility=60, disclosure=30, time_pressure=60),
+            "hard":        DifficultySettings(patience=15, volatility=80, disclosure=15, time_pressure=75),
+            "adversarial": DifficultySettings(patience=5,  volatility=95, disclosure=5,  time_pressure=90),
         },
         opening_npc_says=(
             "Let's skip the pleasantries. Why should I care about you? "
@@ -182,9 +184,10 @@ SCENARIOS: Dict[str, ScenarioInfo] = {
         max_turns=16,
         supported_languages=["en", "es"],
         difficulty_options={
-            "easy": DifficultySettings(npc_patience_modifier=20, challenge_frequency="low"),
-            "normal": DifficultySettings(npc_patience_modifier=0, challenge_frequency="medium"),
-            "hard": DifficultySettings(npc_patience_modifier=-15, challenge_frequency="high"),
+            "warm":        DifficultySettings(patience=80, volatility=20, disclosure=70, time_pressure=20),
+            "standard":    DifficultySettings(patience=50, volatility=50, disclosure=50, time_pressure=50),
+            "hard":        DifficultySettings(patience=25, volatility=70, disclosure=25, time_pressure=60),
+            "adversarial": DifficultySettings(patience=10, volatility=90, disclosure=10, time_pressure=80),
         },
         opening_npc_says=(
             "Welcome! You're looking at one of our best deals. "
@@ -228,8 +231,9 @@ SCENARIOS: Dict[str, ScenarioInfo] = {
         max_turns=20,
         supported_languages=["es", "en"],
         difficulty_options={
-            "easy": DifficultySettings(npc_patience_modifier=15, challenge_frequency="low"),
-            "normal": DifficultySettings(npc_patience_modifier=0, challenge_frequency="medium"),
+            "warm":     DifficultySettings(patience=80, volatility=20, disclosure=80, time_pressure=10),
+            "standard": DifficultySettings(patience=55, volatility=45, disclosure=55, time_pressure=30),
+            "hard":     DifficultySettings(patience=30, volatility=65, disclosure=30, time_pressure=55),
         },
         opening_npc_says="¡Buenos días! ¿Qué le pongo?",
     ),
@@ -269,9 +273,10 @@ SCENARIOS: Dict[str, ScenarioInfo] = {
         max_turns=14,
         supported_languages=["en"],
         difficulty_options={
-            "easy": DifficultySettings(npc_patience_modifier=15, challenge_frequency="low"),
-            "normal": DifficultySettings(npc_patience_modifier=0, challenge_frequency="medium"),
-            "hard": DifficultySettings(npc_patience_modifier=-15, challenge_frequency="high"),
+            "warm":        DifficultySettings(patience=80, volatility=20, disclosure=70, time_pressure=20),
+            "standard":    DifficultySettings(patience=50, volatility=50, disclosure=50, time_pressure=50),
+            "hard":        DifficultySettings(patience=25, volatility=70, disclosure=25, time_pressure=60),
+            "adversarial": DifficultySettings(patience=10, volatility=90, disclosure=10, time_pressure=80),
         },
         opening_npc_says="Hey, you wanted to talk? What's up?",
         state_variable_overrides={
@@ -334,7 +339,7 @@ def get_scenario_info(scenario_id: str) -> ScenarioInfo | None:
     return SCENARIOS.get(scenario_id) or _dynamic_registry.get(scenario_id)
 
 
-def get_scenario_data(scenario_id: str, difficulty: str = "normal") -> ScenarioData | None:
+def get_scenario_data(scenario_id: str, difficulty: str = "standard") -> ScenarioData | None:
     """Return a ScenarioData configured for the given difficulty, or None if unknown."""
     info = get_scenario_info(scenario_id)
     if info is None:
@@ -418,7 +423,7 @@ def load_scenario_info_from_pack(pack_dir: Path, scenario_rel_path: str) -> Scen
         scenario_data=scenario_data,
         max_turns=max_turns,
         supported_languages=["en"],
-        difficulty_options={"normal": DifficultySettings()},
+        difficulty_options={"standard": DifficultySettings()},
         opening_npc_says=opening_npc_says,
         state_variable_overrides=state_variable_overrides,
     )

--- a/services/convsim-core/convsim_core/schemas/debrief.schema.json
+++ b/services/convsim-core/convsim_core/schemas/debrief.schema.json
@@ -194,6 +194,11 @@
           }
         }
       }
+    },
+    "difficulty_preset": {
+      "type": "string",
+      "enum": ["warm", "standard", "hard", "adversarial"],
+      "description": "The difficulty preset the player selected for this session."
     }
   }
 }

--- a/services/convsim-core/convsim_core/schemas/debrief.schema.json
+++ b/services/convsim-core/convsim_core/schemas/debrief.schema.json
@@ -111,6 +111,11 @@
     "used_fallback": {
       "type": "boolean",
       "description": "True if the narrative was generated from a template rather than an LLM call."
+    },
+    "difficulty_preset": {
+      "type": "string",
+      "enum": ["warm", "standard", "hard", "adversarial"],
+      "description": "The difficulty preset the player selected for this session."
     }
   }
 }

--- a/services/convsim-core/convsim_core/schemas/pack-test.schema.json
+++ b/services/convsim-core/convsim_core/schemas/pack-test.schema.json
@@ -44,7 +44,7 @@
     },
     "difficulty": {
       "type": "string",
-      "enum": ["easy", "normal", "hard"],
+      "enum": ["warm", "standard", "hard", "adversarial"],
       "description": "Difficulty setting to use when running the fixture."
     },
     "turns": {

--- a/services/convsim-core/convsim_core/schemas/scenario.schema.json
+++ b/services/convsim-core/convsim_core/schemas/scenario.schema.json
@@ -157,22 +157,22 @@
     "difficulty": {
       "type": "object",
       "additionalProperties": false,
+      "description": "Standardised difficulty system. 'default' names the author's recommended preset. 'options' maps each named preset to its four knobs.",
       "properties": {
         "default": {
           "type": "string",
-          "enum": ["easy", "normal", "hard"]
+          "enum": ["warm", "standard", "hard", "adversarial"],
+          "description": "Author's recommended preset shown pre-selected in setup UI."
         },
         "options": {
           "type": "object",
-          "additionalProperties": {
-            "type": "object",
-            "properties": {
-              "npc_patience_modifier": { "type": "integer" },
-              "challenge_frequency": {
-                "type": "string",
-                "enum": ["low", "medium", "high"]
-              }
-            }
+          "description": "Per-preset knob overrides. Keys must be preset names.",
+          "additionalProperties": false,
+          "properties": {
+            "warm":        { "$ref": "#/$defs/DifficultyPreset" },
+            "standard":    { "$ref": "#/$defs/DifficultyPreset" },
+            "hard":        { "$ref": "#/$defs/DifficultyPreset" },
+            "adversarial": { "$ref": "#/$defs/DifficultyPreset" }
           }
         }
       }
@@ -367,6 +367,48 @@
             }
           ],
           "description": "Optional explicit timeout condition (turn-count-based timeout is always enforced via duration.max_turns)."
+        }
+      }
+    }
+  },
+  "$defs": {
+    "DifficultyPreset": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Knob values for one named difficulty preset.",
+      "properties": {
+        "patience": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Tolerance before the NPC disengages (higher = more patient)."
+        },
+        "volatility": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100,
+          "description": "State-meter sensitivity per turn (higher = meters shift more)."
+        },
+        "disclosure": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100,
+          "description": "How freely the NPC volunteers information (higher = more open)."
+        },
+        "time_pressure": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Turn-budget urgency the NPC conveys (higher = more time pressure)."
+        },
+        "label": {
+          "type": "string",
+          "description": "Short human-readable label shown in setup UI (e.g. 'Warm-up')."
+        },
+        "description": {
+          "type": "string",
+          "maxLength": 120,
+          "description": "One-line description of what changes at this preset, shown in setup UI."
         }
       }
     }

--- a/services/convsim-core/convsim_core/services/debrief_engine.py
+++ b/services/convsim-core/convsim_core/services/debrief_engine.py
@@ -438,6 +438,7 @@ async def generate_debrief(
     scenario_id: str = session_row["scenario_id"]
     setup: Dict[str, Any] = json.loads(session_row["setup_json"] or "{}")
     pack_id: Optional[str] = setup.get("pack_id")
+    difficulty_preset: Optional[str] = setup.get("difficulty")
     outcome: str = session_row["ending_type"] or "player_exit"
     final_state: Dict[str, int] = json.loads(session_row["state_vars_json"] or "{}")
     total_turns: int = int(session_row["turn_count"])
@@ -488,6 +489,7 @@ async def generate_debrief(
             scores=scores,
             turns=turn_records,
             pack_id=pack_id,
+            difficulty_preset=difficulty_preset,
         )
         prompt = compose_debrief_prompt(composer_input)
 
@@ -563,6 +565,8 @@ async def generate_debrief(
         }
         if pack_id:
             debrief_doc["pack_id"] = pack_id
+        if difficulty_preset:
+            debrief_doc["difficulty_preset"] = difficulty_preset
 
         # Persist and transition to DebriefReady.
         with conn:

--- a/services/convsim-core/convsim_core/services/debrief_engine.py
+++ b/services/convsim-core/convsim_core/services/debrief_engine.py
@@ -238,6 +238,7 @@ async def generate_debrief(
     scenario_id: str = session_row["scenario_id"]
     setup: Dict[str, Any] = json.loads(session_row["setup_json"] or "{}")
     pack_id: Optional[str] = setup.get("pack_id")
+    difficulty_preset: Optional[str] = setup.get("difficulty")
     outcome: str = session_row["ending_type"] or "player_exit"
     final_state: Dict[str, int] = json.loads(session_row["state_vars_json"] or "{}")
     total_turns: int = int(session_row["turn_count"])
@@ -282,6 +283,7 @@ async def generate_debrief(
             scores=scores,
             turns=turn_records,
             pack_id=pack_id,
+            difficulty_preset=difficulty_preset,
         )
         prompt = compose_debrief_prompt(composer_input)
 
@@ -356,6 +358,8 @@ async def generate_debrief(
         }
         if pack_id:
             debrief_doc["pack_id"] = pack_id
+        if difficulty_preset:
+            debrief_doc["difficulty_preset"] = difficulty_preset
 
         # Persist and transition to DebriefReady.
         with conn:

--- a/services/convsim-core/tests/helpers.py
+++ b/services/convsim-core/tests/helpers.py
@@ -146,12 +146,18 @@ def make_pack_dir(base: Path, manifest: dict | None = None, extra_files: dict | 
         "  hidden:\n"
         "    - Host is evaluating your communication style\n"
         "difficulty:\n"
-        "  default: easy\n"
+        "  default: warm\n"
         "  options:\n"
-        "    easy:\n"
-        "      npc_patience_modifier: 10\n"
-        "    normal:\n"
-        "      npc_patience_modifier: 0\n",
+        "    warm:\n"
+        "      patience: 80\n"
+        "      volatility: 20\n"
+        "      disclosure: 70\n"
+        "      time_pressure: 20\n"
+        "    standard:\n"
+        "      patience: 50\n"
+        "      volatility: 50\n"
+        "      disclosure: 50\n"
+        "      time_pressure: 50\n",
         encoding="utf-8",
     )
     (scenarios_dir / "advanced.yaml").write_text(
@@ -177,7 +183,7 @@ def make_pack_dir(base: Path, manifest: dict | None = None, extra_files: dict | 
         "  hidden:\n"
         "    - Evaluating leadership qualities\n"
         "difficulty:\n"
-        "  default: hard\n",
+        "  default: adversarial\n",
         encoding="utf-8",
     )
 

--- a/services/convsim-core/tests/test_debrief_engine.py
+++ b/services/convsim-core/tests/test_debrief_engine.py
@@ -72,7 +72,7 @@ def client(tmp_config):
 
 _VALID_SETUP = {
     "scenario_id": "behavioral_interview",
-    "difficulty": "normal",
+    "difficulty": "standard",
     "player_role_name": "Alice",
     "language": "en",
     "input_mode": "text-only",

--- a/services/convsim-core/tests/test_scenarios_api.py
+++ b/services/convsim-core/tests/test_scenarios_api.py
@@ -120,7 +120,7 @@ def test_get_scenario_detail_intro(client, tmp_path):
     assert detail["title"] == "Introduction Scenario"
     assert detail["max_turns"] == 10
     assert detail["estimated_length_minutes"] == 8
-    assert detail["difficulty_default"] == "easy"
+    assert detail["difficulty_default"] == "warm"
     assert detail["player_role"]["label"] == "Participant"
     assert detail["opening_npc_says"] == "Hello! Welcome to the session."
     assert "Build rapport with the host" in detail["player_visible_goals"]
@@ -230,12 +230,12 @@ def test_filter_by_content_rating_no_match(client, tmp_path):
 
 def test_filter_by_difficulty(client, tmp_path):
     _import_pack(client, tmp_path)
-    resp = client.get("/api/scenarios?difficulty=easy")
+    resp = client.get("/api/scenarios?difficulty=warm")
     assert resp.status_code == 200
     scenarios = resp.json()
     assert len(scenarios) >= 1
     for s in scenarios:
-        assert s["difficulty_default"] == "easy"
+        assert s["difficulty_default"] == "warm"
 
 
 def test_filter_by_voice_support_false(client, tmp_path):

--- a/services/convsim-core/tests/test_transcript_persistence.py
+++ b/services/convsim-core/tests/test_transcript_persistence.py
@@ -44,7 +44,7 @@ def client(tmp_config):
 
 _BASE_SETUP = {
     "scenario_id": "behavioral_interview",
-    "difficulty": "normal",
+    "difficulty": "standard",
     "player_role_name": "Alice",
     "language": "en",
     "input_mode": "text-only",

--- a/services/convsim-core/tests/test_tts_queue.py
+++ b/services/convsim-core/tests/test_tts_queue.py
@@ -214,7 +214,7 @@ def test_chunk_result_not_succeeded_when_audio_path_none():
 
 _BASE_SETUP = {
     "scenario_id": "behavioral_interview",
-    "difficulty": "normal",
+    "difficulty": "standard",
     "player_role_name": "Alice",
     "language": "en",
     "input_mode": "text-only",

--- a/services/convsim-core/tests/test_turn_pipeline.py
+++ b/services/convsim-core/tests/test_turn_pipeline.py
@@ -79,7 +79,7 @@ def client(tmp_config):
 
 _VALID_SETUP = {
     "scenario_id": "behavioral_interview",
-    "difficulty": "normal",
+    "difficulty": "standard",
     "player_role_name": "Alice",
     "language": "en",
     "input_mode": "text-only",
@@ -124,7 +124,7 @@ class TestSessionCreate:
         res = client.post("/api/sessions", json={
             **_VALID_SETUP,
             "scenario_id": "hostile_executive_interview",
-            "difficulty": "easy",
+            "difficulty": "warm",
         })
         assert res.status_code == 400
 
@@ -690,7 +690,7 @@ class TestPromptComposerWiring:
         await process_turn(
             session_row=row,
             player_text="I have five years of experience.",
-            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            scenario_data=get_scenario_data("behavioral_interview", "standard"),
             max_turns=10,
             runtime=FakeChatRuntime(),
             conn=conn,
@@ -716,7 +716,7 @@ class TestPromptComposerWiring:
         await process_turn(
             session_row=row,
             player_text="Tell me about the role.",
-            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            scenario_data=get_scenario_data("behavioral_interview", "standard"),
             max_turns=10,
             runtime=FakeChatRuntime(),
             conn=conn,
@@ -737,7 +737,7 @@ class TestPromptComposerWiring:
         await process_turn(
             session_row=row,
             player_text="What does success look like in this role?",
-            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            scenario_data=get_scenario_data("behavioral_interview", "standard"),
             max_turns=10,
             runtime=FakeChatRuntime(),
             conn=conn,
@@ -780,7 +780,7 @@ class TestPromptComposerWiring:
             await process_turn(
                 session_row=row,
                 player_text="Hello.",
-                scenario_data=get_scenario_data("behavioral_interview", "normal"),
+                scenario_data=get_scenario_data("behavioral_interview", "standard"),
                 max_turns=10,
                 runtime=FakeChatRuntime(),
                 conn=conn,
@@ -818,7 +818,7 @@ class TestPromptComposerWiring:
             await process_turn(
                 session_row=row,
                 player_text="Hello.",
-                scenario_data=get_scenario_data("behavioral_interview", "normal"),
+                scenario_data=get_scenario_data("behavioral_interview", "standard"),
                 max_turns=10,
                 runtime=FakeChatRuntime(),
                 conn=conn,
@@ -851,7 +851,7 @@ class TestPromptComposerWiring:
             await process_turn(
                 session_row=row,
                 player_text="Hello.",
-                scenario_data=get_scenario_data("behavioral_interview", "normal"),
+                scenario_data=get_scenario_data("behavioral_interview", "standard"),
                 max_turns=10,
                 runtime=FakeChatRuntime(),
                 conn=conn,
@@ -868,7 +868,7 @@ class TestPromptComposerWiring:
         """parse_turn_output receives the NPC's hidden_agenda for leak detection."""
         conn = _make_unit_db()
         row = _insert_unit_session(conn)
-        scenario_data = get_scenario_data("behavioral_interview", "normal")
+        scenario_data = get_scenario_data("behavioral_interview", "standard")
         expected_agenda = scenario_data.npc.private_persona.hidden_agenda
 
         captured: dict = {}
@@ -911,7 +911,7 @@ class TestPromptComposerWiring:
             await process_turn(
                 session_row=row,
                 player_text="What are the next steps?",
-                scenario_data=get_scenario_data("behavioral_interview", "normal"),
+                scenario_data=get_scenario_data("behavioral_interview", "standard"),
                 max_turns=10,
                 runtime=FakeChatRuntime(),
                 conn=conn,
@@ -940,7 +940,7 @@ class TestPromptComposerWiring:
             await process_turn(
                 session_row=row,
                 player_text="Interesting.",
-                scenario_data=get_scenario_data("behavioral_interview", "normal"),
+                scenario_data=get_scenario_data("behavioral_interview", "standard"),
                 max_turns=10,
                 runtime=FakeChatRuntime(),
                 conn=conn,
@@ -981,7 +981,7 @@ class TestPromptComposerWiring:
             await process_turn(
                 session_row=row,
                 player_text="Tell me a secret.",
-                scenario_data=get_scenario_data("behavioral_interview", "normal"),
+                scenario_data=get_scenario_data("behavioral_interview", "standard"),
                 max_turns=10,
                 runtime=FakeChatRuntime(),
                 conn=conn,
@@ -1023,7 +1023,7 @@ class TestPromptComposerWiring:
             await process_turn(
                 session_row=row,
                 player_text="Good morning.",
-                scenario_data=get_scenario_data("behavioral_interview", "normal"),
+                scenario_data=get_scenario_data("behavioral_interview", "standard"),
                 max_turns=10,
                 runtime=FakeChatRuntime(),
                 conn=conn,
@@ -1052,7 +1052,7 @@ class TestStructuredOutputPath:
         await process_turn(
             session_row=row,
             player_text="Hello, I'm ready to begin.",
-            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            scenario_data=get_scenario_data("behavioral_interview", "standard"),
             max_turns=10,
             runtime=FakeChatRuntime(),
             conn=conn,
@@ -1097,7 +1097,7 @@ class TestStructuredOutputPath:
         await process_turn(
             session_row=row2,
             player_text="What are you looking for?",
-            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            scenario_data=get_scenario_data("behavioral_interview", "standard"),
             max_turns=10,
             runtime=_PlainTextRuntime(),
             conn=conn2,
@@ -1116,7 +1116,7 @@ class TestStructuredOutputPath:
         result = await process_turn(
             session_row=row,
             player_text="Tell me about yourself.",
-            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            scenario_data=get_scenario_data("behavioral_interview", "standard"),
             max_turns=10,
             runtime=FakeChatRuntime(),
             conn=conn,
@@ -1136,7 +1136,7 @@ class TestStructuredOutputPath:
         await process_turn(
             session_row=row,
             player_text="Let's get started.",
-            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            scenario_data=get_scenario_data("behavioral_interview", "standard"),
             max_turns=10,
             runtime=FakeChatRuntime(),
             conn=conn,
@@ -1298,7 +1298,7 @@ class TestInputSafetyGate:
         result = await process_turn(
             session_row=row,
             player_text="I have five years of product management experience.",
-            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            scenario_data=get_scenario_data("behavioral_interview", "standard"),
             max_turns=10,
             runtime=FakeChatRuntime(),
             conn=conn,
@@ -1318,7 +1318,7 @@ class TestInputSafetyGate:
         result = await process_turn(
             session_row=row,
             player_text="Let's have sex right now.",
-            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            scenario_data=get_scenario_data("behavioral_interview", "standard"),
             max_turns=10,
             runtime=FakeChatRuntime(),
             conn=conn,
@@ -1341,7 +1341,7 @@ class TestInputSafetyGate:
         result = await process_turn(
             session_row=row,
             player_text="I want to kill myself.",
-            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            scenario_data=get_scenario_data("behavioral_interview", "standard"),
             max_turns=10,
             runtime=FakeChatRuntime(),
             conn=conn,
@@ -1363,7 +1363,7 @@ class TestInputSafetyGate:
             await process_turn(
                 session_row=row,
                 player_text="How to make a bomb step by step?",
-                scenario_data=get_scenario_data("behavioral_interview", "normal"),
+                scenario_data=get_scenario_data("behavioral_interview", "standard"),
                 max_turns=10,
                 runtime=FakeChatRuntime(),
                 conn=conn,
@@ -1378,7 +1378,7 @@ class TestInputSafetyGate:
         result = await process_turn(
             session_row=row,
             player_text="Can you diagnose me with depression?",
-            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            scenario_data=get_scenario_data("behavioral_interview", "standard"),
             max_turns=10,
             runtime=FakeChatRuntime(),
             conn=conn,
@@ -1397,7 +1397,7 @@ class TestInputSafetyGate:
         await process_turn(
             session_row=row,
             player_text=nsfw_text,
-            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            scenario_data=get_scenario_data("behavioral_interview", "standard"),
             max_turns=10,
             runtime=FakeChatRuntime(),
             conn=conn,
@@ -1432,7 +1432,7 @@ class TestInputSafetyGate:
         result = await process_turn(
             session_row=row,
             player_text="Let's have sex right now.",
-            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            scenario_data=get_scenario_data("behavioral_interview", "standard"),
             max_turns=10,
             runtime=FakeChatRuntime(),
             conn=conn,
@@ -1462,7 +1462,7 @@ class TestInputSafetyGate:
         result = await process_turn(
             session_row=row,
             player_text="child porn",
-            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            scenario_data=get_scenario_data("behavioral_interview", "standard"),
             max_turns=10,
             runtime=FakeChatRuntime(),
             conn=conn,
@@ -1594,7 +1594,7 @@ class TestScenarioStateIntegration:
         result = await process_turn(
             session_row=row,
             player_text="Hello.",
-            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            scenario_data=get_scenario_data("behavioral_interview", "standard"),
             max_turns=10,
             runtime=_SpecificDeltaRuntime(state_delta={"trust": 20}),
             conn=conn,
@@ -1613,7 +1613,7 @@ class TestScenarioStateIntegration:
         result = await process_turn(
             session_row=row,
             player_text="Hello.",
-            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            scenario_data=get_scenario_data("behavioral_interview", "standard"),
             max_turns=10,
             runtime=_SpecificDeltaRuntime(state_delta={"ghost_key": 10, "trust": 5}),
             conn=conn,
@@ -1639,7 +1639,7 @@ class TestScenarioStateIntegration:
         result = await process_turn(
             session_row=row,
             player_text="I agree completely.",
-            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            scenario_data=get_scenario_data("behavioral_interview", "standard"),
             max_turns=20,
             runtime=_SpecificDeltaRuntime(state_delta={"objective_progress": 15}),
             conn=conn,
@@ -1668,7 +1668,7 @@ class TestScenarioStateIntegration:
         result = await process_turn(
             session_row=row,
             player_text="That's not right at all.",
-            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            scenario_data=get_scenario_data("behavioral_interview", "standard"),
             max_turns=20,
             runtime=_SpecificDeltaRuntime(state_delta={"patience": -15}),
             conn=conn,
@@ -1693,7 +1693,7 @@ class TestScenarioStateIntegration:
         result = await process_turn(
             session_row=row,
             player_text="Last turn.",
-            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            scenario_data=get_scenario_data("behavioral_interview", "standard"),
             max_turns=1,
             runtime=FakeChatRuntime(),
             conn=conn,
@@ -1714,7 +1714,7 @@ class TestScenarioStateIntegration:
         result = await process_turn(
             session_row=row,
             player_text="Final answer.",
-            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            scenario_data=get_scenario_data("behavioral_interview", "standard"),
             max_turns=1,  # timeout would fire
             runtime=_SpecificDeltaRuntime(state_delta={"objective_progress": 15}),
             conn=conn,
@@ -1753,7 +1753,7 @@ class TestScenarioStateIntegration:
         result = await process_turn(
             session_row=row,
             player_text="I appreciate your perspective.",
-            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            scenario_data=get_scenario_data("behavioral_interview", "standard"),
             max_turns=20,
             runtime=_SpecificDeltaRuntime(state_delta={"rapport": 15}),
             conn=conn,
@@ -1778,7 +1778,7 @@ class TestScenarioStateIntegration:
         result = await process_turn(
             session_row=row,
             player_text="Hello.",
-            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            scenario_data=get_scenario_data("behavioral_interview", "standard"),
             max_turns=20,
             runtime=FakeChatRuntime(),
             conn=conn,
@@ -1800,7 +1800,7 @@ class TestScenarioStateIntegration:
         result = await process_turn(
             session_row=row,
             player_text="Hello.",
-            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            scenario_data=get_scenario_data("behavioral_interview", "standard"),
             max_turns=10,
             runtime=FakeChatRuntime(),
             conn=conn,
@@ -1824,7 +1824,7 @@ class TestScenarioStateIntegration:
         result = await process_turn(
             session_row=row,
             player_text="Hello.",
-            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            scenario_data=get_scenario_data("behavioral_interview", "standard"),
             max_turns=10,
             runtime=FakeChatRuntime(),
             conn=conn,
@@ -1870,7 +1870,7 @@ class TestScenarioStateIntegration:
         await process_turn(
             session_row=row,
             player_text="Let me be clear.",
-            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            scenario_data=get_scenario_data("behavioral_interview", "standard"),
             max_turns=10,
             runtime=runtime,
             conn=conn,
@@ -1899,7 +1899,7 @@ class TestScenarioStateIntegration:
         result = await process_turn(
             session_row=row,
             player_text="Here is my reasoning.",
-            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            scenario_data=get_scenario_data("behavioral_interview", "standard"),
             max_turns=10,
             runtime=runtime,
             conn=conn,
@@ -1918,7 +1918,7 @@ class TestScenarioStateIntegration:
         await process_turn(
             session_row=row,
             player_text="Hello.",
-            scenario_data=get_scenario_data("behavioral_interview", "normal"),
+            scenario_data=get_scenario_data("behavioral_interview", "standard"),
             max_turns=10,
             runtime=FakeChatRuntime(),
             conn=conn,

--- a/services/convsim-core/tests/test_voice_smoke.py
+++ b/services/convsim-core/tests/test_voice_smoke.py
@@ -164,7 +164,7 @@ def _create_and_start(
     """
     setup = {
         "scenario_id": scenario_id,
-        "difficulty": "normal",
+        "difficulty": "standard",
         "player_role_name": "Smoke Tester",
         "language": language,
         "input_mode": "push-to-talk",

--- a/tests/acceptance/test_developer_flow.py
+++ b/tests/acceptance/test_developer_flow.py
@@ -196,7 +196,7 @@ class TestDebugLogging:
             with TestClient(app) as c:
                 c.post("/api/sessions", json={
                     "scenario_id": "behavioral_interview",
-                    "difficulty": "normal",
+                    "difficulty": "standard",
                     "player_role_name": "Dev Tester",
                     "language": "en",
                     "input_mode": "text-only",

--- a/tests/acceptance/test_network_guard.py
+++ b/tests/acceptance/test_network_guard.py
@@ -205,7 +205,7 @@ _SILENT_WAV: bytes = (
 _TEXT_TURN = "I reduced on-call incidents by forty percent by improving our runbook coverage."
 _SETUP_TEXT = {
     "scenario_id": "behavioral_interview",
-    "difficulty": "normal",
+    "difficulty": "standard",
     "player_role_name": "Guard Tester",
     "language": "en",
     "input_mode": "text-only",

--- a/tests/acceptance/test_player_text_path.py
+++ b/tests/acceptance/test_player_text_path.py
@@ -28,7 +28,7 @@ from convsim_core.runtime.types import ChatFinal
 # Shared session-setup payload; individual tests copy and customise it.
 _SESSION_SETUP = {
     "scenario_id": "behavioral_interview",
-    "difficulty": "normal",
+    "difficulty": "standard",
     "player_role_name": "Acceptance Tester",
     "language": "en",
     "input_mode": "text-only",


### PR DESCRIPTION
## Summary

Implements a standardized difficulty system across the full stack: four preset levels (warm/standard/hard/adversarial) with bounded knobs, scenario-level preset configuration, and player-facing UI to select difficulty with per-preset descriptions.

**Key changes:**
- **Schema:** Replaces ad-hoc difficulty vocabulary with `warm`, `standard`, `hard`, `adversarial` presets; each preset defines four 0–100 knobs (patience, volatility, disclosure, time_pressure)
- **Prompt composer:** Maps difficulty knobs to bounded system-prompt fragments; fragments emit only when knob values fall in low (≤33) or high (≥67) tiers, keeping the standard preset clean (no extra clauses)
- **Evaluator:** Adds `non_null`, `lte`, `gte`, and `between` check forms for fine-grained validation
- **Scenarios:** All pack scenarios annotated with standardized presets (warm/standard/hard/adversarial); preset labels and descriptions included so UI can show picker text
- **Setup UI:** Adds difficulty selector on scenario setup page, displaying preset label and per-preset description inline
- **Packs:** Golden and smoke tests updated for all four difficulty levels; warm and adversarial golden transcripts added for difficult-conversations pack

## Why this matters

Players now have consistent, discoverable difficulty settings across all scenarios. Pack authors define preset knobs once and annotate each scenario with them; the system automatically composes those knobs into bounded prompt fragments, so NPC behavior varies predictably without manual system-prompt engineering per difficulty level. The setup UI clearly signals what each level entails before the player starts.

## Test coverage

- 15 new tests in prompt-composer verify all four presets produce distinct prompts, fragments appear at correct thresholds, and fragments stay out of the output schema section
- Golden and smoke tests cover all four difficulty levels for scenarios in difficult-conversations and negotiations packs
- Validator tests updated for new evaluator check forms

Closes #296