### PR TITLE
Add Linux and SteamOS build artifact support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,6 +136,42 @@ jobs:
       - name: Build Tauri desktop
         run: pnpm --filter @convsim/desktop build
 
+      # ── Verify Linux artifact permissions ────────────────────────────────────
+      # AppImage files must be executable before upload so that players can run
+      # them directly after downloading.  Tauri sets the bit, but we verify here
+      # so the CI log records the exact permissions of what was uploaded.
+      - name: Verify Linux artifact permissions
+        if: runner.os == 'Linux'
+        run: |
+          BUNDLE_ROOT=apps/desktop/src-tauri/target/release/bundle
+
+          echo "── convsim-core binary ──"
+          ls -lh apps/desktop/src-tauri/resources/bin/convsim-core
+          test -x apps/desktop/src-tauri/resources/bin/convsim-core || {
+            echo "ERROR: convsim-core is not executable" >&2; exit 1
+          }
+
+          echo ""
+          echo "── AppImage ──"
+          find "$BUNDLE_ROOT/appimage" -name "*.AppImage" | while read -r f; do
+            ls -lh "$f"
+            if [[ ! -x "$f" ]]; then
+              echo "WARNING: $f is not executable — fixing..."
+              chmod +x "$f"
+            fi
+          done
+
+          echo ""
+          echo "── Debian package ──"
+          find "$BUNDLE_ROOT/deb" -name "*.deb" | while read -r f; do
+            ls -lh "$f"
+          done
+
+          echo ""
+          echo "── SHA-256 checksums ──"
+          find "$BUNDLE_ROOT" \( -name "*.AppImage" -o -name "*.deb" \) | \
+            sort | xargs sha256sum
+
       # ── Collect installers ───────────────────────────────────────────────────
       # Tauri v2 places bundles under target/release/bundle/<format>/.
       - name: Upload desktop installer artifacts

--- a/docs/linux-steamos-requirements.md
+++ b/docs/linux-steamos-requirements.md
@@ -1,0 +1,257 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+# Linux and SteamOS system requirements
+
+This document records the runtime library assumptions, GLibC version requirements,
+fallback guidance, and the minimum and recommended system requirements for the
+Conversation Simulator Linux depot on Steam.
+
+---
+
+## Installer formats
+
+Two Linux artifacts are produced by the CI release build:
+
+| Format | File | Use case |
+|--------|------|----------|
+| **AppImage** | `ConversationSimulator_<ver>_amd64.AppImage` | Portable — runs on any compatible x86_64 Linux without installation. Recommended for Steam Deck and Flatpak-style installs. |
+| **Debian package** | `conversation-simulator_<ver>_amd64.deb` | Ubuntu 22.04+ and Debian 12+. Installs to `/usr/bin/` with system-managed runtime dependencies. |
+
+The Steam depot ships the AppImage as the primary artifact. The `.deb` is
+available as a GitHub release asset for users who prefer system packages.
+
+---
+
+## GLibC version requirements
+
+The C standard library (glibc) is the one shared library that is **not
+bundled** inside the AppImage — it must be present on the target system at a
+version equal to or newer than what was used on the build machine.
+
+| Artifact | Build machine | Minimum glibc on target |
+|----------|--------------|------------------------|
+| AppImage | Ubuntu 22.04 LTS (CI runner) | **≥ 2.35** |
+| `.deb` | Ubuntu 22.04 LTS (CI runner) | **≥ 2.35** |
+
+### Distribution compatibility (AppImage)
+
+| Distribution | Shipped glibc | Compatible |
+|-------------|--------------|------------|
+| Ubuntu 22.04 LTS | 2.35 | Yes (exact match) |
+| Ubuntu 24.04 LTS | 2.39 | Yes |
+| Debian 12 (Bookworm) | 2.36 | Yes |
+| Fedora 38+ | 2.37 | Yes |
+| Arch Linux (rolling) | 2.38+ | Yes |
+| **SteamOS 3.x** (Arch-based) | 2.37+ | **Yes** |
+| Ubuntu 20.04 LTS | 2.31 | **No** — upgrade required |
+| Debian 11 (Bullseye) | 2.31 | **No** — upgrade required |
+
+> **Rationale:** Ubuntu 22.04 LTS is the minimum supported distribution because
+> the Tauri 2 WebKitGTK 4.1 binding (`libwebkit2gtk-4.1`) is not packaged in
+> Ubuntu 20.04 or Debian 11 repositories. Extending support to older releases
+> would require a custom build toolchain (e.g. a Docker image based on Debian
+> 11 with backported WebKitGTK) — deferred to a post-launch milestone if
+> demand warrants it.
+
+---
+
+## Runtime library requirements
+
+### AppImage
+
+The AppImage bundles most user-space dependencies, including:
+
+- **WebKitGTK 4.1** (`libwebkit2gtk-4.1.so`) — web view engine
+- **GTK 3** (`libgtk-3.so`) — window chrome
+- **libayatana-appindicator3** — system tray icon support
+- **librsvg2** — SVG icon rendering
+- **glib2, gio, gobject** — GLib base libraries
+
+The AppImage does **not** bundle:
+
+- glibc / libgcc (must be ≥ 2.35 on host)
+- libX11 / libXext / libXrender / libXcursor (X11 display server, or Wayland
+  via XWayland) — must be present on host
+- FUSE 2 (`libfuse.so.2`) — required to mount the AppImage at runtime
+
+> **FUSE note:** On systems where FUSE 2 is not available (e.g. Ubuntu 22.04
+> ships FUSE 3 by default), run the AppImage with `--appimage-extract-and-run`
+> to bypass FUSE mounting and extract to a temporary directory instead:
+> ```bash
+> ./ConversationSimulator.AppImage --appimage-extract-and-run
+> ```
+> Alternatively, install FUSE 2: `sudo apt-get install libfuse2`
+
+### Debian package (.deb)
+
+The `.deb` declares the following `Depends:` entries (set by the Tauri bundler):
+
+```
+libwebkit2gtk-4.1-0, libgtk-3-0, libayatana-appindicator3-1, librsvg2-2
+```
+
+Install these on Ubuntu 22.04 before installing the `.deb`:
+
+```bash
+sudo apt-get install -y \
+  libwebkit2gtk-4.1-0 \
+  libgtk-3-0 \
+  libayatana-appindicator3-1 \
+  librsvg2-2
+```
+
+### Microphone (voice input)
+
+Voice input requires `xdg-desktop-portal` and a running PipeWire or PulseAudio
+session. On headless or minimal desktop environments, microphone access may
+silently fail; text-only input mode works without audio hardware.
+
+```bash
+# Install xdg-desktop-portal on Ubuntu
+sudo apt-get install -y xdg-desktop-portal xdg-desktop-portal-gtk
+```
+
+---
+
+## SteamOS 3.x / Steam Deck
+
+SteamOS 3.x is based on Arch Linux and ships with glibc 2.37+, satisfying the
+≥ 2.35 requirement. The AppImage runs without modification.
+
+### Steam Deck hardware profile
+
+| Component | Spec |
+|-----------|------|
+| CPU | AMD Zen 2, 4-core / 8-thread, 2.4–3.5 GHz |
+| RAM | 16 GB LPDDR5 (shared with GPU) |
+| GPU | AMD RDNA 2, 8 CUs, 1.0–1.6 GHz |
+| VRAM | Shared from RAM pool (1–8 GB configurable) |
+| Storage | 64 GB eMMC / 256 GB NVMe / 512 GB NVMe |
+| Screen | 1280×800 (LCD model) / 1280×800 OLED |
+| Input | Gamepad buttons, dual trackpads, gyro, touchscreen |
+
+### Installation on Steam Deck
+
+Via the Steam library (after depot upload):
+
+1. Install from the Steam library entry — no terminal required.
+2. On first launch the Model Manager wizard appears — download the recommended
+   starter model (Qwen3 4B Q4_K_M, ≈ 2.6 GB).
+
+Manual AppImage install for testing (Desktop Mode):
+
+```bash
+# In Desktop Mode, open Konsole:
+chmod +x ConversationSimulator_*.AppImage
+./ConversationSimulator_*.AppImage
+```
+
+To add as a non-Steam game for Gaming Mode launch:
+
+1. Open Steam in Desktop Mode → **Add a game** → **Add a Non-Steam Game**.
+2. Browse to the AppImage and select it.
+3. Set Launch Options: *(empty for default)*
+4. Switch to Gaming Mode and launch from the library.
+
+### Steam Deck verification checklist
+
+Complete all items on a physical Steam Deck running SteamOS 3.x in Gaming Mode
+before the Stage 4 gate (G4-02) can be declared PASS. This checklist extends
+the general QA matrix in `docs/QA_STEAM_PLATFORM_MATRIX.md`.
+
+- [ ] App launches in Gaming Mode from the Steam library without extra setup.
+- [ ] Home screen, scenario picker, and Model Manager are fully navigable with
+      the controller alone (D-pad, A/B/X/Y, left stick, right trackpad).
+- [ ] On-screen keyboard appears automatically when any text input field is
+      focused.
+- [ ] All text is readable at 1280×800 without zooming or horizontal scrolling.
+- [ ] No required action is hidden behind a mouse-only hover state.
+- [ ] Offline smoke test passes under SteamOS 3.x (no outbound network during
+      play).
+- [ ] Steam overlay (Shift+Tab) opens and closes without breaking the current
+      session.
+- [ ] Push-to-talk key (if using voice) does not conflict with the Steam overlay
+      binding.
+- [ ] Battery draw during a text session is documented (target: < 15 W average).
+- [ ] App exits cleanly and returns to the Steam library home screen.
+
+### Performance expectations on Steam Deck (Starter tier)
+
+| Metric | Target |
+|--------|--------|
+| App cold-start to home screen | ≤ 10 s |
+| Model load (Qwen3 4B Q4_K_M, first load) | ≤ 90 s |
+| First-token latency during text session | ≤ 30 s |
+| Battery draw during text session | < 15 W average |
+
+> The Steam Deck GPU can run the Qwen3 4B Q4_K_M model with partial GPU
+> offload. Set the number of GPU layers in the Model Manager settings to
+> maximise performance. CPU-only inference is slower but fully functional.
+
+---
+
+## Minimum and recommended system requirements (Steam store page)
+
+These are the values for the Linux section of the Steam store page.
+
+### Minimum
+
+| | |
+|--|--|
+| **OS** | Ubuntu 22.04 LTS or equivalent (glibc 2.35+, x86-64) |
+| **Processor** | 64-bit x86 processor, 4 cores, 2.0 GHz |
+| **Memory** | 8 GB RAM |
+| **Graphics** | Any GPU or CPU with integrated graphics |
+| **Storage** | 2 GB available (app) + 3–6 GB for a starter model |
+| **Additional notes** | Text-only play mode; voice input requires PipeWire or PulseAudio. |
+
+### Recommended
+
+| | |
+|--|--|
+| **OS** | Ubuntu 22.04 LTS / Ubuntu 24.04 LTS / SteamOS 3.x (x86-64) |
+| **Processor** | 64-bit x86 processor, 6+ cores, 3.0 GHz |
+| **Memory** | 16 GB RAM |
+| **Graphics** | GPU with 4 GB VRAM (NVIDIA RTX 2060 / AMD RX 6600 or better) |
+| **Storage** | 2 GB available (app) + 6–10 GB for recommended models |
+| **Additional notes** | GPU acceleration significantly reduces inference latency. Microphone recommended for voice input mode. |
+
+### Steam Deck
+
+| | |
+|--|--|
+| **Compatibility** | Steam Deck Verified (target; requires Valve review) |
+| **Notes** | All official packs playable in text-only mode. Voice input available in Desktop Mode via microphone dongle. |
+
+---
+
+## Fallback guidance for older distributions
+
+If a player's system does not meet the glibc 2.35 minimum:
+
+1. **Upgrade the distribution.** Ubuntu 22.04 LTS has free upgrade paths from
+   20.04 via `do-release-upgrade`.
+
+2. **Run in a container.** A Podman or Docker container based on Ubuntu 22.04
+   can host the AppImage with full library access. This is a developer option,
+   not a supported player workflow.
+
+3. **Build from source.** Players comfortable with Rust/Node/Python toolchains
+   can build directly from the GitHub repository on their own distro. See
+   `docs/platform-notes.md` and `scripts/setup.sh`.
+
+Conversation Simulator does not ship a "legacy" build targeting older
+distributions in v1. If demand for older glibc compatibility is confirmed
+post-launch, a Debian 11 / Ubuntu 20.04 compatible build can be explored as a
+Stage 5 follow-on using an older build toolchain (linuxdeploy / appimagetool
+with glibc 2.31 base image).
+
+---
+
+## References
+
+- [platform-notes.md](platform-notes.md) — Linux build prerequisites and dev environment
+- [QA_STEAM_PLATFORM_MATRIX.md](QA_STEAM_PLATFORM_MATRIX.md) — full manual and automated QA test matrix
+- [release-checklist.md](release-checklist.md) — release smoke steps and CI gate list
+- [publishing/STEAM_DEPOT_CONTENTS.md](../publishing/STEAM_DEPOT_CONTENTS.md) — depot content policy
+- `scripts/build-linux.sh` — local Linux build command
+- `scripts/depot-audit.sh` — pre-upload depot content audit

--- a/docs/platform-notes.md
+++ b/docs/platform-notes.md
@@ -213,8 +213,10 @@ Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 
 ### Supported distributions
 
-Ubuntu 22.04 LTS is the primary test target. Other glibc-based distros
-(Fedora 38+, Debian 12+, Arch) should work but are not regularly tested.
+Ubuntu 22.04 LTS is the primary test target and the CI build machine.
+Other glibc-based distros (Fedora 38+, Debian 12+, Arch, SteamOS 3.x)
+are compatible. See [linux-steamos-requirements.md](linux-steamos-requirements.md)
+for the full distribution compatibility matrix and GLibC version details.
 
 ### Build prerequisites
 
@@ -236,11 +238,31 @@ npm install -g pnpm
 sudo apt-get install -y python3.11 python3.11-venv
 ```
 
+Run setup and then the Linux build script:
+
+```bash
+./scripts/setup.sh
+./scripts/build-linux.sh
+```
+
 ### Installer format
 
 Tauri produces:
-- **`.AppImage`** — portable, runs on any x86_64 Linux without installation.
-- **`.deb`** — Debian/Ubuntu package for system-wide installation.
+- **`.AppImage`** — portable, runs on any x86_64 Linux with glibc ≥ 2.35
+  without installation. This is the primary Steam depot artifact and the
+  recommended format for Steam Deck / SteamOS installs.
+- **`.deb`** — Debian/Ubuntu package for system-wide installation on
+  Ubuntu 22.04+ and Debian 12+.
+
+The AppImage bundles WebKitGTK, GTK 3, and most other user-space dependencies.
+The `.deb` package declares them as `Depends:` and installs them via apt.
+
+### Code signing
+
+Linux builds are **not code-signed**. There is no Linux equivalent of macOS
+Gatekeeper or Windows SmartScreen; no signature is required for distribution.
+The AppImage and `.deb` are distributed with SHA-256 checksums listed in the
+GitHub release and verified by the Steam depot audit before upload.
 
 ### Microphone (PipeWire / PulseAudio)
 
@@ -249,6 +271,44 @@ PulseAudio session for the browser `getUserMedia` permission dialog to appear.
 On headless or minimal desktop environments, microphone access may silently
 fail; use text-only input mode in that case.
 
+```bash
+# Install portal support on Ubuntu
+sudo apt-get install -y xdg-desktop-portal xdg-desktop-portal-gtk
+```
+
+### Data directories
+
+```
+~/.local/share/convsim/db/      — SQLite session database
+~/.local/share/convsim/data/    — exports and pack cache
+~/.local/share/convsim/logs/    — runtime logs
+~/.local/share/convsim/models/  — downloaded model weights
+```
+
+If `~/.convsim/` exists from a pre-release dev install, the app migrates
+data on first launch. Override with environment variables:
+`CONVSIM_DB_DIR`, `CONVSIM_DATA_DIR`, `CONVSIM_LOG_DIR`, `CONVSIM_MODELS_DIR`.
+
+### Port conflicts
+
+The app binds ports 7354–7358 on `127.0.0.1`. Find and stop conflicting
+processes:
+
+```bash
+ss -tlnp | grep -E '7354|7355|7356|7357|7358'
+# or
+fuser 7354/tcp 7355/tcp
+kill <PID>
+```
+
+### Steam Deck / SteamOS 3.x
+
+The AppImage runs on SteamOS 3.x (Arch-based, x86-64, glibc 2.37+) without
+modification. Refer to
+[linux-steamos-requirements.md](linux-steamos-requirements.md) for the
+complete Steam Deck installation guide, controller navigation expectations,
+and verification checklist required for the Steam Deck Verified tier.
+
 ---
 
 ## Cross-platform differences summary
@@ -256,11 +316,11 @@ fail; use text-only input mode in that case.
 | Feature | macOS | Windows | Linux |
 |---|---|---|---|
 | Installer format | `.dmg` | `.exe` (NSIS), `.msi` | `.AppImage`, `.deb` |
-| Code signing | Apple Developer ID | EV or OV certificate | Not applicable |
+| Code signing | Apple Developer ID | EV or OV certificate | Not required |
 | Runtime warning | Gatekeeper dialog | SmartScreen dialog | None |
 | WebView engine | WKWebView (Safari) | WebView2 (Chromium) | WebKitGTK |
 | Microphone prompt | System Settings | Windows Security | `xdg-desktop-portal` |
-| Data directory | `~/.convsim/` | `%USERPROFILE%\.convsim\` | `~/.convsim/` |
+| Data directory | `~/.convsim/` | `%USERPROFILE%\.convsim\` | `~/.local/share/convsim/` |
 | Dev script | `./scripts/dev.sh` | `.\scripts\dev.ps1` | `./scripts/dev.sh` |
 | First-run check | `./scripts/first-run-check.sh` | `.\scripts\first-run-check.ps1` | `./scripts/first-run-check.sh` |
 

--- a/docs/platform-notes.md
+++ b/docs/platform-notes.md
@@ -279,15 +279,21 @@ sudo apt-get install -y xdg-desktop-portal xdg-desktop-portal-gtk
 ### Data directories
 
 ```
-~/.local/share/convsim/db/      — SQLite session database
-~/.local/share/convsim/data/    — exports and pack cache
-~/.local/share/convsim/logs/    — runtime logs
-~/.local/share/convsim/models/  — downloaded model weights
+~/.local/share/convsim/db/       — SQLite session database
+~/.local/share/convsim/data/     — general application data
+~/.local/share/convsim/packs/    — installed scenario packs
+~/.local/share/convsim/exports/  — exported transcripts
+~/.local/share/convsim/logs/     — runtime logs
+~/.local/share/convsim/cache/    — regenerable caches
+~/.local/share/convsim/models/   — downloaded model weights
 ```
 
-If `~/.convsim/` exists from a pre-release dev install, the app migrates
-data on first launch. Override with environment variables:
-`CONVSIM_DB_DIR`, `CONVSIM_DATA_DIR`, `CONVSIM_LOG_DIR`, `CONVSIM_MODELS_DIR`.
+The root is `$XDG_DATA_HOME/convsim` when `XDG_DATA_HOME` is set, otherwise
+`~/.local/share/convsim`. If `~/.convsim/` exists from a pre-release dev
+install, the app migrates data on first launch. Every subdirectory can be
+redirected via a `CONVSIM_*` environment variable — e.g. `CONVSIM_DB_DIR`,
+`CONVSIM_DATA_DIR`, `CONVSIM_LOG_DIR`, `CONVSIM_MODELS_DIR` — or relocate the
+whole tree at once with `CONVSIM_DATA_ROOT`.
 
 ### Port conflicts
 

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -1,0 +1,304 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# build-linux.sh — Build the Conversation Simulator Linux desktop artifacts.
+#
+# Produces:
+#   apps/desktop/src-tauri/target/release/bundle/appimage/*.AppImage
+#   apps/desktop/src-tauri/target/release/bundle/deb/*.deb
+#
+# Both artifacts include the packaged convsim-core binary, official scenario
+# packs, and all required sidecars. No Python or Node.js installation is
+# required on the player's machine after installing either artifact.
+#
+# Usage:
+#   ./scripts/build-linux.sh [--skip-deps] [--skip-core] [--clean] [--help]
+#
+# Options:
+#   --skip-deps   Skip apt-get installation of system packages.
+#                 Use when packages are already installed or you manage deps manually.
+#   --skip-core   Skip rebuilding the convsim-core PyInstaller binary.
+#                 Use when a binary already exists in resources/bin/ and has not changed.
+#   --clean       Remove previous Tauri build artifacts before building.
+#   --help        Print this help and exit.
+#
+# Prerequisites:
+#   - Debian/Ubuntu x86_64 host (Ubuntu 22.04 LTS or newer strongly recommended)
+#   - sudo access for system package installation (unless --skip-deps is used)
+#   - Rust toolchain via rustup: https://rustup.rs/
+#   - Node.js 18+ and pnpm 9+
+#   - Python 3.10+ (3.11 recommended to match CI)
+#
+#   Run ./scripts/setup.sh first to create the convsim-core Python venv.
+#
+# GLibC note:
+#   AppImage artifacts built on Ubuntu 22.04 (glibc 2.35) require glibc >= 2.35
+#   on the target system. Ubuntu 22.04+, Fedora 38+, Debian 12+, and
+#   SteamOS 3.x all satisfy this. See docs/linux-steamos-requirements.md.
+#
+# Steam Deck:
+#   The AppImage runs on SteamOS 3.x (Arch-based, glibc 2.37+). After building,
+#   copy the AppImage to the Steam Deck and launch it from a terminal or the
+#   Steam library entry configured in Steamworks.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# ── Parse options ─────────────────────────────────────────────────────────────
+
+SKIP_DEPS=0
+SKIP_CORE=0
+CLEAN=0
+
+for arg in "$@"; do
+    case "$arg" in
+        --skip-deps) SKIP_DEPS=1 ;;
+        --skip-core) SKIP_CORE=1 ;;
+        --clean)     CLEAN=1 ;;
+        --help|-h)
+            sed -n '2,/^set /p' "$0" | grep '^#' | sed 's/^# \?//'
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $arg" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# ── Guard: Linux only ─────────────────────────────────────────────────────────
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+    echo "ERROR: This script must run on Linux. Current platform: $(uname -s)" >&2
+    echo "       For macOS, use: pnpm --filter @convsim/desktop build" >&2
+    echo "       For Windows, use: .\\scripts\\build-core.ps1 then pnpm --filter @convsim/desktop build" >&2
+    exit 1
+fi
+
+# ── Banner ────────────────────────────────────────────────────────────────────
+
+echo ""
+echo "Conversation Simulator — Linux desktop build"
+echo "=============================================="
+echo "Host : $(uname -s) $(uname -m)"
+echo "glibc: $(ldd --version 2>&1 | head -1 | grep -oE '[0-9]+\.[0-9]+$' || echo 'unknown')"
+echo "Root : $REPO_ROOT"
+echo ""
+
+# ── System dependencies ───────────────────────────────────────────────────────
+# Tauri requires WebKitGTK 4.1, GTK 3, and a few support libraries.
+# These are build-time AND runtime dependencies for the .deb package.
+# The AppImage bundles most of them; the .deb does not.
+
+SYSTEM_PACKAGES=(
+    libwebkit2gtk-4.1-dev
+    libgtk-3-dev
+    libayatana-appindicator3-dev
+    librsvg2-dev
+)
+
+if [[ "$SKIP_DEPS" -eq 0 ]]; then
+    echo "Installing system dependencies..."
+    if ! command -v apt-get &>/dev/null; then
+        echo "WARNING: apt-get not found. Install these packages manually:" >&2
+        printf '  %s\n' "${SYSTEM_PACKAGES[@]}" >&2
+        echo "  Then re-run with --skip-deps." >&2
+        # Do not exit — the build may succeed if packages are already installed
+        # via another package manager.
+    else
+        sudo apt-get update -qq
+        sudo apt-get install -y "${SYSTEM_PACKAGES[@]}"
+        echo "  OK — system packages installed."
+    fi
+    echo ""
+fi
+
+# ── Verify toolchain ──────────────────────────────────────────────────────────
+
+echo "Checking toolchain..."
+
+check_tool() {
+    local name="$1"
+    local cmd="$2"
+    local hint="$3"
+    if ! command -v "$cmd" &>/dev/null; then
+        echo "  ERROR: $name not found. $hint" >&2
+        return 1
+    fi
+    echo "  OK    $name: $("$cmd" --version 2>&1 | head -1)"
+}
+
+TOOLCHAIN_OK=1
+check_tool "Rust (cargo)" "cargo" "Install via: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh" || TOOLCHAIN_OK=0
+check_tool "Node.js"      "node"  "Install via NodeSource: https://github.com/nodesource/distributions" || TOOLCHAIN_OK=0
+check_tool "pnpm"         "pnpm"  "Install via: npm install -g pnpm" || TOOLCHAIN_OK=0
+
+PY=""
+for py_cmd in python3.11 python3.10 python3 python; do
+    if command -v "$py_cmd" &>/dev/null; then
+        PY="$py_cmd"
+        break
+    fi
+done
+if [[ -z "$PY" ]]; then
+    echo "  ERROR: Python 3.10+ not found. Install via: sudo apt-get install python3.11 python3.11-venv" >&2
+    TOOLCHAIN_OK=0
+else
+    echo "  OK    Python: $("$PY" --version 2>&1 | head -1) ($PY)"
+fi
+
+if [[ "$TOOLCHAIN_OK" -eq 0 ]]; then
+    echo "" >&2
+    echo "One or more toolchain components are missing. Resolve the errors above and retry." >&2
+    exit 1
+fi
+echo ""
+
+# ── Install JavaScript dependencies ───────────────────────────────────────────
+
+echo "Installing JS dependencies..."
+cd "$REPO_ROOT"
+pnpm install --frozen-lockfile
+echo "  OK — pnpm install complete."
+echo ""
+
+# ── Build shared TypeScript packages ──────────────────────────────────────────
+
+echo "Building shared TypeScript packages..."
+pnpm --filter @convsim/shared-types build
+pnpm --filter @convsim/scenario-schema build
+echo "  OK — shared-types and scenario-schema built."
+echo ""
+
+# ── Build web frontend ────────────────────────────────────────────────────────
+
+echo "Building web frontend..."
+pnpm --filter @convsim/web build
+echo "  OK — web frontend built."
+echo ""
+
+# ── Build convsim-core standalone binary ─────────────────────────────────────
+
+BIN_DIR="$REPO_ROOT/apps/desktop/src-tauri/resources/bin"
+CORE_BIN="$BIN_DIR/convsim-core"
+
+if [[ "$SKIP_CORE" -eq 1 ]]; then
+    if [[ -f "$CORE_BIN" ]]; then
+        echo "Skipping convsim-core build (--skip-core set)."
+        echo "  Found: $CORE_BIN ($(du -sh "$CORE_BIN" | cut -f1))"
+    else
+        echo "ERROR: --skip-core specified but no binary found at $CORE_BIN" >&2
+        echo "       Run without --skip-core to build it first." >&2
+        exit 1
+    fi
+    echo ""
+else
+    echo "Building convsim-core standalone binary (PyInstaller)..."
+    bash "$SCRIPT_DIR/build-core.sh"
+    echo ""
+fi
+
+# Verify executable bit.
+if [[ ! -x "$CORE_BIN" ]]; then
+    echo "ERROR: $CORE_BIN is not executable. Fixing..." >&2
+    chmod +x "$CORE_BIN"
+fi
+
+# ── Clean previous Tauri build artifacts ─────────────────────────────────────
+
+TAURI_TARGET="$REPO_ROOT/apps/desktop/src-tauri/target/release/bundle"
+
+if [[ "$CLEAN" -eq 1 && -d "$TAURI_TARGET" ]]; then
+    echo "Removing previous Tauri bundle artifacts..."
+    rm -rf "$TAURI_TARGET"
+    echo "  Removed $TAURI_TARGET"
+    echo ""
+fi
+
+# ── Build Tauri desktop (AppImage + .deb) ─────────────────────────────────────
+
+echo "Building Tauri desktop (AppImage + .deb)..."
+echo "  This step compiles Rust and may take 5–20 minutes on first run."
+echo ""
+pnpm --filter @convsim/desktop build
+echo ""
+
+# ── Locate and verify artifacts ───────────────────────────────────────────────
+
+echo "Verifying build artifacts..."
+echo ""
+
+APPIMAGE=""
+DEB=""
+ERRORS=0
+
+# Tauri v2 places bundles under target/release/bundle/<format>/
+if [[ -d "$TAURI_TARGET/appimage" ]]; then
+    APPIMAGE="$(find "$TAURI_TARGET/appimage" -name "*.AppImage" | head -1)"
+fi
+if [[ -d "$TAURI_TARGET/deb" ]]; then
+    DEB="$(find "$TAURI_TARGET/deb" -name "*.deb" | head -1)"
+fi
+
+check_artifact() {
+    local label="$1"
+    local path="$2"
+    if [[ -z "$path" || ! -f "$path" ]]; then
+        echo "  MISSING  $label" >&2
+        ERRORS=$((ERRORS + 1))
+        return
+    fi
+    local perms size
+    perms="$(stat -c '%A' "$path")"
+    size="$(du -sh "$path" | cut -f1)"
+    echo "  OK  $label"
+    echo "      Path  : $path"
+    echo "      Size  : $size"
+    echo "      Perms : $perms"
+    if [[ "$label" == "AppImage" ]] && [[ ! -x "$path" ]]; then
+        echo "  WARNING: AppImage is not executable — fixing..." >&2
+        chmod +x "$path"
+        echo "  Fixed   : chmod +x $path"
+    fi
+}
+
+check_artifact "convsim-core binary" "$CORE_BIN"
+check_artifact "AppImage"            "$APPIMAGE"
+check_artifact "Debian package"      "$DEB"
+echo ""
+
+if [[ "$ERRORS" -gt 0 ]]; then
+    echo "ERROR: $ERRORS expected artifact(s) were not produced." >&2
+    echo "       Check the pnpm build output above for errors." >&2
+    exit 1
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+echo "────────────────────────────────────────────────────────────────"
+echo "Build complete — Linux desktop artifacts ready."
+echo ""
+if [[ -n "$APPIMAGE" ]]; then
+    echo "  AppImage (portable, any x86_64 Linux / SteamOS 3.x):"
+    echo "    $APPIMAGE"
+    echo "    Minimum glibc: 2.35  (target: Ubuntu 22.04+, Fedora 38+, SteamOS 3.x)"
+fi
+if [[ -n "$DEB" ]]; then
+    echo ""
+    echo "  Debian package (Ubuntu 22.04+ / Debian 12+):"
+    echo "    $DEB"
+fi
+echo ""
+echo "Steam Deck: copy the AppImage to the device and run it from a terminal"
+echo "  or configure it as a non-Steam game entry in Gaming Mode."
+echo "  See docs/linux-steamos-requirements.md for the full verification guide."
+echo ""
+echo "SHA-256 checksums:"
+if [[ -n "$APPIMAGE" ]]; then
+    sha256sum "$APPIMAGE"
+fi
+if [[ -n "$DEB" ]]; then
+    sha256sum "$DEB"
+fi
+echo "────────────────────────────────────────────────────────────────"
+echo ""

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -71,7 +71,7 @@ done
 if [[ "$(uname -s)" != "Linux" ]]; then
     echo "ERROR: This script must run on Linux. Current platform: $(uname -s)" >&2
     echo "       For macOS, use: pnpm --filter @convsim/desktop build" >&2
-    echo "       For Windows, use: .\\scripts\\build-core.ps1 then pnpm --filter @convsim/desktop build" >&2
+    printf '%s\n' "       For Windows, use: .\\scripts\\build-core.ps1 then pnpm --filter @convsim/desktop build" >&2
     exit 1
 fi
 

--- a/scripts/release-smoke.sh
+++ b/scripts/release-smoke.sh
@@ -125,11 +125,13 @@ smoke_setup() {
         scripts/smoke-check.sh scripts/smoke-check.ps1
         scripts/release-smoke.sh scripts/release-smoke.ps1
         scripts/build-core.sh scripts/build-core.ps1
+        scripts/build-linux.sh
         scripts/depot-audit.sh scripts/depot-audit.ps1
         .github/workflows/ci.yml .github/workflows/release.yml
         .github/workflows/release-smoke.yml
         docs/release-checklist.md
         docs/platform-notes.md docs/release-notes-template.md
+        docs/linux-steamos-requirements.md
         docs/install.md docs/voice-smoke-tests.md
         services/convsim-core/pyproject.toml
         services/convsim-core/convsim-core.spec

--- a/scripts/smoke-check.sh
+++ b/scripts/smoke-check.sh
@@ -120,6 +120,7 @@ check_file "scripts/desktop-smoke.ps1"
 # Packaging and audit scripts
 check_file "scripts/build-core.sh"
 check_file "scripts/build-core.ps1"
+check_file "scripts/build-linux.sh"
 check_file "scripts/depot-audit.sh"
 check_file "scripts/depot-audit.ps1"
 check_file "services/convsim-core/convsim-core.spec"
@@ -134,6 +135,7 @@ check_file ".github/workflows/release-smoke.yml"
 check_file "docs/release-notes-template.md"
 check_file "docs/platform-notes.md"
 check_file "docs/release-checklist.md"
+check_file "docs/linux-steamos-requirements.md"
 
 echo ""
 


### PR DESCRIPTION
## Summary

This PR adds comprehensive Linux and SteamOS support to the Conversation Simulator desktop build pipeline, including a local build script, runtime requirements documentation, and CI automation.

### Changes

**`scripts/build-linux.sh`** — Local Linux desktop build script for contributors. Installs system packages via apt, builds the convsim-core PyInstaller binary, compiles the web frontend, and runs `tauri build` to produce AppImage and `.deb` artifacts. Verifies executable permissions on all outputs and logs SHA-256 checksums. Mirrors the CI release workflow (`release.yml`) so developers can build and test locally without guessing.

**`docs/linux-steamos-requirements.md`** — Complete runtime and distribution compatibility guide. Documents:
- GLibC version requirement (≥ 2.35, built on Ubuntu 22.04 CI runner)
- AppImage vs `.deb` runtime library assumptions
- FUSE fallback guidance (`--appimage-extract-and-run`)
- Distribution compatibility matrix (Ubuntu 22.04+, Fedora 38+, Debian 12+, Arch, SteamOS 3.x)
- Steam Deck / SteamOS 3.x installation instructions and hardware specs
- Controller navigation verification checklist for Valve Verified tier
- Minimum and recommended system requirements for Steam store listing

**`docs/platform-notes.md`** — Enhanced Linux section covering:
- Data directory structure (`~/.local/share/convsim/` with per-directory layout and `CONVSIM_*` environment variable overrides)
- Port conflict detection commands (ports 7354–7358)
- Code signing note (not required on Linux)
- Steam Deck / SteamOS 3.x pointer
- Build quickstart referencing the new `scripts/build-linux.sh`
- Updated cross-platform summary table (Linux data path and signing requirements)

**`.github/workflows/release.yml`** — New Linux artifact verification step in the release workflow:
- Asserts convsim-core binary and AppImage are executable before upload
- Logs permission details and SHA-256 checksums of all produced installers
- Only runs on Linux runners

**`scripts/smoke-check.sh`, `scripts/release-smoke.sh`** — Register `scripts/build-linux.sh` and `docs/linux-steamos-requirements.md` as required monorepo files so CI catches regressions.

## Testing

- `bash scripts/smoke-check.sh` passes with all new files recognized
- Linux release build matrix (Ubuntu 22.04) already in CI; new permission-verification step is additive and only runs on Linux runners
- `scripts/build-linux.sh --help` and option parsing verified locally
- Linux requirements documented against Ubuntu 22.04 glibc 2.35 baseline and verified against Debian 12 (2.36), Fedora 38 (2.37), and SteamOS 3.x (Arch, 2.37+)

Closes #225