### PR TITLE
Produce macOS Steam build artifact with signing and notarization readiness

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,10 +92,55 @@ jobs:
       - name: Build web frontend
         run: pnpm --filter @convsim/web build
 
+      # ── macOS code-signing setup ─────────────────────────────────────────────
+      # Imports the Apple Developer ID p12 certificate into a temporary keychain
+      # so that both PyInstaller (sidecar signing) and Tauri (bundle signing +
+      # notarisation) can find it.
+      #
+      # Required repository secrets (Settings → Secrets and variables → Actions):
+      #   APPLE_CERTIFICATE          Base64-encoded Developer ID Application .p12
+      #   APPLE_CERTIFICATE_PASSWORD Passphrase for the .p12 file
+      #   APPLE_SIGNING_IDENTITY     Full identity string, e.g.
+      #                              "Developer ID Application: Outright Mental (TEAMID)"
+      #   APPLE_ID                   Apple ID email of the notarisation account
+      #   APPLE_PASSWORD             App-specific password for the Apple ID
+      #   APPLE_TEAM_ID              10-character Apple Developer Team ID
+      #
+      # When these secrets are absent (contributor forks, unsigned local builds)
+      # this step is skipped and the build produces an unsigned artifact — suitable
+      # for development and internal testing but not for Stage 3/4 Steam release.
+      - name: Import Apple Developer certificate (macOS only)
+        if: runner.os == 'macOS' && secrets.APPLE_CERTIFICATE != ''
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          KEYCHAIN_PATH="$RUNNER_TEMP/build.keychain"
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          CERT_PATH="$RUNNER_TEMP/build_certificate.p12"
+          printf '%s' "$APPLE_CERTIFICATE" | base64 --decode > "$CERT_PATH"
+          security import "$CERT_PATH" \
+            -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -A -t cert -f pkcs12 \
+            -k "$KEYCHAIN_PATH"
+          security set-key-partition-list \
+            -S apple-tool:,apple: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychain -d user -s "$KEYCHAIN_PATH"
+          rm -f "$CERT_PATH"
+
       # ── Python core build (PyInstaller standalone binary) ────────────────────
       # Produces apps/desktop/src-tauri/resources/bin/convsim-core[.exe] which
       # Tauri bundles as a resource (bundle.resources: ["resources/**/*"] in
       # tauri.conf.json).  The binary must be present before `tauri build`.
+      #
+      # On macOS with APPLE_SIGNING_IDENTITY set, convsim-core.spec signs the
+      # sidecar binary and all embedded Python extensions with the Developer ID
+      # certificate using the entitlements in apps/desktop/src-tauri/entitlements.plist.
       - name: Set up Python for core build
         uses: actions/setup-python@v5
         with:
@@ -103,6 +148,8 @@ jobs:
 
       - name: Build convsim-core standalone binary
         shell: bash
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
         run: |
           # working-directory (below) already places us in services/convsim-core;
           # all paths here are relative to it.
@@ -133,7 +180,17 @@ jobs:
           fi
 
       # ── Tauri desktop build ──────────────────────────────────────────────────
+      # On macOS, Tauri reads APPLE_SIGNING_IDENTITY, APPLE_ID, APPLE_PASSWORD,
+      # and APPLE_TEAM_ID to sign the .app bundle and submit it to Apple's
+      # notarisation service automatically.  These env vars are no-ops on Linux
+      # and Windows.  When the secrets are absent the build is unsigned (suitable
+      # for dev/internal builds but blocked by Gatekeeper on clean installs).
       - name: Build Tauri desktop
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: pnpm --filter @convsim/desktop build
 
       # ── Authenticode signing (Windows only, optional) ─────────────────────────
@@ -274,6 +331,9 @@ jobs:
 
       # ── Collect installers ───────────────────────────────────────────────────
       # Tauri v2 places bundles under target/release/bundle/<format>/.
+      # The .app.tar.gz (macOS) is the raw app bundle in a tarball — Steam depots
+      # require application files directly, not the .dmg installer, so the
+      # steam-deploy workflow extracts this tarball into steam-content/macos/.
       - name: Upload desktop installer artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -281,6 +341,7 @@ jobs:
           # Glob patterns cover all known Tauri installer formats.
           path: |
             apps/desktop/src-tauri/target/release/bundle/**/*.dmg
+            apps/desktop/src-tauri/target/release/bundle/**/*.app.tar.gz
             apps/desktop/src-tauri/target/release/bundle/**/*.AppImage
             apps/desktop/src-tauri/target/release/bundle/**/*.deb
             apps/desktop/src-tauri/target/release/bundle/**/*.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,14 @@ jobs:
     name: Desktop (${{ matrix.name }})
     needs: validate
     runs-on: ${{ matrix.runner }}
+    # The `secrets` context cannot be referenced from a step `if:` conditional
+    # (it evaluates to empty and the condition is always false). Expose only a
+    # boolean presence flag at the job level so the import step can gate on
+    # `env` — deliberately NOT the certificate itself, which must stay scoped to
+    # the import step (leaking APPLE_CERTIFICATE into the Tauri build step would
+    # make Tauri attempt its own keychain import without the password).
+    env:
+      HAS_APPLE_CERT: ${{ secrets.APPLE_CERTIFICATE != '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -110,7 +118,7 @@ jobs:
       # this step is skipped and the build produces an unsigned artifact — suitable
       # for development and internal testing but not for Stage 3/4 Steam release.
       - name: Import Apple Developer certificate (macOS only)
-        if: runner.os == 'macOS' && secrets.APPLE_CERTIFICATE != ''
+        if: runner.os == 'macOS' && env.HAS_APPLE_CERT == 'true'
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -329,11 +337,38 @@ jobs:
           find "$BUNDLE_ROOT" \( -name "*.AppImage" -o -name "*.deb" \) | \
             sort | xargs sha256sum
 
+      # ── Package the macOS .app bundle for the Steam depot ────────────────────
+      # Tauri only emits `.dmg` (installer) and the raw `.app` bundle directory
+      # here; the `.app.tar.gz` updater artifact is NOT produced because the
+      # updater is not configured (no bundle.createUpdaterArtifacts / signing
+      # key).  Steam depots need the raw application files, so we tarball the
+      # signed & notarised `.app` ourselves.  Using `tar` (bsdtar) preserves the
+      # code signature and stapled notarisation ticket, and archiving with the
+      # bundle directory as CWD keeps `<name>.app` at the archive root so
+      # steam-deploy can extract it straight into steam-content/macos/.
+      - name: Package macOS .app bundle for Steam depot (macOS only)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -eu
+          BUNDLE_DIR=apps/desktop/src-tauri/target/release/bundle/macos
+          APP_PATH="$(find "$BUNDLE_DIR" -maxdepth 1 -name '*.app' | head -n1)"
+          if [ -z "$APP_PATH" ]; then
+            echo "ERROR: no .app bundle found under $BUNDLE_DIR" >&2
+            exit 1
+          fi
+          APP_NAME="$(basename "$APP_PATH")"
+          TARBALL="$BUNDLE_DIR/${APP_NAME%.app}.app.tar.gz"
+          echo "Packaging $APP_PATH -> $TARBALL"
+          tar -czf "$TARBALL" -C "$BUNDLE_DIR" "$APP_NAME"
+          ls -lh "$TARBALL"
+
       # ── Collect installers ───────────────────────────────────────────────────
       # Tauri v2 places bundles under target/release/bundle/<format>/.
-      # The .app.tar.gz (macOS) is the raw app bundle in a tarball — Steam depots
-      # require application files directly, not the .dmg installer, so the
-      # steam-deploy workflow extracts this tarball into steam-content/macos/.
+      # The .app.tar.gz (macOS) is the raw app bundle in a tarball, produced by
+      # the packaging step above — Steam depots require application files
+      # directly, not the .dmg installer, so the steam-deploy workflow extracts
+      # this tarball into steam-content/macos/.
       - name: Upload desktop installer artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -337,6 +337,7 @@ jobs:
           find "$BUNDLE_ROOT" \( -name "*.AppImage" -o -name "*.deb" \) | \
             sort | xargs sha256sum
 
+
       # ── Package the macOS .app bundle for the Steam depot ────────────────────
       # Tauri only emits `.dmg` (installer) and the raw `.app` bundle directory
       # here; the `.app.tar.gz` updater artifact is NOT produced because the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,10 +92,55 @@ jobs:
       - name: Build web frontend
         run: pnpm --filter @convsim/web build
 
+      # ── macOS code-signing setup ─────────────────────────────────────────────
+      # Imports the Apple Developer ID p12 certificate into a temporary keychain
+      # so that both PyInstaller (sidecar signing) and Tauri (bundle signing +
+      # notarisation) can find it.
+      #
+      # Required repository secrets (Settings → Secrets and variables → Actions):
+      #   APPLE_CERTIFICATE          Base64-encoded Developer ID Application .p12
+      #   APPLE_CERTIFICATE_PASSWORD Passphrase for the .p12 file
+      #   APPLE_SIGNING_IDENTITY     Full identity string, e.g.
+      #                              "Developer ID Application: Outright Mental (TEAMID)"
+      #   APPLE_ID                   Apple ID email of the notarisation account
+      #   APPLE_PASSWORD             App-specific password for the Apple ID
+      #   APPLE_TEAM_ID              10-character Apple Developer Team ID
+      #
+      # When these secrets are absent (contributor forks, unsigned local builds)
+      # this step is skipped and the build produces an unsigned artifact — suitable
+      # for development and internal testing but not for Stage 3/4 Steam release.
+      - name: Import Apple Developer certificate (macOS only)
+        if: runner.os == 'macOS' && secrets.APPLE_CERTIFICATE != ''
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          KEYCHAIN_PATH="$RUNNER_TEMP/build.keychain"
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          CERT_PATH="$RUNNER_TEMP/build_certificate.p12"
+          printf '%s' "$APPLE_CERTIFICATE" | base64 --decode > "$CERT_PATH"
+          security import "$CERT_PATH" \
+            -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -A -t cert -f pkcs12 \
+            -k "$KEYCHAIN_PATH"
+          security set-key-partition-list \
+            -S apple-tool:,apple: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychain -d user -s "$KEYCHAIN_PATH"
+          rm -f "$CERT_PATH"
+
       # ── Python core build (PyInstaller standalone binary) ────────────────────
       # Produces apps/desktop/src-tauri/resources/bin/convsim-core[.exe] which
       # Tauri bundles as a resource (bundle.resources: ["resources/**/*"] in
       # tauri.conf.json).  The binary must be present before `tauri build`.
+      #
+      # On macOS with APPLE_SIGNING_IDENTITY set, convsim-core.spec signs the
+      # sidecar binary and all embedded Python extensions with the Developer ID
+      # certificate using the entitlements in apps/desktop/src-tauri/entitlements.plist.
       - name: Set up Python for core build
         uses: actions/setup-python@v5
         with:
@@ -103,6 +148,8 @@ jobs:
 
       - name: Build convsim-core standalone binary
         shell: bash
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
         run: |
           # working-directory (below) already places us in services/convsim-core;
           # all paths here are relative to it.
@@ -133,7 +180,17 @@ jobs:
           fi
 
       # ── Tauri desktop build ──────────────────────────────────────────────────
+      # On macOS, Tauri reads APPLE_SIGNING_IDENTITY, APPLE_ID, APPLE_PASSWORD,
+      # and APPLE_TEAM_ID to sign the .app bundle and submit it to Apple's
+      # notarisation service automatically.  These env vars are no-ops on Linux
+      # and Windows.  When the secrets are absent the build is unsigned (suitable
+      # for dev/internal builds but blocked by Gatekeeper on clean installs).
       - name: Build Tauri desktop
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: pnpm --filter @convsim/desktop build
 
       # ── Verify Linux artifact permissions ────────────────────────────────────
@@ -174,6 +231,9 @@ jobs:
 
       # ── Collect installers ───────────────────────────────────────────────────
       # Tauri v2 places bundles under target/release/bundle/<format>/.
+      # The .app.tar.gz (macOS) is the raw app bundle in a tarball — Steam depots
+      # require application files directly, not the .dmg installer, so the
+      # steam-deploy workflow extracts this tarball into steam-content/macos/.
       - name: Upload desktop installer artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -181,6 +241,7 @@ jobs:
           # Glob patterns cover all known Tauri installer formats.
           path: |
             apps/desktop/src-tauri/target/release/bundle/**/*.dmg
+            apps/desktop/src-tauri/target/release/bundle/**/*.app.tar.gz
             apps/desktop/src-tauri/target/release/bundle/**/*.AppImage
             apps/desktop/src-tauri/target/release/bundle/**/*.deb
             apps/desktop/src-tauri/target/release/bundle/**/*.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,14 @@ jobs:
     name: Desktop (${{ matrix.name }})
     needs: validate
     runs-on: ${{ matrix.runner }}
+    # The `secrets` context cannot be referenced from a step `if:` conditional
+    # (it evaluates to empty and the condition is always false). Expose only a
+    # boolean presence flag at the job level so the import step can gate on
+    # `env` — deliberately NOT the certificate itself, which must stay scoped to
+    # the import step (leaking APPLE_CERTIFICATE into the Tauri build step would
+    # make Tauri attempt its own keychain import without the password).
+    env:
+      HAS_APPLE_CERT: ${{ secrets.APPLE_CERTIFICATE != '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -110,7 +118,7 @@ jobs:
       # this step is skipped and the build produces an unsigned artifact — suitable
       # for development and internal testing but not for Stage 3/4 Steam release.
       - name: Import Apple Developer certificate (macOS only)
-        if: runner.os == 'macOS' && secrets.APPLE_CERTIFICATE != ''
+        if: runner.os == 'macOS' && env.HAS_APPLE_CERT == 'true'
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -229,11 +237,38 @@ jobs:
           find "$BUNDLE_ROOT" \( -name "*.AppImage" -o -name "*.deb" \) | \
             sort | xargs sha256sum
 
+      # ── Package the macOS .app bundle for the Steam depot ────────────────────
+      # Tauri only emits `.dmg` (installer) and the raw `.app` bundle directory
+      # here; the `.app.tar.gz` updater artifact is NOT produced because the
+      # updater is not configured (no bundle.createUpdaterArtifacts / signing
+      # key).  Steam depots need the raw application files, so we tarball the
+      # signed & notarised `.app` ourselves.  Using `tar` (bsdtar) preserves the
+      # code signature and stapled notarisation ticket, and archiving with the
+      # bundle directory as CWD keeps `<name>.app` at the archive root so
+      # steam-deploy can extract it straight into steam-content/macos/.
+      - name: Package macOS .app bundle for Steam depot (macOS only)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -eu
+          BUNDLE_DIR=apps/desktop/src-tauri/target/release/bundle/macos
+          APP_PATH="$(find "$BUNDLE_DIR" -maxdepth 1 -name '*.app' | head -n1)"
+          if [ -z "$APP_PATH" ]; then
+            echo "ERROR: no .app bundle found under $BUNDLE_DIR" >&2
+            exit 1
+          fi
+          APP_NAME="$(basename "$APP_PATH")"
+          TARBALL="$BUNDLE_DIR/${APP_NAME%.app}.app.tar.gz"
+          echo "Packaging $APP_PATH -> $TARBALL"
+          tar -czf "$TARBALL" -C "$BUNDLE_DIR" "$APP_NAME"
+          ls -lh "$TARBALL"
+
       # ── Collect installers ───────────────────────────────────────────────────
       # Tauri v2 places bundles under target/release/bundle/<format>/.
-      # The .app.tar.gz (macOS) is the raw app bundle in a tarball — Steam depots
-      # require application files directly, not the .dmg installer, so the
-      # steam-deploy workflow extracts this tarball into steam-content/macos/.
+      # The .app.tar.gz (macOS) is the raw app bundle in a tarball, produced by
+      # the packaging step above — Steam depots require application files
+      # directly, not the .dmg installer, so the steam-deploy workflow extracts
+      # this tarball into steam-content/macos/.
       - name: Upload desktop installer artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,14 @@ jobs:
     name: Desktop (${{ matrix.name }})
     needs: validate
     runs-on: ${{ matrix.runner }}
+    # The `secrets` context cannot be referenced from a step `if:` conditional
+    # (it evaluates to empty and the condition is always false). Expose only a
+    # boolean presence flag at the job level so the import step can gate on
+    # `env` — deliberately NOT the certificate itself, which must stay scoped to
+    # the import step (leaking APPLE_CERTIFICATE into the Tauri build step would
+    # make Tauri attempt its own keychain import without the password).
+    env:
+      HAS_APPLE_CERT: ${{ secrets.APPLE_CERTIFICATE != '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -110,7 +118,7 @@ jobs:
       # this step is skipped and the build produces an unsigned artifact — suitable
       # for development and internal testing but not for Stage 3/4 Steam release.
       - name: Import Apple Developer certificate (macOS only)
-        if: runner.os == 'macOS' && secrets.APPLE_CERTIFICATE != ''
+        if: runner.os == 'macOS' && env.HAS_APPLE_CERT == 'true'
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -193,11 +201,38 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: pnpm --filter @convsim/desktop build
 
+      # ── Package the macOS .app bundle for the Steam depot ────────────────────
+      # Tauri only emits `.dmg` (installer) and the raw `.app` bundle directory
+      # here; the `.app.tar.gz` updater artifact is NOT produced because the
+      # updater is not configured (no bundle.createUpdaterArtifacts / signing
+      # key).  Steam depots need the raw application files, so we tarball the
+      # signed & notarised `.app` ourselves.  Using `tar` (bsdtar) preserves the
+      # code signature and stapled notarisation ticket, and archiving with the
+      # bundle directory as CWD keeps `<name>.app` at the archive root so
+      # steam-deploy can extract it straight into steam-content/macos/.
+      - name: Package macOS .app bundle for Steam depot (macOS only)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -eu
+          BUNDLE_DIR=apps/desktop/src-tauri/target/release/bundle/macos
+          APP_PATH="$(find "$BUNDLE_DIR" -maxdepth 1 -name '*.app' | head -n1)"
+          if [ -z "$APP_PATH" ]; then
+            echo "ERROR: no .app bundle found under $BUNDLE_DIR" >&2
+            exit 1
+          fi
+          APP_NAME="$(basename "$APP_PATH")"
+          TARBALL="$BUNDLE_DIR/${APP_NAME%.app}.app.tar.gz"
+          echo "Packaging $APP_PATH -> $TARBALL"
+          tar -czf "$TARBALL" -C "$BUNDLE_DIR" "$APP_NAME"
+          ls -lh "$TARBALL"
+
       # ── Collect installers ───────────────────────────────────────────────────
       # Tauri v2 places bundles under target/release/bundle/<format>/.
-      # The .app.tar.gz (macOS) is the raw app bundle in a tarball — Steam depots
-      # require application files directly, not the .dmg installer, so the
-      # steam-deploy workflow extracts this tarball into steam-content/macos/.
+      # The .app.tar.gz (macOS) is the raw app bundle in a tarball, produced by
+      # the packaging step above — Steam depots require application files
+      # directly, not the .dmg installer, so the steam-deploy workflow extracts
+      # this tarball into steam-content/macos/.
       - name: Upload desktop installer artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,10 +92,55 @@ jobs:
       - name: Build web frontend
         run: pnpm --filter @convsim/web build
 
+      # ── macOS code-signing setup ─────────────────────────────────────────────
+      # Imports the Apple Developer ID p12 certificate into a temporary keychain
+      # so that both PyInstaller (sidecar signing) and Tauri (bundle signing +
+      # notarisation) can find it.
+      #
+      # Required repository secrets (Settings → Secrets and variables → Actions):
+      #   APPLE_CERTIFICATE          Base64-encoded Developer ID Application .p12
+      #   APPLE_CERTIFICATE_PASSWORD Passphrase for the .p12 file
+      #   APPLE_SIGNING_IDENTITY     Full identity string, e.g.
+      #                              "Developer ID Application: Outright Mental (TEAMID)"
+      #   APPLE_ID                   Apple ID email of the notarisation account
+      #   APPLE_PASSWORD             App-specific password for the Apple ID
+      #   APPLE_TEAM_ID              10-character Apple Developer Team ID
+      #
+      # When these secrets are absent (contributor forks, unsigned local builds)
+      # this step is skipped and the build produces an unsigned artifact — suitable
+      # for development and internal testing but not for Stage 3/4 Steam release.
+      - name: Import Apple Developer certificate (macOS only)
+        if: runner.os == 'macOS' && secrets.APPLE_CERTIFICATE != ''
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          KEYCHAIN_PATH="$RUNNER_TEMP/build.keychain"
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          CERT_PATH="$RUNNER_TEMP/build_certificate.p12"
+          printf '%s' "$APPLE_CERTIFICATE" | base64 --decode > "$CERT_PATH"
+          security import "$CERT_PATH" \
+            -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -A -t cert -f pkcs12 \
+            -k "$KEYCHAIN_PATH"
+          security set-key-partition-list \
+            -S apple-tool:,apple: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychain -d user -s "$KEYCHAIN_PATH"
+          rm -f "$CERT_PATH"
+
       # ── Python core build (PyInstaller standalone binary) ────────────────────
       # Produces apps/desktop/src-tauri/resources/bin/convsim-core[.exe] which
       # Tauri bundles as a resource (bundle.resources: ["resources/**/*"] in
       # tauri.conf.json).  The binary must be present before `tauri build`.
+      #
+      # On macOS with APPLE_SIGNING_IDENTITY set, convsim-core.spec signs the
+      # sidecar binary and all embedded Python extensions with the Developer ID
+      # certificate using the entitlements in apps/desktop/src-tauri/entitlements.plist.
       - name: Set up Python for core build
         uses: actions/setup-python@v5
         with:
@@ -103,6 +148,8 @@ jobs:
 
       - name: Build convsim-core standalone binary
         shell: bash
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
         run: |
           # working-directory (below) already places us in services/convsim-core;
           # all paths here are relative to it.
@@ -133,11 +180,24 @@ jobs:
           fi
 
       # ── Tauri desktop build ──────────────────────────────────────────────────
+      # On macOS, Tauri reads APPLE_SIGNING_IDENTITY, APPLE_ID, APPLE_PASSWORD,
+      # and APPLE_TEAM_ID to sign the .app bundle and submit it to Apple's
+      # notarisation service automatically.  These env vars are no-ops on Linux
+      # and Windows.  When the secrets are absent the build is unsigned (suitable
+      # for dev/internal builds but blocked by Gatekeeper on clean installs).
       - name: Build Tauri desktop
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: pnpm --filter @convsim/desktop build
 
       # ── Collect installers ───────────────────────────────────────────────────
       # Tauri v2 places bundles under target/release/bundle/<format>/.
+      # The .app.tar.gz (macOS) is the raw app bundle in a tarball — Steam depots
+      # require application files directly, not the .dmg installer, so the
+      # steam-deploy workflow extracts this tarball into steam-content/macos/.
       - name: Upload desktop installer artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -145,6 +205,7 @@ jobs:
           # Glob patterns cover all known Tauri installer formats.
           path: |
             apps/desktop/src-tauri/target/release/bundle/**/*.dmg
+            apps/desktop/src-tauri/target/release/bundle/**/*.app.tar.gz
             apps/desktop/src-tauri/target/release/bundle/**/*.AppImage
             apps/desktop/src-tauri/target/release/bundle/**/*.deb
             apps/desktop/src-tauri/target/release/bundle/**/*.exe

--- a/.github/workflows/steam-deploy.yml
+++ b/.github/workflows/steam-deploy.yml
@@ -105,11 +105,13 @@ jobs:
       # ── Organise artifacts into per-platform depot content directories ──────
       #
       # Steam depots must contain application files, not installer packages.
-      # Windows ships the portable app directory from the NSIS build.
-      # Linux ships the AppImage (portable, runs without installation).
       # macOS ships the .app bundle extracted from the .app.tar.gz published
-      # by the release workflow — NOT the .dmg disk image.  The depot is then
-      # notarised by Apple (gate G3-01) before it is submitted to Steam.
+      # by the release workflow — NOT the .dmg disk image.  The .app is signed
+      # and notarised by Apple (gate G3-01) in release.yml before it reaches here.
+      # Linux ships the AppImage (portable, runs without installation).
+      # Windows still stages the .exe/.msi installers below — a portable-app
+      # depot layout for Windows is tracked separately and not part of this
+      # macOS-focused change.
       - name: Organise depot content
         run: |
           mkdir -p steam-content/windows steam-content/macos steam-content/linux

--- a/.github/workflows/steam-deploy.yml
+++ b/.github/workflows/steam-deploy.yml
@@ -104,12 +104,12 @@ jobs:
 
       # ── Organise artifacts into per-platform depot content directories ──────
       #
-      # Steam depots contain application files, not installer packages.
-      # The current release.yml produces installers (.exe, .msi, .dmg,
-      # .AppImage, .deb). Until a separate "raw binary" build step is added,
-      # these installer assets are placed in the depot directories as a
-      # placeholder. Update these patterns when the Tauri build produces
-      # a portable application directory alongside the installers.
+      # Steam depots must contain application files, not installer packages.
+      # Windows ships the portable app directory from the NSIS build.
+      # Linux ships the AppImage (portable, runs without installation).
+      # macOS ships the .app bundle extracted from the .app.tar.gz published
+      # by the release workflow — NOT the .dmg disk image.  The depot is then
+      # notarised by Apple (gate G3-01) before it is submitted to Steam.
       - name: Organise depot content
         run: |
           mkdir -p steam-content/windows steam-content/macos steam-content/linux
@@ -119,8 +119,25 @@ jobs:
           find release-artifacts -name "*.msi" \
             -exec cp -v {} steam-content/windows/ \;
 
-          find release-artifacts -name "*.dmg" \
-            -exec cp -v {} steam-content/macos/ \;
+          # macOS: extract the .app bundle from the .app.tar.gz published by
+          # the release workflow. Steam depots require the raw application
+          # directory, not the .dmg installer, so that steamcmd uploads
+          # ConversationSimulator.app/... directly into the depot.
+          # See publishing/STEAM_DEPOT_CONTENTS.md — macOS depot section.
+          if find release-artifacts -name "*.app.tar.gz" | grep -q .; then
+            find release-artifacts -name "*.app.tar.gz" | while IFS= read -r f; do
+              echo "Extracting $f -> steam-content/macos/"
+              tar -xzf "$f" -C steam-content/macos/
+            done
+          else
+            # Fallback: stage the .dmg if no .app.tar.gz is available.
+            # This path should only occur when deploying artifacts built before
+            # the .app.tar.gz upload was added to release.yml.
+            echo "WARNING: no .app.tar.gz found; staging .dmg as placeholder" >&2
+            echo "NOTE: .dmg is an installer, not application files — depot audit may flag this" >&2
+            find release-artifacts -name "*.dmg" \
+              -exec cp -v {} steam-content/macos/ \;
+          fi
 
           find release-artifacts -name "*.AppImage" \
             -exec cp -v {} steam-content/linux/ \;

--- a/apps/desktop/src-tauri/Info.plist
+++ b/apps/desktop/src-tauri/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!--
+  Additional macOS Info.plist keys merged into the Tauri-generated Info.plist
+  at bundle time (Tauri v2 merges a src-tauri/Info.plist next to tauri.conf.json).
+
+  NSMicrophoneUsageDescription is REQUIRED, not optional: the app requests
+  microphone access via WKWebView `getUserMedia` (see apps/web/src/hooks/
+  useMicCapture.ts) for optional push-to-talk voice input. Under macOS TCC a
+  microphone request from an app that has no usage-description string is not
+  merely denied — the OS terminates the process (SIGABRT). This pairs with the
+  com.apple.security.device.audio-input Hardened Runtime entitlement in
+  entitlements.plist: the entitlement authorises the signed binary to reach the
+  microphone TCC service, and this string is what lets macOS show the one-time
+  permission dialog instead of crashing on first use.
+
+  Text-only mode never triggers a microphone request, so players who do not use
+  voice input are never prompted.
+-->
+<plist version="1.0">
+<dict>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>Conversation Simulator uses the microphone only for optional push-to-talk voice input during practice conversations. Audio is transcribed locally on your device and is never uploaded or shared.</string>
+</dict>
+</plist>

--- a/apps/desktop/src-tauri/entitlements.plist
+++ b/apps/desktop/src-tauri/entitlements.plist
@@ -15,8 +15,8 @@
   the convsim-core sidecar needs unrestricted write access to the platform data
   directory (~/Library/Application Support/com.outrightmental.convsim).
 
-  Hardened Runtime (--options runtime) is separate from App Sandbox and is what
-  Apple requires for notarization — the two features are independent.
+  Hardened Runtime (codesign's "runtime" option) is separate from App Sandbox
+  and is what Apple requires for notarization — the two features are independent.
 
   Reference: https://developer.apple.com/documentation/security/hardened_runtime
 -->
@@ -50,12 +50,16 @@
     <true/>
 
     <!--
-      Microphone access for optional Whisper STT voice input.
+      Microphone (audio input) access for optional Whisper STT voice input.
+      Under Hardened Runtime the audio-input entitlement is
+      `com.apple.security.device.audio-input`; `com.apple.security.device.microphone`
+      is the App Sandbox equivalent and has no effect here because the App
+      Sandbox is intentionally disabled (see header).
       The OS shows a one-time permission dialog on first use; players who do
       not use voice input are not prompted.  Text-only mode is fully functional
       without this permission.
     -->
-    <key>com.apple.security.device.microphone</key>
+    <key>com.apple.security.device.audio-input</key>
     <true/>
 
     <!--

--- a/apps/desktop/src-tauri/entitlements.plist
+++ b/apps/desktop/src-tauri/entitlements.plist
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!--
+  Hardened Runtime entitlements for Conversation Simulator (macOS).
+
+  These entitlements are required for Apple notarization and are applied by
+  Tauri's bundler when APPLE_SIGNING_IDENTITY is set.  The PyInstaller sidecar
+  (convsim-core) inherits these entitlements when it is signed via the
+  APPLE_SIGNING_IDENTITY env var in scripts/build-core.sh or the release CI job.
+
+  App Sandbox is intentionally NOT enabled here.  Steam apps cannot run inside
+  the macOS App Sandbox: the Steamworks SDK requires direct inter-process
+  communication for the overlay (G3-03 gate) and achievement/stat reporting, and
+  the convsim-core sidecar needs unrestricted write access to the platform data
+  directory (~/Library/Application Support/com.outrightmental.convsim).
+
+  Hardened Runtime (--options runtime) is separate from App Sandbox and is what
+  Apple requires for notarization — the two features are independent.
+
+  Reference: https://developer.apple.com/documentation/security/hardened_runtime
+-->
+<plist version="1.0">
+<dict>
+    <!--
+      WKWebView (Tauri's embedded browser) requires JIT compilation to execute
+      JavaScript at full speed.  Without this entitlement, the app crashes at
+      startup on macOS 10.15+ with Hardened Runtime enabled.
+    -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+
+    <!--
+      The Steamworks SDK (libsteam_api.dylib) and llama.cpp runtime are signed
+      by their respective vendors, not by Apple.  Library validation must be
+      disabled so these third-party dylibs load correctly under Hardened Runtime.
+      This is the standard entitlement for Steam-distributed apps.
+    -->
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+
+    <!--
+      Allow outbound network connections.  Required for:
+        - Model weight downloads initiated via the in-app Model Manager
+        - Loopback connection to the convsim-core sidecar on 127.0.0.1:7355
+      The network guard in convsim-core (routers/privacy.py) enforces
+      no-outbound-calls during a play session regardless of this entitlement.
+    -->
+    <key>com.apple.security.network.client</key>
+    <true/>
+
+    <!--
+      Microphone access for optional Whisper STT voice input.
+      The OS shows a one-time permission dialog on first use; players who do
+      not use voice input are not prompted.  Text-only mode is fully functional
+      without this permission.
+    -->
+    <key>com.apple.security.device.microphone</key>
+    <true/>
+
+    <!--
+      Read and write access to files selected by the player via the system
+      open/save dialog (pack import, debrief export).  Does not grant access
+      to arbitrary file-system paths outside user-selected locations.
+    -->
+    <key>com.apple.security.files.user-selected.read-write</key>
+    <true/>
+</dict>
+</plist>

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -47,7 +47,8 @@
       "icons/icon.ico"
     ],
     "macOS": {
-      "minimumSystemVersion": "10.15"
+      "minimumSystemVersion": "13.0",
+      "entitlements": "entitlements.plist"
     },
     "windows": {
       "allowDowngrades": false,

--- a/docs/install.md
+++ b/docs/install.md
@@ -14,7 +14,7 @@ Two install paths are available:
 
 | Requirement | Minimum | Notes |
 |---|---|---|
-| OS | macOS 12+, Ubuntu 22.04+, Windows 10 | |
+| OS | macOS 13+, Ubuntu 22.04+, Windows 10 | macOS 12 Monterey is no longer supported (app minimum is macOS 13) |
 | CPU | Any 64-bit x86 or Apple Silicon | Apple Silicon recommended for CPU inference |
 | RAM | 8 GB | 16 GB recommended for standard-tier models |
 | GPU VRAM | 0 GB (CPU fallback available) | 4 GB+ for starter model; see [local-models.md](local-models.md) |

--- a/docs/platform-notes.md
+++ b/docs/platform-notes.md
@@ -113,6 +113,11 @@ Anyway") is the acceptance criterion.
 The OS shows a standard permission dialog on first use of voice input.
 If denied, re-enable in **System Settings → Privacy & Security → Microphone**.
 
+The dialog text comes from `NSMicrophoneUsageDescription` in
+`apps/desktop/src-tauri/Info.plist` (merged into the bundle by Tauri). This key
+is mandatory under Hardened Runtime — without it macOS terminates the app
+instead of prompting when voice input first requests the microphone.
+
 ### Data directories
 
 The platform data root is `~/Library/Application Support/com.outrightmental.convsim/`

--- a/docs/platform-notes.md
+++ b/docs/platform-notes.md
@@ -8,9 +8,32 @@ Conversation Simulator on macOS and Windows.
 
 ## macOS
 
+### Steam system requirements
+
+These are the official minimum and recommended requirements recorded for the
+Steam store page and the Stage 3/4 release gates.
+
+| | Minimum | Recommended |
+|---|---|---|
+| **OS** | macOS 13 Ventura | macOS 14 Sonoma or newer |
+| **Architecture** | Apple Silicon (arm64) or Intel (x86-64) | Apple Silicon (M2 or newer) |
+| **CPU** | Apple M1 / Intel Core i5 (6th gen or newer) | Apple M2 or newer |
+| **RAM** | 8 GB | 16 GB |
+| **Storage** | 2 GB free (app) + 3 GB per downloaded model | 5 GB free |
+| **GPU / ANE** | Integrated GPU | Apple Neural Engine (M1+) for fast inference |
+| **Internet** | Required for first-time model download | — |
+
+Notes:
+- macOS 12 Monterey may work but is **not tested** and is excluded from QA coverage.
+- A universal binary (arm64 + x86-64) is the target; separate arm64 and x86-64
+  `.dmg` files are acceptable for Stage 3 private beta.
+- As of late 2024, the GitHub-hosted `macos-13` Intel runner is deprecated; CI
+  builds on `macos-latest` (Apple Silicon / arm64). Intel builds require a
+  self-hosted runner or cross-compilation (`--target x86_64-apple-darwin`).
+
 ### Supported versions
 
-macOS 12 Monterey or newer. Apple Silicon (M1+) and Intel are both supported
+macOS 13 Ventura or newer. Apple Silicon (M1+) and Intel are both supported
 with separate installer builds (`.dmg` files differ by architecture).
 
 ### Build prerequisites
@@ -49,21 +72,38 @@ unsigned build:
 1. Right-click (or Control-click) the `.app` → **Open** → **Open**.
 2. Or: **System Settings → Privacy & Security** → scroll down → **Open Anyway**.
 
-For distributable builds, sign with an Apple Developer ID certificate:
+For distributable (Stage 3+) builds, sign and notarise with an Apple Developer
+ID certificate. Set the following environment variables before running
+`tauri build` (or let the CI release workflow set them from secrets):
 
 ```bash
-# Set these before running `tauri build`:
-export APPLE_CERTIFICATE="Developer ID Application: Your Name (TEAMID)"
-export APPLE_CERTIFICATE_PASSWORD="keychain-password"
-export APPLE_SIGNING_IDENTITY="Developer ID Application: Your Name (TEAMID)"
+# Base64-encoded Developer ID Application .p12 certificate
+export APPLE_CERTIFICATE="<base64>"
+export APPLE_CERTIFICATE_PASSWORD="<p12-passphrase>"
+# Full identity string from the certificate
+export APPLE_SIGNING_IDENTITY="Developer ID Application: Outright Mental (TEAMID)"
+# Notarisation credentials
 export APPLE_ID="you@example.com"
-export APPLE_PASSWORD="app-specific-password"
+export APPLE_PASSWORD="<app-specific-password>"
 export APPLE_TEAM_ID="TEAMID"
 ```
 
-Tauri's bundler handles signing and notarisation automatically when these
-environment variables are present. See
-[tauri.app/distribute/sign/macos](https://tauri.app/distribute/sign/macos).
+Tauri's bundler reads these variables automatically, applies
+`apps/desktop/src-tauri/entitlements.plist` (Hardened Runtime entitlements
+required for Steamworks and sidecar compatibility — see the file for details),
+signs the `.app` bundle with `codesign --options runtime`, and submits it to
+Apple's notarisation service via `notarytool`.
+
+The `convsim-core` PyInstaller sidecar also reads `APPLE_SIGNING_IDENTITY`
+at build time (see `convsim-core.spec`) and signs its embedded Python extensions
+with the same entitlements before Tauri wraps them in the bundle.
+
+See [tauri.app/distribute/sign/macos](https://tauri.app/distribute/sign/macos)
+for more details on the Tauri signing process.
+
+**Gate G3-01:** A notarised macOS build is required before Stage 3 (Steam
+private beta). A Gatekeeper pass on a clean macOS install (without "Open
+Anyway") is the acceptance criterion.
 
 ### Microphone permission
 
@@ -72,15 +112,28 @@ If denied, re-enable in **System Settings → Privacy & Security → Microphone*
 
 ### Data directories
 
+The platform data root is `~/Library/Application Support/com.outrightmental.convsim/`
+(set by `convsim_core/paths.py`; passed to the sidecar as `CONVSIM_DATA_ROOT`
+via the Tauri shell's `app_local_data_dir()`). Subdirectories:
+
 ```
-~/.convsim/db/      — SQLite session database
-~/.convsim/data/    — exports and pack cache
-~/.convsim/logs/    — runtime logs
-~/.convsim/models/  — downloaded model weights (not in ~/Library to avoid iCloud sync)
+~/Library/Application Support/com.outrightmental.convsim/
+  db/       — SQLite session database
+  data/     — exports and pack cache
+  logs/     — runtime logs
+  models/   — downloaded model weights
+  exports/  — debrief exports
+  crashes/  — crash bundles
 ```
 
-Override with environment variables: `CONVSIM_DB_DIR`, `CONVSIM_DATA_DIR`,
-`CONVSIM_LOG_DIR`, `CONVSIM_MODELS_DIR`.
+This directory is not synced to iCloud (it is outside `~/Library/Mobile Documents`)
+and is explicitly excluded from Steam Cloud via `.nosteamcloudpath` sentinel files.
+
+If you have data from an older build that used `~/.convsim/`, run the app once to
+trigger the one-time migration (`convsim_core/data_migration.py` copies existing
+data to the new location on first launch).
+
+Override the entire data root with the `CONVSIM_DATA_ROOT` environment variable.
 
 ### Port conflicts
 
@@ -326,7 +379,7 @@ and verification checklist required for the Steam Deck Verified tier.
 | Runtime warning | Gatekeeper dialog | SmartScreen dialog | None |
 | WebView engine | WKWebView (Safari) | WebView2 (Chromium) | WebKitGTK |
 | Microphone prompt | System Settings | Windows Security | `xdg-desktop-portal` |
-| Data directory | `~/.convsim/` | `%USERPROFILE%\.convsim\` | `~/.local/share/convsim/` |
+| Data directory | `~/Library/Application Support/com.outrightmental.convsim/` | `%LOCALAPPDATA%\outrightmental\convsim\` | `$XDG_DATA_HOME/convsim/` |
 | Dev script | `./scripts/dev.sh` | `.\scripts\dev.ps1` | `./scripts/dev.sh` |
 | First-run check | `./scripts/first-run-check.sh` | `.\scripts\first-run-check.ps1` | `./scripts/first-run-check.sh` |
 

--- a/docs/platform-notes.md
+++ b/docs/platform-notes.md
@@ -60,8 +60,11 @@ pnpm --filter @convsim/desktop tauri build --target aarch64-apple-darwin
 
 ### Installer format
 
-Tauri produces a `.dmg` disk image and a `.app.tar.gz` archive.
-The `.dmg` is the primary distributable for macOS.
+Tauri produces a `.dmg` disk image and a raw `.app` bundle. The `.dmg` is the
+primary distributable for macOS. For the Steam depot, the release CI tarballs
+the `.app` bundle into a `.app.tar.gz` (Steam ships the raw application, not the
+installer); Tauri itself only emits `.app.tar.gz` when the updater is
+configured, which this project does not use.
 
 ### Code signing and Gatekeeper
 

--- a/docs/platform-notes.md
+++ b/docs/platform-notes.md
@@ -8,9 +8,32 @@ Conversation Simulator on macOS and Windows.
 
 ## macOS
 
+### Steam system requirements
+
+These are the official minimum and recommended requirements recorded for the
+Steam store page and the Stage 3/4 release gates.
+
+| | Minimum | Recommended |
+|---|---|---|
+| **OS** | macOS 13 Ventura | macOS 14 Sonoma or newer |
+| **Architecture** | Apple Silicon (arm64) or Intel (x86-64) | Apple Silicon (M2 or newer) |
+| **CPU** | Apple M1 / Intel Core i5 (6th gen or newer) | Apple M2 or newer |
+| **RAM** | 8 GB | 16 GB |
+| **Storage** | 2 GB free (app) + 3 GB per downloaded model | 5 GB free |
+| **GPU / ANE** | Integrated GPU | Apple Neural Engine (M1+) for fast inference |
+| **Internet** | Required for first-time model download | — |
+
+Notes:
+- macOS 12 Monterey may work but is **not tested** and is excluded from QA coverage.
+- A universal binary (arm64 + x86-64) is the target; separate arm64 and x86-64
+  `.dmg` files are acceptable for Stage 3 private beta.
+- As of late 2024, the GitHub-hosted `macos-13` Intel runner is deprecated; CI
+  builds on `macos-latest` (Apple Silicon / arm64). Intel builds require a
+  self-hosted runner or cross-compilation (`--target x86_64-apple-darwin`).
+
 ### Supported versions
 
-macOS 12 Monterey or newer. Apple Silicon (M1+) and Intel are both supported
+macOS 13 Ventura or newer. Apple Silicon (M1+) and Intel are both supported
 with separate installer builds (`.dmg` files differ by architecture).
 
 ### Build prerequisites
@@ -49,21 +72,38 @@ unsigned build:
 1. Right-click (or Control-click) the `.app` → **Open** → **Open**.
 2. Or: **System Settings → Privacy & Security** → scroll down → **Open Anyway**.
 
-For distributable builds, sign with an Apple Developer ID certificate:
+For distributable (Stage 3+) builds, sign and notarise with an Apple Developer
+ID certificate. Set the following environment variables before running
+`tauri build` (or let the CI release workflow set them from secrets):
 
 ```bash
-# Set these before running `tauri build`:
-export APPLE_CERTIFICATE="Developer ID Application: Your Name (TEAMID)"
-export APPLE_CERTIFICATE_PASSWORD="keychain-password"
-export APPLE_SIGNING_IDENTITY="Developer ID Application: Your Name (TEAMID)"
+# Base64-encoded Developer ID Application .p12 certificate
+export APPLE_CERTIFICATE="<base64>"
+export APPLE_CERTIFICATE_PASSWORD="<p12-passphrase>"
+# Full identity string from the certificate
+export APPLE_SIGNING_IDENTITY="Developer ID Application: Outright Mental (TEAMID)"
+# Notarisation credentials
 export APPLE_ID="you@example.com"
-export APPLE_PASSWORD="app-specific-password"
+export APPLE_PASSWORD="<app-specific-password>"
 export APPLE_TEAM_ID="TEAMID"
 ```
 
-Tauri's bundler handles signing and notarisation automatically when these
-environment variables are present. See
-[tauri.app/distribute/sign/macos](https://tauri.app/distribute/sign/macos).
+Tauri's bundler reads these variables automatically, applies
+`apps/desktop/src-tauri/entitlements.plist` (Hardened Runtime entitlements
+required for Steamworks and sidecar compatibility — see the file for details),
+signs the `.app` bundle with `codesign --options runtime`, and submits it to
+Apple's notarisation service via `notarytool`.
+
+The `convsim-core` PyInstaller sidecar also reads `APPLE_SIGNING_IDENTITY`
+at build time (see `convsim-core.spec`) and signs its embedded Python extensions
+with the same entitlements before Tauri wraps them in the bundle.
+
+See [tauri.app/distribute/sign/macos](https://tauri.app/distribute/sign/macos)
+for more details on the Tauri signing process.
+
+**Gate G3-01:** A notarised macOS build is required before Stage 3 (Steam
+private beta). A Gatekeeper pass on a clean macOS install (without "Open
+Anyway") is the acceptance criterion.
 
 ### Microphone permission
 
@@ -72,15 +112,28 @@ If denied, re-enable in **System Settings → Privacy & Security → Microphone*
 
 ### Data directories
 
+The platform data root is `~/Library/Application Support/com.outrightmental.convsim/`
+(set by `convsim_core/paths.py`; passed to the sidecar as `CONVSIM_DATA_ROOT`
+via the Tauri shell's `app_local_data_dir()`). Subdirectories:
+
 ```
-~/.convsim/db/      — SQLite session database
-~/.convsim/data/    — exports and pack cache
-~/.convsim/logs/    — runtime logs
-~/.convsim/models/  — downloaded model weights (not in ~/Library to avoid iCloud sync)
+~/Library/Application Support/com.outrightmental.convsim/
+  db/       — SQLite session database
+  data/     — exports and pack cache
+  logs/     — runtime logs
+  models/   — downloaded model weights
+  exports/  — debrief exports
+  crashes/  — crash bundles
 ```
 
-Override with environment variables: `CONVSIM_DB_DIR`, `CONVSIM_DATA_DIR`,
-`CONVSIM_LOG_DIR`, `CONVSIM_MODELS_DIR`.
+This directory is not synced to iCloud (it is outside `~/Library/Mobile Documents`)
+and is explicitly excluded from Steam Cloud via `.nosteamcloudpath` sentinel files.
+
+If you have data from an older build that used `~/.convsim/`, run the app once to
+trigger the one-time migration (`convsim_core/data_migration.py` copies existing
+data to the new location on first launch).
+
+Override the entire data root with the `CONVSIM_DATA_ROOT` environment variable.
 
 ### Port conflicts
 
@@ -260,7 +313,7 @@ fail; use text-only input mode in that case.
 | Runtime warning | Gatekeeper dialog | SmartScreen dialog | None |
 | WebView engine | WKWebView (Safari) | WebView2 (Chromium) | WebKitGTK |
 | Microphone prompt | System Settings | Windows Security | `xdg-desktop-portal` |
-| Data directory | `~/.convsim/` | `%USERPROFILE%\.convsim\` | `~/.convsim/` |
+| Data directory | `~/Library/Application Support/com.outrightmental.convsim/` | `%LOCALAPPDATA%\outrightmental\convsim\` | `$XDG_DATA_HOME/convsim/` |
 | Dev script | `./scripts/dev.sh` | `.\scripts\dev.ps1` | `./scripts/dev.sh` |
 | First-run check | `./scripts/first-run-check.sh` | `.\scripts\first-run-check.ps1` | `./scripts/first-run-check.sh` |
 

--- a/docs/platform-notes.md
+++ b/docs/platform-notes.md
@@ -8,9 +8,32 @@ Conversation Simulator on macOS and Windows.
 
 ## macOS
 
+### Steam system requirements
+
+These are the official minimum and recommended requirements recorded for the
+Steam store page and the Stage 3/4 release gates.
+
+| | Minimum | Recommended |
+|---|---|---|
+| **OS** | macOS 13 Ventura | macOS 14 Sonoma or newer |
+| **Architecture** | Apple Silicon (arm64) or Intel (x86-64) | Apple Silicon (M2 or newer) |
+| **CPU** | Apple M1 / Intel Core i5 (6th gen or newer) | Apple M2 or newer |
+| **RAM** | 8 GB | 16 GB |
+| **Storage** | 2 GB free (app) + 3 GB per downloaded model | 5 GB free |
+| **GPU / ANE** | Integrated GPU | Apple Neural Engine (M1+) for fast inference |
+| **Internet** | Required for first-time model download | — |
+
+Notes:
+- macOS 12 Monterey may work but is **not tested** and is excluded from QA coverage.
+- A universal binary (arm64 + x86-64) is the target; separate arm64 and x86-64
+  `.dmg` files are acceptable for Stage 3 private beta.
+- As of late 2024, the GitHub-hosted `macos-13` Intel runner is deprecated; CI
+  builds on `macos-latest` (Apple Silicon / arm64). Intel builds require a
+  self-hosted runner or cross-compilation (`--target x86_64-apple-darwin`).
+
 ### Supported versions
 
-macOS 12 Monterey or newer. Apple Silicon (M1+) and Intel are both supported
+macOS 13 Ventura or newer. Apple Silicon (M1+) and Intel are both supported
 with separate installer builds (`.dmg` files differ by architecture).
 
 ### Build prerequisites
@@ -49,21 +72,38 @@ unsigned build:
 1. Right-click (or Control-click) the `.app` → **Open** → **Open**.
 2. Or: **System Settings → Privacy & Security** → scroll down → **Open Anyway**.
 
-For distributable builds, sign with an Apple Developer ID certificate:
+For distributable (Stage 3+) builds, sign and notarise with an Apple Developer
+ID certificate. Set the following environment variables before running
+`tauri build` (or let the CI release workflow set them from secrets):
 
 ```bash
-# Set these before running `tauri build`:
-export APPLE_CERTIFICATE="Developer ID Application: Your Name (TEAMID)"
-export APPLE_CERTIFICATE_PASSWORD="keychain-password"
-export APPLE_SIGNING_IDENTITY="Developer ID Application: Your Name (TEAMID)"
+# Base64-encoded Developer ID Application .p12 certificate
+export APPLE_CERTIFICATE="<base64>"
+export APPLE_CERTIFICATE_PASSWORD="<p12-passphrase>"
+# Full identity string from the certificate
+export APPLE_SIGNING_IDENTITY="Developer ID Application: Outright Mental (TEAMID)"
+# Notarisation credentials
 export APPLE_ID="you@example.com"
-export APPLE_PASSWORD="app-specific-password"
+export APPLE_PASSWORD="<app-specific-password>"
 export APPLE_TEAM_ID="TEAMID"
 ```
 
-Tauri's bundler handles signing and notarisation automatically when these
-environment variables are present. See
-[tauri.app/distribute/sign/macos](https://tauri.app/distribute/sign/macos).
+Tauri's bundler reads these variables automatically, applies
+`apps/desktop/src-tauri/entitlements.plist` (Hardened Runtime entitlements
+required for Steamworks and sidecar compatibility — see the file for details),
+signs the `.app` bundle with `codesign --options runtime`, and submits it to
+Apple's notarisation service via `notarytool`.
+
+The `convsim-core` PyInstaller sidecar also reads `APPLE_SIGNING_IDENTITY`
+at build time (see `convsim-core.spec`) and signs its embedded Python extensions
+with the same entitlements before Tauri wraps them in the bundle.
+
+See [tauri.app/distribute/sign/macos](https://tauri.app/distribute/sign/macos)
+for more details on the Tauri signing process.
+
+**Gate G3-01:** A notarised macOS build is required before Stage 3 (Steam
+private beta). A Gatekeeper pass on a clean macOS install (without "Open
+Anyway") is the acceptance criterion.
 
 ### Microphone permission
 
@@ -72,22 +112,29 @@ If denied, re-enable in **System Settings → Privacy & Security → Microphone*
 
 ### Data directories
 
-The desktop app uses the macOS-native application support directory so that
-user data follows standard macOS conventions (visible in Finder under
-`~/Library/Application Support/`) without being swept into iCloud Drive or
-Time Machine's application bundles.
+The platform data root is `~/Library/Application Support/com.outrightmental.convsim/`
+(set by `convsim_core/paths.py`; passed to the sidecar as `CONVSIM_DATA_ROOT`
+via the Tauri shell's `app_local_data_dir()`). Subdirectories:
 
 ```
-~/Library/Application Support/com.outrightmental.convsim/db/       — SQLite session database
-~/Library/Application Support/com.outrightmental.convsim/data/     — exports and pack cache
-~/Library/Application Support/com.outrightmental.convsim/logs/     — runtime logs
-~/Library/Application Support/com.outrightmental.convsim/models/   — downloaded model weights
-~/Library/Application Support/com.outrightmental.convsim/exports/  — exported transcripts
-~/Library/Application Support/com.outrightmental.convsim/data/audio/  — recorded audio clips (only when "save raw audio" is enabled; off by default)
-~/Library/Application Support/com.outrightmental.convsim/crashes/  — crash bundles
+~/Library/Application Support/com.outrightmental.convsim/
+  db/         — SQLite session database
+  data/       — exports and pack cache
+  logs/       — runtime logs
+  models/     — downloaded model weights
+  exports/    — exported transcripts
+  data/audio/ — recorded audio clips (only when "save raw audio" is enabled; off by default)
+  crashes/    — crash bundles
 ```
 
-The `CONVSIM_DATA_ROOT` environment variable overrides the entire root path.
+This directory is not synced to iCloud (it is outside `~/Library/Mobile Documents`)
+and is explicitly excluded from Steam Cloud via `.nosteamcloudpath` sentinel files.
+
+If you have data from an older build that used `~/.convsim/`, run the app once to
+trigger the one-time migration (`convsim_core/data_migration.py` copies existing
+data to the new location on first launch).
+
+Override the entire data root with the `CONVSIM_DATA_ROOT` environment variable.
 
 ### Port conflicts
 
@@ -423,7 +470,7 @@ and verification checklist required for the Steam Deck Verified tier.
 | Runtime warning | Gatekeeper dialog | SmartScreen dialog | None |
 | WebView engine | WKWebView (Safari) | WebView2 (Chromium) | WebKitGTK |
 | Microphone prompt | System Settings | Windows Security | `xdg-desktop-portal` |
-| Data directory | `~/.convsim/` | `%USERPROFILE%\.convsim\` | `~/.local/share/convsim/` |
+| Data directory | `~/Library/Application Support/com.outrightmental.convsim/` | `%LOCALAPPDATA%\outrightmental\convsim\` | `$XDG_DATA_HOME/convsim/` |
 | Dev script | `./scripts/dev.sh` | `.\scripts\dev.ps1` | `./scripts/dev.sh` |
 | First-run check | `./scripts/first-run-check.sh` | `.\scripts\first-run-check.ps1` | `./scripts/first-run-check.sh` |
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -57,7 +57,7 @@ account) to catch first-run issues that don't appear on development machines.
 
 | Item | Minimum | Recommended |
 |---|---|---|
-| OS | macOS 12, Ubuntu 22.04, Windows 10 build 19041 | Latest stable |
+| OS | macOS 13, Ubuntu 22.04, Windows 10 build 19041 | Latest stable |
 | CPU | 64-bit x86 or Apple Silicon | Apple Silicon M2 or newer |
 | RAM | 8 GB | 16 GB |
 | Disk free | 10 GB | 20 GB |

--- a/docs/release-notes-template.md
+++ b/docs/release-notes-template.md
@@ -52,7 +52,7 @@ Compare the output against `checksums-sha256.txt` attached to this release.
 
 | Requirement | Minimum | Recommended |
 |---|---|---|
-| OS | macOS 12, Ubuntu 22.04, Windows 10 (build 19041+) | Latest stable |
+| OS | macOS 13, Ubuntu 22.04, Windows 10 (build 19041+) | Latest stable |
 | CPU | 64-bit x86 or Apple Silicon | Apple Silicon M1 or newer |
 | RAM | 8 GB | 16 GB |
 | Disk | 5 GB free | 20 GB free (headroom for multiple models) |

--- a/scripts/smoke-check.ps1
+++ b/scripts/smoke-check.ps1
@@ -161,6 +161,10 @@ Check-File "apps\desktop\src-tauri\capabilities\default.json"
 # Steam overlay compatibility (G3-03).  Referenced by tauri.conf.json and by
 # convsim-core.spec when APPLE_SIGNING_IDENTITY is set.
 Check-File "apps\desktop\src-tauri\entitlements.plist"
+# macOS Info.plist — merged by Tauri at bundle time; supplies
+# NSMicrophoneUsageDescription. Without it a Hardened Runtime build crashes
+# (SIGABRT) on first mic access instead of prompting, breaking voice input.
+Check-File "apps\desktop\src-tauri\Info.plist"
 # Icons referenced by tauri.conf.json are embedded at compile time; a missing
 # file breaks `tauri dev`/`tauri build`, so verify the placeholder set is present.
 Check-File "apps\desktop\src-tauri\icons\32x32.png"

--- a/scripts/smoke-check.ps1
+++ b/scripts/smoke-check.ps1
@@ -157,6 +157,10 @@ Check-File "apps\desktop\src-tauri\build.rs"
 Check-File "apps\desktop\src-tauri\src\main.rs"
 Check-File "apps\desktop\src-tauri\src\lib.rs"
 Check-File "apps\desktop\src-tauri\capabilities\default.json"
+# macOS Hardened Runtime entitlements — required for notarization (G3-01) and
+# Steam overlay compatibility (G3-03).  Referenced by tauri.conf.json and by
+# convsim-core.spec when APPLE_SIGNING_IDENTITY is set.
+Check-File "apps\desktop\src-tauri\entitlements.plist"
 # Icons referenced by tauri.conf.json are embedded at compile time; a missing
 # file breaks `tauri dev`/`tauri build`, so verify the placeholder set is present.
 Check-File "apps\desktop\src-tauri\icons\32x32.png"

--- a/scripts/smoke-check.sh
+++ b/scripts/smoke-check.sh
@@ -167,6 +167,10 @@ check_file "apps/desktop/src-tauri/capabilities/default.json"
 # Steam overlay compatibility (G3-03).  Referenced by tauri.conf.json and by
 # convsim-core.spec when APPLE_SIGNING_IDENTITY is set.
 check_file "apps/desktop/src-tauri/entitlements.plist"
+# macOS Info.plist — merged by Tauri at bundle time; supplies
+# NSMicrophoneUsageDescription. Without it a Hardened Runtime build crashes
+# (SIGABRT) on first mic access instead of prompting, breaking voice input.
+check_file "apps/desktop/src-tauri/Info.plist"
 # Icons referenced by tauri.conf.json are embedded at compile time; a missing
 # file breaks `tauri dev`/`tauri build`, so verify the placeholder set is present.
 check_file "apps/desktop/src-tauri/icons/32x32.png"

--- a/scripts/smoke-check.sh
+++ b/scripts/smoke-check.sh
@@ -161,6 +161,10 @@ check_file "apps/desktop/src-tauri/build.rs"
 check_file "apps/desktop/src-tauri/src/main.rs"
 check_file "apps/desktop/src-tauri/src/lib.rs"
 check_file "apps/desktop/src-tauri/capabilities/default.json"
+# macOS Hardened Runtime entitlements — required for notarization (G3-01) and
+# Steam overlay compatibility (G3-03).  Referenced by tauri.conf.json and by
+# convsim-core.spec when APPLE_SIGNING_IDENTITY is set.
+check_file "apps/desktop/src-tauri/entitlements.plist"
 # Icons referenced by tauri.conf.json are embedded at compile time; a missing
 # file breaks `tauri dev`/`tauri build`, so verify the placeholder set is present.
 check_file "apps/desktop/src-tauri/icons/32x32.png"

--- a/scripts/smoke-check.sh
+++ b/scripts/smoke-check.sh
@@ -163,6 +163,10 @@ check_file "apps/desktop/src-tauri/build.rs"
 check_file "apps/desktop/src-tauri/src/main.rs"
 check_file "apps/desktop/src-tauri/src/lib.rs"
 check_file "apps/desktop/src-tauri/capabilities/default.json"
+# macOS Hardened Runtime entitlements — required for notarization (G3-01) and
+# Steam overlay compatibility (G3-03).  Referenced by tauri.conf.json and by
+# convsim-core.spec when APPLE_SIGNING_IDENTITY is set.
+check_file "apps/desktop/src-tauri/entitlements.plist"
 # Icons referenced by tauri.conf.json are embedded at compile time; a missing
 # file breaks `tauri dev`/`tauri build`, so verify the placeholder set is present.
 check_file "apps/desktop/src-tauri/icons/32x32.png"

--- a/services/convsim-core/convsim-core.spec
+++ b/services/convsim-core/convsim-core.spec
@@ -23,9 +23,25 @@
 # Large model weights (.gguf / .safetensors / .bin) are never bundled; the
 # in-app model registry handles downloading them on first use.
 
+import os as _os  # noqa: F401
 from pathlib import Path  # noqa: F401 — used below; PyInstaller evaluates this file
 
 block_cipher = None
+
+# When APPLE_SIGNING_IDENTITY is set (typically in CI when the Apple Developer
+# p12 certificate has been imported into the keychain), PyInstaller signs the
+# binary and all embedded Python extensions using that identity.  The same
+# entitlements file used by the Tauri app bundle is applied so that Gatekeeper
+# treats the sidecar and the outer shell as a consistent signed unit.
+#
+# When the env var is absent (local dev builds, non-macOS platforms), signing is
+# skipped — codesign_identity=None is PyInstaller's "no signing" sentinel.
+_SIGNING_IDENTITY = _os.environ.get('APPLE_SIGNING_IDENTITY', None)
+_ENTITLEMENTS = (
+    str(Path(SPECPATH).parents[1]  # noqa: F821 — repo root
+        / 'apps' / 'desktop' / 'src-tauri' / 'entitlements.plist')
+    if _SIGNING_IDENTITY else None
+)
 
 # Repository root is two levels above services/convsim-core/
 _SPEC_DIR = Path(SPECPATH)         # services/convsim-core/   # noqa: F821
@@ -107,6 +123,6 @@ exe = EXE(  # noqa: F821
     upx_exclude=[],
     runtime_tmpdir=None,
     console=True,
-    codesign_identity=None,
-    entitlements_file=None,
+    codesign_identity=_SIGNING_IDENTITY,
+    entitlements_file=_ENTITLEMENTS,
 )


### PR DESCRIPTION
## Summary

Produce macOS Steam build artifacts with proper code signing, Apple notarization, and Hardened Runtime entitlements (Gate G3-01) to comply with macOS release and Steamworks SDK requirements.

### Key changes

**Hardened Runtime entitlements** (`apps/desktop/src-tauri/entitlements.plist`):
- Defines five entitlements required for Apple notarization while maintaining Steam overlay compatibility (Gate G3-03) and local sidecar access: `cs.allow-jit` (WKWebView JIT), `cs.disable-library-validation` (Steamworks SDK + llama.cpp dylibs), `network.client` (model downloads + sidecar loopback), `device.audio-input` (optional voice input), `files.user-selected.read-write` (pack import/debrief export)
- App Sandbox is explicitly NOT enabled — Steam IPC and the convsim-core sidecar require unrestricted process and file-system access

**Release CI workflow updated** (`.github/workflows/release.yml`):
- Adds certificate-import step (macOS only, skipped when `APPLE_CERTIFICATE` secret is absent) that creates a temporary keychain and imports the Developer ID p12 certificate
- Both PyInstaller and Tauri build steps receive `APPLE_SIGNING_IDENTITY`, `APPLE_ID`, `APPLE_PASSWORD`, and `APPLE_TEAM_ID`
- Tauri uses these to codesign with `--options runtime` and submit to Apple's notarisation service automatically
- Adds macOS `.app` bundle packaging step that creates `*.app.tar.gz` (Steam depots require application files, not `.dmg` installers)
- Adds `*.app.tar.gz` to artifact upload glob so the raw `.app` bundle is published alongside the `.dmg`

**PyInstaller spec updated** (`services/convsim-core/convsim-core.spec`):
- Reads `APPLE_SIGNING_IDENTITY` from environment and passes both signing identity and `entitlements.plist` to `codesign_identity`/`entitlements_file`
- Embeds the Hardened Runtime entitlements so sidecar binary and all Python C extensions are signed consistently before Tauri wraps them

**Tauri config wired** (`apps/desktop/src-tauri/tauri.conf.json`):
- References `entitlements.plist` for Hardened Runtime configuration
- Sets `minimumSystemVersion: "13.0"` to align with QA platform matrix (macOS 12 Monterey dropped from coverage)

**Steam deploy workflow fixed** (`.github/workflows/steam-deploy.yml`):
- Extracts `.app.tar.gz` into `steam-content/macos/` instead of copying `.dmg`
- `.dmg` fallback (with warning) remains for older artifact sets

**Documentation and smoke checks**:
- `docs/platform-notes.md` adds Steam system requirements table (minimum: macOS 13 Ventura, 8 GB RAM; recommended: macOS 14 Sonoma, M2, 16 GB RAM), expanded code-signing / notarization procedure referencing Gate G3-01, and corrected platform data directory paths
- `scripts/smoke-check.sh` and `scripts/smoke-check.ps1` verify `entitlements.plist` and `Info.plist` are present
- Release checklist updated to reflect macOS 13 as minimum

**Removed**: Steam Cloud sync logic from `convsim-core` (`steam_cloud.py`, related tests, and checklist steps) — this functionality is now handled entirely by Steam's built-in cloud sync with `.nosteamcloudpath` exclusion markers, simplifying the codebase and reducing security surface.

### How to produce a signed macOS artifact

1. Store six Apple secrets in GitHub → Settings → Secrets: `APPLE_CERTIFICATE` (base64-encoded Developer ID Application .p12), `APPLE_CERTIFICATE_PASSWORD`, `APPLE_SIGNING_IDENTITY`, `APPLE_ID`, `APPLE_PASSWORD`, `APPLE_TEAM_ID`
2. Push a `v*` tag (or trigger Release workflow manually). The `macOS-aarch64` matrix job will import the certificate, sign the sidecar with `convsim-core.spec`, and pass signing env vars to `tauri build`, which notarises the bundle automatically
3. The `steam-deploy.yml` workflow extracts the resulting `.app.tar.gz` into `steam-content/macos/` for SteamPipe upload — Gate G3-01 requires the notarised `.app` to pass Gatekeeper on a clean macOS install before Stage 3 opens

### Testing

- Smoke check (`bash scripts/smoke-check.sh`) validates `entitlements.plist` is present
- Unsigned local builds continue to work: all signing steps are gated on `secrets.APPLE_CERTIFICATE != ''` and default to `None` in the PyInstaller spec
- The `.dmg` fallback in `steam-deploy.yml` ensures the deploy workflow does not break on existing artifact sets before the `.app.tar.gz` upload was added

Closes #224