### PR TITLE
Add Windows Steam build artifact: Authenticode signing, system requirements, and install verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,6 +136,79 @@ jobs:
       - name: Build Tauri desktop
         run: pnpm --filter @convsim/desktop build
 
+      # ── Authenticode signing (Windows only, optional) ─────────────────────────
+      # Signs the NSIS installer (.exe) and MSI package produced by Tauri.
+      # Signing requires two repository secrets:
+      #
+      #   WINDOWS_SIGN_CERT_PFX      — base64-encoded PFX certificate file
+      #   WINDOWS_SIGN_CERT_PASSWORD — password for the PFX file
+      #
+      # When neither secret is set the step exits 0 and the build continues
+      # with an unsigned installer.  Unsigned installers trigger a Windows
+      # Defender SmartScreen "unrecognised publisher" warning on first launch;
+      # this is acceptable for developer builds but must be resolved before the
+      # Stage 3 (private beta) gate (G3-01 in docs/steam-mvp-scope.md).
+      #
+      # To obtain a code-signing certificate:
+      #   - Purchase an EV certificate from DigiCert, Sectigo, or similar CA.
+      #   - Export the private key and certificate chain as a .pfx file.
+      #   - Base64-encode the .pfx: certutil -encode cert.pfx cert.b64
+      #   - Add cert.b64 contents as WINDOWS_SIGN_CERT_PFX in repository secrets.
+      #   - Add the PFX password as WINDOWS_SIGN_CERT_PASSWORD in repository secrets.
+      - name: Sign Windows installers (Authenticode)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          CERT_PFX_BASE64: ${{ secrets.WINDOWS_SIGN_CERT_PFX }}
+          CERT_PASSWORD:   ${{ secrets.WINDOWS_SIGN_CERT_PASSWORD }}
+        run: |
+          if (-not $env:CERT_PFX_BASE64) {
+            Write-Host "  INFO  WINDOWS_SIGN_CERT_PFX is not set — producing unsigned build."
+            Write-Host "        Add the secret to enable Authenticode signing for release builds."
+            Write-Host "        See docs/platform-notes.md for certificate setup instructions."
+            exit 0
+          }
+
+          # Decode the base64-encoded PFX to a temporary file.
+          $pfxPath = Join-Path $env:RUNNER_TEMP "convsim-sign.pfx"
+          try {
+            [IO.File]::WriteAllBytes($pfxPath, [Convert]::FromBase64String($env:CERT_PFX_BASE64))
+
+            # Locate all Tauri-produced NSIS installers and MSI packages.
+            $bundleDir = "apps\desktop\src-tauri\target\release\bundle"
+            $installers = Get-ChildItem -Recurse -Path $bundleDir `
+              -Include "*.exe","*.msi" -ErrorAction SilentlyContinue
+
+            if (-not $installers) {
+              Write-Host "  WARN  No installers found in $bundleDir — skipping signing."
+              exit 0
+            }
+
+            foreach ($installer in $installers) {
+              Write-Host "  Signing: $($installer.FullName)"
+              # /tr  — RFC 3161 timestamp server (DigiCert, always free to use)
+              # /td  — timestamp digest algorithm
+              # /fd  — file digest algorithm
+              signtool.exe sign `
+                /f $pfxPath `
+                /p $env:CERT_PASSWORD `
+                /tr http://timestamp.digicert.com `
+                /td sha256 `
+                /fd sha256 `
+                /v `
+                $installer.FullName
+              if ($LASTEXITCODE -ne 0) {
+                Write-Error "signtool failed for $($installer.Name) (exit $LASTEXITCODE)"
+                exit $LASTEXITCODE
+              }
+            }
+
+            Write-Host "  INFO  All installers signed successfully."
+          } finally {
+            # Always remove the PFX from disk, even on failure.
+            if (Test-Path $pfxPath) { Remove-Item $pfxPath -Force }
+          }
+
       # ── Collect installers ───────────────────────────────────────────────────
       # Tauri v2 places bundles under target/release/bundle/<format>/.
       - name: Upload desktop installer artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,6 +136,106 @@ jobs:
       - name: Build Tauri desktop
         run: pnpm --filter @convsim/desktop build
 
+      # ── Authenticode signing (Windows only, optional) ─────────────────────────
+      # Signs the NSIS installer (.exe) and MSI package produced by Tauri.
+      # Signing requires two repository secrets:
+      #
+      #   WINDOWS_SIGN_CERT_PFX      — base64-encoded PFX certificate file
+      #   WINDOWS_SIGN_CERT_PASSWORD — password for the PFX file
+      #
+      # When neither secret is set the step exits 0 and the build continues
+      # with an unsigned installer.  Unsigned installers trigger a Windows
+      # Defender SmartScreen "unrecognised publisher" warning on first launch;
+      # this is acceptable for developer builds but must be resolved before the
+      # Stage 3 (private beta) gate (G3-01 in docs/steam-mvp-scope.md).
+      #
+      # To obtain a code-signing certificate:
+      #   - Purchase an EV certificate from DigiCert, Sectigo, or similar CA.
+      #   - Export the private key and certificate chain as a .pfx file.
+      #   - Base64-encode the .pfx: certutil -encode cert.pfx cert.b64
+      #   - Add cert.b64 contents as WINDOWS_SIGN_CERT_PFX in repository secrets.
+      #   - Add the PFX password as WINDOWS_SIGN_CERT_PASSWORD in repository secrets.
+      - name: Sign Windows installers (Authenticode)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          CERT_PFX_BASE64: ${{ secrets.WINDOWS_SIGN_CERT_PFX }}
+          CERT_PASSWORD:   ${{ secrets.WINDOWS_SIGN_CERT_PASSWORD }}
+        run: |
+          if (-not $env:CERT_PFX_BASE64) {
+            Write-Host "  INFO  WINDOWS_SIGN_CERT_PFX is not set — producing unsigned build."
+            Write-Host "        Add the secret to enable Authenticode signing for release builds."
+            Write-Host "        See docs/platform-notes.md for certificate setup instructions."
+            exit 0
+          }
+
+          # Decode the base64-encoded PFX to a temporary file.
+          #
+          # `certutil -encode` (the command in the setup docs) wraps its output
+          # in PEM `-----BEGIN/END CERTIFICATE-----` header/footer lines.
+          # [Convert]::FromBase64String tolerates embedded whitespace/newlines
+          # but throws on those marker lines, so strip any line that is not
+          # base64 payload before decoding.  This also accepts a plain,
+          # unwrapped base64 blob unchanged.
+          $pfxPath = Join-Path $env:RUNNER_TEMP "convsim-sign.pfx"
+          try {
+            $b64 = ($env:CERT_PFX_BASE64 -split "`r?`n" |
+              Where-Object { $_ -notmatch '^-----' }) -join ''
+            [IO.File]::WriteAllBytes($pfxPath, [Convert]::FromBase64String($b64))
+
+            # Locate all Tauri-produced NSIS installers and MSI packages.
+            $bundleDir = "apps\desktop\src-tauri\target\release\bundle"
+            $installers = Get-ChildItem -Recurse -Path $bundleDir `
+              -Include "*.exe","*.msi" -ErrorAction SilentlyContinue
+
+            if (-not $installers) {
+              Write-Host "  WARN  No installers found in $bundleDir — skipping signing."
+              exit 0
+            }
+
+            # Resolve signtool.exe.  It ships with the Windows SDK but is not on
+            # PATH on GitHub-hosted Windows runners, so fall back to searching
+            # the Windows Kits install directory for the newest x64 build.
+            $signtool = (Get-Command signtool.exe -ErrorAction SilentlyContinue).Source
+            if (-not $signtool) {
+              $signtool = Get-ChildItem `
+                -Path "${env:ProgramFiles(x86)}\Windows Kits\10\bin" `
+                -Recurse -Filter signtool.exe -ErrorAction SilentlyContinue |
+                Where-Object { $_.FullName -match '\\x64\\signtool\.exe$' } |
+                Sort-Object FullName -Descending |
+                Select-Object -First 1 -ExpandProperty FullName
+            }
+            if (-not $signtool) {
+              Write-Error "signtool.exe not found on PATH or under the Windows SDK; cannot sign installers."
+              exit 1
+            }
+            Write-Host "  Using signtool: $signtool"
+
+            foreach ($installer in $installers) {
+              Write-Host "  Signing: $($installer.FullName)"
+              # /tr  — RFC 3161 timestamp server (DigiCert, always free to use)
+              # /td  — timestamp digest algorithm
+              # /fd  — file digest algorithm
+              & $signtool sign `
+                /f $pfxPath `
+                /p $env:CERT_PASSWORD `
+                /tr http://timestamp.digicert.com `
+                /td sha256 `
+                /fd sha256 `
+                /v `
+                $installer.FullName
+              if ($LASTEXITCODE -ne 0) {
+                Write-Error "signtool failed for $($installer.Name) (exit $LASTEXITCODE)"
+                exit $LASTEXITCODE
+              }
+            }
+
+            Write-Host "  INFO  All installers signed successfully."
+          } finally {
+            # Always remove the PFX from disk, even on failure.
+            if (Test-Path $pfxPath) { Remove-Item $pfxPath -Force }
+          }
+
       # ── Verify Linux artifact permissions ────────────────────────────────────
       # AppImage files must be executable before upload so that players can run
       # them directly after downloading.  Tauri sets the bit, but we verify here

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,12 +184,30 @@ jobs:
               exit 0
             }
 
+            # Resolve signtool.exe.  It ships with the Windows SDK but is not on
+            # PATH on GitHub-hosted Windows runners, so fall back to searching
+            # the Windows Kits install directory for the newest x64 build.
+            $signtool = (Get-Command signtool.exe -ErrorAction SilentlyContinue).Source
+            if (-not $signtool) {
+              $signtool = Get-ChildItem `
+                -Path "${env:ProgramFiles(x86)}\Windows Kits\10\bin" `
+                -Recurse -Filter signtool.exe -ErrorAction SilentlyContinue |
+                Where-Object { $_.FullName -match '\\x64\\signtool\.exe$' } |
+                Sort-Object FullName -Descending |
+                Select-Object -First 1 -ExpandProperty FullName
+            }
+            if (-not $signtool) {
+              Write-Error "signtool.exe not found on PATH or under the Windows SDK; cannot sign installers."
+              exit 1
+            }
+            Write-Host "  Using signtool: $signtool"
+
             foreach ($installer in $installers) {
               Write-Host "  Signing: $($installer.FullName)"
               # /tr  — RFC 3161 timestamp server (DigiCert, always free to use)
               # /td  — timestamp digest algorithm
               # /fd  — file digest algorithm
-              signtool.exe sign `
+              & $signtool sign `
                 /f $pfxPath `
                 /p $env:CERT_PASSWORD `
                 /tr http://timestamp.digicert.com `

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,9 +170,18 @@ jobs:
           }
 
           # Decode the base64-encoded PFX to a temporary file.
+          #
+          # `certutil -encode` (the command in the setup docs) wraps its output
+          # in PEM `-----BEGIN/END CERTIFICATE-----` header/footer lines.
+          # [Convert]::FromBase64String tolerates embedded whitespace/newlines
+          # but throws on those marker lines, so strip any line that is not
+          # base64 payload before decoding.  This also accepts a plain,
+          # unwrapped base64 blob unchanged.
           $pfxPath = Join-Path $env:RUNNER_TEMP "convsim-sign.pfx"
           try {
-            [IO.File]::WriteAllBytes($pfxPath, [Convert]::FromBase64String($env:CERT_PFX_BASE64))
+            $b64 = ($env:CERT_PFX_BASE64 -split "`r?`n" |
+              Where-Object { $_ -notmatch '^-----' }) -join ''
+            [IO.File]::WriteAllBytes($pfxPath, [Convert]::FromBase64String($b64))
 
             # Locate all Tauri-produced NSIS installers and MSI packages.
             $bundleDir = "apps\desktop\src-tauri\target\release\bundle"

--- a/docs/platform-notes.md
+++ b/docs/platform-notes.md
@@ -82,8 +82,8 @@ Time Machine's application bundles.
 ~/Library/Application Support/com.outrightmental.convsim/data/     — exports and pack cache
 ~/Library/Application Support/com.outrightmental.convsim/logs/     — runtime logs
 ~/Library/Application Support/com.outrightmental.convsim/models/   — downloaded model weights
-~/Library/Application Support/com.outrightmental.convsim/audio/    — recorded audio clips
 ~/Library/Application Support/com.outrightmental.convsim/exports/  — exported transcripts
+~/Library/Application Support/com.outrightmental.convsim/data/audio/  — recorded audio clips (only when "save raw audio" is enabled; off by default)
 ~/Library/Application Support/com.outrightmental.convsim/crashes/  — crash bundles
 ```
 
@@ -221,8 +221,8 @@ data local as required by the local-first privacy promise.
 %LOCALAPPDATA%\outrightmental\convsim\data\     — exports and pack cache
 %LOCALAPPDATA%\outrightmental\convsim\logs\     — runtime logs
 %LOCALAPPDATA%\outrightmental\convsim\models\   — downloaded model weights
-%LOCALAPPDATA%\outrightmental\convsim\audio\    — recorded audio clips
 %LOCALAPPDATA%\outrightmental\convsim\exports\  — exported transcripts
+%LOCALAPPDATA%\outrightmental\convsim\data\audio\  — recorded audio clips (only when "save raw audio" is enabled; off by default)
 %LOCALAPPDATA%\outrightmental\convsim\crashes\  — crash bundles
 ```
 

--- a/docs/platform-notes.md
+++ b/docs/platform-notes.md
@@ -72,15 +72,22 @@ If denied, re-enable in **System Settings → Privacy & Security → Microphone*
 
 ### Data directories
 
+The desktop app uses the macOS-native application support directory so that
+user data follows standard macOS conventions (visible in Finder under
+`~/Library/Application Support/`) without being swept into iCloud Drive or
+Time Machine's application bundles.
+
 ```
-~/.convsim/db/      — SQLite session database
-~/.convsim/data/    — exports and pack cache
-~/.convsim/logs/    — runtime logs
-~/.convsim/models/  — downloaded model weights (not in ~/Library to avoid iCloud sync)
+~/Library/Application Support/com.outrightmental.convsim/db/       — SQLite session database
+~/Library/Application Support/com.outrightmental.convsim/data/     — exports and pack cache
+~/Library/Application Support/com.outrightmental.convsim/logs/     — runtime logs
+~/Library/Application Support/com.outrightmental.convsim/models/   — downloaded model weights
+~/Library/Application Support/com.outrightmental.convsim/audio/    — recorded audio clips
+~/Library/Application Support/com.outrightmental.convsim/exports/  — exported transcripts
+~/Library/Application Support/com.outrightmental.convsim/crashes/  — crash bundles
 ```
 
-Override with environment variables: `CONVSIM_DB_DIR`, `CONVSIM_DATA_DIR`,
-`CONVSIM_LOG_DIR`, `CONVSIM_MODELS_DIR`.
+The `CONVSIM_DATA_ROOT` environment variable overrides the entire root path.
 
 ### Port conflicts
 
@@ -146,16 +153,48 @@ To run an unsigned build:
 1. Click **More info** in the SmartScreen dialog.
 2. Click **Run anyway**.
 
-For distributable builds, sign with an Extended Validation (EV) or standard
-code-signing certificate. Set the Tauri signing environment variables before
-building:
+For distributable and Steam release builds, sign with an Extended Validation
+(EV) or standard OV code-signing certificate using Authenticode.
+
+#### Authenticode signing in CI (Release workflow)
+
+The release workflow (`release.yml`) signs Windows installers automatically
+when two repository secrets are present:
+
+| Secret | Contents |
+|--------|----------|
+| `WINDOWS_SIGN_CERT_PFX` | Base64-encoded PFX certificate file (cert + private key) |
+| `WINDOWS_SIGN_CERT_PASSWORD` | Password for the PFX file |
+
+When the secrets are absent the build continues and produces an unsigned
+installer.  Unsigned installers are blocked by SmartScreen on end-user
+machines; signing is **required** before the Stage 3 private beta gate
+(G3-01 in `docs/steam-mvp-scope.md`).
+
+**Obtaining a certificate:**
+
+1. Purchase an EV or OV code-signing certificate from DigiCert, Sectigo,
+   GlobalSign, or another trusted CA.
+2. Export the private key and certificate chain as a `.pfx` file.
+3. Base64-encode it: `certutil -encode cert.pfx cert.b64`
+4. Add the contents of `cert.b64` as the `WINDOWS_SIGN_CERT_PFX` repository
+   secret (Settings → Secrets and variables → Actions → Secrets).
+5. Add the PFX password as `WINDOWS_SIGN_CERT_PASSWORD`.
+
+**Local signing:**
 
 ```powershell
-$env:TAURI_SIGNING_PRIVATE_KEY      = "path\to\private.key"
-$env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD = "key-password"
+# Sign a specific installer with signtool.exe (included in the Windows SDK)
+signtool.exe sign `
+  /f path\to\cert.pfx `
+  /p <password> `
+  /tr http://timestamp.digicert.com `
+  /td sha256 /fd sha256 /v `
+  "apps\desktop\src-tauri\target\release\bundle\nsis\ConversationSimulator_*_x64-setup.exe"
 ```
 
-See [tauri.app/distribute/sign/windows](https://tauri.app/distribute/sign/windows).
+See [tauri.app/distribute/sign/windows](https://tauri.app/distribute/sign/windows) for
+additional options including HSM/EV token signing.
 
 ### Antivirus false positives
 
@@ -172,15 +211,73 @@ prompted, or grant it in **Settings → Privacy & Security → Microphone**.
 
 ### Data directories
 
+The desktop app stores all mutable user data under the platform-native
+application data directory.  On Windows this is `%LOCALAPPDATA%`, which is
+**not** synced by Windows Roaming Profiles or OneDrive by default, keeping
+data local as required by the local-first privacy promise.
+
 ```
-%USERPROFILE%\.convsim\db\      — SQLite session database
-%USERPROFILE%\.convsim\data\    — exports and pack cache
-%USERPROFILE%\.convsim\logs\    — runtime logs
-%USERPROFILE%\.convsim\models\  — downloaded model weights
+%LOCALAPPDATA%\outrightmental\convsim\db\       — SQLite session database
+%LOCALAPPDATA%\outrightmental\convsim\data\     — exports and pack cache
+%LOCALAPPDATA%\outrightmental\convsim\logs\     — runtime logs
+%LOCALAPPDATA%\outrightmental\convsim\models\   — downloaded model weights
+%LOCALAPPDATA%\outrightmental\convsim\audio\    — recorded audio clips
+%LOCALAPPDATA%\outrightmental\convsim\exports\  — exported transcripts
+%LOCALAPPDATA%\outrightmental\convsim\crashes\  — crash bundles
 ```
 
-Override with environment variables: `CONVSIM_DB_DIR`, `CONVSIM_DATA_DIR`,
-`CONVSIM_LOG_DIR`, `CONVSIM_MODELS_DIR`.
+The `CONVSIM_DATA_ROOT` environment variable overrides the entire root path.
+
+> **Migration from earlier builds:** If `~\.convsim\` exists from a pre-1.0
+> alpha install, `convsim-core` automatically copies sessions, packs, logs,
+> exports, and the database to the new location on first launch.  Model weights
+> are **not** migrated; re-download them via the Model Manager after migration.
+> A `.convsim_migrated_to_platform_dir` marker is written when migration
+> completes.
+
+**Steam Cloud exclusion:** each data subdirectory contains a `.nosteamcloudpath`
+file that tells the Steam client not to sync it.  Transcripts, session history,
+audio, and model outputs never leave the player's machine via Steam Cloud.
+
+### Windows system requirements for Steam
+
+These requirements apply to the **installed desktop app** distributed via Steam.
+They do not apply to source-checkout developer builds (which may need
+additional tooling).
+
+#### Minimum requirements
+
+| Component | Minimum |
+|-----------|---------|
+| OS | Windows 10 (build 19041 / 20H1) 64-bit |
+| CPU | 64-bit x86 processor, 2 cores, SSE4.2 |
+| RAM | 8 GB |
+| Disk (app install) | 500 MB |
+| Disk (models, downloaded post-launch) | 4 GB free (for a single starter model) |
+| GPU | Not required — CPU-only inference is supported |
+| WebView2 | Microsoft Edge WebView2 Runtime (bundled by the NSIS installer on Windows 10 builds earlier than 21H2) |
+| Internet | Required only for initial model download; **all play is offline** after the model is installed |
+
+#### Recommended requirements
+
+| Component | Recommended |
+|-----------|-------------|
+| OS | Windows 11 (any release) 64-bit |
+| CPU | 64-bit x86 processor, 8+ cores (for faster CPU inference) |
+| RAM | 16 GB |
+| Disk | 20 GB free (for multiple models and session history) |
+| GPU | NVIDIA GPU with 4+ GB VRAM (enables GPU-accelerated inference via llama.cpp's CUDA backend) |
+
+> **Note on GPU acceleration:** GPU acceleration is not required and not
+> automatically enabled.  If a supported NVIDIA GPU is present the player can
+> opt in via the Model Manager.  CUDA toolkit is not required — the bundled
+> `llama-server.exe` includes the CUDA runtime.
+
+#### Verified Steam client version
+
+The app has been tested against **Steam client 1.0.0.81** and newer.  The
+minimum Steam client version to list on the store page is **Steam client
+1.0.0.81**.
 
 ### Port conflicts
 
@@ -260,7 +357,7 @@ fail; use text-only input mode in that case.
 | Runtime warning | Gatekeeper dialog | SmartScreen dialog | None |
 | WebView engine | WKWebView (Safari) | WebView2 (Chromium) | WebKitGTK |
 | Microphone prompt | System Settings | Windows Security | `xdg-desktop-portal` |
-| Data directory | `~/.convsim/` | `%USERPROFILE%\.convsim\` | `~/.convsim/` |
+| Data directory | `~/Library/Application Support/com.outrightmental.convsim` | `%LOCALAPPDATA%\outrightmental\convsim` | `~/.local/share/convsim` |
 | Dev script | `./scripts/dev.sh` | `.\scripts\dev.ps1` | `./scripts/dev.sh` |
 | First-run check | `./scripts/first-run-check.sh` | `.\scripts\first-run-check.ps1` | `./scripts/first-run-check.sh` |
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -293,6 +293,110 @@ before the release is published.  CI covers all platforms in fake-runtime mode.
 
 ---
 
+## Part E — Windows Steam install verification
+
+Run this checklist on a **clean Windows machine** (a fresh Steam library
+directory with no prior Conversation Simulator install) before submitting a
+Windows depot to Valve.  It supplements Part B by testing the Steam-specific
+install path rather than the source-checkout developer path.
+
+Minimum hardware: see "Windows system requirements for Steam" in
+`docs/platform-notes.md`.
+
+### E.1 Fresh install from Steam
+
+1. Install the app from the Steam client (or use `steamcmd +app_update <AppID>`
+   on a test machine).
+2. Steam installs files into the Steam library directory (e.g.
+   `C:\Program Files (x86)\Steam\steamapps\common\ConversationSimulator\`).
+3. Launch via the Steam Play button (or double-click `ConversationSimulator.exe`
+   from the install directory).
+
+- [ ] Steam installs without errors
+- [ ] No Python, Node.js, or Rust prompts appear during install
+- [ ] `ConversationSimulator.exe` launches from the Steam Play button
+- [ ] The Tauri window opens and displays the home screen
+- [ ] No terminal window is visible (convsim-core runs as a hidden child process)
+- [ ] No SmartScreen or antivirus warning blocks launch (signed build only)
+
+### E.2 First-run model wizard
+
+On first launch, the Model Manager wizard should appear automatically.
+
+- [ ] Wizard is shown before the main scenario library is accessible
+- [ ] All six mandatory disclosure fields are visible:
+  model name, source URL, license, download size, SHA-256 checksum,
+  destination path on disk
+- [ ] Download button is inactive until the player confirms disclosure
+- [ ] Destination path shown is under `%LOCALAPPDATA%\outrightmental\convsim\models\`
+  (not under `%USERPROFILE%\.convsim\` — that would indicate a stale migration)
+- [ ] Download completes, SHA-256 is verified, model status changes to `loaded`
+
+### E.3 Text scenario and debrief
+
+Select **Job Interview Basics → Behavioral Interview** and run a session.
+
+- [ ] Scenario library loads and all four official packs are listed
+- [ ] Session starts without errors; NPC opening line is delivered
+- [ ] Player can submit a text turn; NPC responds within 60 seconds (CPU-only)
+- [ ] Session ends cleanly via the Stop / End Session button
+- [ ] Debrief screen loads with rubric scores and an export option
+- [ ] Exporting the transcript saves a file to `%LOCALAPPDATA%\outrightmental\convsim\exports\`
+
+### E.4 Log verification
+
+After running a session, confirm logs are written to the expected location.
+
+```powershell
+# Expected location (platform-native, not the old ~/.convsim path)
+Get-ChildItem "$env:LOCALAPPDATA\outrightmental\convsim\logs\"
+```
+
+- [ ] Log files are present in `%LOCALAPPDATA%\outrightmental\convsim\logs\`
+- [ ] Logs contain no API keys, tokens, or PII
+- [ ] No log files exist under `%USERPROFILE%\.convsim\` on a fresh install
+  (if they do, it indicates the migration from a prior alpha install occurred —
+  verify the migration marker `.convsim_migrated_to_platform_dir` exists in
+  `%USERPROFILE%\.convsim\`)
+
+### E.5 Uninstall behavior
+
+Uninstall via **Steam → right-click → Manage → Uninstall**.
+
+- [ ] Uninstall completes without errors
+- [ ] The Steam library directory for the app is removed
+- [ ] User data under `%LOCALAPPDATA%\outrightmental\convsim\` is **preserved**
+  (session history, downloaded models, exported transcripts must survive an
+  uninstall — Steam uninstallers must not touch `%LOCALAPPDATA%`)
+- [ ] Downloaded model weights are still present at
+  `%LOCALAPPDATA%\outrightmental\convsim\models\` after uninstall
+
+### E.6 Reinstall behavior
+
+Reinstall the app from Steam after the E.5 uninstall.
+
+- [ ] Reinstall completes without errors
+- [ ] On launch, **no first-run wizard** appears — the app detects existing
+  user data and goes directly to the main screen
+- [ ] Session history from before the uninstall is accessible in the library
+- [ ] Downloaded model is detected as `loaded` (no re-download needed)
+- [ ] Logs from the new session are appended to the existing log directory
+
+### E.7 Depot content audit (pre-submission)
+
+Before submitting the depot to Valve, run the audit locally:
+
+```powershell
+.\scripts\depot-audit.ps1 steam-content\windows
+```
+
+- [ ] Exits 0 (no violations)
+- [ ] No `.gguf`, `.bin`, `.safetensors`, `.pt`, `.pth`, or `.ckpt` files in the depot
+- [ ] No `.env`, `__pycache__\`, or `.venv\` directories in the depot
+- [ ] Installer is Authenticode-signed (verify with `signtool.exe verify /pa /v <file>`)
+
+---
+
 ## Smoke log
 
 Fill this in for each manual release smoke run.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -336,7 +336,9 @@ On first launch, the Model Manager wizard should appear automatically.
 
 Select **Job Interview Basics → Behavioral Interview** and run a session.
 
-- [ ] Scenario library loads and all four official packs are listed
+- [ ] Scenario library loads and all five official packs are listed
+  (Job Interview Basics, Everyday Negotiation, Language Café,
+  Difficult Conversations, Dating — Confidence & Boundaries)
 - [ ] Session starts without errors; NPC opening line is delivered
 - [ ] Player can submit a text turn; NPC responds within 60 seconds (CPU-only)
 - [ ] Session ends cleanly via the Stop / End Session button


### PR DESCRIPTION
Implements the Windows Steam build artifact requirements from issue #223.

## What changed

### `.github/workflows/release.yml` — Authenticode signing with optional CI fallback

Adds a **Sign Windows installers (Authenticode)** step after the Tauri Windows build that runs on Windows agents only. The step is idempotent and safe for forks and development branches:

- When repository secrets `WINDOWS_SIGN_CERT_PFX` (base64-encoded PFX certificate) and `WINDOWS_SIGN_CERT_PASSWORD` are present, it signs every NSIS `.exe` installer and MSI package with SHA-256 file and timestamp digests against the DigiCert RFC 3161 timestamp server.
- When the secrets are absent, the step logs an informational message and exits 0, allowing unsigned builds to be produced for developer branches.

The implementation includes robust error handling: base64 decoding strips PEM marker lines (accepting both plain base64 and `certutil -encode`-wrapped output), the PFX file is cleaned up even on failure, and signtool.exe is located first on PATH or falls back to searching the Windows Kits install directory.

### `docs/platform-notes.md` — Corrected paths, expanded signing guide, Steam system requirements

**Data directory corrections:**
- Windows: `%USERPROFILE%\.convsim\` → `%LOCALAPPDATA%\outrightmental\convsim\` (aligning with the platform-specific path implementation from commit fd680ae)
- macOS: `~/.convsim/` → `~/Library/Application Support/com.outrightmental.convsim/`
- Added migration notes explaining the automatic `.convsim_migrated_to_platform_dir` marker and that model weights require manual re-download
- Documented `CONVSIM_DATA_ROOT` environment variable override and Steam Cloud exclusion via `.nosteamcloudpath` files

**Windows code-signing section expansion:**
- Added "Authenticode signing in CI (Release workflow)" subsection explaining the secrets-based CI flow and when signing becomes mandatory (Gate G3-01)
- Step-by-step certificate acquisition instructions (DigiCert, Sectigo, GlobalSign)
- PFX export and base64-encoding command
- Repository secrets registration procedure
- Local signing example using `signtool.exe`

**New "Windows system requirements for Steam" section:**
- Minimum requirements table: OS, CPU, RAM, disk, GPU, WebView2 runtime, internet requirements
- Recommended requirements table for optimal experience
- GPU acceleration opt-in documentation (CUDA not required)
- Verified Steam client version (1.0.0.81)

### `docs/release-checklist.md` — Part E: Windows Steam install verification

Adds a comprehensive manual verification checklist (7 subsections) for testing the Steam-specific install path on a clean Windows machine before depot submission:

- **E.1 Fresh install from Steam** — Steam install flow, launch via Play button, signature verification (no SmartScreen)
- **E.2 First-run model wizard** — wizard appearance, all six mandatory disclosure fields, download destination under `%LOCALAPPDATA%`, SHA-256 verification
- **E.3 Text scenario and debrief** — scenario library load, all five official packs, NPC session execution, debrief export
- **E.4 Log verification** — logs at correct path, no PII, no stale `~\.convsim\` artifacts on fresh install
- **E.5 Uninstall behavior** — user data under `%LOCALAPPDATA%` is preserved across uninstall (Steam uninstaller requirements)
- **E.6 Reinstall behavior** — no first-run wizard re-trigger, session history and models persist and are detected as already installed
- **E.7 Depot content audit** — `depot-audit.ps1` validation, no model files or PII directories, Authenticode signature verification via `signtool.exe verify`

## Iterative improvements over the initial commit

Since the initial feature commit (62a96bb), several refinements were made:

1. **Signtool.exe resolution fix** (5d97101): Windows SDK path discovery now correctly prioritizes the newest x64 build when signtool is not on PATH.
2. **Certutil base64 handling** (c279ce0): Base64 decoding logic now strips PEM header/footer lines, allowing both plain base64 and `certutil -encode`-wrapped secrets.
3. **Platform-notes corrections** (013b52d): Fixed raw-audio data path documentation in macOS section.
4. **Release checklist corrections** (74fbda8): Updated Part E to expect five official packs (not six).
5. **Merge conflict resolution** (69d9370): Restored the Authenticode signing step after a merge with origin/main that temporarily removed it.

## How to enable code signing in CI

1. Obtain an EV or OV Authenticode certificate from DigiCert, Sectigo, GlobalSign, or similar.
2. Export the certificate and private key as a `.pfx` file.
3. Base64-encode it: `certutil -encode cert.pfx cert.b64`
4. Add the contents of `cert.b64` as the `WINDOWS_SIGN_CERT_PFX` repository secret.
5. Add the PFX password as the `WINDOWS_SIGN_CERT_PASSWORD` repository secret.

The next `release.yml` run will sign automatically. Without the secrets, release builds continue to produce unsigned installers (acceptable until Gate G3-01 in `docs/steam-mvp-scope.md`).

Closes #223