### PR TITLE
Add moment replay and branch retry: fork any session at any completed turn

### DIFF
--- a/packages/shared/src/types/session.ts
+++ b/packages/shared/src/types/session.ts
@@ -146,3 +146,37 @@ export interface SessionTransitionError {
   message: string;
   current_state?: SessionState;
 }
+
+export interface BranchSessionRequest {
+  /** 1-indexed game turn to retry; copies parent transcript up to turn N-1. */
+  fork_turn_number: number;
+}
+
+export interface BranchSessionResponse {
+  branch_session_id: string;
+  parent_session_id: string;
+  fork_turn_number: number;
+  state: SessionState;
+  created_at: string;
+}
+
+export interface SessionCompareSummary {
+  session_id: string;
+  outcome: string | null;
+  total_turns: number;
+  overall_score: number | null;
+  headline_metrics: {
+    talk_ratio: number | null;
+    open_questions: number | null;
+    words_per_turn_player: number | null;
+    response_latency_p50_ms: number | null;
+  } | null;
+}
+
+export interface SessionCompareResponse {
+  parent_session_id: string;
+  branch_session_id: string;
+  fork_turn_number: number;
+  parent: SessionCompareSummary;
+  branch: SessionCompareSummary;
+}

--- a/services/convsim-core/convsim_core/routers/sessions.py
+++ b/services/convsim-core/convsim_core/routers/sessions.py
@@ -26,6 +26,7 @@ from pydantic import BaseModel, field_validator
 
 from convsim_core.scenario_state import build_variable_defs, partition_state_by_visibility
 from convsim_core.scenarios import get_scenario_info
+from convsim_core.services.branch_service import fork_session
 from convsim_core.services.debrief_engine import generate_debrief
 from convsim_core.services.transcript_export import format_transcript_as_markdown
 from convsim_core.services.tts_queue import synthesize_utterance
@@ -220,6 +221,34 @@ class DebriefResponse(BaseModel):
     generated_at: str
     used_fallback: bool
     metrics: Optional[Dict[str, Any]] = None
+
+
+class BranchSessionRequest(BaseModel):
+    fork_turn_number: int
+
+
+class BranchSessionResponse(BaseModel):
+    branch_session_id: str
+    parent_session_id: str
+    fork_turn_number: int
+    state: str
+    created_at: str
+
+
+class SessionCompareSummary(BaseModel):
+    session_id: str
+    outcome: Optional[str] = None
+    total_turns: int
+    overall_score: Optional[float] = None
+    headline_metrics: Optional[Dict[str, Any]] = None
+
+
+class SessionCompareResponse(BaseModel):
+    parent_session_id: str
+    branch_session_id: str
+    fork_turn_number: int
+    parent: SessionCompareSummary
+    branch: SessionCompareSummary
 
 
 # ---------------------------------------------------------------------------
@@ -826,6 +855,133 @@ async def export_session_text(session_id: str, request: Request) -> PlainTextRes
         content=markdown,
         media_type="text/markdown; charset=utf-8",
         headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+@router.post("/{session_id}/branch", status_code=201, response_model=BranchSessionResponse)
+async def create_branch_session(
+    session_id: str, body: BranchSessionRequest, request: Request
+) -> BranchSessionResponse:
+    """Fork the session at the start of game turn *fork_turn_number*.
+
+    Creates a new branch session that inherits the parent's state and transcript
+    up to turn N-1, then resumes in PlayerTurnListening so the player can try a
+    different approach at turn N.  The branch session is fully independent and
+    supports its own debrief.  Use GET /{branch_id}/compare to compare outcomes.
+
+    Requires the parent session to have at least *fork_turn_number* completed
+    game turns and to have been played with snapshot-enabled pipeline (any
+    session created after this feature was shipped).
+    """
+    db = request.app.state.db
+    conn = db.connection()
+
+    try:
+        branch_session_id, created_at = fork_session(
+            parent_session_id=session_id,
+            fork_turn_number=body.fork_turn_number,
+            conn=conn,
+        )
+    except ValueError as exc:
+        msg = str(exc)
+        if "not found" in msg:
+            raise HTTPException(status_code=404, detail=msg) from exc
+        raise HTTPException(status_code=400, detail=msg) from exc
+
+    return BranchSessionResponse(
+        branch_session_id=branch_session_id,
+        parent_session_id=session_id,
+        fork_turn_number=body.fork_turn_number,
+        state="PlayerTurnListening",
+        created_at=created_at,
+    )
+
+
+def _debrief_headline(conn: Any, session_id: str) -> tuple[Optional[str], Optional[float], Optional[Dict[str, Any]]]:
+    """Return (outcome, overall_score, headline_metrics) from the stored debrief, or Nones."""
+    debrief_row = conn.execute(
+        "SELECT content_json, metrics_json FROM session_debriefs "
+        "WHERE session_id = ? ORDER BY id DESC LIMIT 1",
+        (session_id,),
+    ).fetchone()
+    if debrief_row is None:
+        return None, None, None
+    doc = json.loads(debrief_row["content_json"])
+    outcome: Optional[str] = doc.get("outcome")
+    overall_score: Optional[float] = doc.get("overall_score")
+    metrics_raw = debrief_row["metrics_json"] or doc.get("metrics")
+    headline: Optional[Dict[str, Any]] = None
+    if metrics_raw:
+        m = json.loads(metrics_raw) if isinstance(metrics_raw, str) else metrics_raw
+        headline = {
+            "talk_ratio": m.get("talk_ratio"),
+            "open_questions": m.get("open_questions"),
+            "words_per_turn_player": m.get("words_per_turn_player"),
+            "response_latency_p50_ms": m.get("response_latency_p50_ms"),
+        }
+    return outcome, overall_score, headline
+
+
+@router.get("/{session_id}/compare", response_model=SessionCompareResponse)
+async def compare_branch_session(session_id: str, request: Request) -> SessionCompareResponse:
+    """Compare this branch session against its parent run.
+
+    Returns headline outcome and metric summaries for both sessions so the
+    player can see how their different choice at the fork point played out.
+    Debrief data is included when available; sessions without a debrief return
+    ``null`` for score and metrics fields.
+
+    Returns 404 if the session is not a branch (has no parent in
+    ``session_branches``).
+    """
+    db = request.app.state.db
+    conn = db.connection()
+
+    branch_row = conn.execute(
+        "SELECT * FROM session_branches WHERE branch_session_id = ?", (session_id,)
+    ).fetchone()
+    if branch_row is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Session {session_id!r} is not a branch session or has no recorded parent",
+        )
+
+    parent_id: str = branch_row["parent_session_id"]
+    fork_turn: int = branch_row["fork_turn_number"]
+
+    parent_session = conn.execute(
+        "SELECT turn_count, ending_type FROM turn_sessions WHERE session_id = ?", (parent_id,)
+    ).fetchone()
+    branch_session = conn.execute(
+        "SELECT turn_count, ending_type FROM turn_sessions WHERE session_id = ?", (session_id,)
+    ).fetchone()
+
+    if parent_session is None:
+        raise HTTPException(status_code=404, detail=f"Parent session {parent_id!r} not found")
+    if branch_session is None:
+        raise HTTPException(status_code=404, detail=f"Branch session {session_id!r} not found")
+
+    p_outcome, p_score, p_metrics = _debrief_headline(conn, parent_id)
+    b_outcome, b_score, b_metrics = _debrief_headline(conn, session_id)
+
+    return SessionCompareResponse(
+        parent_session_id=parent_id,
+        branch_session_id=session_id,
+        fork_turn_number=fork_turn,
+        parent=SessionCompareSummary(
+            session_id=parent_id,
+            outcome=p_outcome or parent_session["ending_type"],
+            total_turns=int(parent_session["turn_count"]),
+            overall_score=p_score,
+            headline_metrics=p_metrics,
+        ),
+        branch=SessionCompareSummary(
+            session_id=session_id,
+            outcome=b_outcome or branch_session["ending_type"],
+            total_turns=int(branch_session["turn_count"]),
+            overall_score=b_score,
+            headline_metrics=b_metrics,
+        ),
     )
 
 

--- a/services/convsim-core/convsim_core/services/branch_service.py
+++ b/services/convsim-core/convsim_core/services/branch_service.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Branch session service: fork a completed session at any NPC-turn boundary.
+
+A branch session is a new session that:
+  - Starts from the exact simulation state at the end of game turn N-1.
+  - Has a verbatim copy of all transcript turns up to game turn N-1.
+  - Resumes in PlayerTurnListening so the player can try a different choice
+    at game turn N.
+
+Determinism policy:
+  - State variables and fired event IDs are restored exactly from the
+    ``state_snapshot_json`` stored on the parent NPC turn.
+  - Player turns 1..N-1 are copied verbatim into the branch transcript.
+  - NPC turns within the copied prefix are also copied verbatim; they serve
+    as context for the NPC but are not re-simulated.
+  - From turn N onwards, the NPC is re-simulated. Where the runtime accepts a
+    seed (see ``setup_json.seed``), the parent seed is inherited to support
+    reproducible comparison runs.
+  - Storage of snapshots is bounded: ``state_snapshot_json`` lives on the turn
+    row and is pruned automatically when the session is deleted (CASCADE).
+"""
+from __future__ import annotations
+
+import json
+import secrets
+import sqlite3
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Tuple
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _generate_session_id() -> str:
+    return f"sess-{secrets.token_hex(8)}"
+
+
+def fork_session(
+    parent_session_id: str,
+    fork_turn_number: int,
+    conn: sqlite3.Connection,
+) -> Tuple[str, str]:
+    """Create a branch session forked at the start of game turn *fork_turn_number*.
+
+    *fork_turn_number* is 1-indexed: ``1`` means retry the very first player
+    turn (only the NPC opening is copied); ``N`` means retry game turn N (all
+    turns through game turn N-1 are copied).
+
+    Returns ``(branch_session_id, created_at_iso)`` so callers can build an
+    HTTP response without a second DB round-trip.
+
+    Raises:
+        ValueError: parent session not found, fork_turn_number out of range
+            [1, parent.turn_count], or the required state snapshot is absent.
+    """
+    parent_row = conn.execute(
+        "SELECT * FROM turn_sessions WHERE session_id = ?", (parent_session_id,)
+    ).fetchone()
+    if parent_row is None:
+        raise ValueError(f"Session {parent_session_id!r} not found")
+
+    total_turns: int = int(parent_row["turn_count"])
+    if fork_turn_number < 1 or fork_turn_number > total_turns:
+        raise ValueError(
+            f"fork_turn_number {fork_turn_number} is out of range "
+            f"[1, {total_turns}] for session {parent_session_id!r}"
+        )
+
+    # Resolve the simulation state at the fork boundary.
+    # fork_turn_number=1 → retry turn 1 → no prior NPC turn → initial state ({}).
+    # fork_turn_number=N → retry turn N → state after NPC turn N-1.
+    if fork_turn_number == 1:
+        state_vars: Dict[str, Any] = {}
+        fired_events: List[str] = []
+    else:
+        # DB turn_number for the NPC response at game turn fork_turn_number-1 is
+        # 2*(fork_turn_number-1).
+        prior_npc_db_turn = 2 * (fork_turn_number - 1)
+        snapshot_row = conn.execute(
+            "SELECT state_snapshot_json FROM turn_session_turns "
+            "WHERE session_id = ? AND turn_number = ?",
+            (parent_session_id, prior_npc_db_turn),
+        ).fetchone()
+        if snapshot_row is None or not snapshot_row["state_snapshot_json"]:
+            raise ValueError(
+                f"State snapshot missing for turn {prior_npc_db_turn} "
+                f"in session {parent_session_id!r}. "
+                "This session was played before per-turn snapshots were introduced; "
+                "replay it to generate a fork-capable transcript."
+            )
+        snapshot = json.loads(snapshot_row["state_snapshot_json"])
+        state_vars = snapshot.get("state_vars", {})
+        fired_events = snapshot.get("fired_events", [])
+
+    # Turns to copy: NPC opening (turn_number=0) through the last NPC turn
+    # before the fork (turn_number=2*(fork_turn_number-1)).
+    max_db_turn_to_copy = 2 * (fork_turn_number - 1)
+    turns_to_copy = conn.execute(
+        "SELECT turn_number, role, content, emotion, state_delta_json, "
+        "event_flags_json, safety_json, raw_output_json, source_mode, "
+        "flow_state_after, state_snapshot_json, created_at "
+        "FROM turn_session_turns "
+        "WHERE session_id = ? AND turn_number <= ? ORDER BY turn_number ASC",
+        (parent_session_id, max_db_turn_to_copy),
+    ).fetchall()
+
+    new_session_id = _generate_session_id()
+    now = _now_iso()
+    setup_json: str = parent_row["setup_json"]
+    setup: Dict[str, Any] = json.loads(setup_json)
+    save_transcript: bool = setup.get("save_transcript", True)
+
+    with conn:
+        conn.execute(
+            "INSERT INTO turn_sessions "
+            "(session_id, scenario_id, flow_state, state_vars_json, "
+            "fired_events_json, turn_count, setup_json, created_at) "
+            "VALUES (?, ?, 'PlayerTurnListening', ?, ?, ?, ?, ?)",
+            (
+                new_session_id,
+                parent_row["scenario_id"],
+                json.dumps(state_vars),
+                json.dumps(fired_events),
+                fork_turn_number - 1,
+                setup_json,
+                now,
+            ),
+        )
+
+        if turns_to_copy:
+            conn.executemany(
+                "INSERT INTO turn_session_turns "
+                "(session_id, turn_number, role, content, emotion, "
+                "state_delta_json, event_flags_json, safety_json, "
+                "raw_output_json, source_mode, flow_state_after, "
+                "state_snapshot_json, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                [
+                    (
+                        new_session_id,
+                        t["turn_number"],
+                        t["role"],
+                        t["content"],
+                        t["emotion"],
+                        t["state_delta_json"],
+                        t["event_flags_json"],
+                        t["safety_json"],
+                        t["raw_output_json"],
+                        t["source_mode"],
+                        t["flow_state_after"],
+                        t["state_snapshot_json"],
+                        t["created_at"],
+                    )
+                    for t in turns_to_copy
+                ],
+            )
+
+        conn.execute(
+            "INSERT INTO session_branches "
+            "(branch_session_id, parent_session_id, fork_turn_number, created_at) "
+            "VALUES (?, ?, ?, ?)",
+            (new_session_id, parent_session_id, fork_turn_number, now),
+        )
+
+        if save_transcript and turns_to_copy:
+            conn.executemany(
+                "INSERT INTO session_transcript_fts(session_id, turn_number, role, content) "
+                "VALUES (?, ?, ?, ?)",
+                [
+                    (new_session_id, t["turn_number"], t["role"], t["content"])
+                    for t in turns_to_copy
+                ],
+            )
+
+    return new_session_id, now

--- a/services/convsim-core/convsim_core/services/turn_pipeline.py
+++ b/services/convsim-core/convsim_core/services/turn_pipeline.py
@@ -220,6 +220,14 @@ def _persist_input_safety_stop(
         session_id, turn_number, decision.category, decision.action.value,
     )
 
+    # Snapshot the simulation state at this turn boundary (state unchanged by safety stop).
+    current_state_vars: Dict[str, int] = json.loads(session_row["state_vars_json"] or "{}")
+    current_fired_events: List[str] = json.loads(session_row["fired_events_json"] or "[]")
+    safety_stop_snapshot_json = json.dumps({
+        "state_vars": current_state_vars,
+        "fired_events": current_fired_events,
+    })
+
     with conn:
         player_cursor = conn.execute(
             "INSERT INTO turn_session_turns "
@@ -230,14 +238,15 @@ def _persist_input_safety_stop(
         npc_cursor = conn.execute(
             "INSERT INTO turn_session_turns "
             "(session_id, turn_number, role, content, emotion, state_delta_json, event_flags_json, "
-            "safety_json, raw_output_json, flow_state_after, created_at) "
-            "VALUES (?, ?, 'npc', ?, 'neutral', '{}', '[]', ?, NULL, ?, ?)",
+            "safety_json, raw_output_json, flow_state_after, state_snapshot_json, created_at) "
+            "VALUES (?, ?, 'npc', ?, 'neutral', '{}', '[]', ?, NULL, ?, ?, ?)",
             (
                 session_id,
                 npc_turn_number,
                 npc_utterance,
                 json.dumps({"status": safety_status, "reason": decision.category}),
                 new_flow_state,
+                safety_stop_snapshot_json,
                 now,
             ),
         )
@@ -508,6 +517,13 @@ async def process_turn(
     player_turn_number = turn_number * 2 - 1
     npc_turn_number = turn_number * 2
 
+    # State snapshot stored on the NPC turn row so any completed game turn can
+    # serve as a fork point for branch sessions (see branch_service.py).
+    state_snapshot_json = json.dumps({
+        "state_vars": delta_result.new_state,
+        "fired_events": list(fired_event_ids),
+    })
+
     # Prompt metadata stored for debugging. Only non-private fields are kept:
     # token count, truncation flag, and which layers were present. The raw
     # prompt text and NPC private persona content are never written to the log.
@@ -527,8 +543,8 @@ async def process_turn(
         npc_cursor = conn.execute(
             "INSERT INTO turn_session_turns "
             "(session_id, turn_number, role, content, emotion, state_delta_json, event_flags_json, "
-            "safety_json, raw_output_json, flow_state_after, created_at) "
-            "VALUES (?, ?, 'npc', ?, ?, ?, ?, ?, ?, ?, ?)",
+            "safety_json, raw_output_json, flow_state_after, state_snapshot_json, created_at) "
+            "VALUES (?, ?, 'npc', ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 session_id,
                 npc_turn_number,
@@ -542,6 +558,7 @@ async def process_turn(
                 }),
                 raw_text,
                 new_flow_state,
+                state_snapshot_json,
                 now,
             ),
         )

--- a/services/convsim-core/convsim_core/storage/migrations.py
+++ b/services/convsim-core/convsim_core/storage/migrations.py
@@ -304,6 +304,20 @@ _SESSION_METRICS_SQL = """
 ALTER TABLE session_debriefs ADD COLUMN metrics_json TEXT;
 """
 
+_BRANCH_SESSIONS_SQL = """
+ALTER TABLE turn_session_turns ADD COLUMN state_snapshot_json TEXT;
+
+CREATE TABLE session_branches (
+    id                INTEGER PRIMARY KEY AUTOINCREMENT,
+    branch_session_id TEXT    NOT NULL REFERENCES turn_sessions(session_id) ON DELETE CASCADE,
+    parent_session_id TEXT    NOT NULL,
+    fork_turn_number  INTEGER NOT NULL,
+    created_at        TEXT    NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE UNIQUE INDEX session_branches_branch_idx ON session_branches(branch_session_id);
+"""
+
 MIGRATIONS: list[tuple[str, str]] = [
     ("0001_initial_schema", _INITIAL_SCHEMA_SQL),
     ("0002_model_registry_v2", _MODEL_REGISTRY_V2_SQL),
@@ -317,6 +331,7 @@ MIGRATIONS: list[tuple[str, str]] = [
     ("0010_user_gguf_profiles", _USER_GGUF_PROFILES_SQL),
     ("0011_model_download_verified", _MODEL_DOWNLOAD_VERIFIED_SQL),
     ("0012_session_metrics", _SESSION_METRICS_SQL),
+    ("0013_branch_sessions", _BRANCH_SESSIONS_SQL),
 ]
 
 

--- a/services/convsim-core/tests/test_branch_session.py
+++ b/services/convsim-core/tests/test_branch_session.py
@@ -74,7 +74,7 @@ def client(tmp_config):
 
 _VALID_SETUP = {
     "scenario_id": "behavioral_interview",
-    "difficulty": "normal",
+    "difficulty": "standard",
     "player_role_name": "Alice",
     "language": "en",
     "input_mode": "text-only",
@@ -170,7 +170,7 @@ class TestForkSession:
                 turn_count,
                 json.dumps(setup or {
                     "save_transcript": True,
-                    "difficulty": "normal",
+                    "difficulty": "standard",
                 }),
             ),
         )

--- a/services/convsim-core/tests/test_branch_session.py
+++ b/services/convsim-core/tests/test_branch_session.py
@@ -1,0 +1,562 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for moment replay and branch retry (issue #306).
+
+Test plan:
+  Migration:
+    - session_branches table exists after migration 0013.
+    - state_snapshot_json column exists on turn_session_turns.
+
+  Unit — fork_session():
+    - fork at turn 1 creates branch with empty state (initial state).
+    - fork at turn N restores exact state from parent snapshot (golden transcript).
+    - branch session has NPC opening + all prior turns copied verbatim.
+    - fork_turn_number out of range raises ValueError.
+    - missing snapshot raises ValueError (legacy session guard).
+    - FTS is populated for copied turns when save_transcript=True.
+
+  Integration — POST /sessions/{id}/branch:
+    - 201 with BranchSessionResponse on valid fork.
+    - branch session is in PlayerTurnListening state immediately.
+    - 400 for fork_turn_number out of range.
+    - 404 for unknown parent session.
+    - branch session can continue with new player turn.
+
+  Integration — GET /sessions/{id}/compare:
+    - 404 when session_id is not a branch.
+    - returns parent and branch summaries with fork_turn_number.
+    - headline_metrics populated after debrief generated.
+
+  Storage growth:
+    - snapshots pruned when session deleted (CASCADE).
+    - session_branches row deleted when branch session deleted.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any, AsyncGenerator, Dict
+
+import pytest
+from fastapi.testclient import TestClient
+
+from convsim_core.app import create_app
+from convsim_core.config import ServiceConfig
+from convsim_core.runtime.fake import FakeChatRuntime
+from convsim_core.runtime.types import ChatFinal, ChatRequest, ChatToken
+from convsim_core.scenario_state import build_variable_defs, initialize_state
+from convsim_core.scenarios import get_scenario_info
+from convsim_core.services.branch_service import fork_session
+from convsim_core.storage.migrations import MIGRATIONS, run_migrations
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def tmp_config(tmp_path):
+    return ServiceConfig(
+        host="127.0.0.1",
+        port=7355,
+        data_dir=str(tmp_path / "data"),
+        log_dir=str(tmp_path / "logs"),
+        db_dir=str(tmp_path / "db"),
+    )
+
+
+@pytest.fixture()
+def client(tmp_config):
+    app = create_app(tmp_config)
+    with TestClient(app) as c:
+        yield c
+
+
+_VALID_SETUP = {
+    "scenario_id": "behavioral_interview",
+    "difficulty": "normal",
+    "player_role_name": "Alice",
+    "language": "en",
+    "input_mode": "text-only",
+    "tts_enabled": False,
+    "show_state_meters": False,
+    "save_transcript": True,
+    "seed": None,
+}
+
+
+def _play_turns(client: TestClient, n: int = 2) -> str:
+    """Create, start, and play *n* turns; return session_id."""
+    res = client.post("/api/sessions", json=_VALID_SETUP)
+    assert res.status_code == 201
+    session_id = res.json()["session_id"]
+
+    client.post(f"/api/sessions/{session_id}/start")
+    for i in range(n):
+        res = client.post(
+            f"/api/sessions/{session_id}/turn",
+            json={"content": f"Player message {i + 1}"},
+        )
+        assert res.status_code == 200
+    return session_id
+
+
+# ---------------------------------------------------------------------------
+# Migration tests
+# ---------------------------------------------------------------------------
+
+
+class TestMigration0013:
+    def test_session_branches_table_exists(self, tmp_path):
+        db_path = str(tmp_path / "app.db")
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        run_migrations(conn)
+        tables = {
+            row["name"]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+        assert "session_branches" in tables
+        conn.close()
+
+    def test_state_snapshot_json_column_exists(self, tmp_path):
+        db_path = str(tmp_path / "app.db")
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        run_migrations(conn)
+        cols = {
+            row["name"]
+            for row in conn.execute(
+                "PRAGMA table_info(turn_session_turns)"
+            ).fetchall()
+        }
+        assert "state_snapshot_json" in cols
+        conn.close()
+
+    def test_migration_list_includes_0013(self):
+        names = [name for name, _ in MIGRATIONS]
+        assert "0013_branch_sessions" in names
+        assert names.index("0013_branch_sessions") == len(names) - 1
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — fork_session()
+# ---------------------------------------------------------------------------
+
+
+class TestForkSession:
+    def _make_db(self, tmp_path) -> sqlite3.Connection:
+        conn = sqlite3.connect(str(tmp_path / "app.db"))
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON")
+        run_migrations(conn)
+        return conn
+
+    def _insert_session(self, conn, session_id: str, scenario_id: str = "behavioral_interview",
+                        turn_count: int = 0, state_vars: dict = None, fired_events: list = None,
+                        setup: dict = None) -> None:
+        conn.execute(
+            "INSERT INTO turn_sessions "
+            "(session_id, scenario_id, flow_state, state_vars_json, "
+            "fired_events_json, turn_count, setup_json, created_at) "
+            "VALUES (?, ?, 'Ended', ?, ?, ?, ?, datetime('now'))",
+            (
+                session_id,
+                scenario_id,
+                json.dumps(state_vars or {}),
+                json.dumps(fired_events or []),
+                turn_count,
+                json.dumps(setup or {
+                    "save_transcript": True,
+                    "difficulty": "normal",
+                }),
+            ),
+        )
+        conn.commit()
+
+    def _insert_npc_opening(self, conn, session_id: str) -> None:
+        conn.execute(
+            "INSERT INTO turn_session_turns "
+            "(session_id, turn_number, role, content, flow_state_after, created_at) "
+            "VALUES (?, 0, 'npc_opening', 'Hello!', 'PlayerTurnListening', datetime('now'))",
+            (session_id,),
+        )
+        conn.commit()
+
+    def _insert_game_turn(self, conn, session_id: str, game_turn: int,
+                          state_snapshot: dict = None) -> None:
+        """Insert a player + NPC turn pair for *game_turn* (1-indexed)."""
+        player_db_turn = 2 * game_turn - 1
+        npc_db_turn = 2 * game_turn
+        snapshot_json = json.dumps(state_snapshot) if state_snapshot else None
+        conn.execute(
+            "INSERT INTO turn_session_turns "
+            "(session_id, turn_number, role, content, flow_state_after, created_at) "
+            "VALUES (?, ?, 'player', ?, 'PlayerTurnListening', datetime('now'))",
+            (session_id, player_db_turn, f"Player turn {game_turn}"),
+        )
+        conn.execute(
+            "INSERT INTO turn_session_turns "
+            "(session_id, turn_number, role, content, emotion, state_delta_json, "
+            "event_flags_json, safety_json, flow_state_after, state_snapshot_json, created_at) "
+            "VALUES (?, ?, 'npc', ?, 'neutral', '{}', '[]', "
+            "'{\"status\":\"ok\"}', 'PlayerTurnListening', ?, datetime('now'))",
+            (session_id, npc_db_turn, f"NPC turn {game_turn}", snapshot_json),
+        )
+        conn.commit()
+
+    def test_fork_at_turn_1_creates_branch_with_empty_state(self, tmp_path):
+        conn = self._make_db(tmp_path)
+        self._insert_session(conn, "parent", turn_count=2,
+                             state_vars={"trust": 60, "patience": 70},
+                             fired_events=["event_a"])
+        self._insert_npc_opening(conn, "parent")
+        self._insert_game_turn(conn, "parent", 1, state_snapshot={
+            "state_vars": {"trust": 60, "patience": 70},
+            "fired_events": ["event_a"],
+        })
+        self._insert_game_turn(conn, "parent", 2, state_snapshot={
+            "state_vars": {"trust": 65, "patience": 65},
+            "fired_events": ["event_a", "event_b"],
+        })
+
+        branch_id, _ = fork_session("parent", 1, conn)
+
+        branch = conn.execute(
+            "SELECT * FROM turn_sessions WHERE session_id = ?", (branch_id,)
+        ).fetchone()
+        assert branch is not None
+        assert json.loads(branch["state_vars_json"]) == {}
+        assert json.loads(branch["fired_events_json"]) == []
+        assert int(branch["turn_count"]) == 0
+        assert branch["flow_state"] == "PlayerTurnListening"
+
+    def test_fork_at_turn_2_restores_state_from_snapshot(self, tmp_path):
+        """Golden-transcript test: fork at turn N reproduces exact pre-fork state."""
+        conn = self._make_db(tmp_path)
+        expected_state = {"trust": 58, "patience": 72, "rapport": 55}
+        expected_events = ["intro_event"]
+
+        self._insert_session(conn, "parent", turn_count=3,
+                             state_vars={"trust": 61, "patience": 68})
+        self._insert_npc_opening(conn, "parent")
+        self._insert_game_turn(conn, "parent", 1, state_snapshot={
+            "state_vars": expected_state,
+            "fired_events": expected_events,
+        })
+        self._insert_game_turn(conn, "parent", 2, state_snapshot={
+            "state_vars": {"trust": 61, "patience": 68},
+            "fired_events": expected_events,
+        })
+        self._insert_game_turn(conn, "parent", 3, state_snapshot={
+            "state_vars": {"trust": 65, "patience": 65},
+            "fired_events": expected_events,
+        })
+
+        branch_id, _ = fork_session("parent", 2, conn)
+
+        branch = conn.execute(
+            "SELECT * FROM turn_sessions WHERE session_id = ?", (branch_id,)
+        ).fetchone()
+        assert json.loads(branch["state_vars_json"]) == expected_state
+        assert json.loads(branch["fired_events_json"]) == expected_events
+        assert int(branch["turn_count"]) == 1
+
+    def test_branch_has_npc_opening_and_prior_turns_copied(self, tmp_path):
+        conn = self._make_db(tmp_path)
+        self._insert_session(conn, "parent", turn_count=2)
+        self._insert_npc_opening(conn, "parent")
+        self._insert_game_turn(conn, "parent", 1, state_snapshot={
+            "state_vars": {"trust": 55},
+            "fired_events": [],
+        })
+        self._insert_game_turn(conn, "parent", 2, state_snapshot={
+            "state_vars": {"trust": 60},
+            "fired_events": [],
+        })
+
+        branch_id, _ = fork_session("parent", 2, conn)
+
+        turns = conn.execute(
+            "SELECT turn_number, role, content FROM turn_session_turns "
+            "WHERE session_id = ? ORDER BY turn_number ASC",
+            (branch_id,),
+        ).fetchall()
+        # fork at 2 → copy: NPC opening (0), player turn 1 (1), NPC turn 1 (2)
+        assert len(turns) == 3
+        assert turns[0]["turn_number"] == 0
+        assert turns[0]["role"] == "npc_opening"
+        assert turns[1]["turn_number"] == 1
+        assert turns[1]["role"] == "player"
+        assert turns[2]["turn_number"] == 2
+        assert turns[2]["role"] == "npc"
+
+    def test_fork_at_turn_1_copies_only_npc_opening(self, tmp_path):
+        conn = self._make_db(tmp_path)
+        self._insert_session(conn, "parent", turn_count=1)
+        self._insert_npc_opening(conn, "parent")
+        self._insert_game_turn(conn, "parent", 1, state_snapshot={
+            "state_vars": {"trust": 55},
+            "fired_events": [],
+        })
+
+        branch_id, _ = fork_session("parent", 1, conn)
+
+        turns = conn.execute(
+            "SELECT turn_number, role FROM turn_session_turns "
+            "WHERE session_id = ? ORDER BY turn_number ASC",
+            (branch_id,),
+        ).fetchall()
+        assert len(turns) == 1
+        assert turns[0]["turn_number"] == 0
+        assert turns[0]["role"] == "npc_opening"
+
+    def test_session_branches_row_recorded(self, tmp_path):
+        conn = self._make_db(tmp_path)
+        self._insert_session(conn, "parent", turn_count=1)
+        self._insert_npc_opening(conn, "parent")
+        self._insert_game_turn(conn, "parent", 1, state_snapshot={
+            "state_vars": {}, "fired_events": [],
+        })
+
+        branch_id, _ = fork_session("parent", 1, conn)
+
+        row = conn.execute(
+            "SELECT * FROM session_branches WHERE branch_session_id = ?", (branch_id,)
+        ).fetchone()
+        assert row is not None
+        assert row["parent_session_id"] == "parent"
+        assert row["fork_turn_number"] == 1
+
+    def test_fork_turn_number_out_of_range_raises(self, tmp_path):
+        conn = self._make_db(tmp_path)
+        self._insert_session(conn, "parent", turn_count=1)
+        self._insert_npc_opening(conn, "parent")
+        self._insert_game_turn(conn, "parent", 1, state_snapshot={
+            "state_vars": {}, "fired_events": [],
+        })
+
+        with pytest.raises(ValueError, match="out of range"):
+            fork_session("parent", 0, conn)
+
+        with pytest.raises(ValueError, match="out of range"):
+            fork_session("parent", 2, conn)
+
+    def test_missing_snapshot_raises(self, tmp_path):
+        """Sessions played before snapshot support cannot be forked at turn > 1."""
+        conn = self._make_db(tmp_path)
+        self._insert_session(conn, "legacy", turn_count=2)
+        self._insert_npc_opening(conn, "legacy")
+        # Insert turns without state_snapshot_json (legacy rows).
+        self._insert_game_turn(conn, "legacy", 1, state_snapshot=None)
+        self._insert_game_turn(conn, "legacy", 2, state_snapshot=None)
+
+        with pytest.raises(ValueError, match="snapshot missing"):
+            fork_session("legacy", 2, conn)
+
+    def test_unknown_parent_raises(self, tmp_path):
+        conn = self._make_db(tmp_path)
+        with pytest.raises(ValueError, match="not found"):
+            fork_session("nonexistent", 1, conn)
+
+    def test_snapshots_pruned_on_session_delete(self, tmp_path):
+        """Snapshot rows (on turn rows) are deleted via CASCADE when the session is deleted."""
+        conn = self._make_db(tmp_path)
+        self._insert_session(conn, "parent", turn_count=1)
+        self._insert_npc_opening(conn, "parent")
+        self._insert_game_turn(conn, "parent", 1, state_snapshot={
+            "state_vars": {"trust": 55}, "fired_events": [],
+        })
+
+        branch_id, _ = fork_session("parent", 1, conn)
+
+        # Confirm branch turns exist.
+        assert conn.execute(
+            "SELECT COUNT(*) FROM turn_session_turns WHERE session_id = ?", (branch_id,)
+        ).fetchone()[0] > 0
+
+        # Delete the branch session; its turn rows (and snapshots) are cascade-deleted.
+        conn.execute(
+            "DELETE FROM session_transcript_fts WHERE session_id = ?", (branch_id,)
+        )
+        conn.execute("DELETE FROM turn_sessions WHERE session_id = ?", (branch_id,))
+        conn.commit()
+
+        assert conn.execute(
+            "SELECT COUNT(*) FROM turn_session_turns WHERE session_id = ?", (branch_id,)
+        ).fetchone()[0] == 0
+
+    def test_session_branches_row_deleted_on_branch_delete(self, tmp_path):
+        conn = self._make_db(tmp_path)
+        self._insert_session(conn, "parent", turn_count=1)
+        self._insert_npc_opening(conn, "parent")
+        self._insert_game_turn(conn, "parent", 1, state_snapshot={
+            "state_vars": {}, "fired_events": [],
+        })
+
+        branch_id, _ = fork_session("parent", 1, conn)
+
+        assert conn.execute(
+            "SELECT COUNT(*) FROM session_branches WHERE branch_session_id = ?", (branch_id,)
+        ).fetchone()[0] == 1
+
+        conn.execute("DELETE FROM session_transcript_fts WHERE session_id = ?", (branch_id,))
+        conn.execute("DELETE FROM turn_sessions WHERE session_id = ?", (branch_id,))
+        conn.commit()
+
+        assert conn.execute(
+            "SELECT COUNT(*) FROM session_branches WHERE branch_session_id = ?", (branch_id,)
+        ).fetchone()[0] == 0
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — POST /sessions/{id}/branch
+# ---------------------------------------------------------------------------
+
+
+class TestBranchEndpoint:
+    def test_branch_returns_201_with_response_shape(self, client):
+        session_id = _play_turns(client, n=2)
+
+        res = client.post(
+            f"/api/sessions/{session_id}/branch",
+            json={"fork_turn_number": 1},
+        )
+        assert res.status_code == 201
+        body = res.json()
+        assert body["parent_session_id"] == session_id
+        assert body["branch_session_id"].startswith("sess-")
+        assert body["fork_turn_number"] == 1
+        assert body["state"] == "PlayerTurnListening"
+        assert "created_at" in body
+
+    def test_branch_session_is_immediately_in_player_turn_listening(self, client):
+        session_id = _play_turns(client, n=1)
+
+        res = client.post(
+            f"/api/sessions/{session_id}/branch",
+            json={"fork_turn_number": 1},
+        )
+        branch_id = res.json()["branch_session_id"]
+
+        get_res = client.get(f"/api/sessions/{branch_id}")
+        assert get_res.status_code == 200
+        assert get_res.json()["state"] == "PlayerTurnListening"
+
+    def test_branch_session_can_accept_a_new_turn(self, client):
+        session_id = _play_turns(client, n=2)
+
+        res = client.post(
+            f"/api/sessions/{session_id}/branch",
+            json={"fork_turn_number": 2},
+        )
+        assert res.status_code == 201
+        branch_id = res.json()["branch_session_id"]
+
+        turn_res = client.post(
+            f"/api/sessions/{branch_id}/turn",
+            json={"content": "A different approach at turn 2"},
+        )
+        assert turn_res.status_code == 200
+
+    def test_branch_fork_at_turn_2_has_correct_transcript(self, client):
+        """Branch forked at turn 2 retains NPC opening + game turn 1 verbatim."""
+        session_id = _play_turns(client, n=2)
+
+        res = client.post(
+            f"/api/sessions/{session_id}/branch",
+            json={"fork_turn_number": 2},
+        )
+        branch_id = res.json()["branch_session_id"]
+
+        transcript = client.get(f"/api/sessions/{branch_id}/transcript")
+        turns = transcript.json()["turns"]
+        # NPC opening (0) + player 1 (1) + NPC 1 (2) → 3 turns copied.
+        assert len(turns) == 3
+        assert turns[0]["role"] == "npc_opening"
+        assert turns[1]["role"] == "player"
+        assert turns[2]["role"] == "npc"
+
+    def test_branch_returns_400_for_out_of_range_turn(self, client):
+        session_id = _play_turns(client, n=1)
+
+        res = client.post(
+            f"/api/sessions/{session_id}/branch",
+            json={"fork_turn_number": 99},
+        )
+        assert res.status_code == 400
+
+    def test_branch_returns_404_for_unknown_session(self, client):
+        res = client.post(
+            "/api/sessions/sess-doesnotexist/branch",
+            json={"fork_turn_number": 1},
+        )
+        assert res.status_code == 404
+
+    def test_state_snapshot_is_saved_on_npc_turn(self, client):
+        """Turn pipeline must store state_snapshot_json on every NPC turn row."""
+        session_id = _play_turns(client, n=1)
+
+        # Access DB via the app's internal state via the export endpoint as a
+        # proxy (we can't easily reach the raw DB from a TestClient fixture).
+        # Instead: branch at turn 1 — if the snapshot is missing for turn>1 we'd
+        # get a 400; at turn 1 we get 201 regardless (no prior NPC snapshot needed).
+        res = client.post(
+            f"/api/sessions/{session_id}/branch",
+            json={"fork_turn_number": 1},
+        )
+        assert res.status_code == 201
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — GET /sessions/{id}/compare
+# ---------------------------------------------------------------------------
+
+
+class TestCompareEndpoint:
+    def test_compare_returns_404_for_non_branch_session(self, client):
+        session_id = _play_turns(client, n=1)
+
+        res = client.get(f"/api/sessions/{session_id}/compare")
+        assert res.status_code == 404
+
+    def test_compare_returns_parent_and_branch_summaries(self, client):
+        session_id = _play_turns(client, n=2)
+
+        branch_res = client.post(
+            f"/api/sessions/{session_id}/branch",
+            json={"fork_turn_number": 1},
+        )
+        assert branch_res.status_code == 201
+        branch_id = branch_res.json()["branch_session_id"]
+
+        compare_res = client.get(f"/api/sessions/{branch_id}/compare")
+        assert compare_res.status_code == 200
+        body = compare_res.json()
+        assert body["parent_session_id"] == session_id
+        assert body["branch_session_id"] == branch_id
+        assert body["fork_turn_number"] == 1
+        assert body["parent"]["session_id"] == session_id
+        assert body["branch"]["session_id"] == branch_id
+        assert isinstance(body["parent"]["total_turns"], int)
+        assert isinstance(body["branch"]["total_turns"], int)
+
+    def test_compare_includes_debrief_data_when_available(self, client):
+        session_id = _play_turns(client, n=1)
+        # End the parent session and generate a debrief.
+        client.post(f"/api/sessions/{session_id}/end")
+        client.post(f"/api/sessions/{session_id}/debrief")
+
+        branch_res = client.post(
+            f"/api/sessions/{session_id}/branch",
+            json={"fork_turn_number": 1},
+        )
+        branch_id = branch_res.json()["branch_session_id"]
+
+        compare_res = client.get(f"/api/sessions/{branch_id}/compare")
+        assert compare_res.status_code == 200
+        body = compare_res.json()
+        # Parent has a debrief; outcome should be populated.
+        assert body["parent"]["outcome"] is not None


### PR DESCRIPTION
## Summary

Implements issue #306 — checkpoint restart for conversations. Players can now fork any completed session at any NPC-turn boundary and retry that moment with a different approach, then compare outcomes side-by-side.

### What changed

**Migration 0013 (`branch_sessions`)** adds two schema pieces:
- `state_snapshot_json` column on `turn_session_turns` — every NPC turn row now carries the full simulation state (variables + fired events) needed to reconstruct the session at that boundary. Safety-stop synthetic NPC turns also get a snapshot. Snapshots are stored inline on the turn row and are automatically pruned when the session is deleted (CASCADE), keeping storage growth bounded.
- `session_branches` table — records the parent→child relationship, the fork turn number, and creation time. Deleted when the branch session is deleted (CASCADE); parent deletion leaves branches intact.

**`turn_pipeline.py`** — after applying the NPC state delta, serializes `{state_vars, fired_events}` as `state_snapshot_json` on the NPC turn INSERT. Safety-stop path also captures the unchanged state as a snapshot.

**`services/branch_service.py`** (new) — `fork_session()` implements the fork logic:
- Validates parent exists and `fork_turn_number` is in `[1, turn_count]`.
- Loads the state snapshot from NPC turn `2*(N-1)` (or uses empty state for `fork_turn_number=1`).
- Creates a branch session with `flow_state=PlayerTurnListening`, `turn_count=N-1`, and the restored state.
- Copies the transcript verbatim up to the fork boundary (NPC opening + all turns through game turn N-1).
- Inserts the `session_branches` row and populates FTS.
- **Determinism policy**: player turns 1..N-1 are copied verbatim; NPC turns in the prefix are also copied verbatim (historical context); from turn N onwards the NPC is re-simulated. The parent `seed` is inherited via `setup_json` for reproducible comparison runs.

**`routers/sessions.py`** — two new endpoints:
- `POST /api/sessions/{id}/branch` — creates a branch session ready for a new player turn at the fork point. Returns `BranchSessionResponse`.
- `GET /api/sessions/{id}/compare` — returns outcome, total turns, overall score, and headline metrics for both the branch and its parent. Returns 404 if the session has no parent.

**`packages/shared/src/types/session.ts`** — TypeScript types: `BranchSessionRequest`, `BranchSessionResponse`, `SessionCompareSummary`, `SessionCompareResponse`.

### How it was tested

`tests/test_branch_session.py` — 23 tests:
- **Migration**: `session_branches` table and `state_snapshot_json` column exist after migration 0013.
- **Unit `fork_session()`**: fork at turn 1 produces empty initial state; fork at turn N restores exact snapshot state (golden-transcript test); branch has verbatim prior transcript; out-of-range turn raises; missing snapshot on legacy sessions raises; storage cascade-prune verified with `PRAGMA foreign_keys = ON`.
- **Integration `POST /branch`**: 201 with correct response shape; branch immediately in `PlayerTurnListening`; branch can accept a new player turn; transcript contents verified after fork at turn 2; 400 for out-of-range; 404 for unknown parent.
- **Integration `GET /compare`**: 404 for non-branch sessions; returns parent and branch summaries with `fork_turn_number`; debrief data included when available.

All 196 pre-existing tests continue to pass (migrations, turn pipeline, debrief engine, transcript persistence, session state, scenario state).

Closes #306