### PR TITLE
Add desktop-distro workflow: test gate then cross-platform Tauri builds

### DIFF
--- a/.github/workflows/desktop-distro.yml
+++ b/.github/workflows/desktop-distro.yml
@@ -2,9 +2,17 @@
 # Desktop distribution workflow — runs the full test suite then builds
 # cross-platform Tauri installers and publishes a draft GitHub release.
 #
-# Triggered by a semver tag push (v*) or manual dispatch.  All backend,
-# frontend, schema, pack, and offline smoke tests must pass before the
-# per-platform builds start.
+# Triggered by manual dispatch only (supply the release tag as input).  All
+# backend, frontend, schema, pack, and offline smoke tests must pass before
+# the per-platform builds start.
+#
+# NOTE: this workflow is intentionally NOT wired to `push: tags: 'v*'`.  The
+# canonical automatic tag-push release is owned by `release.yml` (the workflow
+# advertised by the README badge, documented in docs/platform-notes.md, and
+# whose existence the offline smoke tests assert).  Wiring both workflows to
+# the same tag would run the cross-platform Tauri build twice and create two
+# competing draft releases for one tag.  This workflow is the on-demand,
+# fully test-gated build/release you dispatch for a specific tag.
 #
 # Build matrix:
 #   Windows x86_64  — NSIS installer (.exe) + MSI package (.msi)
@@ -20,9 +28,6 @@
 name: Desktop distribution
 
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/desktop-distro.yml
+++ b/.github/workflows/desktop-distro.yml
@@ -1,0 +1,665 @@
+# SPDX-License-Identifier: Apache-2.0
+# Desktop distribution workflow — runs the full test suite then builds
+# cross-platform Tauri installers and publishes a draft GitHub release.
+#
+# Triggered by a semver tag push (v*) or manual dispatch.  All backend,
+# frontend, schema, pack, and offline smoke tests must pass before the
+# per-platform builds start.
+#
+# Build matrix:
+#   Windows x86_64  — NSIS installer (.exe) + MSI package (.msi)
+#   macOS  aarch64  — disk image (.dmg) + Steam depot tarball (.app.tar.gz)
+#   Linux  x86_64   — AppImage (.AppImage) + Debian package (.deb)
+#
+# App version is stamped from the release tag (v0.1.0 → 0.1.0) into
+# tauri.conf.json before the Tauri build runs, so every bundle filename
+# and About dialog reflects the exact release tag.
+#
+# Artifact layout is verified for each platform before upload.
+
+name: Desktop distribution
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g. v0.1.0-alpha.1)'
+        required: true
+        type: string
+
+# Write permission needed to create GitHub releases and upload assets.
+permissions:
+  contents: write
+
+jobs:
+  # ── Test gate — backend ───────────────────────────────────────────────────────
+  test-backend:
+    name: Backend tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: |
+            services/convsim-core/pyproject.toml
+            packages/prompt-composer/pyproject.toml
+
+      - name: Install prompt-composer
+        run: pip install -e "packages/prompt-composer[dev]"
+
+      - name: Test prompt-composer
+        working-directory: packages/prompt-composer
+        run: python -m pytest
+
+      - name: Install convsim-core
+        run: pip install -e "services/convsim-core[dev]"
+
+      - name: Test convsim-core
+        working-directory: services/convsim-core
+        run: python -m pytest
+
+  # ── Test gate — frontend ──────────────────────────────────────────────────────
+  test-frontend:
+    name: Frontend typecheck and tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build shared TypeScript packages
+        run: |
+          pnpm --filter @convsim/shared-types build
+          pnpm --filter @convsim/scenario-schema build
+
+      - name: Typecheck packages
+        run: pnpm test:types
+
+      - name: Typecheck web app
+        run: pnpm --filter @convsim/web typecheck
+
+      - name: i18n check (pseudo-locale hardcoded string audit)
+        run: pnpm --filter @convsim/web check-i18n
+
+      - name: Run web tests
+        run: pnpm --filter @convsim/web test
+
+      - name: Run pack-loader tests
+        run: pnpm --filter @convsim/pack-loader test
+
+      - name: Run offline smoke tests (mock runtime)
+        run: |
+          pnpm --filter @convsim/cli exec vitest run \
+            tests/offline-smoke-test.test.ts tests/runner.test.ts
+
+      - name: Run CLI unit tests
+        run: pnpm --filter @convsim/cli exec vitest run tests/cli.test.ts
+
+  # ── Test gate — schema ────────────────────────────────────────────────────────
+  test-schemas:
+    name: Schema validation tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run schema load tests
+        run: node packages/scenario-schema/tests/load-schemas.js
+
+      - name: Run schema validation tests (examples + rejection)
+        run: node packages/scenario-schema/tests/validate-schemas.js
+
+      - name: Run scenario-schema unit tests (Zod validators + YAML round-trips)
+        run: pnpm --filter @convsim/scenario-schema exec vitest run
+
+  # ── Test gate — packs ─────────────────────────────────────────────────────────
+  test-packs:
+    name: Pack validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: pnpm
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: |
+            services/convsim-core/pyproject.toml
+            packages/prompt-composer/pyproject.toml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate official packs (schema check)
+        run: node packages/scenario-schema/tests/validate-packs.js packs/official
+
+      - name: Validate sample pack (schema check)
+        run: node packages/scenario-schema/tests/validate-packs.js packs/sample
+
+      - name: Install prompt-composer
+        run: pip install -e "packages/prompt-composer[dev]"
+
+      - name: Install convsim-core
+        run: pip install -e "services/convsim-core[dev]"
+
+      - name: Validate official packs (full policy check)
+        run: |
+          for d in packs/official/*/; do
+            convsim-validate-pack "$d"
+          done
+
+      - name: Validate sample pack (full policy check)
+        run: |
+          for d in packs/sample/*/; do
+            convsim-validate-pack "$d"
+          done
+
+  # ── Test gate — offline smoke (all three platforms) ────────────────────────────
+  test-smoke:
+    name: Offline smoke / ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux x86_64
+            slug: linux-x86_64
+            runner: ubuntu-latest
+            shell: bash
+            script: bash scripts/release-smoke.sh --ci
+          - name: macOS aarch64
+            slug: macos-aarch64
+            runner: macos-latest
+            shell: bash
+            script: bash scripts/release-smoke.sh --ci
+          - name: Windows x86_64
+            slug: windows-x86_64
+            runner: windows-2022
+            shell: pwsh
+            script: .\scripts\release-smoke.ps1
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: |
+            services/convsim-core/pyproject.toml
+            packages/prompt-composer/pyproject.toml
+
+      - name: Install prompt-composer
+        run: pip install -e "packages/prompt-composer[dev]"
+
+      - name: Install convsim-core
+        run: pip install -e "services/convsim-core[dev]"
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: pnpm
+
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build shared TypeScript packages
+        run: |
+          pnpm --filter @convsim/shared-types build
+          pnpm --filter @convsim/scenario-schema build
+
+      - name: Run release smoke (CI subset)
+        shell: ${{ matrix.shell }}
+        env:
+          CONVSIM_SMOKE_ARTIFACT_DIR: ${{ runner.temp }}/convsim-release-smoke-ci
+        run: ${{ matrix.script }}
+
+      - name: Upload smoke artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-${{ matrix.slug }}
+          path: ${{ runner.temp }}/convsim-release-smoke-*
+          retention-days: 7
+          if-no-files-found: ignore
+
+  # ── Cross-platform desktop builds ─────────────────────────────────────────────
+  build-desktop:
+    name: Desktop (${{ matrix.name }})
+    needs: [test-backend, test-frontend, test-schemas, test-packs, test-smoke]
+    runs-on: ${{ matrix.runner }}
+    # Expose a boolean presence flag for the Apple certificate so the import
+    # step can gate on `env` — the `secrets` context cannot be referenced from
+    # a step `if:` conditional (it evaluates to empty, making the condition
+    # always false).  Deliberately NOT the certificate itself; it must stay
+    # scoped to the import step so Tauri does not attempt its own import.
+    env:
+      HAS_APPLE_CERT: ${{ secrets.APPLE_CERTIFICATE != '' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # macOS ARM64 — macos-latest is Apple Silicon (M-series) since late 2024.
+          # macos-13 (last Intel/x86_64 runner) was deprecated by GitHub.
+          - name: macOS-aarch64
+            runner: macos-latest
+          # Linux x86_64 — AppImage + .deb
+          - name: Linux-x86_64
+            runner: ubuntu-latest
+          # Windows x86_64 — NSIS installer + MSI
+          - name: Windows-x86_64
+            runner: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # ── Resolve and stamp release version ────────────────────────────────────
+      # Strip the leading 'v' from the tag (v0.1.0 → 0.1.0) and write it into
+      # tauri.conf.json so that every bundle, filename, and About dialog shows
+      # the version that matches the release tag exactly.
+      - name: Stamp release version into tauri.conf.json
+        id: version
+        shell: bash
+        run: |
+          RAW_TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          VERSION="${RAW_TAG#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          jq --arg v "$VERSION" '.version = $v' \
+            apps/desktop/src-tauri/tauri.conf.json \
+            > apps/desktop/src-tauri/tauri.conf.json.tmp
+          mv apps/desktop/src-tauri/tauri.conf.json.tmp \
+            apps/desktop/src-tauri/tauri.conf.json
+          echo "Stamped version $VERSION into tauri.conf.json"
+          grep '"version"' apps/desktop/src-tauri/tauri.conf.json
+
+      # ── Linux system packages required by Tauri / WebKitGTK ──────────────────
+      - name: Install Linux system dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
+
+      # ── Node.js / pnpm ───────────────────────────────────────────────────────
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: pnpm
+
+      # ── Rust toolchain ───────────────────────────────────────────────────────
+      - name: Install Rust stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: apps/desktop/src-tauri -> target
+
+      # ── Frontend build ───────────────────────────────────────────────────────
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build shared TypeScript packages
+        run: |
+          pnpm --filter @convsim/shared-types build
+          pnpm --filter @convsim/scenario-schema build
+
+      - name: Build web frontend
+        run: pnpm --filter @convsim/web build
+
+      # ── macOS code-signing setup ─────────────────────────────────────────────
+      # Imports the Apple Developer ID p12 certificate into a temporary keychain
+      # so that both PyInstaller (sidecar signing) and Tauri (bundle signing +
+      # notarisation) can find it.
+      #
+      # Required repository secrets (Settings → Secrets and variables → Actions):
+      #   APPLE_CERTIFICATE          Base64-encoded Developer ID Application .p12
+      #   APPLE_CERTIFICATE_PASSWORD Passphrase for the .p12 file
+      #   APPLE_SIGNING_IDENTITY     Full identity string, e.g.
+      #                              "Developer ID Application: Outright Mental (TEAMID)"
+      #   APPLE_ID                   Apple ID email of the notarisation account
+      #   APPLE_PASSWORD             App-specific password for the Apple ID
+      #   APPLE_TEAM_ID              10-character Apple Developer Team ID
+      #
+      # When these secrets are absent (contributor forks, unsigned local builds)
+      # this step is skipped and the build produces an unsigned artifact — suitable
+      # for development and internal testing but not for Stage 3/4 Steam release.
+      - name: Import Apple Developer certificate (macOS only)
+        if: runner.os == 'macOS' && env.HAS_APPLE_CERT == 'true'
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          KEYCHAIN_PATH="$RUNNER_TEMP/build.keychain"
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          CERT_PATH="$RUNNER_TEMP/build_certificate.p12"
+          printf '%s' "$APPLE_CERTIFICATE" | base64 --decode > "$CERT_PATH"
+          security import "$CERT_PATH" \
+            -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -A -t cert -f pkcs12 \
+            -k "$KEYCHAIN_PATH"
+          security set-key-partition-list \
+            -S apple-tool:,apple: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychain -d user -s "$KEYCHAIN_PATH"
+          rm -f "$CERT_PATH"
+
+      # ── Python core build (PyInstaller standalone binary) ────────────────────
+      # Produces apps/desktop/src-tauri/resources/bin/convsim-core[.exe] which
+      # Tauri bundles as a resource (bundle.resources: ["resources/**/*"] in
+      # tauri.conf.json).  The binary must be present before `tauri build`.
+      - name: Set up Python for core build
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Build convsim-core standalone binary
+        shell: bash
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+        run: |
+          python -m pip install -q -e "../../packages/prompt-composer"
+          python -m pip install -q -e ".[build]"
+          python -m PyInstaller convsim-core.spec --noconfirm
+
+          mkdir -p ../../apps/desktop/src-tauri/resources/bin
+          if [ -f dist/convsim-core.exe ]; then
+            cp dist/convsim-core.exe ../../apps/desktop/src-tauri/resources/bin/
+          else
+            cp dist/convsim-core ../../apps/desktop/src-tauri/resources/bin/
+            chmod +x ../../apps/desktop/src-tauri/resources/bin/convsim-core
+          fi
+        working-directory: services/convsim-core
+
+      - name: Verify bundled core binary
+        shell: bash
+        run: |
+          BIN_DIR=apps/desktop/src-tauri/resources/bin
+          if [ -f "$BIN_DIR/convsim-core" ] || [ -f "$BIN_DIR/convsim-core.exe" ]; then
+            echo "OK: convsim-core binary present in $BIN_DIR"
+            ls -lh "$BIN_DIR"
+          else
+            echo "ERROR: convsim-core binary missing from $BIN_DIR" >&2
+            exit 1
+          fi
+
+      # ── Tauri desktop build ──────────────────────────────────────────────────
+      - name: Build Tauri desktop
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: pnpm --filter @convsim/desktop build
+
+      # ── Authenticode signing (Windows only, optional) ─────────────────────────
+      # Signs the NSIS installer (.exe) and MSI package produced by Tauri.
+      # When the signing secrets are absent the step exits 0 and the workflow
+      # continues with an unsigned installer (acceptable for development builds).
+      - name: Sign Windows installers (Authenticode)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          CERT_PFX_BASE64: ${{ secrets.WINDOWS_SIGN_CERT_PFX }}
+          CERT_PASSWORD:   ${{ secrets.WINDOWS_SIGN_CERT_PASSWORD }}
+        run: |
+          if (-not $env:CERT_PFX_BASE64) {
+            Write-Host "  INFO  WINDOWS_SIGN_CERT_PFX is not set — producing unsigned build."
+            Write-Host "        See docs/platform-notes.md for certificate setup instructions."
+            exit 0
+          }
+
+          $pfxPath = Join-Path $env:RUNNER_TEMP "convsim-sign.pfx"
+          try {
+            $b64 = ($env:CERT_PFX_BASE64 -split "`r?`n" |
+              Where-Object { $_ -notmatch '^-----' }) -join ''
+            [IO.File]::WriteAllBytes($pfxPath, [Convert]::FromBase64String($b64))
+
+            $bundleDir = "apps\desktop\src-tauri\target\release\bundle"
+            $installers = Get-ChildItem -Recurse -Path $bundleDir `
+              -Include "*.exe","*.msi" -ErrorAction SilentlyContinue
+
+            if (-not $installers) {
+              Write-Host "  WARN  No installers found in $bundleDir — skipping signing."
+              exit 0
+            }
+
+            $signtool = (Get-Command signtool.exe -ErrorAction SilentlyContinue).Source
+            if (-not $signtool) {
+              $signtool = Get-ChildItem `
+                -Path "${env:ProgramFiles(x86)}\Windows Kits\10\bin" `
+                -Recurse -Filter signtool.exe -ErrorAction SilentlyContinue |
+                Where-Object { $_.FullName -match '\\x64\\signtool\.exe$' } |
+                Sort-Object FullName -Descending |
+                Select-Object -First 1 -ExpandProperty FullName
+            }
+            if (-not $signtool) {
+              Write-Error "signtool.exe not found on PATH or under the Windows SDK."
+              exit 1
+            }
+            Write-Host "  Using signtool: $signtool"
+
+            foreach ($installer in $installers) {
+              Write-Host "  Signing: $($installer.FullName)"
+              & $signtool sign `
+                /f $pfxPath `
+                /p $env:CERT_PASSWORD `
+                /tr http://timestamp.digicert.com `
+                /td sha256 `
+                /fd sha256 `
+                /v `
+                $installer.FullName
+              if ($LASTEXITCODE -ne 0) {
+                Write-Error "signtool failed for $($installer.Name) (exit $LASTEXITCODE)"
+                exit $LASTEXITCODE
+              }
+            }
+            Write-Host "  INFO  All installers signed successfully."
+          } finally {
+            if (Test-Path $pfxPath) { Remove-Item $pfxPath -Force }
+          }
+
+      # ── Package macOS .app bundle for Steam depot ────────────────────────────
+      # Steam depots need raw application files, not the .dmg installer, so we
+      # tarball the signed and notarised .app bundle.  bsdtar preserves the code
+      # signature and stapled notarisation ticket.  Archiving with the bundle
+      # directory as CWD keeps <name>.app at the archive root so steam-deploy
+      # can extract it straight into steam-content/macos/.
+      - name: Package macOS .app bundle for Steam depot (macOS only)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -eu
+          BUNDLE_DIR=apps/desktop/src-tauri/target/release/bundle/macos
+          APP_PATH="$(find "$BUNDLE_DIR" -maxdepth 1 -name '*.app' | head -n1)"
+          if [ -z "$APP_PATH" ]; then
+            echo "ERROR: no .app bundle found under $BUNDLE_DIR" >&2
+            exit 1
+          fi
+          APP_NAME="$(basename "$APP_PATH")"
+          TARBALL="$BUNDLE_DIR/${APP_NAME%.app}.app.tar.gz"
+          echo "Packaging $APP_PATH -> $TARBALL"
+          tar -czf "$TARBALL" -C "$BUNDLE_DIR" "$APP_NAME"
+          ls -lh "$TARBALL"
+
+      # ── Verify artifact layout ───────────────────────────────────────────────
+      # Asserts that all expected installer/bundle files are present before
+      # upload.  On Linux also verifies the AppImage executable bit and prints
+      # SHA-256 checksums for the upload log record.
+      - name: Verify artifact layout
+        shell: bash
+        run: |
+          set -e
+          BUNDLE_ROOT=apps/desktop/src-tauri/target/release/bundle
+          VERSION="${{ steps.version.outputs.version }}"
+          echo "=== Artifact layout check: ${{ matrix.name }} (v${VERSION}) ==="
+          fail=0
+
+          case "${{ runner.os }}" in
+            Linux)
+              if ! find "$BUNDLE_ROOT/appimage" -name "*.AppImage" 2>/dev/null | grep -q .; then
+                echo "ERROR: no .AppImage found under $BUNDLE_ROOT/appimage" >&2
+                fail=1
+              else
+                find "$BUNDLE_ROOT/appimage" -name "*.AppImage" | while read -r f; do
+                  ls -lh "$f"
+                  if [[ ! -x "$f" ]]; then
+                    echo "WARNING: $f is not executable — fixing..."
+                    chmod +x "$f"
+                  fi
+                done
+              fi
+              if ! find "$BUNDLE_ROOT/deb" -name "*.deb" 2>/dev/null | grep -q .; then
+                echo "ERROR: no .deb found under $BUNDLE_ROOT/deb" >&2
+                fail=1
+              else
+                find "$BUNDLE_ROOT/deb" -name "*.deb" | while read -r f; do ls -lh "$f"; done
+              fi
+              echo ""
+              echo "=== SHA-256 checksums ==="
+              find "$BUNDLE_ROOT" \( -name "*.AppImage" -o -name "*.deb" \) | \
+                sort | xargs sha256sum
+              ;;
+            macOS)
+              if ! find "$BUNDLE_ROOT/macos" -name "*.app.tar.gz" 2>/dev/null | grep -q .; then
+                echo "ERROR: no .app.tar.gz found under $BUNDLE_ROOT/macos" >&2
+                fail=1
+              else
+                find "$BUNDLE_ROOT/macos" -name "*.app.tar.gz" | while read -r f; do ls -lh "$f"; done
+              fi
+              if ! find "$BUNDLE_ROOT/dmg" -name "*.dmg" 2>/dev/null | grep -q .; then
+                echo "ERROR: no .dmg found under $BUNDLE_ROOT/dmg" >&2
+                fail=1
+              else
+                find "$BUNDLE_ROOT/dmg" -name "*.dmg" | while read -r f; do ls -lh "$f"; done
+              fi
+              ;;
+            Windows)
+              if ! find "$BUNDLE_ROOT/nsis" -name "*.exe" 2>/dev/null | grep -q .; then
+                echo "ERROR: no NSIS .exe installer found under $BUNDLE_ROOT/nsis" >&2
+                fail=1
+              else
+                find "$BUNDLE_ROOT/nsis" -name "*.exe" | while read -r f; do ls -lh "$f"; done
+              fi
+              if ! find "$BUNDLE_ROOT/msi" -name "*.msi" 2>/dev/null | grep -q .; then
+                echo "ERROR: no .msi found under $BUNDLE_ROOT/msi" >&2
+                fail=1
+              else
+                find "$BUNDLE_ROOT/msi" -name "*.msi" | while read -r f; do ls -lh "$f"; done
+              fi
+              ;;
+          esac
+
+          [ "$fail" -eq 0 ] || exit 1
+          echo ""
+          echo "=== All expected artifacts present ==="
+
+      # ── Upload per-platform artifacts ────────────────────────────────────────
+      - name: Upload desktop artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-${{ matrix.name }}
+          path: |
+            apps/desktop/src-tauri/target/release/bundle/**/*.dmg
+            apps/desktop/src-tauri/target/release/bundle/**/*.app.tar.gz
+            apps/desktop/src-tauri/target/release/bundle/**/*.AppImage
+            apps/desktop/src-tauri/target/release/bundle/**/*.deb
+            apps/desktop/src-tauri/target/release/bundle/**/*.exe
+            apps/desktop/src-tauri/target/release/bundle/**/*.msi
+          if-no-files-found: error
+          retention-days: 30
+
+  # ── Publish GitHub release ────────────────────────────────────────────────────
+  release:
+    name: Publish release
+    needs: build-desktop
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all desktop artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release-artifacts
+          pattern: desktop-*
+          merge-multiple: true
+
+      - name: List collected artifacts
+        run: find release-artifacts -type f | sort
+
+      - name: Generate SHA-256 checksums
+        # Record bare filenames (not the release-artifacts/... paths) so the
+        # manifest matches the flattened asset names on the release page and
+        # `sha256sum -c checksums-sha256.txt` works next to the downloads.
+        run: |
+          find release-artifacts -type f | sort | while IFS= read -r f; do
+            ( cd "$(dirname "$f")" && sha256sum "$(basename "$f")" )
+          done > checksums-sha256.txt
+          cat checksums-sha256.txt
+
+      - name: Create draft GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
+          name: >-
+            Conversation Simulator
+            ${{ github.event.inputs.tag || github.ref_name }}
+          body_path: docs/release-notes-template.md
+          draft: true
+          prerelease: true
+          files: |
+            release-artifacts/**
+            checksums-sha256.txt
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/desktop-distro.yml
+++ b/.github/workflows/desktop-distro.yml
@@ -283,9 +283,15 @@ jobs:
           # macos-13 (last Intel/x86_64 runner) was deprecated by GitHub.
           - name: macOS-aarch64
             runner: macos-latest
-          # Linux x86_64 — AppImage + .deb
+          # Linux x86_64 — AppImage + .deb.  Pinned to ubuntu-22.04 (glibc 2.35)
+          # rather than ubuntu-latest: the AppImage/.deb link against the build
+          # machine's glibc, and the documented compatibility floor is glibc
+          # ≥ 2.35 (Ubuntu 22.04+, Debian 12+, SteamOS 3.x — see
+          # docs/platform-notes.md).  Building on ubuntu-latest (24.04, glibc
+          # 2.39) would raise that floor and break the release on SteamOS and
+          # every LTS distro we promise to support.  Matches release.yml.
           - name: Linux-x86_64
-            runner: ubuntu-latest
+            runner: ubuntu-22.04
           # Windows x86_64 — NSIS installer + MSI
           - name: Windows-x86_64
             runner: windows-latest


### PR DESCRIPTION
## Summary

Adds `.github/workflows/desktop-distro.yml`, a new GitHub Actions workflow providing a fully test-gated, on-demand build and release process for cross-platform Tauri desktop installers.

## What changed

**New file: `.github/workflows/desktop-distro.yml`**

The workflow is triggered only via `workflow_dispatch` (manual dispatch with a `tag` input). This design avoids colliding with the existing automatic tag-push release in `release.yml`, preventing duplicate cross-platform builds and competing draft releases.

### Five parallel test gates

Before any build starts, all of these jobs must succeed:

- **test-backend** — pytest for `packages/prompt-composer` and `services/convsim-core`
- **test-frontend** — pnpm typecheck, i18n audit, and vitest for web, pack-loader, CLI, and offline smoke scenarios
- **test-schemas** — JSON schema load, validation, and Zod/YAML round-trip tests
- **test-packs** — schema check and `convsim-validate-pack` policy validation for official and sample packs
- **test-smoke** (matrix: Linux x86_64 / ubuntu-latest, macOS aarch64 / macos-latest, Windows x86_64 / windows-2022) — offline smoke suite via `release-smoke.sh --ci` and `release-smoke.ps1`

### Cross-platform build matrix

Once all test gates pass, the `build-desktop` job runs in parallel for three platforms (macOS aarch64, Linux x86_64, Windows x86_64):

1. **Version stamping** — strips the leading `v` from the tag and writes it into `apps/desktop/src-tauri/tauri.conf.json` so every bundle filename and About dialog reflects the exact tag
2. Install platform dependencies, Node.js 20, pnpm, and Rust stable (with artifact caching)
3. Frontend build pipeline: `@convsim/shared-types` → `@convsim/scenario-schema` → `@convsim/web`
4. macOS only: optional Apple Developer certificate import into a temporary keychain (skipped if secrets absent)
5. PyInstaller build of `convsim-core` sidecar → binary copied to `resources/bin/` and verified present
6. `pnpm --filter @convsim/desktop build` (Tauri build)
7. Windows only: optional Authenticode signing via `signtool.exe` (skipped if secrets absent)
8. macOS only: tar the signed `.app` bundle for Steam depot
9. **Artifact layout verification** — platform-specific assertions confirm expected files (.dmg, .app.tar.gz, .AppImage, .deb, .exe, .msi); on Linux, AppImage executable bit is checked and fixed, and SHA-256 checksums are printed
10. Upload platform-specific artifacts via `actions/upload-artifact@v4` (fails if no files found)

**Linux build pinned to ubuntu-22.04** for glibc compatibility. The AppImage and .deb link against the builder's glibc; using ubuntu-22.04 (glibc 2.35) ensures the release works on documented targets (Ubuntu 22.04+, Debian 12+, SteamOS 3.x) rather than raising the floor to glibc 2.39 (ubuntu-latest / 24.04).

### Release job

The `release` job (after all build jobs succeed) downloads all `desktop-*` artifacts, generates a `checksums-sha256.txt` manifest, and creates a draft prerelease on GitHub with all files attached.

Closes #234