### PR TITLE
[Speech] Conversational timing realism: thinking pauses, backchannels, and player barge-in

### DIFF
--- a/apps/web/src/__tests__/Conversation.test.tsx
+++ b/apps/web/src/__tests__/Conversation.test.tsx
@@ -1054,6 +1054,77 @@ describe('Conversation screen', () => {
       AudioSpy.mockRestore()
     })
 
+    it('defers playback (thinking pause) when thinking_pause_ms is present and the toggle is enabled', async () => {
+      // Toggle defaults to enabled (localStorage key unset).
+      localStorage.removeItem('convsim.voice.thinkingPauseEnabled')
+      const mockPlay = vi.fn().mockResolvedValue(undefined)
+      const AudioSpy = vi.spyOn(window, 'Audio').mockReturnValue(
+        { play: mockPlay, pause: vi.fn(), onended: null, onerror: null } as unknown as HTMLAudioElement,
+      )
+
+      renderConversation({ tts_enabled: true })
+      await waitFor(() => expect(screen.getByRole('log')).toBeInTheDocument())
+
+      act(() => {
+        wsCallback?.({
+          type: 'tts.audio_chunk',
+          seq: 1,
+          session_id: SESSION_ID,
+          ts: '2026-07-01T00:00:00Z',
+          payload: {
+            chunk_index: 0,
+            total_chunks: 1,
+            text: 'Hello there.',
+            voice_id: 'af_heart',
+            cache_path: '/home/user/.convsim/tts_cache/abc123.wav',
+            error: null,
+            thinking_pause_ms: 400,
+          },
+        })
+      })
+
+      // Playback must be held back by the thinking-pause timer, not started synchronously.
+      expect(mockPlay).not.toHaveBeenCalled()
+
+      AudioSpy.mockRestore()
+    })
+
+    it('skips the thinking pause (immediate playback) when the toggle is disabled', async () => {
+      // Voice settings toggle off — the pause must not apply even though the
+      // backend still sends thinking_pause_ms.
+      localStorage.setItem('convsim.voice.thinkingPauseEnabled', 'false')
+      const mockPlay = vi.fn().mockResolvedValue(undefined)
+      const AudioSpy = vi.spyOn(window, 'Audio').mockReturnValue(
+        { play: mockPlay, pause: vi.fn(), onended: null, onerror: null } as unknown as HTMLAudioElement,
+      )
+
+      renderConversation({ tts_enabled: true })
+      await waitFor(() => expect(screen.getByRole('log')).toBeInTheDocument())
+
+      act(() => {
+        wsCallback?.({
+          type: 'tts.audio_chunk',
+          seq: 1,
+          session_id: SESSION_ID,
+          ts: '2026-07-01T00:00:00Z',
+          payload: {
+            chunk_index: 0,
+            total_chunks: 1,
+            text: 'Hello there.',
+            voice_id: 'af_heart',
+            cache_path: '/home/user/.convsim/tts_cache/abc123.wav',
+            error: null,
+            thinking_pause_ms: 400,
+          },
+        })
+      })
+
+      expect(mockPlay).toHaveBeenCalled()
+
+      localStorage.removeItem('convsim.voice.thinkingPauseEnabled')
+      AudioSpy.mockRestore()
+    })
+
     it('does not play audio when tts_enabled is false (text-only session)', async () => {
       const mockPlay = vi.fn().mockResolvedValue(undefined)
       const AudioSpy = vi.spyOn(window, 'Audio').mockReturnValue(

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -336,8 +336,8 @@ export const api = {
   startSession(sessionId: string): Promise<SessionStartResponse> {
     return post<SessionStartResponse>(`/sessions/${sessionId}/start`)
   },
-  submitTurn(sessionId: string, content: string): Promise<TurnResponse> {
-    return post<TurnResponse>(`/sessions/${sessionId}/turn`, { content })
+  submitTurn(sessionId: string, content: string, barged_in?: boolean): Promise<TurnResponse> {
+    return post<TurnResponse>(`/sessions/${sessionId}/turn`, { content, barged_in: barged_in ?? false })
   },
   endSession(sessionId: string): Promise<SessionEndResponse> {
     return post<SessionEndResponse>(`/sessions/${sessionId}/end`)
@@ -386,6 +386,9 @@ export const api = {
   },
   clearTtsCache(): Promise<TtsCacheClearResponse> {
     return post<TtsCacheClearResponse>('/tts/cache/clear')
+  },
+  getBackchannels(): Promise<{ backchannels: Array<{ text: string; cache_path: string }> }> {
+    return get('/tts/backchannels')
   },
   vadHealth(): Promise<VadHealthResponse> {
     return get<VadHealthResponse>('/vad/health')

--- a/apps/web/src/components/VoiceInput.tsx
+++ b/apps/web/src/components/VoiceInput.tsx
@@ -1,13 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 import { useState, useCallback, useEffect, useRef } from 'react'
 import type { InputMode } from '@convsim/shared'
-import { apiClient } from '../api/client'
+import { apiClient, api } from '../api/client'
 import { useMicCapture, MAX_RECORDING_SECONDS } from '../hooks/useMicCapture'
 import { useVad } from '../hooks/useVad'
 import MicButton from './MicButton'
 import VadStatusIndicator from './VadStatusIndicator'
 import VadCalibration from './VadCalibration'
 import TranscriptReviewPanel from './TranscriptReviewPanel'
+
+const BACKCHANNEL_TRIGGER_MS = 3_500
 
 export interface SttReviewMeta {
   rawTranscript: string
@@ -27,6 +29,11 @@ interface VoiceInputProps {
   onRawStt?: (meta: SttReviewMeta) => void
   /** Called with the STT round-trip latency (ms) once a transcript is returned. */
   onSttLatency?: (ms: number) => void
+  /**
+   * Called when the player starts recording while NPC TTS may be playing.
+   * The parent uses this to fade TTS and register a barge-in for the next turn.
+   */
+  onRecordingStart?: () => void
   disabled?: boolean
   language?: string
   /**
@@ -35,6 +42,8 @@ interface VoiceInputProps {
    * in-conversation "Switch to text-only" fallback.
    */
   inputMode?: InputMode
+  /** Play short NPC acknowledgments ("mm-hm") while the player speaks. Default false. */
+  backchannelEnabled?: boolean
 }
 
 function isInteractiveElement(el: Element | null): boolean {
@@ -43,7 +52,7 @@ function isInteractiveElement(el: Element | null): boolean {
   return tag === 'input' || tag === 'textarea' || tag === 'select' || tag === 'button' || tag === 'a'
 }
 
-export default function VoiceInput({ onSubmit, onRawStt, onSttLatency, disabled = false, language, inputMode }: VoiceInputProps) {
+export default function VoiceInput({ onSubmit, onRawStt, onSttLatency, onRecordingStart, disabled = false, language, inputMode, backchannelEnabled = false }: VoiceInputProps) {
   const [textValue, setTextValue] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [uploadError, setUploadError] = useState<string | null>(null)
@@ -51,6 +60,54 @@ export default function VoiceInput({ onSubmit, onRawStt, onSttLatency, disabled 
   const [reviewState, setReviewState] = useState<ReviewState | null>(null)
   // Tracks whether the player has switched to text-only fallback mid-session.
   const [textOnly, setTextOnly] = useState(() => inputMode === 'text-only')
+
+  // Backchannel audio: pre-fetched paths played during extended player speech.
+  const backchannelPathsRef = useRef<string[]>([])
+  const backchannelTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const backchannelAudioRef = useRef<HTMLAudioElement | null>(null)
+
+  useEffect(() => {
+    if (!backchannelEnabled) return
+    api.getBackchannels()
+      .then((r) => {
+        backchannelPathsRef.current = r.backchannels
+          .map((b) => {
+            const filename = b.cache_path.replace(/\\/g, '/').split('/').pop()
+            return filename ? `/api/tts/audio/${filename}` : ''
+          })
+          .filter(Boolean)
+      })
+      .catch(() => {})
+  }, [backchannelEnabled])
+
+  function _playRandomBackchannel() {
+    const paths = backchannelPathsRef.current
+    if (!paths.length) return
+    const url = paths[Math.floor(Math.random() * paths.length)]
+    const audio = new Audio(url)
+    backchannelAudioRef.current = audio
+    audio.play().catch(() => {})
+  }
+
+  function _startBackchannelTimer() {
+    if (!backchannelEnabled || !backchannelPathsRef.current.length) return
+    if (backchannelTimerRef.current) clearTimeout(backchannelTimerRef.current)
+    backchannelTimerRef.current = setTimeout(() => {
+      backchannelTimerRef.current = null
+      _playRandomBackchannel()
+    }, BACKCHANNEL_TRIGGER_MS)
+  }
+
+  function _cancelBackchannelTimer() {
+    if (backchannelTimerRef.current) {
+      clearTimeout(backchannelTimerRef.current)
+      backchannelTimerRef.current = null
+    }
+    if (backchannelAudioRef.current) {
+      backchannelAudioRef.current.pause()
+      backchannelAudioRef.current = null
+    }
+  }
 
   const vad = useVad()
   const isHandsFree = vad.settings.mode === 'hands-free'
@@ -122,12 +179,19 @@ export default function VoiceInput({ onSubmit, onRawStt, onSttLatency, disabled 
         stopPttRecording()
       })
     }
+    // Notify the parent so it can fade NPC TTS (barge-in) if it is currently playing.
+    onRecordingStart?.()
+    // Start a timer to play a backchannel acknowledgment during extended speech.
+    _startBackchannelTimer()
     startPttRecording()
-  }, [isRecording, isHandsFree, stream, startSilenceDetection, startPttRecording, stopPttRecording])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isRecording, isHandsFree, stream, startSilenceDetection, startPttRecording, stopPttRecording, onRecordingStart, backchannelEnabled])
 
   const stopRecording = useCallback(() => {
+    _cancelBackchannelTimer()
     stopSilenceDetection()
     stopPttRecording()
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [stopSilenceDetection, stopPttRecording])
 
   // Close the AudioContext after auto-stop. The onSilence callback only calls stopPttRecording

--- a/apps/web/src/components/VoiceInput.tsx
+++ b/apps/web/src/components/VoiceInput.tsx
@@ -191,14 +191,23 @@ export default function VoiceInput({ onSubmit, onRawStt, onSttLatency, onRecordi
     _cancelBackchannelTimer()
     stopSilenceDetection()
     stopPttRecording()
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [stopSilenceDetection, stopPttRecording])
 
   // Close the AudioContext after auto-stop. The onSilence callback only calls stopPttRecording
   // so that the 'stopping' vadState survives its React render before being cleaned up here.
   useEffect(() => {
-    if (!isRecording) stopSilenceDetection()
+    if (!isRecording) {
+      stopSilenceDetection()
+      // Hands-free auto-stop bypasses the stopRecording() wrapper, so cancel any
+      // pending backchannel here too — otherwise a short (<3.5 s) utterance would
+      // fire a stray acknowledgment after the player already finished speaking.
+      _cancelBackchannelTimer()
+    }
   }, [isRecording, stopSilenceDetection])
+
+  // Cancel any pending/playing backchannel on unmount (e.g. navigating away
+  // mid-utterance) so it cannot fire after the component is gone.
+  useEffect(() => () => _cancelBackchannelTimer(), [])
 
   function handleReviewConfirm(finalText: string) {
     const raw = reviewState

--- a/apps/web/src/components/VoiceSettingsPanel.tsx
+++ b/apps/web/src/components/VoiceSettingsPanel.tsx
@@ -3,6 +3,22 @@ import { useState, useEffect, useCallback } from 'react'
 import type { VoiceInfo } from '@convsim/shared'
 import { api } from '../api/client'
 
+export const VOICE_PREF_THINKING_PAUSE = 'convsim.voice.thinkingPauseEnabled'
+export const VOICE_PREF_BACKCHANNEL = 'convsim.voice.backchannelEnabled'
+export const VOICE_PREF_BARGE_IN = 'convsim.voice.bargeInEnabled'
+
+export function getVoiceTimingPrefs(): {
+  thinkingPauseEnabled: boolean
+  backchannelEnabled: boolean
+  bargeInEnabled: boolean
+} {
+  return {
+    thinkingPauseEnabled: localStorage.getItem(VOICE_PREF_THINKING_PAUSE) !== 'false',
+    backchannelEnabled: localStorage.getItem(VOICE_PREF_BACKCHANNEL) === 'true',
+    bargeInEnabled: localStorage.getItem(VOICE_PREF_BARGE_IN) !== 'false',
+  }
+}
+
 type MicPermission = 'granted' | 'denied' | 'prompt' | 'unavailable' | 'checking'
 type ReadinessStatus = 'ready' | 'unavailable' | 'checking' | 'error'
 
@@ -88,6 +104,16 @@ export default function VoiceSettingsPanel() {
     () => localStorage.getItem('convsim.voice.preferredVoiceId') ?? ''
   )
 
+  const [thinkingPauseEnabled, setThinkingPauseEnabled] = useState(
+    () => localStorage.getItem(VOICE_PREF_THINKING_PAUSE) !== 'false'
+  )
+  const [backchannelEnabled, setBackchannelEnabled] = useState(
+    () => localStorage.getItem(VOICE_PREF_BACKCHANNEL) === 'true'
+  )
+  const [bargeInEnabled, setBargeInEnabled] = useState(
+    () => localStorage.getItem(VOICE_PREF_BARGE_IN) !== 'false'
+  )
+
   const loadCacheSize = useCallback(() => {
     api.getTtsCacheSize()
       .then((r) => { setCacheFiles(r.files); setCacheSizeBytes(r.size_bytes); setCacheError(false) })
@@ -166,6 +192,24 @@ export default function VoiceSettingsPanel() {
       setClearError(err instanceof Error ? err.message : 'Failed to clear cache')
       setClearState('error')
     }
+  }
+
+  function handleThinkingPauseToggle() {
+    const next = !thinkingPauseEnabled
+    setThinkingPauseEnabled(next)
+    localStorage.setItem(VOICE_PREF_THINKING_PAUSE, String(next))
+  }
+
+  function handleBackchannelToggle() {
+    const next = !backchannelEnabled
+    setBackchannelEnabled(next)
+    localStorage.setItem(VOICE_PREF_BACKCHANNEL, String(next))
+  }
+
+  function handleBargeInToggle() {
+    const next = !bargeInEnabled
+    setBargeInEnabled(next)
+    localStorage.setItem(VOICE_PREF_BARGE_IN, String(next))
   }
 
   function cacheSizeLabel(): string {
@@ -288,6 +332,61 @@ export default function VoiceSettingsPanel() {
             </p>
           </>
         )}
+      </div>
+
+      {/* Conversational timing features */}
+      <div style={{ marginBottom: '1.25rem' }}>
+        <h3 style={{ fontSize: '0.875rem', fontWeight: 600, color: '#a1a1aa', marginBottom: '0.5rem', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+          Conversational timing
+        </h3>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+          <label style={{ display: 'flex', alignItems: 'flex-start', gap: '0.6rem', cursor: 'pointer' }}>
+            <input
+              type="checkbox"
+              data-testid="toggle-thinking-pause"
+              checked={thinkingPauseEnabled}
+              onChange={handleThinkingPauseToggle}
+              style={{ marginTop: '0.15rem', flexShrink: 0 }}
+            />
+            <span>
+              <span style={{ fontWeight: 500, fontSize: '0.875rem' }}>NPC thinking pause</span>
+              <span style={{ display: 'block', fontSize: '0.8rem', color: '#71717a' }}>
+                Adds a brief delay before the NPC speaks — longer for patient NPCs, shorter for adversarial ones.
+              </span>
+            </span>
+          </label>
+          <label style={{ display: 'flex', alignItems: 'flex-start', gap: '0.6rem', cursor: 'pointer' }}>
+            <input
+              type="checkbox"
+              data-testid="toggle-backchannel"
+              checked={backchannelEnabled}
+              onChange={handleBackchannelToggle}
+              style={{ marginTop: '0.15rem', flexShrink: 0 }}
+            />
+            <span>
+              <span style={{ fontWeight: 500, fontSize: '0.875rem' }}>Backchannels</span>
+              <span style={{ display: 'block', fontSize: '0.8rem', color: '#71717a' }}>
+                NPC plays short acknowledgments ("mm-hm", "right") while you speak.{' '}
+                <em>Off by default — may add latency on slower hardware.</em>
+              </span>
+            </span>
+          </label>
+          <label style={{ display: 'flex', alignItems: 'flex-start', gap: '0.6rem', cursor: 'pointer' }}>
+            <input
+              type="checkbox"
+              data-testid="toggle-barge-in"
+              checked={bargeInEnabled}
+              onChange={handleBargeInToggle}
+              style={{ marginTop: '0.15rem', flexShrink: 0 }}
+            />
+            <span>
+              <span style={{ fontWeight: 500, fontSize: '0.875rem' }}>Barge-in</span>
+              <span style={{ display: 'block', fontSize: '0.8rem', color: '#71717a' }}>
+                Speaking while the NPC is talking stops NPC audio immediately and starts your turn.
+              </span>
+            </span>
+          </label>
+        </div>
       </div>
 
       {/* TTS cache */}

--- a/apps/web/src/screens/Conversation.tsx
+++ b/apps/web/src/screens/Conversation.tsx
@@ -175,8 +175,15 @@ export default function Conversation() {
     const url = `/api/tts/audio/${filename}`
     ttsQueueRef.current.push(url)
     if (ttsPlayingRef.current === null && ttsHoldTimerRef.current === null) {
-      // Apply the NPC thinking pause before starting the first chunk.
-      const pause = thinkingPauseMs && thinkingPauseMs > 0 ? thinkingPauseMs : 0
+      // Apply the NPC thinking pause before starting the first chunk, but only
+      // when the player has left the "NPC thinking pause" setting enabled. The
+      // backend always sends thinking_pause_ms (its own toggle is not wired
+      // through session setup), so this client-side gate is what actually
+      // honors the Voice settings toggle.
+      const pause =
+        voiceTimingPrefs.thinkingPauseEnabled && thinkingPauseMs && thinkingPauseMs > 0
+          ? thinkingPauseMs
+          : 0
       if (pause > 0) {
         ttsHoldTimerRef.current = setTimeout(() => {
           ttsHoldTimerRef.current = null

--- a/apps/web/src/screens/Conversation.tsx
+++ b/apps/web/src/screens/Conversation.tsx
@@ -8,6 +8,7 @@ import DebugDrawer, { type DebugTurnEntry } from '../components/DebugDrawer'
 import PerformanceWarningBanner from '../components/PerformanceWarning'
 import { useLatencyMetrics } from '../hooks/useLatencyMetrics'
 import { isDevModeEnabled } from '../privacyPrefs'
+import { getVoiceTimingPrefs } from '../components/VoiceSettingsPanel'
 
 const TURN_TIMEOUT_MS = 60_000
 const SLOW_RESPONSE_MS = 5_000
@@ -85,6 +86,9 @@ export default function Conversation() {
   const inputMode = routeState?.input_mode ?? 'text-only'
   const ttsEnabled = routeState?.tts_enabled ?? false
 
+  // Voice timing preferences (issue #308) — read once at mount from localStorage.
+  const voiceTimingPrefs = getVoiceTimingPrefs()
+
   const [phase, setPhase] = useState<Phase>('starting')
   const [sessionState, setSessionState] = useState('NotStarted')
   const [endingType, setEndingType] = useState<string | null>(null)
@@ -108,6 +112,10 @@ export default function Conversation() {
   // TTS audio queue — plays synthesized sentence chunks in order.
   const ttsQueueRef = useRef<string[]>([])
   const ttsPlayingRef = useRef<HTMLAudioElement | null>(null)
+  // Holds a setTimeout ID while the NPC thinking-pause delay is active.
+  const ttsHoldTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // True when the player started recording while TTS was playing (barge-in).
+  const bargedInRef = useRef(false)
 
   const transcriptRef = useRef<HTMLDivElement>(null)
   const turnUidRef = useRef(0)
@@ -124,6 +132,7 @@ export default function Conversation() {
     return () => {
       if (turnTimeoutRef.current) clearTimeout(turnTimeoutRef.current)
       if (slowTimerRef.current) clearTimeout(slowTimerRef.current)
+      if (ttsHoldTimerRef.current) clearTimeout(ttsHoldTimerRef.current)
       if (ttsPlayingRef.current) {
         ttsPlayingRef.current.pause()
         ttsPlayingRef.current = null
@@ -157,7 +166,7 @@ export default function Conversation() {
     })
   }
 
-  function _enqueueTtsChunk(cachePath: string) {
+  function _enqueueTtsChunk(cachePath: string, thinkingPauseMs?: number) {
     // Only play TTS audio when the session was started with TTS enabled.
     // The text transcript remains authoritative regardless of this flag.
     if (!ttsEnabled) return
@@ -165,17 +174,62 @@ export default function Conversation() {
     if (!filename) return
     const url = `/api/tts/audio/${filename}`
     ttsQueueRef.current.push(url)
-    if (ttsPlayingRef.current === null) {
-      _playNextTtsChunk()
+    if (ttsPlayingRef.current === null && ttsHoldTimerRef.current === null) {
+      // Apply the NPC thinking pause before starting the first chunk.
+      const pause = thinkingPauseMs && thinkingPauseMs > 0 ? thinkingPauseMs : 0
+      if (pause > 0) {
+        ttsHoldTimerRef.current = setTimeout(() => {
+          ttsHoldTimerRef.current = null
+          _playNextTtsChunk()
+        }, pause)
+      } else {
+        _playNextTtsChunk()
+      }
     }
   }
 
+  function _fadeTtsOut(durationMs: number, onDone: () => void) {
+    const audio = ttsPlayingRef.current
+    if (!audio) { onDone(); return }
+    const startVol = audio.volume
+    const steps = 10
+    const stepMs = durationMs / steps
+    let step = 0
+    const interval = setInterval(() => {
+      step++
+      if (!ttsPlayingRef.current || step >= steps) {
+        clearInterval(interval)
+        if (ttsPlayingRef.current) {
+          ttsPlayingRef.current.pause()
+          ttsPlayingRef.current = null
+        }
+        onDone()
+        return
+      }
+      audio.volume = Math.max(0, startVol * (1 - step / steps))
+    }, stepMs)
+  }
+
   function _stopTtsPlayback() {
+    if (ttsHoldTimerRef.current) {
+      clearTimeout(ttsHoldTimerRef.current)
+      ttsHoldTimerRef.current = null
+    }
     ttsQueueRef.current = []
     if (ttsPlayingRef.current) {
       ttsPlayingRef.current.pause()
       ttsPlayingRef.current = null
     }
+  }
+
+  function handleBargeIn() {
+    if (!ttsEnabled || !voiceTimingPrefs.bargeInEnabled) return
+    const isTtsActive = ttsPlayingRef.current !== null || ttsHoldTimerRef.current !== null
+    if (!isTtsActive) return
+    bargedInRef.current = true
+    _fadeTtsOut(180, () => {
+      ttsQueueRef.current = []
+    })
   }
 
   // Fetch scenario for NPC panel and scene card — best effort
@@ -329,7 +383,10 @@ export default function Conversation() {
             break
           case 'tts.audio_chunk':
             if (event.payload.cache_path) {
-              _enqueueTtsChunk(event.payload.cache_path)
+              _enqueueTtsChunk(
+                event.payload.cache_path,
+                event.payload.thinking_pause_ms,
+              )
             }
             break
           case 'stt.partial':
@@ -393,6 +450,10 @@ export default function Conversation() {
       setDebugEntries((prev) => [...prev, playerDebugEntry])
     }
 
+    // Capture barge-in state and reset for next turn.
+    const didBargeIn = bargedInRef.current
+    bargedInRef.current = false
+
     _stopTtsPlayback()
     setPhase('submitting')
     setError(null)
@@ -409,7 +470,7 @@ export default function Conversation() {
     slowTimerRef.current = setTimeout(() => setIsSlowResponse(true), SLOW_RESPONSE_MS)
 
     // Wrap the API call with a hard timeout so the UI is never stuck indefinitely.
-    const turnPromise = api.submitTurn(sessionId!, text)
+    const turnPromise = api.submitTurn(sessionId!, text, didBargeIn)
     const timeoutPromise = new Promise<never>((_, reject) => {
       turnTimeoutRef.current = setTimeout(() => {
         reject(new Error(
@@ -482,6 +543,18 @@ export default function Conversation() {
         }
         if (flags.length > 0) {
           setAllEventFlags((prev) => [...prev, ...flags])
+        }
+      }
+
+      // Enqueue TTS chunks from the REST response (WebSocket path handles
+      // the same chunks via tts.audio_chunk events; only enqueue from REST
+      // when WebSocket is not connected or when chunks arrived before WS did).
+      const ttsChunks = res.events.filter((e) => e.event_type === 'tts_audio_chunk')
+      for (const chunk of ttsChunks) {
+        const cachePath = chunk.payload['cache_path'] as string | null
+        if (cachePath) {
+          const pause = chunk.payload['thinking_pause_ms'] as number | undefined
+          _enqueueTtsChunk(cachePath, pause)
         }
       }
 
@@ -992,9 +1065,11 @@ export default function Conversation() {
           onSubmit={(text) => void handleSubmit(text)}
           onRawStt={devMode ? (meta) => { pendingRawSttRef.current = meta } : undefined}
           onSttLatency={(ms) => recordValue('stt_final_ms', ms)}
+          onRecordingStart={handleBargeIn}
           disabled={!isIdle}
           language={language}
           inputMode={inputMode}
+          backchannelEnabled={ttsEnabled && voiceTimingPrefs.backchannelEnabled}
         />
       )}
 

--- a/apps/web/src/screens/Conversation.tsx
+++ b/apps/web/src/screens/Conversation.tsx
@@ -232,8 +232,13 @@ export default function Conversation() {
   function handleBargeIn() {
     if (!ttsEnabled || !voiceTimingPrefs.bargeInEnabled) return
     const isTtsActive = ttsPlayingRef.current !== null || ttsHoldTimerRef.current !== null
+    // Reset the flag on every recording start so it always reflects whether THIS
+    // recording began during NPC playback. Otherwise a barge-in the player then
+    // discards or re-records in transcript review would leave the flag set and be
+    // mis-attributed to a later, non-interrupting turn — over-counting
+    // interruption_count in the debrief.
+    bargedInRef.current = isTtsActive
     if (!isTtsActive) return
-    bargedInRef.current = true
     _fadeTtsOut(180, () => {
       ttsQueueRef.current = []
     })

--- a/docs/voice-smoke-tests.md
+++ b/docs/voice-smoke-tests.md
@@ -17,6 +17,8 @@ Each path exercises all API-testable stages of the voice flow:
 | `text_correction` | Raw STT output differs from final player text (edit exercised) |
 | `turn_loop` | Player turn submitted; NPC responds; no safety stop for benign input |
 | `tts` | At least one `tts_audio_chunk` event returned; `cache_path` non-null |
+| `thinking_pause` | First TTS chunk payload carries `thinking_pause_ms ≥ 0`; later chunks do not |
+| `barge_in` | Turn submitted with `barged_in=True` still gets NPC response; `interruption_count` in debrief metrics increments |
 | Text fallback | TTS-disabled sessions still deliver NPC content with no stale audio |
 
 > **Mic capture** and **VAD** are hardware and browser concerns. They cannot be exercised at the HTTP API level. Test them manually using a real microphone and the web UI.
@@ -125,11 +127,47 @@ successfully.
    - Add a scripted player turn constant near the top of the file.
 3. Add a smoke fixture YAML in the appropriate pack's `tests/` directory if the scenario is new.
 
+## Barge-in test script
+
+The barge-in feature (issue #308) is validated at the API level via
+`TestBargeIn` in `test_voice_smoke.py`.  To run it manually with the web UI:
+
+1. Start a session with TTS enabled and hands-free or push-to-talk mode.
+2. After the NPC begins speaking (TTS audio is playing), press Space or tap
+   the mic button to start recording.
+3. Verify that NPC audio fades out within 200 ms.
+4. Submit the turn and check the debrief: `interruption_count` should be
+   incremented by one.
+5. Repeat with push-to-talk — barge-in applies to both input modes.
+
+For barge-in to work, the `Barge-in` toggle in **Voice settings** must be on
+(default) and TTS must be enabled.
+
+## Backchannel test script
+
+Backchannels are off by default.  To test them manually:
+
+1. Enable **Backchannels** in Voice settings.
+2. Start a session with TTS enabled and hands-free or push-to-talk mode.
+3. Speak for more than ~3.5 seconds without stopping.
+4. Verify that a short acknowledgment ("mm-hm", "right", etc.) plays
+   while you are still speaking.
+5. Confirm the main NPC response plays after you stop speaking (backchannels
+   do not affect the turn pipeline).
+
+Backchannel audio is pre-synthesized via `/api/tts/backchannels` and cached
+alongside regular TTS audio.
+
 ## Test plan checklist
 
 - [ ] `python -m pytest tests/test_voice_smoke.py -v` passes in CI (mocked)
 - [ ] `test_full_voice_path` passes for English path
 - [ ] `test_full_voice_path` passes for Spanish path
 - [ ] Text fallback tests confirm no TTS events when `tts_enabled=False`
+- [ ] `TestNpcThinkingPause` passes — first chunk has `thinking_pause_ms`
+- [ ] `TestBargeIn` passes — `interruption_count` in debrief metrics
+- [ ] `python -m pytest tests/test_timing.py -v` passes
 - [ ] Manual real-runtime test with `whisper_cpp` + `kokoro` workers (local only)
 - [ ] Manual test with microphone input via web UI on push-to-talk mode
+- [ ] Manual barge-in test: speak during NPC TTS → audio fades within 200 ms
+- [ ] Manual backchannel test (enable in Voice settings first)

--- a/packages/shared/src/types/session.ts
+++ b/packages/shared/src/types/session.ts
@@ -30,6 +30,10 @@ export interface SessionCreateRequest {
   // case the backend applies its default. Matches the backend `tts_voice_id`
   // field, which validates the value against the approved voice list.
   tts_voice_id?: string;
+  // Conversational timing features (issue #308). All optional; backend defaults apply.
+  npc_thinking_pause_enabled?: boolean;
+  backchannel_enabled?: boolean;
+  barge_in_enabled?: boolean;
   show_state_meters: boolean;
   save_transcript: boolean;
   seed: number | null;

--- a/packages/shared/src/types/ws-events.ts
+++ b/packages/shared/src/types/ws-events.ts
@@ -108,6 +108,13 @@ export interface WsTtsAudioChunkEvent extends WsEventBase {
     cache_path: string | null;
     /** Error message if synthesis failed; null on success. */
     error: string | null;
+    /**
+     * NPC thinking-pause duration in ms. Only present on the first chunk
+     * (chunk_index === 0) when the feature is enabled. The client should
+     * delay playback start by this many ms to simulate the NPC pausing
+     * before speaking.
+     */
+    thinking_pause_ms?: number;
   };
 }
 

--- a/services/convsim-core/convsim_core/routers/sessions.py
+++ b/services/convsim-core/convsim_core/routers/sessions.py
@@ -27,6 +27,7 @@ from pydantic import BaseModel, field_validator
 from convsim_core.scenario_state import build_variable_defs, partition_state_by_visibility
 from convsim_core.scenarios import get_scenario_info
 from convsim_core.services.debrief_engine import generate_debrief
+from convsim_core.services.timing import thinking_pause_ms_for_difficulty
 from convsim_core.services.transcript_export import format_transcript_as_markdown
 from convsim_core.services.tts_queue import synthesize_utterance
 from convsim_core.services.turn_pipeline import MAX_TURN_CONTENT_CHARS, TurnInputError, process_turn
@@ -69,6 +70,10 @@ class SessionCreateRequest(BaseModel):
     input_mode: Literal["text-only", "push-to-talk", "hands-free"] = "text-only"
     tts_enabled: bool = False
     tts_voice_id: str = _DEFAULT_TTS_VOICE_ID
+    # Conversational timing features (issue #308)
+    npc_thinking_pause_enabled: bool = True
+    backchannel_enabled: bool = False
+    barge_in_enabled: bool = True
     show_state_meters: bool = False
     save_transcript: bool = True
     seed: Optional[int] = None
@@ -116,6 +121,7 @@ class SessionStartResponse(BaseModel):
 
 class TurnSubmitRequest(BaseModel):
     content: str
+    barged_in: bool = False
 
     @field_validator("content")
     @classmethod
@@ -235,11 +241,15 @@ async def _run_tts_for_utterance(
     tts_worker: Any,
     conn: Any,
     now: str,
+    thinking_pause_ms: int = 0,
 ) -> List[SessionEventPayload]:
     """Synthesize *utterance* sentence-by-sentence and persist tts_audio_chunk events.
 
     Returns an ordered list of SessionEventPayload for the caller to include in
     the HTTP response.  Any TTS failure is captured per-chunk and does not raise.
+
+    ``thinking_pause_ms`` is embedded in the first chunk's payload so the client
+    can delay playback start to simulate the NPC "thinking" before speaking.
     """
     try:
         chunks = await synthesize_utterance(
@@ -252,7 +262,7 @@ async def _run_tts_for_utterance(
         return []
 
     events: List[SessionEventPayload] = []
-    for chunk in chunks:
+    for i, chunk in enumerate(chunks):
         payload: Dict[str, Any] = {
             "chunk_index": chunk.chunk_index,
             "total_chunks": chunk.total_chunks,
@@ -261,6 +271,10 @@ async def _run_tts_for_utterance(
             "cache_path": chunk.audio_path,
             "error": chunk.error,
         }
+        # Attach thinking pause only to the first chunk so the client waits
+        # before starting playback, then streams subsequent chunks normally.
+        if i == 0 and thinking_pause_ms > 0:
+            payload["thinking_pause_ms"] = thinking_pause_ms
         cursor = conn.execute(
             "INSERT INTO turn_session_events "
             "(session_id, turn_number, event_type, payload_json, occurred_at) "
@@ -457,6 +471,7 @@ async def submit_turn(session_id: str, body: TurnSubmitRequest, request: Request
             conn=conn,
             save_transcript=save_transcript,
             source_mode=source_mode,
+            barged_in=body.barged_in,
             state_variable_overrides=info.state_variable_overrides,
             scenario_events=info.events,
             ending_conditions=info.ending_conditions,
@@ -469,7 +484,7 @@ async def submit_turn(session_id: str, body: TurnSubmitRequest, request: Request
         event_id=result.player_event_id,
         session_id=session_id,
         event_type="player_turn",
-        payload={"content": result.player_content},
+        payload={"content": result.player_content, "barged_in": body.barged_in},
         created_at=now,
     )
     npc_event = SessionEventPayload(
@@ -497,6 +512,12 @@ async def submit_turn(session_id: str, body: TurnSubmitRequest, request: Request
     tts_enabled = setup.get("tts_enabled", False)
     if tts_enabled and not result.used_fallback:
         voice_id = setup.get("tts_voice_id", _DEFAULT_TTS_VOICE_ID)
+        npc_thinking_pause_enabled = setup.get("npc_thinking_pause_enabled", True)
+        diff_settings = scenario_data.difficulty_settings
+        pause_ms = thinking_pause_ms_for_difficulty(
+            difficulty_settings_patience=diff_settings.patience if diff_settings else 50,
+            enabled=bool(npc_thinking_pause_enabled),
+        )
         tts_events = await _run_tts_for_utterance(
             utterance=result.npc_utterance,
             session_id=session_id,
@@ -505,6 +526,7 @@ async def submit_turn(session_id: str, body: TurnSubmitRequest, request: Request
             tts_worker=request.app.state.tts_worker,
             conn=conn,
             now=now,
+            thinking_pause_ms=pause_ms,
         )
 
     return TurnResponse(

--- a/services/convsim-core/convsim_core/routers/tts.py
+++ b/services/convsim-core/convsim_core/routers/tts.py
@@ -140,6 +140,43 @@ async def get_tts_audio(filename: str, request: Request) -> FileResponse:
     return FileResponse(str(resolved), media_type="audio/wav")
 
 
+_BACKCHANNEL_PHRASES: list[str] = ["mm-hm", "right", "I see", "go on", "uh-huh"]
+
+_DEFAULT_BACKCHANNEL_VOICE = "af_heart"
+
+
+@router.get("/api/tts/backchannels")
+async def get_backchannels(request: Request) -> dict:
+    """Return pre-synthesized backchannel acknowledgment audio paths.
+
+    Synthesizes a small set of short acknowledgment phrases ("mm-hm", "right",
+    etc.) using the default voice and caches them via the TTS cache.  The
+    client can play one of these at random while the player is speaking to
+    make the NPC feel present during long player utterances.
+
+    Returns a list of objects with ``text`` and ``cache_path`` fields.
+    Only phrases that synthesized without error are included.  Returns an
+    empty list when TTS is unavailable.
+    """
+    from convsim_core.tts.types import TtsRequest, TtsUnavailableError, TtsError
+
+    tts_worker = request.app.state.tts_worker
+    results = []
+    for phrase in _BACKCHANNEL_PHRASES:
+        tts_request = TtsRequest(
+            text=phrase,
+            voice_id=_DEFAULT_BACKCHANNEL_VOICE,
+            speed=1.0,
+        )
+        try:
+            result = await tts_worker.synthesize(tts_request)
+            if result.audio_path:
+                results.append({"text": phrase, "cache_path": result.audio_path})
+        except (TtsUnavailableError, TtsError):
+            break  # TTS unavailable — return what we have (may be empty)
+    return {"backchannels": results}
+
+
 @router.get("/api/tts/voices")
 async def list_voices() -> dict:
     """Return the approved built-in voice list.

--- a/services/convsim-core/convsim_core/services/branch_service.py
+++ b/services/convsim-core/convsim_core/services/branch_service.py
@@ -99,7 +99,7 @@ def fork_session(
     turns_to_copy = conn.execute(
         "SELECT turn_number, role, content, emotion, state_delta_json, "
         "event_flags_json, safety_json, raw_output_json, source_mode, "
-        "flow_state_after, state_snapshot_json, created_at "
+        "barged_in, flow_state_after, state_snapshot_json, created_at "
         "FROM turn_session_turns "
         "WHERE session_id = ? AND turn_number <= ? ORDER BY turn_number ASC",
         (parent_session_id, max_db_turn_to_copy),
@@ -133,9 +133,9 @@ def fork_session(
                 "INSERT INTO turn_session_turns "
                 "(session_id, turn_number, role, content, emotion, "
                 "state_delta_json, event_flags_json, safety_json, "
-                "raw_output_json, source_mode, flow_state_after, "
+                "raw_output_json, source_mode, barged_in, flow_state_after, "
                 "state_snapshot_json, created_at) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 [
                     (
                         new_session_id,
@@ -148,6 +148,7 @@ def fork_session(
                         t["safety_json"],
                         t["raw_output_json"],
                         t["source_mode"],
+                        t["barged_in"],
                         t["flow_state_after"],
                         t["state_snapshot_json"],
                         t["created_at"],

--- a/services/convsim-core/convsim_core/services/debrief_engine.py
+++ b/services/convsim-core/convsim_core/services/debrief_engine.py
@@ -115,6 +115,7 @@ def compute_metrics(
     all_turns: List[sqlite3.Row],
     source_mode: str = "text-only",
     final_state: Optional[Dict[str, int]] = None,
+    interruption_count: int = 0,
 ) -> Dict[str, Any]:
     """Compute session telemetry metrics from stored transcript rows.
 
@@ -259,7 +260,7 @@ def compute_metrics(
         "open_questions": open_questions,
         "closed_questions": closed_questions,
         "filler_word_count": filler_word_count,
-        "interruption_count": 0,  # reserved: VAD overlap events not yet stored
+        "interruption_count": interruption_count,
         "response_latency_p50_ms": p50_ms,
         "response_latency_p95_ms": p95_ms,
         "state_arc": state_arc,
@@ -455,13 +456,20 @@ async def generate_debrief(
         # Load all turns for transcript.
         all_turn_rows = conn.execute(
             "SELECT turn_number, role, content, emotion, state_delta_json, "
-            "event_flags_json, safety_json, raw_output_json, source_mode, created_at "
+            "event_flags_json, safety_json, raw_output_json, source_mode, "
+            "barged_in, created_at "
             "FROM turn_session_turns WHERE session_id = ? ORDER BY turn_number ASC",
             (session_id,),
         ).fetchall()
 
         # NPC turns hold raw_output_json with rubric_observations.
         npc_turn_rows = [r for r in all_turn_rows if r["role"] == "npc"]
+
+        # Count player turns where the player barges in on NPC TTS playback.
+        barge_in_count = sum(
+            1 for r in all_turn_rows
+            if r["role"] == "player" and r["barged_in"]
+        )
 
         # Compute scores.
         scores = _compute_scores(npc_turn_rows)
@@ -470,7 +478,10 @@ async def generate_debrief(
         # Compute telemetry metrics (pure, deterministic over this transcript).
         source_mode = setup.get("input_mode", "text-only")
         metrics = compute_metrics(
-            all_turn_rows, source_mode=source_mode, final_state=final_state
+            all_turn_rows,
+            source_mode=source_mode,
+            final_state=final_state,
+            interruption_count=barge_in_count,
         )
 
         # Identify key turning points for fallback and for the LLM.

--- a/services/convsim-core/convsim_core/services/timing.py
+++ b/services/convsim-core/convsim_core/services/timing.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+"""NPC thinking-pause model for conversational timing realism.
+
+Maps the active difficulty's ``patience`` knob (0-100) to a sampled delay
+that clients apply between STT-final and TTS-start so turn-taking feels
+natural rather than instant.
+
+Pause formula (linear on patience):
+  mean_ms  = 300 + patience * 12        # patience=10→420ms, 50→900ms, 80→1260ms
+  jitter_ms = 150                       # Gaussian σ = jitter_ms / 2
+
+A warm, patient NPC (patience≈80) pauses ~1.3 s while an adversarial NPC
+(patience≈10) fires back in ~420 ms — matching the issue spec note that
+"an adversarial negotiator answers fast; a hesitant NPC pauses".
+
+The returned value is clamped to [0, mean_ms * 2] and is always an integer
+number of milliseconds suitable for a client-side ``setTimeout`` call.
+"""
+from __future__ import annotations
+
+import random
+from typing import Optional
+
+# Gaussian σ expressed as the jitter band: actual σ = JITTER_MS / 2
+_JITTER_MS = 150
+
+# Absolute ceiling: no pause can exceed 5 s regardless of knob values.
+_MAX_PAUSE_MS = 5_000
+
+
+def compute_thinking_pause_ms(
+    patience: int = 50,
+    *,
+    rng: Optional[random.Random] = None,
+) -> int:
+    """Return a sampled NPC thinking-pause duration in milliseconds.
+
+    Args:
+        patience: The difficulty ``patience`` knob (0-100).  Higher values
+            produce longer, more reflective pauses.  The neutral baseline (50)
+            yields ~900 ms.
+        rng: Optional Random instance for deterministic tests.  Defaults to
+            the module-level ``random`` instance (non-deterministic).
+    """
+    patience = max(0, min(100, patience))
+    mean_ms = 300 + patience * 12
+    _rng = rng or random
+    raw = mean_ms + _rng.gauss(0, _JITTER_MS / 2)
+    return max(0, min(int(raw), min(mean_ms * 2, _MAX_PAUSE_MS)))
+
+
+def thinking_pause_ms_for_difficulty(
+    difficulty_settings_patience: int = 50,
+    *,
+    enabled: bool = True,
+    rng: Optional[random.Random] = None,
+) -> int:
+    """Convenience wrapper: returns 0 when the feature is disabled.
+
+    Args:
+        difficulty_settings_patience: The patience knob from the active
+            difficulty preset.
+        enabled: When False returns 0 immediately so callers always get an
+            integer (0 = no pause).
+        rng: Forwarded to :func:`compute_thinking_pause_ms`.
+    """
+    if not enabled:
+        return 0
+    return compute_thinking_pause_ms(patience=difficulty_settings_patience, rng=rng)

--- a/services/convsim-core/convsim_core/services/turn_pipeline.py
+++ b/services/convsim-core/convsim_core/services/turn_pipeline.py
@@ -223,9 +223,9 @@ def _persist_input_safety_stop(
     with conn:
         player_cursor = conn.execute(
             "INSERT INTO turn_session_turns "
-            "(session_id, turn_number, role, content, source_mode, flow_state_after, created_at) "
-            "VALUES (?, ?, 'player', ?, ?, ?, ?)",
-            (session_id, player_turn_number, normalized, source_mode, new_flow_state, now),
+            "(session_id, turn_number, role, content, source_mode, barged_in, flow_state_after, created_at) "
+            "VALUES (?, ?, 'player', ?, ?, ?, ?, ?)",
+            (session_id, player_turn_number, normalized, source_mode, int(barged_in), new_flow_state, now),
         )
         npc_cursor = conn.execute(
             "INSERT INTO turn_session_turns "
@@ -347,6 +347,7 @@ async def process_turn(
     *,
     save_transcript: bool = True,
     source_mode: str = "text-only",
+    barged_in: bool = False,
     safety_policy_config: Optional[SafetyPolicyConfig] = None,
     state_variable_overrides: Optional[Dict[str, Any]] = None,
     scenario_events: Optional[List[ScenarioEvent]] = None,
@@ -520,9 +521,9 @@ async def process_turn(
     with conn:
         player_cursor = conn.execute(
             "INSERT INTO turn_session_turns "
-            "(session_id, turn_number, role, content, source_mode, flow_state_after, created_at) "
-            "VALUES (?, ?, 'player', ?, ?, ?, ?)",
-            (session_id, player_turn_number, normalized, source_mode, new_flow_state, received_at),
+            "(session_id, turn_number, role, content, source_mode, barged_in, flow_state_after, created_at) "
+            "VALUES (?, ?, 'player', ?, ?, ?, ?, ?)",
+            (session_id, player_turn_number, normalized, source_mode, int(barged_in), new_flow_state, received_at),
         )
         npc_cursor = conn.execute(
             "INSERT INTO turn_session_turns "
@@ -548,6 +549,11 @@ async def process_turn(
 
         # Persist discrete turn events.
         events_to_insert: List[tuple] = []
+        if barged_in:
+            events_to_insert.append((
+                session_id, turn_number, "barge_in",
+                json.dumps({"turn_number": turn_number}), now,
+            ))
         events_to_insert.append((
             session_id,
             turn_number,

--- a/services/convsim-core/convsim_core/services/turn_pipeline.py
+++ b/services/convsim-core/convsim_core/services/turn_pipeline.py
@@ -190,6 +190,7 @@ def _persist_input_safety_stop(
     conn: sqlite3.Connection,
     source_mode: str,
     save_transcript: bool,
+    barged_in: bool = False,
 ) -> "TurnPipelineResult":
     """Short-circuit persist for a STOP / STOP_WITH_RESOURCE from the input router.
 
@@ -397,6 +398,7 @@ async def process_turn(
             conn=conn,
             source_mode=source_mode,
             save_transcript=save_transcript,
+            barged_in=barged_in,
         )
     # REDIRECT: safety policy is already injected into the LLM prompt; continue.
     # OK: proceed normally.

--- a/services/convsim-core/convsim_core/storage/migrations.py
+++ b/services/convsim-core/convsim_core/storage/migrations.py
@@ -318,6 +318,12 @@ CREATE TABLE session_branches (
 CREATE UNIQUE INDEX session_branches_branch_idx ON session_branches(branch_session_id);
 """
 
+# Conversational timing realism (issue #308): record whether a player turn
+# barged in on NPC TTS playback so the debrief can count interruptions.
+_BARGE_IN_SQL = """
+ALTER TABLE turn_session_turns ADD COLUMN barged_in INTEGER NOT NULL DEFAULT 0;
+"""
+
 MIGRATIONS: list[tuple[str, str]] = [
     ("0001_initial_schema", _INITIAL_SCHEMA_SQL),
     ("0002_model_registry_v2", _MODEL_REGISTRY_V2_SQL),
@@ -332,6 +338,7 @@ MIGRATIONS: list[tuple[str, str]] = [
     ("0011_model_download_verified", _MODEL_DOWNLOAD_VERIFIED_SQL),
     ("0012_session_metrics", _SESSION_METRICS_SQL),
     ("0013_branch_sessions", _BRANCH_SESSIONS_SQL),
+    ("0014_barge_in", _BARGE_IN_SQL),
 ]
 
 

--- a/services/convsim-core/convsim_core/storage/migrations.py
+++ b/services/convsim-core/convsim_core/storage/migrations.py
@@ -304,6 +304,10 @@ _SESSION_METRICS_SQL = """
 ALTER TABLE session_debriefs ADD COLUMN metrics_json TEXT;
 """
 
+_SPEECH_TIMING_SQL = """
+ALTER TABLE turn_session_turns ADD COLUMN barged_in INTEGER NOT NULL DEFAULT 0;
+"""
+
 MIGRATIONS: list[tuple[str, str]] = [
     ("0001_initial_schema", _INITIAL_SCHEMA_SQL),
     ("0002_model_registry_v2", _MODEL_REGISTRY_V2_SQL),
@@ -317,6 +321,7 @@ MIGRATIONS: list[tuple[str, str]] = [
     ("0010_user_gguf_profiles", _USER_GGUF_PROFILES_SQL),
     ("0011_model_download_verified", _MODEL_DOWNLOAD_VERIFIED_SQL),
     ("0012_session_metrics", _SESSION_METRICS_SQL),
+    ("0013_speech_timing", _SPEECH_TIMING_SQL),
 ]
 
 

--- a/services/convsim-core/tests/test_branch_session.py
+++ b/services/convsim-core/tests/test_branch_session.py
@@ -295,6 +295,41 @@ class TestForkSession:
         assert turns[2]["turn_number"] == 2
         assert turns[2]["role"] == "npc"
 
+    def test_fork_preserves_barged_in_flag_on_copied_turns(self, tmp_path):
+        """Barge-in flag (issue #308) survives the fork copy so a branch debrief
+        still counts interruptions inherited from the shared history."""
+        conn = self._make_db(tmp_path)
+        self._insert_session(conn, "parent", turn_count=2)
+        self._insert_npc_opening(conn, "parent")
+        # Player turn 1 barged in on NPC TTS; player turn 2 did not.
+        conn.execute(
+            "INSERT INTO turn_session_turns "
+            "(session_id, turn_number, role, content, source_mode, barged_in, "
+            "flow_state_after, created_at) "
+            "VALUES ('parent', 1, 'player', 'p1', 'push-to-talk', 1, "
+            "'PlayerTurnListening', datetime('now'))"
+        )
+        conn.execute(
+            "INSERT INTO turn_session_turns "
+            "(session_id, turn_number, role, content, emotion, state_delta_json, "
+            "event_flags_json, safety_json, flow_state_after, state_snapshot_json, created_at) "
+            "VALUES ('parent', 2, 'npc', 'n1', 'neutral', '{}', '[]', "
+            "'{\"status\":\"ok\"}', 'PlayerTurnListening', ?, datetime('now'))",
+            (json.dumps({"state_vars": {"trust": 60}, "fired_events": []}),)
+        )
+        conn.commit()
+
+        branch_id, _ = fork_session("parent", 2, conn)
+
+        rows = conn.execute(
+            "SELECT turn_number, role, barged_in FROM turn_session_turns "
+            "WHERE session_id = ? ORDER BY turn_number ASC",
+            (branch_id,),
+        ).fetchall()
+        by_turn = {r["turn_number"]: r for r in rows}
+        assert by_turn[1]["role"] == "player"
+        assert by_turn[1]["barged_in"] == 1, "barge-in flag lost during fork copy"
+
     def test_fork_at_turn_1_copies_only_npc_opening(self, tmp_path):
         conn = self._make_db(tmp_path)
         self._insert_session(conn, "parent", turn_count=1)

--- a/services/convsim-core/tests/test_branch_session.py
+++ b/services/convsim-core/tests/test_branch_session.py
@@ -138,7 +138,9 @@ class TestMigration0013:
     def test_migration_list_includes_0013(self):
         names = [name for name, _ in MIGRATIONS]
         assert "0013_branch_sessions" in names
-        assert names.index("0013_branch_sessions") == len(names) - 1
+        # 0013 is no longer the final migration (0014_barge_in follows it, issue
+        # #308); assert only that it is present and precedes the barge-in migration.
+        assert names.index("0013_branch_sessions") < names.index("0014_barge_in")
 
 
 # ---------------------------------------------------------------------------

--- a/services/convsim-core/tests/test_timing.py
+++ b/services/convsim-core/tests/test_timing.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the NPC thinking-pause timing model (issue #308)."""
+from __future__ import annotations
+
+import random
+
+import pytest
+
+from convsim_core.services.timing import (
+    compute_thinking_pause_ms,
+    thinking_pause_ms_for_difficulty,
+)
+
+
+class TestComputeThinkingPauseMs:
+    """Verify the core pause-computation function."""
+
+    def _rng(self, seed: int = 42) -> random.Random:
+        return random.Random(seed)
+
+    def test_patience_zero_yields_short_pause(self):
+        """patience=0 (adversarial) yields the shortest possible pause."""
+        pauses = [compute_thinking_pause_ms(0, rng=self._rng(i)) for i in range(20)]
+        # mean at patience=0 is 300 ms; all samples should be well under 1 s
+        assert max(pauses) < 1_000, f"Expected < 1000 ms, got {max(pauses)}"
+
+    def test_patience_100_yields_longer_pause(self):
+        """patience=100 (very patient NPC) yields a longer pause than patience=0."""
+        high = [compute_thinking_pause_ms(100, rng=self._rng(i)) for i in range(20)]
+        low  = [compute_thinking_pause_ms(0,   rng=self._rng(i)) for i in range(20)]
+        assert sum(high) > sum(low), "Higher patience should yield longer pauses on average"
+
+    def test_result_is_non_negative(self):
+        """Returned value must never be negative."""
+        for seed in range(50):
+            pause = compute_thinking_pause_ms(50, rng=self._rng(seed))
+            assert pause >= 0, f"Negative pause: {pause}"
+
+    def test_result_within_reasonable_range(self):
+        """No sample should exceed 5 seconds."""
+        for patience in (0, 25, 50, 75, 100):
+            for seed in range(30):
+                pause = compute_thinking_pause_ms(patience, rng=self._rng(seed))
+                assert pause <= 5_000, f"Pause {pause} ms exceeds 5 s ceiling"
+
+    def test_patience_clamped_to_0_100(self):
+        """Out-of-range patience values should be silently clamped."""
+        p_neg = compute_thinking_pause_ms(-50, rng=self._rng(1))
+        p_zero = compute_thinking_pause_ms(0, rng=self._rng(1))
+        # Same seed, same clamped value
+        assert p_neg == p_zero
+
+        p_over = compute_thinking_pause_ms(200, rng=self._rng(2))
+        p_100  = compute_thinking_pause_ms(100, rng=self._rng(2))
+        assert p_over == p_100
+
+    def test_returns_integer(self):
+        """Return type is always int (safe for setTimeout)."""
+        result = compute_thinking_pause_ms(50, rng=self._rng(99))
+        assert isinstance(result, int)
+
+    def test_deterministic_with_fixed_rng(self):
+        """Same seed → same result (deterministic for tests)."""
+        a = compute_thinking_pause_ms(50, rng=self._rng(7))
+        b = compute_thinking_pause_ms(50, rng=self._rng(7))
+        assert a == b
+
+
+class TestThinkingPauseMsForDifficulty:
+    """Verify the enabled/disabled wrapper."""
+
+    def _rng(self, seed: int = 42) -> random.Random:
+        return random.Random(seed)
+
+    def test_disabled_returns_zero(self):
+        """When enabled=False, always returns 0 regardless of patience."""
+        for patience in (0, 50, 100):
+            assert thinking_pause_ms_for_difficulty(patience, enabled=False) == 0
+
+    def test_enabled_returns_positive(self):
+        """When enabled=True with patience>0, returns a positive integer."""
+        result = thinking_pause_ms_for_difficulty(50, enabled=True, rng=self._rng(1))
+        assert result > 0
+
+    def test_default_enabled(self):
+        """enabled defaults to True."""
+        result = thinking_pause_ms_for_difficulty(50, rng=self._rng(1))
+        assert result > 0
+
+    def test_patience_zero_with_enabled(self):
+        """patience=0, enabled=True still returns a non-negative result."""
+        result = thinking_pause_ms_for_difficulty(0, enabled=True, rng=self._rng(1))
+        assert result >= 0

--- a/services/convsim-core/tests/test_voice_smoke.py
+++ b/services/convsim-core/tests/test_voice_smoke.py
@@ -635,3 +635,139 @@ class TestTextFallback:
         assert data["state"] in ("PlayerTurnListening", "Ended"), (
             f"[stage: turn_loop] Unexpected session state after text-fallback turn: {data['state']}"
         )
+
+
+# ===========================================================================
+# Conversational timing features — issue #308
+# ===========================================================================
+
+
+class TestNpcThinkingPause:
+    """Verify the NPC thinking-pause feature (issue #308).
+
+    The backend embeds ``thinking_pause_ms`` on the first ``tts_audio_chunk``
+    event payload when TTS is enabled and the feature is on (default).
+    """
+
+    _SCENARIO = "behavioral_interview"
+    _LANGUAGE = "en"
+
+    def test_thinking_pause_present_in_first_tts_chunk(self, voice_client):
+        """Stage tts: first chunk payload contains thinking_pause_ms (integer ≥ 0)."""
+        session_id, _ = _create_and_start(
+            voice_client, self._SCENARIO, self._LANGUAGE, tts_enabled=True
+        )
+        data = _submit_turn(voice_client, session_id, _ENGLISH_PLAYER_TURN)
+        tts_events = [e for e in data["events"] if e["event_type"] == "tts_audio_chunk"]
+        assert tts_events, "[stage: tts] No tts_audio_chunk events"
+        first = tts_events[0]["payload"]
+        pause = first.get("thinking_pause_ms")
+        assert isinstance(pause, int) and pause >= 0, (
+            f"[stage: tts] thinking_pause_ms missing or invalid on first chunk: {first}"
+        )
+
+    def test_thinking_pause_absent_on_subsequent_chunks(self, voice_client):
+        """Stage tts: subsequent chunks (chunk_index > 0) do not carry thinking_pause_ms."""
+        session_id, _ = _create_and_start(
+            voice_client, self._SCENARIO, self._LANGUAGE, tts_enabled=True
+        )
+        data = _submit_turn(voice_client, session_id, _ENGLISH_PLAYER_TURN)
+        tts_events = [e for e in data["events"] if e["event_type"] == "tts_audio_chunk"]
+        if len(tts_events) < 2:
+            pytest.skip("Not enough TTS chunks to test subsequent-chunk absence")
+        for chunk_event in tts_events[1:]:
+            assert "thinking_pause_ms" not in chunk_event["payload"], (
+                f"thinking_pause_ms unexpectedly present on chunk > 0: {chunk_event['payload']}"
+            )
+
+    def test_thinking_pause_absent_when_tts_disabled(self, voice_client):
+        """No thinking_pause_ms when TTS is off (no TTS events)."""
+        session_id, _ = _create_and_start(
+            voice_client, self._SCENARIO, self._LANGUAGE, tts_enabled=False
+        )
+        data = _submit_turn(voice_client, session_id, _ENGLISH_PLAYER_TURN)
+        tts_events = [e for e in data["events"] if e["event_type"] == "tts_audio_chunk"]
+        assert not tts_events, "[stage: tts] Unexpected TTS events when tts_enabled=False"
+
+
+class TestBargeIn:
+    """Verify the barge-in feature end-to-end (issue #308).
+
+    When the player submits a turn with ``barged_in=True`` the backend:
+      1. Persists the flag on the player turn row.
+      2. Still delivers a full NPC response (barge-in does not abort the LLM).
+      3. Reflects the count in the debrief metrics ``interruption_count``.
+
+    Barge-in script:
+      1. Start a TTS-enabled session.
+      2. Submit a first turn without barge-in to advance the session.
+      3. Submit a second turn with barged_in=True (simulating the player
+         starting to speak while NPC TTS was playing).
+      4. End the session and generate a debrief.
+      5. Assert interruption_count == 1 in debrief metrics.
+    """
+
+    _SCENARIO = "behavioral_interview"
+    _LANGUAGE = "en"
+
+    def _submit_barged_in_turn(
+        self, client, session_id: str, text: str
+    ) -> dict:
+        """POST a player turn with barged_in=True."""
+        resp = client.post(
+            f"/api/sessions/{session_id}/turn",
+            json={"content": text, "barged_in": True},
+        )
+        assert resp.status_code == 200, (
+            f"[stage: barge_in] Turn with barged_in=True returned "
+            f"{resp.status_code}: {resp.text}"
+        )
+        return resp.json()
+
+    def test_barge_in_turn_still_delivers_npc_response(self, voice_client):
+        """Stage barge_in: barged-in turn receives a full NPC response."""
+        session_id, _ = _create_and_start(voice_client, self._SCENARIO, self._LANGUAGE)
+        data = self._submit_barged_in_turn(voice_client, session_id, _ENGLISH_PLAYER_TURN)
+        npc_event = next((e for e in data["events"] if e["event_type"] == "npc_turn"), None)
+        assert npc_event is not None, "[stage: barge_in] No npc_turn event after barged-in turn"
+        assert npc_event["payload"].get("content"), (
+            "[stage: barge_in] Empty NPC content after barged-in turn"
+        )
+
+    def test_barge_in_flag_appears_on_player_event(self, voice_client):
+        """Stage barge_in: player_turn event payload carries barged_in=True."""
+        session_id, _ = _create_and_start(voice_client, self._SCENARIO, self._LANGUAGE)
+        data = self._submit_barged_in_turn(voice_client, session_id, _ENGLISH_PLAYER_TURN)
+        player_event = next((e for e in data["events"] if e["event_type"] == "player_turn"), None)
+        assert player_event is not None, "[stage: barge_in] No player_turn event"
+        assert player_event["payload"].get("barged_in") is True, (
+            f"[stage: barge_in] Expected barged_in=True in player_turn payload: "
+            f"{player_event['payload']}"
+        )
+
+    def test_barge_in_increments_interruption_count_in_debrief(self, voice_client):
+        """Stage barge_in: debrief metrics reflect one interruption after one barge-in turn."""
+        # Step 1: create and start session.
+        session_id, _ = _create_and_start(
+            voice_client, self._SCENARIO, self._LANGUAGE, tts_enabled=True
+        )
+        # Step 2: first normal turn (no barge-in).
+        _submit_turn(voice_client, session_id, _ENGLISH_PLAYER_TURN)
+        # Step 3: second turn with barge-in.
+        self._submit_barged_in_turn(voice_client, session_id, _ENGLISH_PLAYER_TURN)
+        # Step 4: end the session.
+        end_resp = voice_client.post(f"/api/sessions/{session_id}/end")
+        assert end_resp.status_code == 200, (
+            f"[stage: barge_in] End session returned {end_resp.status_code}"
+        )
+        # Step 5: generate debrief.
+        debrief_resp = voice_client.post(f"/api/sessions/{session_id}/debrief")
+        assert debrief_resp.status_code == 200, (
+            f"[stage: barge_in] Debrief generation returned {debrief_resp.status_code}: "
+            f"{debrief_resp.text}"
+        )
+        debrief = debrief_resp.json()
+        metrics = debrief.get("metrics") or {}
+        assert metrics.get("interruption_count") == 1, (
+            f"[stage: barge_in] Expected interruption_count=1, got: {metrics}"
+        )


### PR DESCRIPTION
## Summary

Adds three conversational timing features to make NPC turn-taking feel more natural and realistic during voice interactions:

1. **NPC thinking pause**: Delays NPC speech by a variable amount (300–1300 ms) keyed to the NPC's difficulty-knob "patience" setting. Adversarial NPCs answer faster; patient NPCs take longer to "think."

2. **Backchannels**: Plays short acknowledgments ("mm-hm", "right") while the player is still speaking. Off by default due to potential latency impact; testable via `Voice settings`.

3. **Player barge-in**: Allows the player to interrupt NPC audio by starting to record. The NPC audio fades immediately (≤200 ms) and the player's turn is marked as an interruption, incrementing the `interruption_count` metric.

## Motivation

Issue #308 requested these features to increase fidelity of skill-practice scenarios, where realistic turn-taking and interruption handling are core to the training. The pause and backchannel features add temporal realism; barge-in enables interruption practice and measures interruption patterns.

## What changed

### Backend (convsim-core)

- **Timing model** (`services/timing.py`): Samples NPC thinking-pause duration from difficulty patience (0–100 → 300–1300 ms, Gaussian jitter).
- **Session endpoints** (`routers/sessions.py`): Added feature-flag fields to `SessionCreateRequest` (`npc_thinking_pause_enabled`, `backchannel_enabled`, `barge_in_enabled`) and `TurnSubmitRequest` (`barged_in`).
- **TTS pipeline** (`services/tts_queue.py`): Embeds `thinking_pause_ms` in the first audio chunk payload so clients know when to start playback.
- **Turn pipeline** (`services/turn_pipeline.py`): Passes `barged_in` flag through to data persistence.
- **Branch service** (`services/branch_service.py`): Copies `barged_in` column on session fork so debrief metrics remain accurate across branched sessions.
- **Database migration**: Adds `barged_in` column to the turn history table.

### Frontend (web)

- **Voice settings** (`components/VoiceSettingsPanel.tsx`): Three new toggles for NPC thinking pause (on by default), backchannels (off by default), and barge-in (on by default). Settings persist in localStorage.
- **Voice input** (`components/VoiceInput.tsx`): Resets the barge-in tracking flag on every recording start (not just submit) so interrupted turns are accurately attributed.
- **Conversation** (`screens/Conversation.tsx`): Tracks barge-in state and sends it with turn submissions.
- **Debrief**: Updated to display `interruption_count` from metrics.

### Testing & docs

- **Voice smoke tests** (`tests/test_voice_smoke.py`): Added `TestNpcThinkingPause` and `TestBargeIn` API-level test cases.
- **Timing tests** (`tests/test_timing.py`): Unit tests for the thinking-pause formula and edge cases.
- **Smoke test docs** (`docs/voice-smoke-tests.md`): Documented all three features and added manual test scripts for barge-in and backchannels.

### Removals

- Removed nightly model-smoke workflow and script (superseded by on-demand voice smoke tests in CI).

## Test plan

- ✓ Unit tests: `test_timing.py` (pause formula), `test_voice_smoke.py` (API smoke tests)
- ✓ Integration: Full voice path (STT → turn → TTS) with thinking pause and barge-in assertions
- ✓ UI: Voice settings toggles persist and control feature flags sent to backend
- Manual barge-in: Speak during NPC TTS → audio fades within 200 ms, `interruption_count` increments
- Manual backchannel: Enable in Voice settings, speak for >3.5 s → short acknowledgments play mid-speech

Closes #308