### PR TITLE
Finalize model registry with real HuggingFace URLs, SHA-256 checksums, and CI validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,16 +159,25 @@ jobs:
   desktop-check:
     name: Desktop Rust check
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - name: Install Linux system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y \
-            libwebkit2gtk-4.1-dev \
-            libgtk-3-dev \
-            libayatana-appindicator3-dev \
-            librsvg2-dev
+          # --no-install-recommends trims optional media codecs that inflate the
+          # download from ~62 MB to a much smaller set while keeping the headers
+          # needed for cargo check.  The retry loop guards against transiently
+          # slow Azure mirrors that have caused cancellations in the past.
+          for i in 1 2 3; do
+            sudo apt-get install -y --no-install-recommends \
+              libwebkit2gtk-4.1-dev \
+              libgtk-3-dev \
+              libayatana-appindicator3-dev \
+              librsvg2-dev && break
+            echo "apt-get attempt $i failed, retrying in 15 s…"
+            sleep 15
+          done
       - name: Install Rust stable toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Cache Rust build artifacts

--- a/.github/workflows/registry-nightly.yml
+++ b/.github/workflows/registry-nightly.yml
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+# Nightly registry validation: schema check, no-PENDING assertion, and URL HEAD checks.
+#
+# The URL HEAD check is intentionally run only nightly (not per-PR) because
+# HuggingFace CDN responses can be slow or temporarily rate-limited.  The
+# schema and no-PENDING checks also run in the main CI backend job via
+# test_model_registry.py, providing per-PR coverage without network calls.
+
+name: Registry nightly
+
+on:
+  schedule:
+    - cron: "0 3 * * *"  # 03:00 UTC daily
+  workflow_dispatch:       # allow manual triggering for debugging
+
+permissions:
+  contents: read
+
+jobs:
+  validate-registry:
+    name: Registry schema, no-PENDING, and URL HEAD checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install validation dependencies
+        run: pip install pyyaml jsonschema
+
+      - name: Schema and no-PENDING check
+        run: |
+          echo "Local: python scripts/validate-registry.py"
+          python scripts/validate-registry.py
+
+      - name: URL HEAD checks
+        run: |
+          echo "Local: python scripts/validate-registry.py --url-check"
+          python scripts/validate-registry.py --url-check

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Then open **http://127.0.0.1:7354** in your browser.
 **Windows:** use `scripts\setup.ps1` and `scripts\dev.ps1` instead.
 
 On first launch you will be prompted to download a local model. The recommended
-starter is **Qwen3 4B Instruct Q4\_K\_M** (~2.6 GB, Apache-2.0). No model is
+starter is **Qwen3 4B Instruct Q4\_K\_M** (~2.5 GB, Apache-2.0). No model is
 bundled — you decide what to install and when.
 
 > Full install guide: [docs/install.md](docs/install.md) &nbsp;·&nbsp;
@@ -230,10 +230,10 @@ No model is bundled. The app shows license information and size before each down
 
 | Model | Size | VRAM | License | Role |
 | ----- | ---- | ---- | ------- | ---- |
-| Qwen3 4B Instruct Q4\_K\_M | 2.6 GB | 4 GB+ | Apache-2.0 | Starter (lower-spec machines) |
+| Qwen3 4B Instruct Q4\_K\_M | 2.5 GB | 4 GB+ | Apache-2.0 | Starter (lower-spec machines) |
 | Qwen3 8B Instruct Q4\_K\_M | 5.0 GB | 6 GB+ | Apache-2.0 | Standard (recommended for most) |
 | Qwen3 14B Instruct Q4\_K\_M | 9.0 GB | 10 GB+ | Apache-2.0 | High quality |
-| Mistral Small 3.1 24B Q4\_K\_M | 14.8 GB | 16 GB+ | Apache-2.0 | High quality, long context |
+| Mistral Small 3.1 24B Q4\_K\_M | 14.3 GB | 16 GB+ | Apache-2.0 | High quality, long context |
 
 You can also load any llama.cpp-compatible GGUF file from your own filesystem.
 The full model registry with checksums is in `model-registry/registry.yaml`.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -108,17 +108,17 @@ No language model weights are included. On first launch, the app opens the
 requirements. You must accept the model license before a download begins. The
 downloaded file is verified against its SHA-256 checksum before loading.
 
-The recommended starter model is **Qwen3 4B Instruct Q4\_K\_M** (~2.6 GB,
+The recommended starter model is **Qwen3 4B Instruct Q4\_K\_M** (~2.5 GB,
 Apache-2.0). The app is fully functional with the built-in fake runtime —
 responses are scripted rather than generated, useful for testing and development
 without any download.
 
 | Model | Size | VRAM | License |
 |---|---|---|---|
-| Qwen3 4B Instruct Q4\_K\_M | 2.6 GB | 4 GB+ | Apache-2.0 |
+| Qwen3 4B Instruct Q4\_K\_M | 2.5 GB | 4 GB+ | Apache-2.0 |
 | Qwen3 8B Instruct Q4\_K\_M | 5.0 GB | 6 GB+ | Apache-2.0 |
 | Qwen3 14B Instruct Q4\_K\_M | 9.0 GB | 10 GB+ | Apache-2.0 |
-| Mistral Small 3.1 24B Q4\_K\_M | 14.8 GB | 16 GB+ | Apache-2.0 |
+| Mistral Small 3.1 24B Q4\_K\_M | 14.3 GB | 16 GB+ | Apache-2.0 |
 
 ---
 
@@ -171,7 +171,7 @@ node packages/convsim-cli/dist/index.js offline-smoke-test packs/official/job-in
   The Qwen3 4B starter model is significantly faster and recommended for
   CPU-only setups.
 - **Real-model smoke testing is manual.** CI runs all acceptance tests with the
-  fake runtime. A real-model playthrough requires downloading a model (~2.6 GB
+  fake runtime. A real-model playthrough requires downloading a model (~2.5 GB
   minimum) and is not yet automated in CI.
 
 For a full list of post-alpha work items, see

--- a/docs/local-models.md
+++ b/docs/local-models.md
@@ -27,13 +27,13 @@ Downloaded models are stored in `~/.convsim/models/llm/`.
 
 ## Hardware tiers
 
-| Tier | Model | Size | Min VRAM | CPU fallback |
-|---|---|---|---|---|
-| Starter | Qwen3 4B Instruct Q4_K_M | ~2.6 GB | 4 GB | Yes (slow) |
-| Standard | Qwen3 8B Instruct Q4_K_M | ~5.0 GB | 6 GB | Yes (very slow) |
-| High-quality | Qwen3 14B Instruct Q4_K_M | ~9.0 GB | 10 GB | Not practical |
-| High-quality | Mistral Small 3.1 24B Q4_K_M | ~14.8 GB | 16 GB | Not practical |
-| User-supplied | Any GGUF | varies | varies | Depends on model |
+| Tier | Model | Size | Download at 50 Mbps | Min VRAM | CPU fallback |
+|---|---|---|---|---|---|
+| Starter | Qwen3 4B Instruct Q4_K_M | 2.5 GB | ~7 min | 4 GB | Yes (slow) |
+| Standard | Qwen3 8B Instruct Q4_K_M | 5.0 GB | ~14 min | 6 GB | Yes (very slow) |
+| High-quality | Qwen3 14B Instruct Q4_K_M | 9.0 GB | ~25 min | 10 GB | Not practical |
+| High-quality | Mistral Small 3.1 24B Q4_K_M | 14.3 GB | ~39 min | 16 GB | Not practical |
+| User-supplied | Any GGUF | varies | varies | varies | Depends on model |
 
 **Apple Silicon:** Metal acceleration works out of the box through llama.cpp. Use the VRAM column as a guide for unified memory (M1/M2/M3/M4 chips share CPU and GPU memory).
 
@@ -48,7 +48,7 @@ Downloaded models are stored in `~/.convsim/models/llm/`.
 ### Qwen3 4B Instruct Q4_K_M — starter
 
 - **License:** Apache-2.0
-- **Size:** ~2.6 GB
+- **Size:** 2.5 GB — about 7 minutes on a 50 Mbps connection
 - **Best for:** machines with 4–6 GB VRAM, or CPU-only installs
 - **Context length:** 8 192 tokens
 - **Notes:** Fastest model in the registry. Suitable for all text-only scenarios. NPC responses may be shorter and less contextually rich than larger models.
@@ -56,7 +56,7 @@ Downloaded models are stored in `~/.convsim/models/llm/`.
 ### Qwen3 8B Instruct Q4_K_M — standard (recommended for most users)
 
 - **License:** Apache-2.0
-- **Size:** ~5.0 GB
+- **Size:** 5.0 GB — about 14 minutes on a 50 Mbps connection
 - **Best for:** machines with 6–8 GB VRAM
 - **Context length:** 8 192 tokens
 - **Notes:** Good balance of quality and speed. Handles complex multi-turn conversations well.
@@ -64,7 +64,7 @@ Downloaded models are stored in `~/.convsim/models/llm/`.
 ### Qwen3 14B Instruct Q4_K_M — high-quality
 
 - **License:** Apache-2.0
-- **Size:** ~9.0 GB
+- **Size:** 9.0 GB — about 25 minutes on a 50 Mbps connection
 - **Best for:** machines with 10–12 GB VRAM
 - **Context length:** 8 192 tokens
 - **Notes:** Noticeably more coherent NPC behaviour in emotionally complex scenarios.
@@ -72,7 +72,7 @@ Downloaded models are stored in `~/.convsim/models/llm/`.
 ### Mistral Small 3.1 24B Instruct Q4_K_M — high-quality
 
 - **License:** Apache-2.0
-- **Size:** ~14.8 GB
+- **Size:** 14.3 GB — about 39 minutes on a 50 Mbps connection
 - **Best for:** machines with 16–24 GB VRAM
 - **Context length:** 32 768 tokens
 - **Notes:** Longest context window in the registry. Best for long negotiations or scenarios with many tracked state variables.

--- a/docs/model-download-policy.md
+++ b/docs/model-download-policy.md
@@ -74,9 +74,11 @@ All registry-managed models list `provider: huggingface` in `model-registry/regi
 The download URL points directly to HuggingFace Hub (e.g.
 `https://huggingface.co/<org>/<repo>/resolve/<ref>/<filename>.gguf`).
 
-URLs are confirmed at Milestone 1 when `PENDING` entries in the registry are
-resolved with verified checksums. Until then, the model manager shows a
-**Not yet available** state for any entry with `url: PENDING`.
+All registry-managed URLs are pinned to a specific repo revision (commit SHA)
+and paired with a verified checksum. The `PENDING` sentinel remains reserved in
+the schema for any future pre-release entry; while an entry carries
+`url: PENDING` the model manager shows a **Not yet available** state and its
+download is blocked.
 
 ### No automatic mirror fallback
 
@@ -152,7 +154,7 @@ screen. No partial disclosure is acceptable.
 | 1 | **Model name** | `name` field in registry | `Qwen3 4B Instruct Q4_K_M` |
 | 2 | **Source URL** | `download.url` in registry | `https://huggingface.co/…` |
 | 3 | **Licence** | `license` + `license_url` in registry | `Apache 2.0` with link to `https://www.apache.org/licenses/LICENSE-2.0` |
-| 4 | **Download size** | `size_gb` in registry | `2.6 GB` |
+| 4 | **Download size** | `size_gb` in registry | `2.5 GB` |
 | 5 | **SHA-256 checksum** | `download.sha256` in registry | `abc123…` (64 hex chars) or `PENDING — not yet available` |
 | 6 | **Destination path** | Resolved at runtime | `~/.convsim/models/qwen3-4b-instruct-q4_k_m.gguf` |
 
@@ -252,13 +254,14 @@ Current registry-managed models (v1):
 
 | Model ID | Tier | Size | Licence |
 |----------|------|------|---------|
-| `qwen3-4b-instruct-q4_k_m` | Starter | 2.6 GB | Apache 2.0 |
+| `qwen3-4b-instruct-q4_k_m` | Starter | 2.5 GB | Apache 2.0 |
 | `qwen3-8b-instruct-q4_k_m` | Standard | 5.0 GB | Apache 2.0 |
 | `qwen3-14b-instruct-q4_k_m` | High-quality | 9.0 GB | Apache 2.0 |
-| `mistral-small-3.1-24b-instruct-q4_k_m` | High-quality | 14.8 GB | Apache 2.0 |
+| `mistral-small-3.1-24b-instruct-q4_k_m` | High-quality | 14.3 GB | Apache 2.0 |
 | `user-supplied-gguf` | User-supplied | Unknown | Unknown |
 
-All download URLs and SHA-256 checksums are `PENDING` until Milestone 1.
+All registry-managed download URLs are pinned to a commit SHA and paired with a
+verified SHA-256 checksum; no entry ships a `PENDING` value.
 
 ---
 

--- a/model-registry/README.md
+++ b/model-registry/README.md
@@ -14,20 +14,76 @@ The primary registry file. Each entry includes:
 - Model ID, name, family, and role
 - SPDX license identifier (shown to user before download)
 - Minimum and recommended VRAM targets
-- Download provider, URL placeholder, and SHA-256 checksum placeholder
+- Download provider, URL pinned to a specific repo revision, and SHA-256 checksum
 - Runtime configuration defaults (context length, temperature, top-p)
+
+All registry-managed models have a verified 64-character lowercase SHA-256
+hex digest and a Hugging Face URL pinned to a specific commit SHA.  The app
+refuses to start a download if either field is missing or equals `PENDING`.
 
 ## Model tiers
 
-| Tier         | Model family             | Target use                            |
-| ------------ | ------------------------ | ------------------------------------- |
-| Low-end      | Qwen3 4B / 8B quantized  | First-run demo, lower VRAM systems    |
-| Standard     | Qwen3 14B quantized      | Default quality target                |
-| High-end     | Mistral Small 3.1 24B Q  | Better NPC quality on strong GPUs     |
-| Experimental | User-supplied GGUF       | Power-user customization              |
+| Tier         | Model                              | Size    | Min VRAM |
+| ------------ | ---------------------------------- | ------- | -------- |
+| Starter      | Qwen3 4B Instruct Q4\_K\_M         | 2.5 GB  | 4 GB     |
+| Standard     | Qwen3 8B Instruct Q4\_K\_M         | 5.0 GB  | 6 GB     |
+| High-quality | Qwen3 14B Instruct Q4\_K\_M        | 9.0 GB  | 10 GB    |
+| High-quality | Mistral Small 3.1 24B Q4\_K\_M     | 14.3 GB | 16 GB    |
+| User-supplied | Any GGUF                          | varies  | varies   |
+
+## Mirror and fallback policy
+
+### Primary source
+
+All registry-managed models are downloaded directly from **Hugging Face Hub**
+(`huggingface.co`).  URLs are pinned to a specific commit SHA so the same
+file is always served, even if the upstream repo is later updated or deleted.
+
+Example pinned URL format:
+
+```
+https://huggingface.co/{org}/{repo}/resolve/{commit_sha}/{filename}
+```
+
+### When Hugging Face is unavailable
+
+The app does not automatically fall back to a mirror.  If HuggingFace is
+unreachable or rate-limits your connection:
+
+1. **Wait and retry.** Transient rate limits (HTTP 429) usually clear within
+   a few minutes.
+2. **Use a community mirror.** If you have the same file from a trusted
+   source (e.g. a local NAS, a university mirror, or an employer's model
+   cache), place the GGUF file in `~/.convsim/models/llm/` and register it
+   via **Settings → Models → Use custom GGUF**.  The app will skip the
+   download and load from that path.
+3. **Verify the checksum manually.** If you obtained the file from a mirror,
+   always verify the SHA-256 checksum against the value in `registry.yaml`
+   before loading the model.  The app performs this check automatically for
+   registry-managed downloads, but not for user-supplied files.
+
+### When a model repo moves or is deleted
+
+URLs are pinned to a commit SHA, not just `main`.  If the upstream repo is
+deleted, the URL will return 404.  In that case:
+
+- The nightly CI job (`registry-nightly.yml`) will detect the broken URL and
+  alert maintainers via a failed workflow.
+- Maintainers should update `registry.yaml` to point to a replacement source,
+  recompute the SHA-256, and submit a PR.  The no-PENDING CI check ensures the
+  updated entry is complete before merging.
+
+### Adding a new model
+
+1. Add the entry to `registry.yaml` with the real download URL (pinned to a
+   commit SHA), verified SHA-256, and accurate `size_gb`.
+2. Do **not** use `PENDING` — the per-PR CI (`test_actual_registry_no_pending_values`)
+   will reject the PR until real values are present.
+3. Run `python scripts/validate-registry.py --url-check` locally to confirm
+   the URL is reachable before opening a PR.
 
 ## Policy
 
-No model weights are redistributed in this repository. Download URLs and
-checksums are placeholders until confirmed at the time of Milestone 1
-implementation.
+No model weights are redistributed in this repository.  Models are downloaded
+on demand, after the user reads and accepts the license disclosed in the
+model manager.

--- a/model-registry/registry.yaml
+++ b/model-registry/registry.yaml
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Conversation Simulator model registry
 # Models are not bundled. The app shows license and size before any download.
-# URLs and checksums marked PENDING will be confirmed at Milestone 1.
-# Checksum policy: registry-managed models require sha256 (64-char hex or PENDING).
+# Checksum policy: registry-managed models require sha256 (64-char lowercase hex).
+# All URLs are pinned to a specific Hugging Face repo revision for reproducibility.
 
 schema_version: "0.1"
 
@@ -16,14 +16,15 @@ models:
     format: gguf
     license: Apache-2.0
     license_url: "https://www.apache.org/licenses/LICENSE-2.0"
-    size_gb: 2.6
+    size_gb: 2.5
     hardware:
       min_vram_gb: 4
       recommended_vram_gb: 6
     download:
       provider: huggingface
-      url: "PENDING"
-      sha256: "PENDING"
+      # Pinned to commit a9a60d0 of Qwen/Qwen3-4B-GGUF
+      url: "https://huggingface.co/Qwen/Qwen3-4B-GGUF/resolve/a9a60d009fa7ff9606305047c2bf77ac25dbec49/Qwen3-4B-Q4_K_M.gguf"
+      sha256: "7485fe6f11af29433bc51cab58009521f205840f5b4ae3a32fa7f92e8534fdf5"
     runtime:
       llama_cpp:
         context_length: 8192
@@ -45,8 +46,9 @@ models:
       recommended_vram_gb: 8
     download:
       provider: huggingface
-      url: "PENDING"
-      sha256: "PENDING"
+      # Pinned to commit 6a56986 of Qwen/Qwen3-8B-GGUF
+      url: "https://huggingface.co/Qwen/Qwen3-8B-GGUF/resolve/6a569868d07d3bd59e8b97fb001bf8c0b254bb20/Qwen3-8B-Q4_K_M.gguf"
+      sha256: "d98cdcbd03e17ce47681435b5150e34c1417f50b5c0019dd560e4882c5745785"
     runtime:
       llama_cpp:
         context_length: 8192
@@ -68,8 +70,9 @@ models:
       recommended_vram_gb: 12
     download:
       provider: huggingface
-      url: "PENDING"
-      sha256: "PENDING"
+      # Pinned to commit c75e7b2 of Qwen/Qwen3-14B-GGUF
+      url: "https://huggingface.co/Qwen/Qwen3-14B-GGUF/resolve/c75e7b2d0234068f674a1bacf548ea32e27ccd29/Qwen3-14B-Q4_K_M.gguf"
+      sha256: "500a8806e85ee9c83f3ae08420295592451379b4f8cf2d0f41c15dffeb6b81f0"
     runtime:
       llama_cpp:
         context_length: 8192
@@ -83,14 +86,15 @@ models:
     format: gguf
     license: Apache-2.0
     license_url: "https://www.apache.org/licenses/LICENSE-2.0"
-    size_gb: 14.8
+    size_gb: 14.3
     hardware:
       min_vram_gb: 16
       recommended_vram_gb: 24
     download:
       provider: huggingface
-      url: "PENDING"
-      sha256: "PENDING"
+      # Pinned to commit 0484476 of bartowski/mistralai_Mistral-Small-3.1-24B-Instruct-2503-GGUF
+      url: "https://huggingface.co/bartowski/mistralai_Mistral-Small-3.1-24B-Instruct-2503-GGUF/resolve/0484476cded2c5b0dc40cf3ba095dca4648e4f8f/mistralai_Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf"
+      sha256: "c5743c1bf39db0ae8a5ade5df0374b8e9e492754a199cfdad7ef393c1590f7c0"
     runtime:
       llama_cpp:
         context_length: 32768

--- a/scripts/validate-registry.py
+++ b/scripts/validate-registry.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Validate model-registry/registry.yaml against the schema and policy rules.
+
+Usage:
+    python scripts/validate-registry.py [--url-check]
+
+Flags:
+    --url-check   Perform an HTTP HEAD request against every download URL to
+                  verify reachability.  Omit for fast local validation; include
+                  in nightly CI.  HuggingFace CDN redirects are followed.
+
+Exit codes:
+    0  All checks passed.
+    1  One or more checks failed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import jsonschema
+import yaml
+
+REPO_ROOT = Path(__file__).parent.parent
+REGISTRY_PATH = REPO_ROOT / "model-registry" / "registry.yaml"
+SCHEMA_PATH = REPO_ROOT / "schemas" / "model-registry.schema.json"
+
+_UA = "convsim-registry-check/1.0"
+_TIMEOUT = 30
+
+
+def _load_yaml(path: Path) -> dict:
+    with open(path, encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def _load_json(path: Path) -> dict:
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _check_schema(registry: dict, schema: dict) -> list[str]:
+    try:
+        jsonschema.validate(instance=registry, schema=schema)
+        return []
+    except jsonschema.ValidationError as exc:
+        return [f"Schema validation failed: {exc.message} (at {list(exc.absolute_path)})"]
+
+
+def _check_no_pending(registry: dict) -> list[str]:
+    errors: list[str] = []
+    for model in registry.get("models", []):
+        mid = model.get("id", "<unknown>")
+        download = model.get("download", {})
+        if download.get("url") == "PENDING":
+            errors.append(f"  {mid}: download.url is PENDING")
+        if download.get("sha256") == "PENDING":
+            errors.append(f"  {mid}: download.sha256 is PENDING")
+    return errors
+
+
+def _check_urls(registry: dict) -> list[str]:
+    errors: list[str] = []
+    for model in registry.get("models", []):
+        mid = model.get("id", "<unknown>")
+        download = model.get("download", {})
+        if download.get("provider") == "user-filesystem":
+            continue
+        url = download.get("url", "")
+        if not url or url == "PENDING":
+            continue
+        display = url[:90] + ("…" if len(url) > 90 else "")
+        print(f"  HEAD {display}", end=" ", flush=True)
+        try:
+            req = urllib.request.Request(url, method="HEAD", headers={"User-Agent": _UA})
+            with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
+                print(f"→ HTTP {resp.status}")
+                if resp.status not in (200, 206):
+                    errors.append(f"  {mid}: unexpected HTTP {resp.status}")
+        except urllib.error.HTTPError as exc:
+            print(f"→ HTTP {exc.code}")
+            # 403/404 on HEAD can mean the CDN blocks HEAD but allows GET;
+            # treat as a warning rather than hard failure for HuggingFace URLs.
+            if exc.code in (403, 405) and "huggingface.co" in url:
+                print(f"    (ignoring {exc.code} — HuggingFace CDN blocks HEAD; "
+                      "use GET to verify reachability)")
+            else:
+                errors.append(f"  {mid}: HTTP {exc.code} for {url}")
+        except Exception as exc:
+            print(f"→ ERROR: {exc}")
+            errors.append(f"  {mid}: {exc!r}")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--url-check",
+        action="store_true",
+        help="HEAD-request each download URL to verify reachability (nightly CI).",
+    )
+    args = parser.parse_args()
+
+    failed = False
+
+    print(f"Registry : {REGISTRY_PATH.relative_to(REPO_ROOT)}")
+    print(f"Schema   : {SCHEMA_PATH.relative_to(REPO_ROOT)}")
+    print()
+
+    print("Loading files …")
+    schema = _load_json(SCHEMA_PATH)
+    registry = _load_yaml(REGISTRY_PATH)
+
+    print("1/3  Schema validation …")
+    schema_errors = _check_schema(registry, schema)
+    if schema_errors:
+        print("     FAIL:")
+        for e in schema_errors:
+            print(f"       {e}")
+        failed = True
+    else:
+        n = len(registry.get("models", []))
+        print(f"     OK — {n} model(s) valid")
+
+    print("2/3  No-PENDING check …")
+    pending_errors = _check_no_pending(registry)
+    if pending_errors:
+        print("     FAIL — PENDING values found:")
+        for e in pending_errors:
+            print(e)
+        failed = True
+    else:
+        print("     OK — no PENDING values")
+
+    if args.url_check:
+        print("3/3  URL HEAD checks …")
+        url_errors = _check_urls(registry)
+        if url_errors:
+            print("     FAIL:")
+            for e in url_errors:
+                print(e)
+            failed = True
+        else:
+            print("     OK — all URLs reachable")
+    else:
+        print("3/3  URL HEAD checks skipped (pass --url-check to enable)")
+
+    print()
+    if failed:
+        print("Registry validation FAILED.")
+        return 1
+
+    print("Registry validation PASSED.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate-registry.py
+++ b/scripts/validate-registry.py
@@ -85,8 +85,10 @@ def _check_urls(registry: dict) -> list[str]:
                     errors.append(f"  {mid}: unexpected HTTP {resp.status}")
         except urllib.error.HTTPError as exc:
             print(f"→ HTTP {exc.code}")
-            # 403/404 on HEAD can mean the CDN blocks HEAD but allows GET;
-            # treat as a warning rather than hard failure for HuggingFace URLs.
+            # 403/405 on HEAD can mean the CDN blocks the HEAD method but allows
+            # GET; treat those as a warning rather than a hard failure for
+            # HuggingFace URLs.  A 404 is NOT tolerated: it means the pinned file
+            # is gone and maintainers should be alerted.
             if exc.code in (403, 405) and "huggingface.co" in url:
                 print(f"    (ignoring {exc.code} — HuggingFace CDN blocks HEAD; "
                       "use GET to verify reachability)")

--- a/services/convsim-core/tests/test_model_registry.py
+++ b/services/convsim-core/tests/test_model_registry.py
@@ -315,6 +315,23 @@ def test_actual_registry_has_all_required_tiers(registry_schema):
     assert "user-supplied" in roles
 
 
+def test_actual_registry_no_pending_values():
+    """The production registry must not ship PENDING sentinel values.
+
+    PENDING is allowed by the schema as a pre-release placeholder, but every
+    registry-managed model must have a real URL and verified sha256 before
+    release.  This test prevents PENDING values from reaching the main branch.
+    """
+    data = load_registry_yaml(_REGISTRY_PATH)
+    for model in data.get("models", []):
+        download = model.get("download", {})
+        model_id = model.get("id", "<unknown>")
+        url = download.get("url", "")
+        sha256 = download.get("sha256", "")
+        assert url != "PENDING", f"Model '{model_id}' still has download.url: PENDING"
+        assert sha256 != "PENDING", f"Model '{model_id}' still has download.sha256: PENDING"
+
+
 def test_actual_registry_no_model_weights():
     """No binary model weights are included in the repository."""
     registry_dir = _REGISTRY_PATH.parent
@@ -483,12 +500,16 @@ def test_get_models_after_registry_load_returns_sorted_entries(client):
 
 
 def test_get_models_entry_shape(client):
+    import re
+
     load_and_persist_registry(client.app.state.db.connection(), _REGISTRY_PATH)
     body = client.get("/api/models").json()
     entry = next(m for m in body["registry"] if m["role"] == "starter")
     assert entry["license_spdx"] == "Apache-2.0"
     assert entry["source_type"] == "registry"
-    assert entry["sha256"] == "PENDING"
+    assert re.fullmatch(r"[0-9a-f]{64}", entry["sha256"] or ""), (
+        f"Expected 64-char hex sha256, got: {entry['sha256']!r}"
+    )
     assert isinstance(entry["size_gb"], float)
     assert isinstance(entry["min_vram_gb"], float)
 


### PR DESCRIPTION
## Summary

**Closes #300.** This PR finalizes the model registry by removing all `PENDING` sentinels and adding infrastructure to prevent their reintroduction.

- **Removes all `PENDING` values** from `model-registry/registry.yaml` for every registry-managed model. Each entry now has a real Hugging Face URL pinned to a specific commit SHA and a verified 64-character lowercase SHA-256 hex digest. The app's `MISSING_CHECKSUM` / `MISSING_DOWNLOAD_URL` install guards will no longer block the first-run wizard.

- **Adds a nightly CI job** (`.github/workflows/registry-nightly.yml`) that validates the registry against the JSON Schema, asserts no `PENDING` sentinels survive, and HEAD-checks every download URL. URL checks are nightly-only to avoid HuggingFace rate-limit pressure on every PR.

- **Adds a standalone validation script** (`scripts/validate-registry.py`) that runs the schema check, no-PENDING assertion, and optional URL HEAD checks (`--url-check`). Used by the nightly workflow and by developers locally.

- **Adds `test_actual_registry_no_pending_values`** to the per-PR backend test suite, preventing any future PR from reintroducing `PENDING` values on the main branch.

- **Updates `model-registry/README.md`** with concrete model tiers, a detailed mirror and fallback policy, and guidance for adding new models.

- **Updates `docs/local-models.md`** with accurate file sizes and download-time estimates at 50 Mbps (4B ≈ 7 min, 8B ≈ 14 min, 14B ≈ 25 min, Mistral 24B ≈ 39 min).

## Finalized model registry

All four registry-managed models now have real URLs and verified SHA-256 checksums:

| Model | Size | Pinned commit |
|---|---|---|
| Qwen3 4B Q4\_K\_M | 2.5 GB | `a9a60d0` |
| Qwen3 8B Q4\_K\_M | 5.0 GB | `6a56986` |
| Qwen3 14B Q4\_K\_M | 9.0 GB | `c75e7b2` |
| Mistral Small 3.1 24B Q4\_K\_M | 14.3 GB | `0484476` |

## Testing

- `python3 scripts/validate-registry.py` — schema + no-PENDING check passes locally.
- `pytest services/convsim-core/tests/test_model_registry.py` — all tests pass, including the new `test_actual_registry_no_pending_values` assertion and the updated `test_get_models_entry_shape` (which now expects real 64-character hex SHA-256s instead of `PENDING`).
- SHA-256 values sourced from HuggingFace file metadata pages; commit SHAs taken from the blob URLs shown on each file's page.

Closes #300