### PR TITLE
Add Steam publishing docs: store operations, deployment, integration, and signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,20 @@ deliberately out of scope, and links to the acceptance criteria and docs.
 > [Full specification](docs/SPEC.md) &nbsp;·&nbsp;
 > [Post-alpha issues](docs/post-alpha-issues.md)
 
+### Steam release
+
+The project is being prepared for a free, Outright Mental-sponsored Steam release.
+The Steam edition makes the same local-first guarantee as the open-source build.
+
+| Document | Purpose |
+|----------|---------|
+| [docs/STEAM_ROADMAP.md](docs/STEAM_ROADMAP.md) | Release principles and release train (Stages 1–5) |
+| [publishing/STEAM_STORE_AND_OPERATIONS.md](publishing/STEAM_STORE_AND_OPERATIONS.md) | Store page operations, launch runbook, support triage |
+| [publishing/STEAM_PUBLISHING_AND_DEPLOYMENT.md](publishing/STEAM_PUBLISHING_AND_DEPLOYMENT.md) | SteamPipe concepts, CI deploy, manual upload, branch promotion, troubleshooting |
+| [docs/STEAM_INTEGRATION.md](docs/STEAM_INTEGRATION.md) | Steam API bridge, Steam Cloud exclusions, achievements, stats, rich presence |
+| [publishing/MACOS_SIGNING_AND_NOTARIZATION.md](publishing/MACOS_SIGNING_AND_NOTARIZATION.md) | macOS Apple Developer ID signing and notarisation |
+| [publishing/WINDOWS_CODE_SIGNING.md](publishing/WINDOWS_CODE_SIGNING.md) | Windows Authenticode signing |
+
 ---
 
 ## Contributing

--- a/docs/STEAM_INTEGRATION.md
+++ b/docs/STEAM_INTEGRATION.md
@@ -1,0 +1,330 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+# Steam Integration
+
+> **Purpose:** Developer reference for the optional Steam API bridge built into
+> the Tauri desktop app. Covers the feature-flag model, Steam Cloud exclusions,
+> achievements / stats / rich presence configuration, and graceful fallback
+> behaviour when Steam is absent.
+>
+> **Audience:** Platform engineers implementing or modifying the Steamworks
+> integration in `apps/desktop/src-tauri/src/steam.rs` and the corresponding
+> React hooks. See [`docs/steam-achievements-stats-rich-presence.md`](steam-achievements-stats-rich-presence.md)
+> for the Steamworks portal configuration companion (what to enter in App Admin).
+>
+> **Privacy guarantee:** No conversation content, transcript text, audio, or
+> session details are ever transmitted to Steam. Only aggregate integer counts
+> and generic activity tokens are sent — and only when the Steamworks SDK is
+> active and the player is inside Steam. This is enforced by the integration
+> design, not just policy.
+
+---
+
+## Feature flag and build variants
+
+The Steam integration is compiled in only when the `steam` Cargo feature is
+enabled. Enabling the feature links the `steamworks` crate and activates the
+`SteamRuntime` implementation.
+
+```toml
+# apps/desktop/src-tauri/Cargo.toml
+[features]
+steam = ["steamworks"]
+```
+
+### Build variants
+
+| Build command | Steam SDK | Use case |
+|---------------|-----------|----------|
+| `cargo tauri build` | Not linked | Standard open-source build; Steam features are no-ops |
+| `cargo tauri build --features steam` | Linked | Steam depot build; full integration active when Steam is running |
+
+The open-source release and the Steam depot release are compiled from the same
+source. Enabling the `steam` feature in the Steam depot build is the only
+structural difference between the two.
+
+### Testing with Steam App ID 480
+
+Valve's test App ID `480` (Spacewar) can be used for local integration testing
+without registering the production App ID.
+
+```bash
+# Start the Tauri dev server with the Steam feature and the test App ID.
+SteamAppId=480 cargo tauri dev --features steam
+```
+
+The real App ID is embedded in the depot build by the release workflow via
+`STEAM_APPID` in `tauri.conf.json`. Do not hardcode the production App ID in
+source files — use the variable substitution in the VDF templates and the
+workflow environment.
+
+---
+
+## Steam API bridge
+
+The bridge consists of:
+
+1. **`apps/desktop/src-tauri/src/steam.rs`** — Rust module that wraps the
+   `steamworks` crate. Contains the `SteamRuntime` struct, all Tauri command
+   handlers, and the graceful-fallback logic.
+2. **`useSteamAchievements`** React hook — front-end wrapper that invokes the
+   Tauri `steam_unlock_achievement` and `steam_increment_stat` commands.
+3. **`useSteamRichPresence`** React hook — front-end wrapper that invokes the
+   Tauri `steam_set_rich_presence` command.
+
+### Tauri commands
+
+| Command | Arguments | Effect when Steam active | Effect when Steam absent |
+|---------|-----------|--------------------------|--------------------------|
+| `steam_unlock_achievement` | `name: String` | Calls `steamworks::UserStats::achievement(name).set()` then `store_stats()` | Returns `false`, no-op |
+| `steam_increment_stat` | `name: String` | Reads current value, increments by 1, calls `store_stats()` | Returns `false`, no-op |
+| `steam_set_rich_presence` | `key: String, value: String` | Calls `steamworks::Friends::set_rich_presence(key, value)` | Returns `false`, no-op |
+
+Commands can be called freely without checking whether Steam is available.
+The `SteamRuntime` managed-state object absorbs all failures silently.
+
+### `SteamRuntime` managed state
+
+`SteamRuntime` is registered as a Tauri managed state object in `lib.rs`:
+
+```rust
+// apps/desktop/src-tauri/src/lib.rs
+use crate::steam::SteamRuntime;
+
+tauri::Builder::default()
+    .manage(SteamRuntime::new())
+    ...
+```
+
+`SteamRuntime::new()` attempts `steamworks::Client::init()`. If init fails for
+any reason — Steam not running, `steam` feature disabled, wrong App ID, SDK
+missing — the runtime stores a `None` client and all subsequent commands return
+`false` immediately without logging errors.
+
+---
+
+## Steam Cloud exclusions
+
+Steam Cloud is configured in the Steamworks partner portal to sync only the
+non-sensitive settings file. The integration is documented in detail in
+[`publishing/STEAM_APP_REGISTRATION.md` — Steam Cloud configuration](../publishing/STEAM_APP_REGISTRATION.md#steam-cloud-configuration).
+
+### How exclusions are enforced (two layers)
+
+**Layer 1 — Steamworks portal exclusion patterns**
+
+The authoritative exclusion list is in the Steamworks App Admin → Steam Cloud
+configuration. Every data subdirectory (`db/`, `logs/`, `models/`, `packs/`,
+`exports/`, `cache/`, `crashes/`, `data/`) is excluded with recursive patterns.
+Only `steam_cloud_settings.json` is included.
+
+**Layer 2 — `.nosteamcloudpath` sentinel files**
+
+The app writes a `.nosteamcloudpath` file to each data subdirectory on first
+launch. This sentinel file tells the Steam client not to sync its directory
+even if the portal configuration changes or is misconfigured. The sentinel
+files are created by `convsim_core/paths.py` at the `ensure_data_dirs()` call.
+
+### `steam_cloud_settings.json` schema
+
+This is the only file allowed to reach Steam Cloud. Its purpose is to carry
+non-sensitive UI preferences across the player's machines.
+
+```json
+{
+  "schema_version": 1,
+  "display_theme": "system",
+  "last_used_model_id": "qwen3-4b-q4_k_m",
+  "ui_layout": {}
+}
+```
+
+Fields that may **never** appear in this file:
+- Conversation text, prompts, or transcript excerpts
+- Session IDs, session history, or session scores
+- NPC names or scenario identifiers beyond the model preference
+- Audio data of any kind
+- Personal or identifying information
+
+If a field is added to `steam_cloud_settings.json`, it must be reviewed for
+privacy impact before the feature is merged. The gate G4-04 in
+[`docs/steam-mvp-scope.md`](steam-mvp-scope.md) requires explicit sign-off
+from the platform team on any new synced field.
+
+### Verifying the Steam Cloud configuration
+
+After configuring Steam Cloud in the Steamworks portal, verify with the
+**B.11 Steam Cloud sync verification** steps in
+[`docs/release-checklist.md`](release-checklist.md).
+
+---
+
+## Achievements
+
+Full Steamworks portal configuration (App Admin → Achievements tab) is in
+[`docs/steam-achievements-stats-rich-presence.md`](steam-achievements-stats-rich-presence.md).
+
+This section covers the integration points.
+
+### Defined achievements
+
+| Display name | Enum | API name | Unlock event |
+|---|---|---|---|
+| First Scenario | `SteamAchievement::FIRST_SCENARIO` | `ACH_FIRST_SCENARIO` | Session ends or is manually ended |
+| First Debrief | `SteamAchievement::FIRST_DEBRIEF` | `ACH_FIRST_DEBRIEF` | Debrief screen rendered |
+| Practice Streak | `SteamAchievement::PRACTICE_STREAK` | `ACH_PRACTICE_STREAK` | 3 consecutive calendar days with completed sessions |
+| Pack Explorer | `SteamAchievement::PACK_EXPLORER` | `ACH_PACK_EXPLORER` | Session completed from 3+ distinct packs |
+| Creator First Validate | `SteamAchievement::CREATOR_FIRST_VALIDATE` | `ACH_CREATOR_FIRST_VALIDATE` | Creator workbench validates first custom pack |
+
+### Unlock call pattern
+
+```typescript
+// apps/web/src/hooks/useSteamAchievements.ts
+const { unlock } = useSteamAchievements()
+
+// Called at the debrief screen boundary
+unlock(SteamAchievement.FIRST_SCENARIO)
+```
+
+The hook resolves to a no-op when `window.__TAURI__` is absent (browser context)
+or when the Tauri command returns `false` (Steam not running).
+
+Achievement unlock is **idempotent** — calling `unlock` on an already-unlocked
+achievement is silently ignored by the Steamworks API.
+
+---
+
+## Stats
+
+Full Steamworks portal configuration is in
+[`docs/steam-achievements-stats-rich-presence.md`](steam-achievements-stats-rich-presence.md).
+
+### Defined stats
+
+| Display name | Enum | API name | Increment event |
+|---|---|---|---|
+| Scenarios Completed | `SteamStat::SCENARIOS_COMPLETED` | `STAT_SCENARIOS_COMPLETED` | Session ends |
+| Debriefs Generated | `SteamStat::DEBRIEFS_GENERATED` | `STAT_DEBRIEFS_GENERATED` | Debrief screen displayed |
+| Packs Validated | `SteamStat::PACKS_VALIDATED` | `STAT_PACKS_VALIDATED` | Creator workbench validates a pack |
+| Text Mode Sessions | `SteamStat::TEXT_MODE_SESSIONS` | `STAT_TEXT_MODE_SESSIONS` | Session starts in text mode |
+| Voice Mode Sessions | `SteamStat::VOICE_MODE_SESSIONS` | `STAT_VOICE_MODE_SESSIONS` | Session starts in voice mode |
+
+All stats are **INT** type, **monotonically increasing**, and **count-only**.
+A stat value reveals how many times an event occurred — nothing about the
+content of the event.
+
+### Increment call pattern
+
+```typescript
+const { incrementStat } = useSteamAchievements()
+
+// Called when the session-start API returns success
+incrementStat(SteamStat.TEXT_MODE_SESSIONS)
+```
+
+---
+
+## Rich presence
+
+Full Steamworks portal configuration (including the `richpresence.vdf`
+localization file) is in
+[`docs/steam-achievements-stats-rich-presence.md`](steam-achievements-stats-rich-presence.md).
+
+### Defined tokens
+
+| Token | Display string | Set when |
+|-------|---------------|----------|
+| `#AtMainMenu` | `Browsing scenarios` | `screens/Home` and `screens/ScenarioLibrary` mount |
+| `#InScenario` | `In a practice scenario` | `screens/Conversation` mounts |
+| `#ReviewingDebrief` | `Reviewing a debrief` | `screens/Debrief` mounts |
+| `#EditingPack` | `Editing a scenario pack` | `screens/CreatorWorkbench` mounts |
+
+Tokens are **category labels only**. No scenario title, NPC name, turn count,
+or any content from the conversation is transmitted to Steam.
+
+### Set call pattern
+
+```typescript
+const { setPresence } = useSteamRichPresence()
+
+// Called in screens/Conversation.tsx's useEffect
+setPresence(SteamActivity.IN_SCENARIO)
+```
+
+The `steam_display` key is the only key used. Valve uses the
+`#<token>` value to look up the localized string from the uploaded
+`richpresence.vdf` file.
+
+---
+
+## Graceful fallback outside Steam
+
+Every integration point degrades gracefully when Steam is absent. The
+fallback layers are:
+
+| Layer | Condition | Behaviour |
+|-------|-----------|-----------|
+| Cargo feature disabled | `steam` feature not in build | `SteamRuntime` stubs compile to instant no-ops at zero runtime cost |
+| Feature enabled but `Client::init()` fails | Steam not running, wrong App ID, SDK unavailable | `SteamRuntime` stores `None` client; all commands return `false` |
+| Tauri context absent | App running in browser (not Tauri shell) | Hooks check `window.__TAURI__`; calls are skipped entirely |
+| Command returns `false` | Any of the above | Caller receives `false`; no retry, no error UI shown |
+
+The application functions identically whether Steam is present or not. No UI
+state, no feature gate, no error message is conditioned on Steam availability.
+This is a deliberate product decision: the Steam integration is additive, not
+structural.
+
+---
+
+## End-to-end test
+
+Run this manual test before the Stage 4 public release gate to confirm the
+integration is wired correctly:
+
+```bash
+# Start the app with the test App ID and the steam feature enabled.
+SteamAppId=480 cargo tauri dev --features steam
+```
+
+1. Open Steam in the background (must be logged in).
+2. Launch the Tauri dev app.
+3. Navigate to a scenario and complete it. Confirm the Steam overlay shows the
+   `ACH_FIRST_SCENARIO` unlock notification.
+4. Open the Debrief screen. Confirm `ACH_FIRST_DEBRIEF` notification appears.
+5. Navigate to the Creator Workbench. Confirm rich presence changes to
+   `"Editing a scenario pack"` in the Steam friends list.
+6. Confirm no session title, NPC name, or turn content appears in any
+   Steam-facing string.
+
+Also run with Steam closed to confirm the no-op fallback: all three actions
+above must complete without any error, console warning, or UI change.
+
+---
+
+## Checklist
+
+Use this checklist at the Stage 4 gate:
+
+- [ ] All five achievements created in App Admin with correct API names and icon pairs.
+- [ ] Hidden flag set on `ACH_PRACTICE_STREAK` and `ACH_PACK_EXPLORER`.
+- [ ] All five stats created as INT type.
+- [ ] Rich presence localization file uploaded for English (at minimum).
+- [ ] End-to-end test above completed with Steam running: achievements, stats,
+      and rich presence all fire correctly.
+- [ ] End-to-end test completed with Steam closed: no errors, no UI changes.
+- [ ] Steam Cloud configured in Steamworks portal — only `steam_cloud_settings.json`
+      included; all data subdirectories excluded.
+- [ ] B.11 Steam Cloud sync verification steps in `docs/release-checklist.md`
+      completed and passing.
+- [ ] Confirmed no session content appears in any Steam-facing string.
+
+---
+
+## Links
+
+- [`apps/desktop/src-tauri/src/steam.rs`](../apps/desktop/src-tauri/src/steam.rs) — Rust Steam bridge implementation
+- [`docs/steam-achievements-stats-rich-presence.md`](steam-achievements-stats-rich-presence.md) — Steamworks portal configuration: achievements, stats, rich presence
+- [`publishing/STEAM_APP_REGISTRATION.md`](../publishing/STEAM_APP_REGISTRATION.md) — Steam Cloud quota, root paths, and exclusion patterns
+- [`docs/privacy.md`](privacy.md) — local-first data handling; base privacy policy
+- [`docs/steam-mvp-scope.md`](steam-mvp-scope.md) — Stage 4 gate criteria (G4-04 covers synced-field sign-off)
+- [`docs/release-checklist.md`](release-checklist.md) — B.11 Steam Cloud sync verification
+- [`publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md`](../publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md) — privacy risks PR-01 through PR-03

--- a/docs/STEAM_INTEGRATION.md
+++ b/docs/STEAM_INTEGRATION.md
@@ -137,17 +137,27 @@ semantics are documented in `services/convsim-core/convsim_core/steam_cloud.py`.
 
 ### `steam_cloud_settings.json` schema
 
-This is the only file allowed to reach Steam Cloud. Its purpose is to carry
-non-sensitive UI preferences across the player's machines.
+This is the only file allowed to reach Steam Cloud. It carries a small set of
+non-sensitive preferences so a second machine can pick up where the last one
+left off. The schema is the `CloudSettings` model in
+[`services/convsim-core/convsim_core/steam_cloud.py`](../services/convsim-core/convsim_core/steam_cloud.py);
+today it holds a single field:
 
 ```json
 {
-  "schema_version": 1,
-  "display_theme": "system",
-  "last_used_model_id": "qwen3-4b-q4_k_m",
-  "ui_layout": {}
+  "last_model_id": "qwen3-4b-q4_k_m"
 }
 ```
+
+`last_model_id` pre-selects the same model on a new device. It must be an
+opaque model identifier — a `field_validator` in `CloudSettings` rejects any
+value containing a path separator on both write and read, so a filesystem path
+(which could leak a username or home directory) can never reach the cloud file.
+
+The `docs/steam-mvp-scope.md` sync scope also permits display preferences and
+UI layout state as future additions, but only `last_model_id` is synced today.
+Any new field must be added to `CloudSettings` and reviewed for privacy impact
+before it ships.
 
 Fields that may **never** appear in this file:
 - Conversation text, prompts, or transcript excerpts
@@ -156,8 +166,7 @@ Fields that may **never** appear in this file:
 - Audio data of any kind
 - Personal or identifying information
 
-If a field is added to `steam_cloud_settings.json`, it must be reviewed for
-privacy impact before the feature is merged. The authoritative sync scope is
+The authoritative sync scope is
 the **Steam Cloud sync for non-sensitive settings** row in
 [`docs/steam-mvp-scope.md`](steam-mvp-scope.md) (display preferences,
 last-used model ID, UI layout state only — transcripts, model weights, audio

--- a/docs/STEAM_INTEGRATION.md
+++ b/docs/STEAM_INTEGRATION.md
@@ -28,7 +28,10 @@ enabled. Enabling the feature links the `steamworks` crate and activates the
 ```toml
 # apps/desktop/src-tauri/Cargo.toml
 [features]
-steam = ["steamworks"]
+steam = ["dep:steamworks"]
+
+[dependencies]
+steamworks = { version = "0.11", optional = true }
 ```
 
 ### Build variants
@@ -64,8 +67,10 @@ workflow environment.
 The bridge consists of:
 
 1. **`apps/desktop/src-tauri/src/steam.rs`** — Rust module that wraps the
-   `steamworks` crate. Contains the `SteamRuntime` struct, all Tauri command
-   handlers, and the graceful-fallback logic.
+   `steamworks` crate. Contains the `SteamRuntime` struct (with the
+   `unlock_achievement`, `increment_stat`, and `set_rich_presence` methods) and
+   the graceful-fallback logic. The `#[tauri::command]` handlers that expose
+   these methods to the front end live in `apps/desktop/src-tauri/src/lib.rs`.
 2. **`useSteamAchievements`** React hook — front-end wrapper that invokes the
    Tauri `steam_unlock_achievement` and `steam_increment_stat` commands.
 3. **`useSteamRichPresence`** React hook — front-end wrapper that invokes the
@@ -77,25 +82,28 @@ The bridge consists of:
 |---------|-----------|--------------------------|--------------------------|
 | `steam_unlock_achievement` | `name: String` | Calls `steamworks::UserStats::achievement(name).set()` then `store_stats()` | Returns `false`, no-op |
 | `steam_increment_stat` | `name: String` | Reads current value, increments by 1, calls `store_stats()` | Returns `false`, no-op |
-| `steam_set_rich_presence` | `key: String, value: String` | Calls `steamworks::Friends::set_rich_presence(key, value)` | Returns `false`, no-op |
+| `steam_set_rich_presence` | `value: String` | Calls `steamworks::Friends::set_rich_presence("steam_display", Some(value))` — the key is fixed internally | Returns `false`, no-op |
 
 Commands can be called freely without checking whether Steam is available.
 The `SteamRuntime` managed-state object absorbs all failures silently.
 
 ### `SteamRuntime` managed state
 
-`SteamRuntime` is registered as a Tauri managed state object in `lib.rs`:
+`SteamRuntime` is constructed once by `steam::init()` during `setup()` and
+registered as a Tauri managed state object in `lib.rs`, wrapped in an
+`Arc<Mutex<…>>` newtype (`SteamRuntimeState`) so the command handlers can share it:
 
 ```rust
 // apps/desktop/src-tauri/src/lib.rs
-use crate::steam::SteamRuntime;
+let (steam_status_val, steam_runtime_val) = steam::init();
+let steam_runtime = Arc::new(Mutex::new(steam_runtime_val));
 
 tauri::Builder::default()
-    .manage(SteamRuntime::new())
+    .manage(SteamRuntimeState(Arc::clone(&steam_runtime)))
     ...
 ```
 
-`SteamRuntime::new()` attempts `steamworks::Client::init()`. If init fails for
+`steam::init()` attempts `steamworks::Client::init()`. If init fails for
 any reason — Steam not running, `steam` feature disabled, wrong App ID, SDK
 missing — the runtime stores a `None` client and all subsequent commands return
 `false` immediately without logging errors.
@@ -122,7 +130,10 @@ Only `steam_cloud_settings.json` is included.
 The app writes a `.nosteamcloudpath` file to each data subdirectory on first
 launch. This sentinel file tells the Steam client not to sync its directory
 even if the portal configuration changes or is misconfigured. The sentinel
-files are created by `convsim_core/paths.py` at the `ensure_data_dirs()` call.
+files are written by the FastAPI app lifespan hook in
+`services/convsim-core/convsim_core/app.py`, which touches a
+`.nosteamcloudpath` marker in each data subdirectory on startup. The exclusion
+semantics are documented in `services/convsim-core/convsim_core/steam_cloud.py`.
 
 ### `steam_cloud_settings.json` schema
 
@@ -146,9 +157,13 @@ Fields that may **never** appear in this file:
 - Personal or identifying information
 
 If a field is added to `steam_cloud_settings.json`, it must be reviewed for
-privacy impact before the feature is merged. The gate G4-04 in
-[`docs/steam-mvp-scope.md`](steam-mvp-scope.md) requires explicit sign-off
-from the platform team on any new synced field.
+privacy impact before the feature is merged. The authoritative sync scope is
+the **Steam Cloud sync for non-sensitive settings** row in
+[`docs/steam-mvp-scope.md`](steam-mvp-scope.md) (display preferences,
+last-used model ID, UI layout state only — transcripts, model weights, audio
+files, and session history must never sync), and the privacy risks PR-01
+through PR-03 in
+[`publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md`](../publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md).
 
 ### Verifying the Steam Cloud configuration
 
@@ -325,6 +340,6 @@ Use this checklist at the Stage 4 gate:
 - [`docs/steam-achievements-stats-rich-presence.md`](steam-achievements-stats-rich-presence.md) — Steamworks portal configuration: achievements, stats, rich presence
 - [`publishing/STEAM_APP_REGISTRATION.md`](../publishing/STEAM_APP_REGISTRATION.md) — Steam Cloud quota, root paths, and exclusion patterns
 - [`docs/privacy.md`](privacy.md) — local-first data handling; base privacy policy
-- [`docs/steam-mvp-scope.md`](steam-mvp-scope.md) — Stage 4 gate criteria (G4-04 covers synced-field sign-off)
+- [`docs/steam-mvp-scope.md`](steam-mvp-scope.md) — release gates and the authoritative Steam Cloud sync scope (non-sensitive settings only)
 - [`docs/release-checklist.md`](release-checklist.md) — B.11 Steam Cloud sync verification
 - [`publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md`](../publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md) — privacy risks PR-01 through PR-03

--- a/docs/STEAM_ROADMAP.md
+++ b/docs/STEAM_ROADMAP.md
@@ -221,6 +221,7 @@ issue must not be started until the upstream issue is merged and closed.
 | [[Steam Roadmap] Define Steam MVP scope and release gates](https://github.com/outrightmental/ConversationSimulator/issues?q=is%3Aissue+steam-mvp-scope+in%3Atitle) | [docs/steam-mvp-scope.md](steam-mvp-scope.md) | Stage 2 prerequisite |
 | [[Steam Roadmap] Add issue templates for Steam QA, platform bugs, and content-pack bugs](https://github.com/outrightmental/ConversationSimulator/issues/185) | [docs/steam-triage.md](steam-triage.md) | Stage 3 prerequisite |
 | [[Steamworks] Register Steam app, depots, packages, and free-to-play configuration](https://github.com/outrightmental/ConversationSimulator/issues/226) | [publishing/STEAM_APP_REGISTRATION.md](../publishing/STEAM_APP_REGISTRATION.md), [`steam/`](../steam/), [`.github/workflows/steam-deploy.yml`](../.github/workflows/steam-deploy.yml) | Stage 3 prerequisite (must be complete before first depot submission) |
+| [[Publishing] Write Steam publishing docs matching the FeverTilt pattern](https://github.com/outrightmental/ConversationSimulator/issues/232) | [publishing/STEAM_STORE_AND_OPERATIONS.md](../publishing/STEAM_STORE_AND_OPERATIONS.md), [publishing/STEAM_PUBLISHING_AND_DEPLOYMENT.md](../publishing/STEAM_PUBLISHING_AND_DEPLOYMENT.md), [docs/STEAM_INTEGRATION.md](STEAM_INTEGRATION.md), [publishing/MACOS_SIGNING_AND_NOTARIZATION.md](../publishing/MACOS_SIGNING_AND_NOTARIZATION.md), [publishing/WINDOWS_CODE_SIGNING.md](../publishing/WINDOWS_CODE_SIGNING.md) | Stage 3 prerequisite (operational clarity before private beta) |
 | [[Marketplace] Design future in-game content marketplace architecture](https://github.com/outrightmental/ConversationSimulator/issues/233) | [docs/marketplace-architecture.md](marketplace-architecture.md) | Stage 5 design baseline (post-launch, not launch-blocking) |
 
 All open and closed issues in this work stream:
@@ -233,10 +234,15 @@ All open and closed issues in this work stream:
 - [ROADMAP.md](../ROADMAP.md) — base project roadmap (MVP acceptance criteria, build order, status)
 - [steam-mvp-scope.md](steam-mvp-scope.md) — minimum playable release features, optional targeted features, pass/fail gates, and post-launch deferrals
 - [steam-triage.md](steam-triage.md) — issue triage flow for private beta and public launch
+- [STEAM_INTEGRATION.md](STEAM_INTEGRATION.md) — Steam API bridge, Steam Cloud exclusions, achievements/stats/rich presence, fallback behaviour
 - [post-alpha-issues.md](post-alpha-issues.md) — triaged items deferred from the alpha
 - [privacy.md](privacy.md) — local-first promise and data handling details
 - [network-security.md](network-security.md) — runtime network enforcement
 - [release-checklist.md](release-checklist.md) — platform smoke matrix
 - [model-registry/](../model-registry/) — authoritative model checksums and license metadata
 - [marketplace-architecture.md](marketplace-architecture.md) — post-launch marketplace design baseline; entry gate criteria, distribution path comparison, and schema/signing/moderation/payment scope
+- [publishing/STEAM_STORE_AND_OPERATIONS.md](../publishing/STEAM_STORE_AND_OPERATIONS.md) — store operations, launch runbook, support triage
+- [publishing/STEAM_PUBLISHING_AND_DEPLOYMENT.md](../publishing/STEAM_PUBLISHING_AND_DEPLOYMENT.md) — SteamPipe, CI deploy, manual upload, branch promotion, troubleshooting
+- [publishing/MACOS_SIGNING_AND_NOTARIZATION.md](../publishing/MACOS_SIGNING_AND_NOTARIZATION.md) — macOS signing and notarisation runbook
+- [publishing/WINDOWS_CODE_SIGNING.md](../publishing/WINDOWS_CODE_SIGNING.md) — Windows Authenticode signing runbook
 - [GitHub Milestones](https://github.com/outrightmental/ConversationSimulator/milestones) — issue tracking

--- a/publishing/MACOS_SIGNING_AND_NOTARIZATION.md
+++ b/publishing/MACOS_SIGNING_AND_NOTARIZATION.md
@@ -102,7 +102,7 @@ variables → Actions → Secrets):
 Tauri's bundler reads these environment variables from the CI environment
 automatically. The release workflow (`release.yml`) passes them through
 `env:` blocks. See
-[`docs/platform-notes.md` — Code signing and Gatekeeper](platform-notes.md#code-signing-and-gatekeeper)
+[`docs/platform-notes.md` — Code signing and Gatekeeper](../docs/platform-notes.md#code-signing-and-gatekeeper)
 for the exact variable names used by Tauri.
 
 ---
@@ -113,14 +113,21 @@ The Hardened Runtime is required for notarisation. The entitlements file at
 `apps/desktop/src-tauri/entitlements.plist` grants the capabilities the app
 needs under Hardened Runtime.
 
-The file must include the following entitlements at minimum:
+The file must include the following entitlements at minimum (these match the
+committed `entitlements.plist`):
 
 | Entitlement key | Value | Reason |
 |-----------------|-------|--------|
-| `com.apple.security.cs.allow-unsigned-executable-memory` | `true` | llama.cpp JIT compilation |
-| `com.apple.security.cs.disable-library-validation` | `true` | PyInstaller bundled extensions |
-| `com.apple.security.device.audio-input` | `true` | Microphone access for STT |
-| `com.apple.security.network.client` | `true` | Model download (user-initiated) |
+| `com.apple.security.cs.allow-jit` | `true` | WKWebView (Tauri's embedded browser) requires JIT to run JavaScript under Hardened Runtime |
+| `com.apple.security.cs.disable-library-validation` | `true` | Load vendor-signed third-party dylibs (Steamworks SDK, llama.cpp runtime) |
+| `com.apple.security.device.audio-input` | `true` | Microphone access for optional Whisper STT |
+| `com.apple.security.network.client` | `true` | Model download and loopback to the convsim-core sidecar (user-initiated) |
+| `com.apple.security.files.user-selected.read-write` | `true` | Read/write files chosen via the system open/save dialog (pack import, debrief export) |
+
+The App Sandbox is intentionally **not** enabled — Steam apps require direct
+IPC for the overlay and achievement reporting, which the App Sandbox forbids.
+Hardened Runtime (codesign's `runtime` option) is separate from the App Sandbox
+and is the feature Apple's notary service requires.
 
 Review the entitlements file before each Stage 3 submission. Entitlements that
 are not needed must be removed — Apple's notary service flags unnecessary
@@ -335,7 +342,7 @@ for notary service outages.
 
 - [`apps/desktop/src-tauri/entitlements.plist`](../apps/desktop/src-tauri/entitlements.plist) — Hardened Runtime entitlements
 - [`apps/desktop/src-tauri/tauri.conf.json`](../apps/desktop/src-tauri/tauri.conf.json) — Tauri bundle configuration
-- [`docs/platform-notes.md` — macOS section](platform-notes.md#macos) — system requirements, supported versions, build prerequisites
+- [`docs/platform-notes.md` — macOS section](../docs/platform-notes.md#macos) — system requirements, supported versions, build prerequisites
 - [`docs/steam-mvp-scope.md` — G3-01](../docs/steam-mvp-scope.md) — Stage 3 gate: notarised macOS build required
 - [`publishing/STEAM_DEPOT_CONTENTS.md` — macOS depot](STEAM_DEPOT_CONTENTS.md#macos-depot) — macOS depot layout and notarisation requirement
 - [`publishing/STEAM_PUBLISHING_AND_DEPLOYMENT.md`](STEAM_PUBLISHING_AND_DEPLOYMENT.md) — Steam deploy workflow and troubleshooting

--- a/publishing/MACOS_SIGNING_AND_NOTARIZATION.md
+++ b/publishing/MACOS_SIGNING_AND_NOTARIZATION.md
@@ -344,7 +344,7 @@ for notary service outages.
 - [`apps/desktop/src-tauri/tauri.conf.json`](../apps/desktop/src-tauri/tauri.conf.json) — Tauri bundle configuration
 - [`docs/platform-notes.md` — macOS section](../docs/platform-notes.md#macos) — system requirements, supported versions, build prerequisites
 - [`docs/steam-mvp-scope.md` — G3-01](../docs/steam-mvp-scope.md) — Stage 3 gate: notarised macOS build required
-- [`publishing/STEAM_DEPOT_CONTENTS.md` — macOS depot](STEAM_DEPOT_CONTENTS.md#macos-depot) — macOS depot layout and notarisation requirement
+- [`publishing/STEAM_DEPOT_CONTENTS.md` — macOS depot](STEAM_DEPOT_CONTENTS.md#macos-depot-depot_macosvdftpl) — macOS depot layout and notarisation requirement
 - [`publishing/STEAM_PUBLISHING_AND_DEPLOYMENT.md`](STEAM_PUBLISHING_AND_DEPLOYMENT.md) — Steam deploy workflow and troubleshooting
 - [Tauri macOS signing docs](https://tauri.app/distribute/sign/macos) — upstream reference for `tauri build` signing variables
 - [Apple Developer — Developer ID](https://developer.apple.com/developer-id/) — official certificate documentation

--- a/publishing/MACOS_SIGNING_AND_NOTARIZATION.md
+++ b/publishing/MACOS_SIGNING_AND_NOTARIZATION.md
@@ -1,0 +1,344 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+# macOS Code Signing and Notarization
+
+> **Purpose:** Step-by-step runbook for signing and notarising the macOS
+> Conversation Simulator build with an Apple Developer ID certificate so that
+> Gatekeeper allows the app to run on a clean macOS install without any manual
+> override.
+>
+> **Audience:** Platform team members who run the release CI pipeline and
+> any maintainer performing a manual release build.
+>
+> **Gate:** A notarised macOS build is required before Stage 3 (Steam private
+> beta). See gate G3-01 in [`docs/steam-mvp-scope.md`](../docs/steam-mvp-scope.md).
+
+---
+
+## Background
+
+macOS Gatekeeper blocks apps that are not signed with an Apple Developer ID
+Application certificate and notarised by Apple's notary service. An unsigned
+or un-notarised build shows the error "Apple cannot verify this app is free
+from malware" and requires manual intervention by the user.
+
+The signing and notarisation process:
+
+1. **Sign** — the `.app` bundle is code-signed with `codesign --options runtime`
+   using the Developer ID Application certificate. This covers the main binary
+   and all embedded binaries (including the `convsim-core` PyInstaller sidecar
+   and the llama-server, whisper-cli, and sherpa-onnx sidecars).
+2. **Notarise** — the signed bundle is submitted to Apple's notary service via
+   `notarytool`. Apple scans it for malware and returns a ticket.
+3. **Staple** — the notarisation ticket is stapled to the `.app` bundle so that
+   Gatekeeper can verify it offline, without contacting Apple's servers.
+
+Tauri's bundler automates all three steps when the environment variables
+listed below are set.
+
+---
+
+## Certificate procurement
+
+You need an **Apple Developer ID Application** certificate. This is distinct
+from the distribution certificate used for App Store submissions.
+
+### Steps to obtain the certificate
+
+1. Enrol in the [Apple Developer Programme](https://developer.apple.com/programs/)
+   under the Outright Mental organisation account.
+2. In [Certificates, Identifiers & Profiles](https://developer.apple.com/account/resources/certificates/list),
+   create a new **Developer ID Application** certificate.
+3. Download the certificate and install it in your macOS Keychain.
+4. Export the certificate and its private key as a `.p12` file:
+   - Keychain Access → expand the certificate → right-click the private key →
+     Export → choose `.p12` → set a strong passphrase.
+5. Base64-encode the `.p12` for storage as a GitHub Actions secret:
+   ```bash
+   base64 -i DeveloperID.p12 -o DeveloperID.b64
+   # On macOS, -i/-o flags are required; on Linux omit them and use redirect.
+   ```
+
+### Certificate identity string
+
+The signing identity is the full subject string from the certificate. Retrieve
+it after installation:
+
+```bash
+security find-identity -v -p codesigning
+# Example output:
+# 1) AABBCCDDEE "Developer ID Application: Outright Mental (TEAMID)"
+```
+
+The string in quotes is the `APPLE_SIGNING_IDENTITY` value.
+
+---
+
+## App-specific password for notarisation
+
+The notary service authenticates with an Apple ID and an **app-specific
+password** (not the Apple ID login password).
+
+1. Sign in to [appleid.apple.com](https://appleid.apple.com).
+2. Under Security → App-Specific Passwords, generate a new password.
+3. Label it `convsim-notarytool` or similar for traceability.
+4. Copy the password — it is shown only once.
+
+---
+
+## CI setup (GitHub Actions secrets)
+
+Store the following as **GitHub Actions secrets** (Settings → Secrets and
+variables → Actions → Secrets):
+
+| Secret name | Contents |
+|-------------|----------|
+| `APPLE_CERTIFICATE` | Base64-encoded `.p12` file (the output of the `base64` command above) |
+| `APPLE_CERTIFICATE_PASSWORD` | Passphrase for the `.p12` file |
+| `APPLE_SIGNING_IDENTITY` | Full identity string: `Developer ID Application: Outright Mental (TEAMID)` |
+| `APPLE_ID` | Apple ID email used for notarisation |
+| `APPLE_PASSWORD` | App-specific password generated above |
+| `APPLE_TEAM_ID` | Ten-character Outright Mental team ID (visible in the Apple Developer portal) |
+
+Tauri's bundler reads these environment variables from the CI environment
+automatically. The release workflow (`release.yml`) passes them through
+`env:` blocks. See
+[`docs/platform-notes.md` — Code signing and Gatekeeper](platform-notes.md#code-signing-and-gatekeeper)
+for the exact variable names used by Tauri.
+
+---
+
+## Entitlements
+
+The Hardened Runtime is required for notarisation. The entitlements file at
+`apps/desktop/src-tauri/entitlements.plist` grants the capabilities the app
+needs under Hardened Runtime.
+
+The file must include the following entitlements at minimum:
+
+| Entitlement key | Value | Reason |
+|-----------------|-------|--------|
+| `com.apple.security.cs.allow-unsigned-executable-memory` | `true` | llama.cpp JIT compilation |
+| `com.apple.security.cs.disable-library-validation` | `true` | PyInstaller bundled extensions |
+| `com.apple.security.device.audio-input` | `true` | Microphone access for STT |
+| `com.apple.security.network.client` | `true` | Model download (user-initiated) |
+
+Review the entitlements file before each Stage 3 submission. Entitlements that
+are not needed must be removed — Apple's notary service flags unnecessary
+entitlements.
+
+---
+
+## Signing the sidecar binaries
+
+All binaries embedded in the `.app` bundle must be individually signed before
+the bundle itself is signed. Tauri handles this automatically when
+`APPLE_SIGNING_IDENTITY` is set — it calls `codesign` on each file in
+`Contents/MacOS/`, `Contents/Resources/bin/`, and `Contents/Resources/runtimes/`
+before signing the outer `.app`.
+
+The `convsim-core` PyInstaller bundle also reads `APPLE_SIGNING_IDENTITY`
+at build time (see `convsim-core.spec`) to sign the embedded Python C extensions
+before Tauri wraps them. Verify this is happening by inspecting the PyInstaller
+build log for `codesign` invocations.
+
+If a sidecar binary is updated independently of the Tauri build:
+
+```bash
+codesign \
+  --sign "Developer ID Application: Outright Mental (TEAMID)" \
+  --options runtime \
+  --entitlements apps/desktop/src-tauri/entitlements.plist \
+  --force \
+  --timestamp \
+  path/to/sidecar-binary
+```
+
+---
+
+## Manual signing and notarisation
+
+Use this procedure for local testing of the signing and notarisation flow
+before the CI pipeline is fully configured.
+
+### Prerequisites
+
+```bash
+# Xcode Command Line Tools (provides codesign, spctl, notarytool, stapler)
+xcode-select --install
+
+# Confirm notarytool is available (requires Xcode 13+ or macOS 12+)
+xcrun notarytool --version
+```
+
+### Step 1 — Build the app bundle
+
+```bash
+# From the repo root:
+export APPLE_CERTIFICATE="<base64-p12>"
+export APPLE_CERTIFICATE_PASSWORD="<p12-passphrase>"
+export APPLE_SIGNING_IDENTITY="Developer ID Application: Outright Mental (TEAMID)"
+export APPLE_ID="you@example.com"
+export APPLE_PASSWORD="<app-specific-password>"
+export APPLE_TEAM_ID="TEAMID"
+
+pnpm --filter @convsim/desktop build
+# The signed .app bundle is produced in:
+#   apps/desktop/src-tauri/target/release/bundle/macos/ConversationSimulator.app
+```
+
+### Step 2 — Verify the signature
+
+```bash
+codesign --verify --verbose=2 \
+  apps/desktop/src-tauri/target/release/bundle/macos/ConversationSimulator.app
+
+# Also verify the main binary directly:
+codesign -dv --verbose=4 \
+  apps/desktop/src-tauri/target/release/bundle/macos/ConversationSimulator.app/Contents/MacOS/ConversationSimulator
+```
+
+The output should include `authority=Developer ID Application: Outright Mental`.
+The `--timestamp` seal confirms the signature is timestamped.
+
+### Step 3 — Notarise
+
+Tauri submits the bundle to the notary service automatically as part of
+`tauri build` when the environment variables are set. To notarise manually:
+
+```bash
+# Create a zip of the .app (notarytool requires zip or dmg input)
+ditto -c -k --keepParent \
+  apps/desktop/src-tauri/target/release/bundle/macos/ConversationSimulator.app \
+  ConversationSimulator.zip
+
+xcrun notarytool submit ConversationSimulator.zip \
+  --apple-id "$APPLE_ID" \
+  --password "$APPLE_PASSWORD" \
+  --team-id "$APPLE_TEAM_ID" \
+  --wait
+```
+
+`--wait` polls until notarisation completes (typically 1–10 minutes). The
+command prints the submission ID and the final status.
+
+If notarisation fails, retrieve the detailed log:
+
+```bash
+xcrun notarytool log <submission-id> \
+  --apple-id "$APPLE_ID" \
+  --password "$APPLE_PASSWORD" \
+  --team-id "$APPLE_TEAM_ID"
+```
+
+### Step 4 — Staple the ticket
+
+```bash
+xcrun stapler staple \
+  apps/desktop/src-tauri/target/release/bundle/macos/ConversationSimulator.app
+```
+
+### Step 5 — Verify Gatekeeper acceptance
+
+```bash
+# Run on a separate machine that has not seen this app before, or:
+spctl --assess --type execute --verbose \
+  apps/desktop/src-tauri/target/release/bundle/macos/ConversationSimulator.app
+# Expected output:
+# ConversationSimulator.app: accepted
+# source=Notarized Developer ID
+```
+
+A result of `accepted` with `source=Notarized Developer ID` satisfies gate
+G3-01.
+
+---
+
+## Steam depot preparation
+
+The Steam depot requires the raw `.app` bundle, not the `.dmg` installer.
+The release CI workflow tarballs the notarised, stapled `.app` into a
+`.app.tar.gz` artifact. The Steam deploy workflow then extracts it into
+`steam-content/macos/` before uploading.
+
+```bash
+# If producing the tarball manually:
+tar -czf ConversationSimulator.app.tar.gz \
+  -C apps/desktop/src-tauri/target/release/bundle/macos \
+  ConversationSimulator.app
+```
+
+Do **not** upload the `.dmg` to the Steam depot. The `.dmg` is an installer
+disk image, not application files. SteamPipe requires the application directory
+structure directly.
+
+---
+
+## Rotating the certificate
+
+Apple Developer ID certificates expire after five years. When the certificate
+approaches expiry:
+
+1. Generate a new Developer ID Application certificate in the Apple Developer
+   portal.
+2. Export as `.p12` and base64-encode as described above.
+3. Update the `APPLE_CERTIFICATE` and `APPLE_CERTIFICATE_PASSWORD` GitHub
+   Actions secrets.
+4. Update the `APPLE_SIGNING_IDENTITY` secret if the team ID or name changed.
+5. Rebuild and re-notarise the latest release to confirm the new certificate
+   works end to end.
+6. Existing installed copies signed with the old certificate continue to work —
+   the stapled notarisation ticket is valid permanently.
+
+---
+
+## Troubleshooting
+
+### "Apple cannot verify this app is free from malware"
+
+The app is not notarised or the stapled ticket was lost. Verify with:
+
+```bash
+spctl --assess --type execute --verbose path/to/ConversationSimulator.app
+```
+
+If the result is `rejected`, re-run Steps 3–4 (notarise and staple). If
+the ticket was already stapled but Gatekeeper still rejects, confirm the
+staple with:
+
+```bash
+xcrun stapler validate ConversationSimulator.app
+```
+
+### Notarisation rejected — "OBJC_CLASS$_SomeClass not found"
+
+A dynamically linked library was not signed with `--options runtime`. Run
+`codesign -dv --verbose=4` on the `.app` and on each embedded binary to
+confirm all carry the Hardened Runtime flag.
+
+### "invalid signature" on embedded sidecar
+
+The PyInstaller-bundled `convsim-core` or a sidecar runtime binary was not
+signed. Re-run the `convsim-core` build with `APPLE_SIGNING_IDENTITY` set
+(see the `convsim-core.spec` spec file for the codesign hook), then rebuild
+the Tauri bundle.
+
+### Notarisation timeout
+
+Apple's notary service occasionally experiences delays. Resubmit with the
+same command; the submission ID changes but the content is identical. Check
+[developer.apple.com/system-status](https://developer.apple.com/system-status/)
+for notary service outages.
+
+---
+
+## Links
+
+- [`apps/desktop/src-tauri/entitlements.plist`](../apps/desktop/src-tauri/entitlements.plist) — Hardened Runtime entitlements
+- [`apps/desktop/src-tauri/tauri.conf.json`](../apps/desktop/src-tauri/tauri.conf.json) — Tauri bundle configuration
+- [`docs/platform-notes.md` — macOS section](platform-notes.md#macos) — system requirements, supported versions, build prerequisites
+- [`docs/steam-mvp-scope.md` — G3-01](../docs/steam-mvp-scope.md) — Stage 3 gate: notarised macOS build required
+- [`publishing/STEAM_DEPOT_CONTENTS.md` — macOS depot](STEAM_DEPOT_CONTENTS.md#macos-depot) — macOS depot layout and notarisation requirement
+- [`publishing/STEAM_PUBLISHING_AND_DEPLOYMENT.md`](STEAM_PUBLISHING_AND_DEPLOYMENT.md) — Steam deploy workflow and troubleshooting
+- [Tauri macOS signing docs](https://tauri.app/distribute/sign/macos) — upstream reference for `tauri build` signing variables
+- [Apple Developer — Developer ID](https://developer.apple.com/developer-id/) — official certificate documentation
+- [Apple — notarytool man page](https://developer.apple.com/documentation/technotes/tn3147-migrating-to-the-latest-notarization-tool) — notarytool migration guide

--- a/publishing/STEAM_PUBLISHING_AND_DEPLOYMENT.md
+++ b/publishing/STEAM_PUBLISHING_AND_DEPLOYMENT.md
@@ -1,0 +1,369 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+# Steam Publishing and Deployment
+
+> **Purpose:** End-to-end operational reference for building and uploading
+> Conversation Simulator to Steam using SteamPipe. Covers concepts, depot
+> configuration, CI deployment, manual fallback procedures, branch promotion,
+> and troubleshooting.
+>
+> **Audience:** Platform team members with Steamworks partner portal access and
+> write access to the `steam-release` GitHub Actions environment.
+>
+> **Prerequisites:** App IDs and depot IDs already registered in the Steamworks
+> partner portal and set as GitHub repository variables. See
+> [`publishing/STEAM_APP_REGISTRATION.md`](STEAM_APP_REGISTRATION.md) for
+> the registration checklist and identifier table.
+
+---
+
+## SteamPipe concepts
+
+SteamPipe is Valve's content delivery system. Understanding its object model
+prevents mistakes that corrupt the live branch or leak forbidden files.
+
+### Depots
+
+A **depot** is the atomic unit of content Valve stores and distributes. Each
+depot contains the application files for one platform. Conversation Simulator
+uses exactly three depots — one per target platform:
+
+| Depot variable | Platform | Content root |
+|----------------|----------|--------------|
+| `STEAM_DEPOT_WINDOWS_ID` | Windows 10 / 11 x86-64 | `steam-content/windows/` |
+| `STEAM_DEPOT_MACOS_ID` | macOS 13+ (Apple Silicon + Intel) | `steam-content/macos/` |
+| `STEAM_DEPOT_LINUX_ID` | Linux x86-64 + SteamOS 3.x | `steam-content/linux/` |
+
+A depot ID is a non-secret number assigned by Valve at registration. It appears
+in Steam store URLs and can be referenced in public tooling. Store depot IDs as
+GitHub repository **variables** (not secrets).
+
+What goes in each depot is defined in
+[`publishing/STEAM_DEPOT_CONTENTS.md`](STEAM_DEPOT_CONTENTS.md).
+What must never appear in any depot is enforced by both the VDF `FileExclusion`
+patterns and the pre-upload audit script.
+
+### Packages
+
+A **package** bundles one or more depots and represents what a player "owns".
+Valve automatically creates a **free default package** for free-to-play apps.
+This package must contain all three platform depots and must not be converted
+to a paid package.
+
+For Conversation Simulator: one package, three depots, zero cost, no exceptions.
+
+### Branches
+
+A **branch** determines which build version a player's Steam client downloads.
+
+| Branch | Audience | Gate requirement |
+|--------|----------|-----------------|
+| `default` | All public players | Stage 4 gate fully passed |
+| `beta` | Invited Stage 3 testers | Stage 3 gate passed |
+
+Setting a branch live is a one-way operation that affects every player on that
+branch immediately. Always stage the build without setting a branch live first
+(dry run), then promote only after verification.
+
+### VDF build scripts
+
+SteamPipe is driven by VDF (Valve Data Format) files. The repository ships
+templates in `steam/` that are filled in by `envsubst` in CI:
+
+| Template | Purpose |
+|----------|---------|
+| [`steam/app_build.vdf.tpl`](../steam/app_build.vdf.tpl) | Top-level build manifest: app ID, depots to include, description, branch |
+| [`steam/depot_windows.vdf.tpl`](../steam/depot_windows.vdf.tpl) | Windows depot content root and file exclusions |
+| [`steam/depot_macos.vdf.tpl`](../steam/depot_macos.vdf.tpl) | macOS depot content root and file exclusions |
+| [`steam/depot_linux.vdf.tpl`](../steam/depot_linux.vdf.tpl) | Linux/SteamOS depot content root and file exclusions |
+
+Each template uses `$VARIABLE` placeholders that are substituted from
+environment variables. Never commit a rendered VDF with real IDs to the
+repository — the templates keep IDs out of source control, with actual values
+living only in GitHub repository variables.
+
+---
+
+## CI deployment (primary path)
+
+The Steam deploy workflow in
+[`.github/workflows/steam-deploy.yml`](../.github/workflows/steam-deploy.yml)
+is the primary and preferred deployment path. It enforces the depot audit, uses
+scoped credentials, and requires a manual approval step before any secrets are
+exposed.
+
+### One-time setup
+
+These steps are performed once and do not need to be repeated for each release.
+See [`publishing/STEAM_APP_REGISTRATION.md` — CI credentials](STEAM_APP_REGISTRATION.md#ci-credentials)
+for the detailed procedure to obtain each value.
+
+**Repository variables** (Settings → Secrets and variables → Actions → Variables):
+
+| Variable | Value |
+|----------|-------|
+| `STEAM_APP_ID` | Valve-assigned App ID for Conversation Simulator |
+| `STEAM_DEPOT_WINDOWS_ID` | Windows x86-64 depot ID |
+| `STEAM_DEPOT_MACOS_ID` | macOS depot ID |
+| `STEAM_DEPOT_LINUX_ID` | Linux / SteamOS depot ID |
+
+**Repository secrets** (Settings → Secrets and variables → Actions → Secrets):
+
+| Secret | Value |
+|--------|-------|
+| `STEAM_USERNAME` | Steam username of the dedicated CI build account |
+| `STEAM_CONFIG_VDF` | Base64-encoded `config.vdf` from an authenticated Steam session on the build account |
+
+**GitHub Actions environment:**
+
+Create a `steam-release` environment under Settings → Environments. Add at
+least one required reviewer so the workflow pauses for approval before secrets
+are used. This prevents accidental or unauthorised deployments.
+
+### Triggering a deployment
+
+The workflow is triggered manually under Actions → Steam Deploy → Run workflow.
+
+| Input | Required | Description |
+|-------|----------|-------------|
+| `release_tag` | Yes | The GitHub release tag to upload (e.g. `v0.3.0`). The release must already exist and its build artifacts must be published. |
+| `build_description` | No | Human-readable description shown in Steamworks. Defaults to `Conversation Simulator <tag>`. |
+| `set_live_branch` | No | Leave blank for a staged (dry-run) upload. Use `beta` to promote to Stage 3 testers. Use `default` only for the public release — all Stage 4 gate items must be checked first. |
+
+### Workflow steps
+
+1. **Resolve build description** — fills in the default description from the
+   tag if `build_description` was left empty.
+2. **Download release artifacts** — pulls the platform artifacts from the
+   specified GitHub release using `gh release download`.
+3. **Organise depot content** — copies artifacts into `steam-content/<platform>/`
+   directories. macOS depots receive the `.app` bundle extracted from the
+   `.app.tar.gz` artifact, not the `.dmg` installer.
+4. **Audit depot content** — runs `./scripts/depot-audit.sh` against each
+   `steam-content/<platform>` directory. Exits non-zero if any model weight
+   file, developer artefact, secret file, debug symbol, or test fixture is
+   present. The workflow fails and no upload occurs.
+5. **Generate SteamPipe VDF files** — runs `envsubst` to fill in the VDF
+   templates with the repository variables.
+6. **Install steamcmd** — installs the Steam command-line tool on the
+   ubuntu-latest runner.
+7. **Restore Steam config** — decodes `STEAM_CONFIG_VDF` from base64 to
+   `~/.steam/steam/config/config.vdf` to bypass the interactive SteamGuard
+   prompt.
+8. **Upload build to Steam** — runs `steamcmd +login ... +run_app_build ...`.
+9. **Show steamcmd build output** — logs the output files regardless of success
+   or failure, useful for diagnosing upload errors.
+
+### Verifying a staged build
+
+After a successful run with `set_live_branch` left empty:
+
+1. Open the Steamworks partner portal → App Admin → Builds.
+2. Confirm a new build appears with all three depots and the correct description.
+3. Install the build on each required platform using a Steam beta key to verify
+   the depot layout before promoting to any branch.
+
+---
+
+## Manual upload procedure (fallback)
+
+Use the manual procedure only when CI is unavailable or when a hotfix must be
+deployed outside the standard release pipeline.
+
+### Requirements
+
+- `steamcmd` installed locally (see [Valve docs](https://developer.valvesoftware.com/wiki/SteamCMD)).
+- Steamworks credentials for the build account or a partner account member with
+  Developer access.
+- SteamGuard 2FA code ready (interactive prompt if `config.vdf` is not cached).
+
+### Steps
+
+```bash
+# 1. Build and sign the release artifacts for all three platforms.
+#    (See the signing docs for platform-specific steps.)
+
+# 2. Organise artifacts into per-platform content directories.
+mkdir -p steam-content/windows steam-content/macos steam-content/linux
+# Copy platform files into the appropriate directories.
+
+# 3. Run the depot audit.
+./scripts/depot-audit.sh steam-content/windows
+./scripts/depot-audit.sh steam-content/macos
+./scripts/depot-audit.sh steam-content/linux
+# If any exit with code 1, resolve violations before continuing.
+
+# 4. Generate VDF files from templates.
+export STEAM_APP_ID="<app-id>"
+export STEAM_DEPOT_WINDOWS_ID="<windows-depot-id>"
+export STEAM_DEPOT_MACOS_ID="<macos-depot-id>"
+export STEAM_DEPOT_LINUX_ID="<linux-depot-id>"
+export STEAM_BUILD_DESCRIPTION="Conversation Simulator v0.x.y (manual)"
+export STEAM_SET_LIVE_BRANCH=""   # leave empty for staged upload
+mkdir -p steam-build/output
+envsubst < steam/app_build.vdf.tpl     > steam-build/app_build.vdf
+envsubst < steam/depot_windows.vdf.tpl > steam-build/depot_windows.vdf
+envsubst < steam/depot_macos.vdf.tpl   > steam-build/depot_macos.vdf
+envsubst < steam/depot_linux.vdf.tpl   > steam-build/depot_linux.vdf
+
+# 5. Upload.
+steamcmd \
+  +login <build-account-username> \
+  +run_app_build "$(pwd)/steam-build/app_build.vdf" \
+  +quit
+```
+
+Steam will prompt for the SteamGuard code interactively. Enter it when
+prompted. The upload proceeds after authentication.
+
+After the upload, verify the build appears in Steamworks before promoting
+any branch.
+
+---
+
+## Branch promotion
+
+Promoting a build to a branch makes it immediately available to all players on
+that branch. Always follow the staged-then-promote pattern.
+
+### Stage 3 → beta branch
+
+1. Confirm all Stage 3 gate criteria in
+   [`docs/steam-mvp-scope.md`](../docs/steam-mvp-scope.md) are met.
+2. Trigger the deploy workflow with the Stage 3 release tag and
+   `set_live_branch: beta`.
+3. Provide beta testers with Steam keys (generated in Steamworks → Packages →
+   Free package → Generate Steam Product Codes).
+4. Document the promoted build version and date in the release notes.
+
+### Stage 4 → default branch (public release)
+
+1. Confirm **all** Stage 4 gate criteria in
+   [`docs/steam-mvp-scope.md`](../docs/steam-mvp-scope.md) are met, including
+   Valve store page approval and Steam Deck Verified status.
+2. Trigger the deploy workflow with the Stage 4 release tag and
+   `set_live_branch: default`.
+3. The `default` branch immediately serves all new installs and updates.
+4. Monitor the Steamworks App Admin → Reviews and the GitHub issue queue for
+   the first 72 hours. Follow the launch monitoring checklist in
+   [`publishing/STEAM_STORE_AND_OPERATIONS.md`](STEAM_STORE_AND_OPERATIONS.md#launch-day).
+
+### Rolling back a branch
+
+If a critical defect is found after setting a branch live:
+
+1. In Steamworks App Admin → Builds, find the previous known-good build.
+2. Set that build live on the affected branch.
+3. Open a `severity:critical` GitHub issue with the `steam` and `platform-bug`
+   labels; link it to the rollback action.
+4. Do not re-promote the broken build until the defect is fixed and the depot
+   audit passes on the fixed build.
+
+---
+
+## Troubleshooting
+
+### Authentication errors
+
+**Symptom:** `steamcmd` exits with `Login Failure: Account Logon Denied` or
+`SteamGuard code required`.
+
+**Cause:** The `config.vdf` has expired (SteamGuard session is approximately
+one year). The build account may also have been locked or had its password
+reset.
+
+**Fix:**
+1. Log in to the build account on a local machine with Steam installed.
+2. Complete the SteamGuard prompt.
+3. Copy and re-encode the updated `config.vdf`:
+   ```bash
+   base64 -w0 ~/.steam/steam/config/config.vdf
+   ```
+4. Update the `STEAM_CONFIG_VDF` repository secret with the new value.
+
+---
+
+### Depot audit failure
+
+**Symptom:** The workflow fails at the `Audit depot content` step with output
+such as `[weights] found: model.gguf` or `[secrets] found: config.vdf`.
+
+**Fix:** Investigate where the forbidden file came from in the release artifact
+or the artifact organisation step. Remove it and re-trigger the workflow. Do
+not bypass the audit — it exists to prevent a private-data leak or a model
+weight distribution policy violation (risk MD-04 in the compliance register).
+
+---
+
+### Build appears in Steamworks but depot is empty
+
+**Symptom:** The build is listed in App Admin → Builds but the depot size shows
+zero bytes or the install fails immediately.
+
+**Cause:** Usually caused by a path mismatch between the VDF `ContentRoot`
+setting and the actual `steam-content/<platform>/` directory layout.
+
+**Fix:**
+1. Run the workflow with `set_live_branch` empty to re-generate a staged build.
+2. Check the generated VDF files in the workflow logs to confirm `ContentRoot`
+   points to a directory that actually contains files.
+3. Confirm the `Organise depot content` step ran without errors and that
+   `find steam-content -type f | sort` shows the expected files.
+
+---
+
+### SteamPipe error: `ERROR! BuildOutput/App_<id>.log`
+
+**Symptom:** `steamcmd` exits non-zero and refers to an output log file.
+
+**Fix:** The `Show steamcmd build output` step always runs (even on failure)
+and dumps the log. Read the full log for the root cause — common causes are
+authentication errors, network timeouts, or a missing content directory.
+
+---
+
+### macOS depot fails Gatekeeper after install
+
+**Symptom:** Players on macOS report "Apple cannot verify this app is free
+from malware" after installing via Steam.
+
+**Cause:** The `.app` bundle in the depot is not notarised, or was not
+stapled before upload.
+
+**Fix:** See [`publishing/MACOS_SIGNING_AND_NOTARIZATION.md`](MACOS_SIGNING_AND_NOTARIZATION.md)
+for the full signing and notarisation runbook. In short:
+1. Re-run the release workflow to produce a freshly signed and notarised bundle.
+2. Confirm `spctl --assess --type execute ConversationSimulator.app` exits 0.
+3. Re-upload the corrected depot.
+
+---
+
+### Windows SmartScreen blocks installer
+
+**Symptom:** Players on Windows see "Windows protected your PC" and cannot run
+the installer without clicking "More info → Run anyway".
+
+**Cause:** The installer is unsigned or the certificate has not yet built
+SmartScreen reputation.
+
+**Fix:** See [`publishing/WINDOWS_CODE_SIGNING.md`](WINDOWS_CODE_SIGNING.md)
+for the full Authenticode signing runbook. For the immediate issue, advise
+testers to use "More info → Run anyway" during the Stage 3 private beta
+(before reputation is established) and ensure the Stage 4 public release uses
+a signed build.
+
+---
+
+## Links
+
+- [`publishing/STEAM_APP_REGISTRATION.md`](STEAM_APP_REGISTRATION.md) — app IDs, depot IDs, CI credentials, branch strategy
+- [`publishing/STEAM_DEPOT_CONTENTS.md`](STEAM_DEPOT_CONTENTS.md) — depot layout, exclusions, approved binary payload list
+- [`publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md`](STEAM_COMPLIANCE_AND_RISK_REGISTER.md) — risk register; see MD-04, SR-08
+- [`publishing/STEAM_STORE_AND_OPERATIONS.md`](STEAM_STORE_AND_OPERATIONS.md) — store operations, launch runbook, support triage
+- [`publishing/MACOS_SIGNING_AND_NOTARIZATION.md`](MACOS_SIGNING_AND_NOTARIZATION.md) — macOS signing and notarisation
+- [`publishing/WINDOWS_CODE_SIGNING.md`](WINDOWS_CODE_SIGNING.md) — Windows Authenticode signing
+- [`.github/workflows/steam-deploy.yml`](../.github/workflows/steam-deploy.yml) — CI deploy workflow
+- [`steam/`](../steam/) — SteamPipe VDF templates
+- [`scripts/depot-audit.sh`](../scripts/depot-audit.sh) — depot content audit (Linux / macOS)
+- [`scripts/depot-audit.ps1`](../scripts/depot-audit.ps1) — depot content audit (Windows PowerShell)
+- [`docs/steam-mvp-scope.md`](../docs/steam-mvp-scope.md) — stage gate criteria
+- [`docs/STEAM_ROADMAP.md`](../docs/STEAM_ROADMAP.md) — release principles and release train

--- a/publishing/STEAM_PUBLISHING_AND_DEPLOYMENT.md
+++ b/publishing/STEAM_PUBLISHING_AND_DEPLOYMENT.md
@@ -127,7 +127,7 @@ The workflow is triggered manually under Actions → Steam Deploy → Run workfl
 |-------|----------|-------------|
 | `release_tag` | Yes | The GitHub release tag to upload (e.g. `v0.3.0`). The release must already exist and its build artifacts must be published. |
 | `build_description` | No | Human-readable description shown in Steamworks. Defaults to `Conversation Simulator <tag>`. |
-| `set_live_branch` | No | Leave blank for a staged (dry-run) upload. Use `beta` to promote to Stage 3 testers. Use `default` only for the public release — all Stage 4 gate items must be checked first. |
+| `set_live_branch` | No | **Defaults to `beta`** (Stage 3 promotion). Clear the field for a staged (dry-run) upload that sets no branch live. Use `default` only for the public release — all Stage 4 gate items must be checked first. |
 
 ### Workflow steps
 

--- a/publishing/STEAM_STORE_AND_OPERATIONS.md
+++ b/publishing/STEAM_STORE_AND_OPERATIONS.md
@@ -132,7 +132,8 @@ until every item is checked.
 - [ ] The depot audit passes for all three platform depots — exit code 0 from
       `./scripts/depot-audit.sh` on each `steam-content/<platform>` directory.
 - [ ] The Steam deploy workflow has run successfully for the launch tag with
-      `set_live_branch` left empty (staged build, not yet live).
+      `set_live_branch` cleared (the field defaults to `beta`, so it must be
+      emptied for a staged build that is not yet live).
 - [ ] The staged build was verified in the Steamworks partner portal: build
       appears in the App Admin → Builds section with all three depots.
 

--- a/publishing/STEAM_STORE_AND_OPERATIONS.md
+++ b/publishing/STEAM_STORE_AND_OPERATIONS.md
@@ -1,0 +1,245 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+# Steam Store and Operations
+
+> **Purpose:** Single operational reference for everyone involved in launching
+> and maintaining the Conversation Simulator Steam page. This document maps to
+> the detail docs, defines the launch runbook, and owns the support triage
+> routing that applies after public release.
+>
+> **Audience:** Publishing team, platform team, Outright Mental staff, and
+> any contractor brought in to help with launch or support operations.
+>
+> **Scope:** Steam store page setup, free product configuration, asset
+> production status, compliance sign-off, launch-day operations, and
+> post-launch support triage. For SteamPipe build and depot operations see
+> [`publishing/STEAM_PUBLISHING_AND_DEPLOYMENT.md`](STEAM_PUBLISHING_AND_DEPLOYMENT.md).
+
+---
+
+## Document map
+
+| Topic | Authoritative document |
+|-------|------------------------|
+| Store copy (short desc, long desc, feature bullets, system requirements) | [`publishing/STEAM_STORE_PAGE.md`](STEAM_STORE_PAGE.md) |
+| Store assets (capsules, screenshots, trailer brief) | [`publishing/STEAM_ASSETS_SPEC.md`](STEAM_ASSETS_SPEC.md) |
+| Free product and depot registration | [`publishing/STEAM_APP_REGISTRATION.md`](STEAM_APP_REGISTRATION.md) |
+| Risk register and compliance checklists (SR-01 through SR-09) | [`publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md`](STEAM_COMPLIANCE_AND_RISK_REGISTER.md) |
+| Depot contents and exclusions | [`publishing/STEAM_DEPOT_CONTENTS.md`](STEAM_DEPOT_CONTENTS.md) |
+| SteamPipe build, CI deploy, and troubleshooting | [`publishing/STEAM_PUBLISHING_AND_DEPLOYMENT.md`](STEAM_PUBLISHING_AND_DEPLOYMENT.md) |
+| Steam API integration and fallback behaviour | [`docs/STEAM_INTEGRATION.md`](../docs/STEAM_INTEGRATION.md) |
+| macOS signing and notarisation | [`publishing/MACOS_SIGNING_AND_NOTARIZATION.md`](MACOS_SIGNING_AND_NOTARIZATION.md) |
+| Windows Authenticode signing | [`publishing/WINDOWS_CODE_SIGNING.md`](WINDOWS_CODE_SIGNING.md) |
+| Issue triage flow | [`docs/steam-triage.md`](../docs/steam-triage.md) |
+| Release gates and MVP scope | [`docs/steam-mvp-scope.md`](../docs/steam-mvp-scope.md) |
+| Release principles and release train | [`docs/STEAM_ROADMAP.md`](../docs/STEAM_ROADMAP.md) |
+
+---
+
+## Free product configuration
+
+Conversation Simulator is a **free-to-play** title on Steam. This section
+summarises the store-page and partner-portal settings that enforce that
+commitment; the checklist item numbers refer to
+[`publishing/STEAM_APP_REGISTRATION.md`](STEAM_APP_REGISTRATION.md).
+
+### Key settings
+
+| Setting | Required value |
+|---------|---------------|
+| App type | `Game` |
+| Base price | `Free to Play` |
+| Paid package | None — do not create |
+| DLC or microtransaction package | None — do not create |
+| Release state at registration | `Coming Soon` |
+
+### Free-forever invariants
+
+- No base purchase price is set now or in the future without an explicit
+  Outright Mental decision recorded in a new document.
+- No premium content tier or content unlock exists in any release branch.
+- The free default package (created by Valve automatically for free-to-play
+  apps) contains all three platform depots.
+- All store copy, trailers, and screenshots must accurately represent the
+  free nature of the product (risk SP-05 in the compliance register).
+
+See [`publishing/STEAM_STORE_PAGE.md` — Free edition wording](STEAM_STORE_PAGE.md#free-edition-wording)
+for the canonical approved copy to use wherever the free nature must be stated.
+
+---
+
+## Asset status and production schedule
+
+Assets are tracked in detail in [`publishing/STEAM_ASSETS_SPEC.md`](STEAM_ASSETS_SPEC.md).
+This table shows the current status at a glance.
+
+| Asset | Size spec | Status | Blocking stage |
+|-------|-----------|--------|---------------|
+| Header capsule | 460 × 215 px | Not started | Stage 3 (private beta) |
+| Small capsule | 231 × 87 px | Not started | Stage 3 |
+| Library capsule | 600 × 900 px | Not started | Stage 3 |
+| Main capsule (library hero) | 3840 × 1240 px | Not started | Stage 4 (public release) |
+| Page background | 1438 × 810 px (optional) | Not started | Stage 4 |
+| Screenshots (minimum 5) | 1920 × 1080 px | Placeholder SVGs exist | Stage 3 — replace with real screenshots |
+| Gameplay trailer | MP4, H.264, 30–120 s | Not started | Stage 4 |
+| Achievement icons | 64 × 64 px and 32 × 32 px per achievement (×5) | Not started | Stage 4 |
+
+All assets must be reviewed by Outright Mental before upload. See the sign-off
+table in [`publishing/STEAM_STORE_PAGE.md` — Sign-off](STEAM_STORE_PAGE.md#sign-off)
+for the approval workflow.
+
+### Content constraints (all assets)
+
+- No real human faces or voices.
+- No sensitive data (transcripts, real names, credentials).
+- All NPCs shown are fictional characters defined in official packs.
+- UI shown in screenshots must match the current release build — update assets
+  with each milestone that changes the UI meaningfully.
+
+---
+
+## Compliance sign-off
+
+The compliance register in
+[`publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md`](STEAM_COMPLIANCE_AND_RISK_REGISTER.md)
+tracks every risk that can block the Steam release. The status column in that
+register is the single source of truth for whether a risk is open or closed.
+
+### Compliance gates by stage
+
+| Stage | Required compliance status |
+|-------|--------------------------|
+| Stage 2 — packaged desktop alpha | All privacy risks (PR-01, PR-02, PR-03) MITIGATED |
+| Stage 3 — Steam private beta | All release-blocking risks MITIGATED or ACCEPTED; SR-01 through SR-07 passed |
+| Stage 4 — public free release | SR-08 (depot audit) and SR-09 (post-deployment verification) passed |
+
+Run the store-page review checklist in
+[`publishing/STEAM_STORE_PAGE.md` — Store page review checklist](STEAM_STORE_PAGE.md#store-page-review-checklist)
+before submitting to Valve.
+
+---
+
+## Launch operations
+
+### Pre-launch checklist (Stage 4 gate)
+
+Complete these steps in the order listed. Do not set the `default` branch live
+until every item is checked.
+
+#### Build and deployment
+
+- [ ] The release build for the launch tag is signed and notarised on all three
+      platforms (see signing docs in this folder).
+- [ ] The depot audit passes for all three platform depots — exit code 0 from
+      `./scripts/depot-audit.sh` on each `steam-content/<platform>` directory.
+- [ ] The Steam deploy workflow has run successfully for the launch tag with
+      `set_live_branch` left empty (staged build, not yet live).
+- [ ] The staged build was verified in the Steamworks partner portal: build
+      appears in the App Admin → Builds section with all three depots.
+
+#### Store page
+
+- [ ] All store copy (short description, long description, feature bullets,
+      system requirements) has been reviewed and matches the text in
+      [`publishing/STEAM_STORE_PAGE.md`](STEAM_STORE_PAGE.md).
+- [ ] At least five screenshots uploaded (including at least three that show
+      actual in-app gameplay from the current build).
+- [ ] Gameplay trailer uploaded and approved.
+- [ ] All capsule art uploaded: header, small, library, main.
+- [ ] Genres and tags set correctly (primary: Simulation; secondary: Casual).
+- [ ] IARC questionnaire complete; content descriptors applied (Mild Language only).
+- [ ] Store page has been submitted to Valve and received approval.
+
+#### Platform and QA
+
+- [ ] Smoke matrix from [`docs/release-checklist.md`](../docs/release-checklist.md)
+      has been run and passed on Windows 10/11, macOS 13+, Linux x86-64, and
+      Steam Deck.
+- [ ] Steam Deck Verified tier checklist from
+      [`docs/STEAM_ROADMAP.md`](../docs/STEAM_ROADMAP.md#steam-deck-verification-checklist)
+      has been submitted to Valve and verified.
+- [ ] Offline smoke test passes from the Steam-installed build (not source
+      checkout) on all required platforms.
+
+#### Legal and publishing
+
+- [ ] Outright Mental has read and approved all store copy.
+- [ ] Legal has confirmed no claims of clinical authority or regulated advice in
+      any store-facing text.
+- [ ] `NOTICE` file in the depot is up to date with all bundled runtime licences
+      (see [`publishing/STEAM_DEPOT_CONTENTS.md`](STEAM_DEPOT_CONTENTS.md#third-party-licence-notices-notice)).
+
+### Launch day
+
+1. **Set the beta branch live first** (if not already done at Stage 3):
+   trigger the deploy workflow with `set_live_branch: beta`.
+2. Confirm beta builds install correctly on at least one machine per platform
+   via a fresh Steam install (log out, remove game, reinstall).
+3. **Set the default branch live:**
+   trigger the deploy workflow with `set_live_branch: default` and the launch tag.
+4. Wait 10–15 minutes for Steam CDN propagation.
+5. Verify the app is publicly visible on its store page and that the install
+   button is active and set to `Free`.
+6. Install from a fresh account (not the partner account) on each required
+   platform to confirm end-to-end installation.
+7. Complete the post-deployment checks in SR-09 of the compliance register.
+
+### Post-launch monitoring
+
+During the first 72 hours after public launch, monitor the following:
+
+| Signal | Where to check | Escalation threshold |
+|--------|---------------|---------------------|
+| Steam review sentiment | Steamworks App Admin → Reviews | Any review mentioning unexpected network activity or privacy concern — escalate immediately |
+| GitHub Steam issue queue | GitHub → Issues, filter `label:steam` | Any `severity:critical` — 24-hour response SLA |
+| Crash rate | Steamworks App Admin → Stats (if crash reporting is configured in future) | Baseline comparison against private beta |
+| Store refund rate | Steamworks App Admin → Financials | Not applicable (free game, no purchase price) |
+
+See [`docs/steam-triage.md`](../docs/steam-triage.md) for the full triage
+routing and SLA policy.
+
+---
+
+## Support triage overview
+
+This section is an operational summary. The full triage procedure, escalation
+rules, privacy handling requirements, and SLA targets are in
+[`docs/steam-triage.md`](../docs/steam-triage.md).
+
+### Issue routing at a glance
+
+| Reporter describes | Route to |
+|--------------------|----------|
+| App does not launch, Steam overlay broken, controller broken, Steam Deck crash | `steam` + `platform-bug` |
+| Model download fails, checksum mismatch, model not loading | `steam` + `model-install` |
+| NPC gives wrong response, scoring incorrect, scenario loop broken | `steam` + `pack-bug` |
+| App sent data somewhere, unexpected network activity, privacy concern | `steam` + `privacy` + `safety` — fast-path escalation to lead maintainer |
+| Creator Workbench crash, pack import fails, YAML editor broken | `steam` + `creator-workbench` |
+
+### Privacy fast-path (mandatory)
+
+Any issue containing the words "transcripts", "sent my data", "network",
+"uploaded", "privacy", or "recording" must be escalated immediately to the
+lead maintainer — outside the standard triage cadence — regardless of the
+filed severity label.
+
+Never ask reporters to paste conversation transcripts in GitHub issues.
+See [`docs/steam-triage.md`](../docs/steam-triage.md#privacy-handling-for-all-stages)
+for the full policy.
+
+---
+
+## Links
+
+- [`publishing/STEAM_STORE_PAGE.md`](STEAM_STORE_PAGE.md) — canonical store copy, system requirements, genres/tags, age disclosures, store review checklist, sign-off table
+- [`publishing/STEAM_ASSETS_SPEC.md`](STEAM_ASSETS_SPEC.md) — capsule art, screenshot, and trailer production briefs
+- [`publishing/STEAM_APP_REGISTRATION.md`](STEAM_APP_REGISTRATION.md) — app identity, depot IDs, CI credentials, branch strategy, partner permissions
+- [`publishing/STEAM_DEPOT_CONTENTS.md`](STEAM_DEPOT_CONTENTS.md) — depot layout, exclusions, approved binary payload list, third-party licence notices
+- [`publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md`](STEAM_COMPLIANCE_AND_RISK_REGISTER.md) — risk register (SR-01 through SR-09, MD-04, PR-01 through PR-03)
+- [`publishing/STEAM_PUBLISHING_AND_DEPLOYMENT.md`](STEAM_PUBLISHING_AND_DEPLOYMENT.md) — SteamPipe concepts, CI deployment, manual upload, branch promotion, troubleshooting
+- [`publishing/MACOS_SIGNING_AND_NOTARIZATION.md`](MACOS_SIGNING_AND_NOTARIZATION.md) — macOS Apple Developer ID signing and notarisation
+- [`publishing/WINDOWS_CODE_SIGNING.md`](WINDOWS_CODE_SIGNING.md) — Windows Authenticode signing
+- [`docs/STEAM_INTEGRATION.md`](../docs/STEAM_INTEGRATION.md) — Steam API bridge, Steam Cloud, achievements/stats/rich presence, fallback
+- [`docs/steam-triage.md`](../docs/steam-triage.md) — issue triage flow, SLA targets, privacy handling
+- [`docs/steam-mvp-scope.md`](../docs/steam-mvp-scope.md) — feature requirements and pass/fail release gates
+- [`docs/STEAM_ROADMAP.md`](../docs/STEAM_ROADMAP.md) — release principles and release train
+- [`docs/release-checklist.md`](../docs/release-checklist.md) — platform smoke matrix

--- a/publishing/STEAM_STORE_AND_OPERATIONS.md
+++ b/publishing/STEAM_STORE_AND_OPERATIONS.md
@@ -109,8 +109,8 @@ register is the single source of truth for whether a risk is open or closed.
 | Stage | Required compliance status |
 |-------|--------------------------|
 | Stage 2 — packaged desktop alpha | All privacy risks (PR-01, PR-02, PR-03) MITIGATED |
-| Stage 3 — Steam private beta | All release-blocking risks MITIGATED or ACCEPTED; SR-01 through SR-07 passed |
-| Stage 4 — public free release | SR-08 (depot audit) and SR-09 (post-deployment verification) passed |
+| Stage 3 — Steam private beta | All release-blocking risks MITIGATED or ACCEPTED; SR-01 through SR-08 passed (including SR-08 depot audit) and the SR-09 private beta sign-off completed |
+| Stage 4 — public free release | All Stage 4 gates (G4-01 through G4-05 in [`docs/steam-mvp-scope.md`](../docs/steam-mvp-scope.md)) met; SR-08 depot audit re-run clean on the launch build |
 
 Run the store-page review checklist in
 [`publishing/STEAM_STORE_PAGE.md` — Store page review checklist](STEAM_STORE_PAGE.md#store-page-review-checklist)
@@ -181,7 +181,9 @@ until every item is checked.
    button is active and set to `Free`.
 6. Install from a fresh account (not the partner account) on each required
    platform to confirm end-to-end installation.
-7. Complete the post-deployment checks in SR-09 of the compliance register.
+7. Confirm all Stage 4 gates (G4-01 through G4-05 in
+   [`docs/steam-mvp-scope.md`](../docs/steam-mvp-scope.md)) remain satisfied on
+   the shipped build, then begin the post-launch monitoring below.
 
 ### Post-launch monitoring
 

--- a/publishing/WINDOWS_CODE_SIGNING.md
+++ b/publishing/WINDOWS_CODE_SIGNING.md
@@ -1,0 +1,280 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+# Windows Code Signing
+
+> **Purpose:** Step-by-step runbook for signing the Windows Conversation
+> Simulator installer with an Authenticode certificate so that Windows Defender
+> SmartScreen does not block the installer on end-user machines.
+>
+> **Audience:** Platform team members who run the release CI pipeline and
+> any maintainer performing a manual release build.
+>
+> **Gate:** A signed Windows installer is required before Stage 3 (Steam private
+> beta). See gate G3-01 in [`docs/steam-mvp-scope.md`](../docs/steam-mvp-scope.md).
+
+---
+
+## Background
+
+Windows Defender SmartScreen applies a reputation score to executables. An
+unsigned installer (one with no Authenticode signature) shows "Windows protected
+your PC" and requires the user to click "More info → Run anyway" to proceed.
+A signed installer from a recognised publisher suppresses the SmartScreen
+warning once the certificate has accumulated download reputation.
+
+### EV vs OV certificates
+
+| Type | Immediate SmartScreen reputation | HSM required | Cost |
+|------|----------------------------------|--------------|------|
+| Extended Validation (EV) | Yes — trust is granted immediately | Yes (USB token or cloud HSM) | Higher |
+| Organisation Validation (OV) | No — reputation builds from download count | No | Lower |
+
+Outright Mental should obtain an **EV certificate** for the Stage 4 public
+release to avoid SmartScreen warnings on first install. An OV certificate is
+acceptable for Stage 3 private beta where the tester pool is small.
+
+---
+
+## Certificate procurement
+
+Purchase an Authenticode code-signing certificate from a CA trusted by
+Microsoft, such as DigiCert, Sectigo, or GlobalSign. The certificate must be
+issued to **Outright Mental**.
+
+### EV certificate delivery
+
+EV certificates are delivered on a hardware security module (USB token or
+via a cloud HSM service). The signing process uses the HSM directly:
+
+```powershell
+# Sign with an EV USB token using signtool (Windows SDK)
+signtool.exe sign `
+  /n "Outright Mental" `
+  /tr http://timestamp.digicert.com `
+  /td sha256 /fd sha256 /v `
+  "apps\desktop\src-tauri\target\release\bundle\nsis\ConversationSimulator_*_x64-setup.exe"
+```
+
+For cloud HSM (e.g. DigiCert KeyLocker), install the vendor's signing client
+and use the same `signtool.exe` command with the cloud-signed identity.
+
+### OV certificate delivery
+
+OV certificates are delivered as a `.pfx` file containing the certificate
+chain and private key.
+
+1. Purchase the certificate from a trusted CA.
+2. Complete identity verification (they will contact Outright Mental directly).
+3. Download the `.pfx` file after issuance.
+4. Set a strong passphrase on the `.pfx`.
+
+---
+
+## CI setup (GitHub Actions secrets)
+
+For OV certificates (`.pfx` file), store the following as **GitHub Actions
+secrets** (Settings → Secrets and variables → Actions → Secrets):
+
+| Secret name | Contents |
+|-------------|----------|
+| `WINDOWS_SIGN_CERT_PFX` | Base64-encoded `.pfx` file |
+| `WINDOWS_SIGN_CERT_PASSWORD` | Passphrase for the `.pfx` file |
+
+**To base64-encode the `.pfx` on Windows:**
+```powershell
+certutil -encode cert.pfx cert.b64
+# Copy the content between -----BEGIN CERTIFICATE----- and -----END CERTIFICATE-----
+# (including all lines) into the secret value.
+```
+
+**To base64-encode on macOS / Linux:**
+```bash
+base64 -i cert.pfx -o cert.b64
+```
+
+Tauri's bundler reads these secrets and calls `signtool.exe` automatically
+during `cargo tauri build` on Windows when the secrets are present. When the
+secrets are absent, the build proceeds and produces an unsigned installer.
+
+The release workflow (`release.yml`) passes the secrets as environment
+variables. When CI runs on a non-Windows runner, the signing step is skipped
+automatically.
+
+For **EV certificates via cloud HSM**, the CI integration depends on the
+vendor. Consult DigiCert's or Sectigo's CI documentation for the required
+environment variables and CLI tooling for GitHub Actions.
+
+---
+
+## Manual signing
+
+Use this procedure for local testing or one-off manual signing.
+
+### Prerequisites
+
+- Windows SDK installed (provides `signtool.exe`)
+  - Install via: Visual Studio Installer → Individual Components → Windows 10 SDK
+  - Or download the [Windows SDK](https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/)
+  directly.
+- The `.pfx` file accessible on disk (OV), or the EV USB token plugged in (EV).
+
+### Step 1 — Build the unsigned installer
+
+```powershell
+# From the repo root in PowerShell:
+pnpm --filter @convsim/desktop build
+
+# Unsigned installers are in:
+#   apps\desktop\src-tauri\target\release\bundle\nsis\ConversationSimulator_*_x64-setup.exe
+#   apps\desktop\src-tauri\target\release\bundle\msi\ConversationSimulator_*_x64.msi
+```
+
+### Step 2 — Sign the installers
+
+```powershell
+# OV certificate (.pfx)
+signtool.exe sign `
+  /f path\to\cert.pfx `
+  /p <password> `
+  /tr http://timestamp.digicert.com `
+  /td sha256 /fd sha256 /v `
+  "apps\desktop\src-tauri\target\release\bundle\nsis\ConversationSimulator_*_x64-setup.exe"
+
+# Sign the MSI as well if distributing it
+signtool.exe sign `
+  /f path\to\cert.pfx `
+  /p <password> `
+  /tr http://timestamp.digicert.com `
+  /td sha256 /fd sha256 /v `
+  "apps\desktop\src-tauri\target\release\bundle\msi\ConversationSimulator_*_x64.msi"
+```
+
+The `/tr` flag adds a trusted timestamp so the signature remains valid after
+the certificate expires. Always include it.
+
+### Step 3 — Verify the signature
+
+```powershell
+# Verify via signtool
+signtool.exe verify /pa /v `
+  "apps\desktop\src-tauri\target\release\bundle\nsis\ConversationSimulator_*_x64-setup.exe"
+
+# Or check the Properties dialog: right-click the .exe → Properties → Digital Signatures tab
+```
+
+A valid signature shows `Verified: Outright Mental` in the Properties dialog
+and `Number of files successfully Verified: 1` in the signtool output.
+
+---
+
+## SmartScreen reputation building
+
+Even a signed installer will initially show a SmartScreen warning if the
+certificate is new or the download count is low (this applies to OV certificates;
+EV certificates bypass this check).
+
+### For Stage 3 private beta (OV certificate)
+
+- Advise testers: click **More info → Run anyway**. This is expected during
+  the private beta with a new certificate.
+- Each "Run anyway" click contributes download signal to SmartScreen.
+- After a few hundred downloads from diverse IPs, the warning typically stops
+  appearing for most users.
+
+### For Stage 4 public release (EV certificate recommended)
+
+- An EV certificate grants immediate SmartScreen trust — no download reputation
+  required.
+- If using an OV certificate at public launch, communicate clearly in the
+  Steam store page that users may see a SmartScreen warning and provide the
+  "More info → Run anyway" instructions.
+- Monitor the Steam review queue for reports of SmartScreen warnings; they are
+  a signal that reputation building is incomplete.
+
+---
+
+## Antivirus false positives
+
+Freshly compiled Rust / Tauri executables are occasionally flagged by antivirus
+heuristic detection.
+
+### Triage steps
+
+1. Download a copy of the flagged binary.
+2. Submit it to [VirusTotal](https://www.virustotal.com/) for a multi-engine scan.
+3. If fewer than 3 engines flag it: the binary is likely safe; submit a
+   false-positive report through each flagging vendor's portal.
+4. If 3 or more engines flag it: investigate the build pipeline for unexpected
+   file inclusions; run the depot audit to confirm no prohibited content is
+   embedded.
+5. Wait 24–48 hours after submitting false-positive reports; vendor definitions
+   update on that cycle.
+
+The depot audit (`./scripts/depot-audit.sh` or `depot-audit.ps1`) catches the
+most common sources of false positives — large binary files, Python pickles,
+and unexpected model checkpoints.
+
+---
+
+## Rotating the certificate
+
+When the code-signing certificate approaches expiry:
+
+1. Purchase a new certificate from the same or another trusted CA.
+2. Export as `.pfx` and base64-encode as described above.
+3. Update `WINDOWS_SIGN_CERT_PFX` and `WINDOWS_SIGN_CERT_PASSWORD` in GitHub
+   Actions secrets.
+4. Rebuild and sign the current release to confirm the new certificate works.
+5. Files signed with the old certificate remain valid because of the trusted
+   timestamp embedded at signing time (`/tr`).
+
+---
+
+## Troubleshooting
+
+### SmartScreen blocks the installer despite a valid signature
+
+**Cause:** The certificate is newly issued (OV) and has not yet built reputation.
+
+**Fix:** Advise users to click "More info → Run anyway". Continue distributing
+the signed installer — each install contributes to SmartScreen reputation. If
+this is the Stage 4 public release, obtain an EV certificate for the next build.
+
+### `signtool.exe` exits with error 0x800b0101 (certificate expired)
+
+**Cause:** The signing certificate has expired.
+
+**Fix:** Rotate to a new certificate as described above. Files previously signed
+with a valid timestamp are unaffected; only new builds need to be signed with
+the new certificate.
+
+### `signtool.exe` exits with error 0x80096010 (subject does not match)
+
+**Cause:** The installer file path pattern does not match any files, or the
+wrong working directory was used.
+
+**Fix:** Use the full absolute path to the installer or confirm the glob pattern
+matches the actual filename. Run `dir apps\desktop\src-tauri\target\release\bundle\nsis\`
+to see the exact file name.
+
+### CI build produces unsigned installer even when secrets are set
+
+**Cause:** The release workflow only signs on Windows runners. If the
+`windows-latest` runner was not used, or if the Tauri signing variables were
+not passed through the `env:` block, the signing step was silently skipped.
+
+**Fix:** Confirm the release workflow uses `windows-latest` for the Windows
+build job and that `WINDOWS_SIGN_CERT_PFX` and `WINDOWS_SIGN_CERT_PASSWORD`
+are in the job's `env:` block. Check the workflow step output for the line
+`INFO tauri::bundle::windows::sign: Signing binary`.
+
+---
+
+## Links
+
+- [`docs/platform-notes.md` — Windows section](../docs/platform-notes.md#windows) — system requirements, build prerequisites, code signing overview
+- [`docs/steam-mvp-scope.md` — G3-01](../docs/steam-mvp-scope.md) — Stage 3 gate: signed Windows installer required
+- [`publishing/STEAM_PUBLISHING_AND_DEPLOYMENT.md`](STEAM_PUBLISHING_AND_DEPLOYMENT.md) — Steam deploy workflow and troubleshooting
+- [`publishing/STEAM_DEPOT_CONTENTS.md`](STEAM_DEPOT_CONTENTS.md) — depot content policy and approved binary payload list
+- [Tauri Windows signing docs](https://tauri.app/distribute/sign/windows) — upstream reference for Tauri signing variables
+- [Microsoft — signtool reference](https://docs.microsoft.com/en-us/windows/win32/seccrypto/signtool) — full signtool flag reference
+- [DigiCert timestamp URL](http://timestamp.digicert.com) — recommended timestamp authority (also: Sectigo `http://timestamp.sectigo.com`, GlobalSign `http://timestamp.globalsign.com`)

--- a/publishing/WINDOWS_CODE_SIGNING.md
+++ b/publishing/WINDOWS_CODE_SIGNING.md
@@ -91,13 +91,15 @@ certutil -encode cert.pfx cert.b64
 base64 -i cert.pfx -o cert.b64
 ```
 
-Tauri's bundler reads these secrets and calls `signtool.exe` automatically
-during `cargo tauri build` on Windows when the secrets are present. When the
-secrets are absent, the build proceeds and produces an unsigned installer.
-
-The release workflow (`release.yml`) passes the secrets as environment
-variables. When CI runs on a non-Windows runner, the signing step is skipped
-automatically.
+The release workflow (`release.yml`) signs the installers in a dedicated
+**"Sign Windows installers (Authenticode)"** step that runs *after*
+`cargo tauri build`, not through Tauri's own bundler. That step decodes
+`WINDOWS_SIGN_CERT_PFX` to a temporary `.pfx`, locates `signtool.exe` from the
+Windows SDK, and signs every `.exe` and `.msi` under
+`apps\desktop\src-tauri\target\release\bundle`. When `WINDOWS_SIGN_CERT_PFX`
+is absent (contributor forks, unsigned local builds), the step logs a notice
+and exits 0, producing an unsigned installer. The step only runs on Windows
+runners (`if: runner.os == 'Windows'`).
 
 For **EV certificates via cloud HSM**, the CI integration depends on the
 vendor. Consult DigiCert's or Sectigo's CI documentation for the required
@@ -258,14 +260,17 @@ to see the exact file name.
 
 ### CI build produces unsigned installer even when secrets are set
 
-**Cause:** The release workflow only signs on Windows runners. If the
-`windows-latest` runner was not used, or if the Tauri signing variables were
-not passed through the `env:` block, the signing step was silently skipped.
+**Cause:** The "Sign Windows installers (Authenticode)" step only runs on
+Windows runners, and it skips (exits 0) when `WINDOWS_SIGN_CERT_PFX` is empty.
+If the `windows-latest` runner was not used, or the secret was not exposed to
+the step's `env:` block, the installer is produced unsigned.
 
-**Fix:** Confirm the release workflow uses `windows-latest` for the Windows
-build job and that `WINDOWS_SIGN_CERT_PFX` and `WINDOWS_SIGN_CERT_PASSWORD`
-are in the job's `env:` block. Check the workflow step output for the line
-`INFO tauri::bundle::windows::sign: Signing binary`.
+**Fix:** Confirm the release workflow runs the Windows build job on
+`windows-latest` and that `WINDOWS_SIGN_CERT_PFX` / `WINDOWS_SIGN_CERT_PASSWORD`
+are mapped in that step's `env:` block. In the step log, look for
+`Using signtool: ...` and `Signing: ...` lines. The message
+`WINDOWS_SIGN_CERT_PFX is not set — producing unsigned build` means the secret
+did not reach the step.
 
 ---
 


### PR DESCRIPTION
## Summary

Implements the five Steam publishing and deployment documentation modules requested in issue #232, following the high-quality operational-docs pattern established in the repo (the "FeverTilt pattern"). These documents provide complete reference material for store operations, SteamPipe deployment, Steam API integration, and code-signing procedures across macOS and Windows platforms.

## What changed

### New files

- **`publishing/STEAM_STORE_AND_OPERATIONS.md`** — Operational hub for the Steam store launch and day-to-day operations. Covers store-page setup and asset status, free product configuration invariants, compliance gates by release stage, pre-launch and launch-day checklists, post-launch monitoring signals, and support triage routing with privacy-aware fast-path.

- **`publishing/STEAM_PUBLISHING_AND_DEPLOYMENT.md`** — End-to-end SteamPipe deployment reference: depot/package/branch architecture, VDF template mechanics, step-by-step walkthrough of the CI pipeline (`.github/workflows/steam-deploy.yml`), manual `steamcmd` upload procedure, branch promotion and rollback steps for Stages 3 and 4, and troubleshooting for auth errors, audit failures, empty depots, macOS Gatekeeper rejections, and Windows SmartScreen.

- **`docs/STEAM_INTEGRATION.md`** — Developer reference for the optional Steam API bridge. Covers Cargo feature model and build variants, `SteamRuntime` managed-state design pattern, Tauri command handler table, Steam Cloud two-layer synced-field exclusion (sentinel patterns + `.nosteamcloudpath` guards), `steam_cloud_settings.json` schema and prohibited-field rules, achievements/stats/rich presence with TypeScript call examples, graceful offline-mode fallback table, end-to-end test procedure, and Stage 4 pre-launch checklist.

- **`publishing/MACOS_SIGNING_AND_NOTARIZATION.md`** — macOS code-signing runbook: Apple Developer ID certificate procurement and `.p12` export, app-specific password setup for `notarytool`, CI secrets configuration, Hardened Runtime entitlements review (with current `entitlements.plist` spec), sidecar binary signing, manual `codesign` / `notarize-submit` / `staple` / `spctl verify` workflow, Steam depot tarball preparation, certificate rotation, and troubleshooting for Gatekeeper rejection, invalid signatures, and notarisation timeouts.

- **`publishing/WINDOWS_CODE_SIGNING.md`** — Windows Authenticode signing runbook: EV vs. OV certificate trade-offs, procurement steps, CI secrets setup for post-build `signtool.exe` automation, manual signing commands for both NSIS and MSI packages, SmartScreen reputation-building guidance per release stage, antivirus false-positive triage via VirusTotal, certificate rotation, and troubleshooting for common `signtool` exit codes.

### Updated files

- **`README.md`** — Added a "Steam release" section under Roadmap with a six-row table linking all new publishing documents and existing Steam-release reference docs.

- **`docs/STEAM_ROADMAP.md`** — Added issue #232 to the Stage 3 prerequisites (with all five new document links), and registered the four new docs in the cross-reference links section at the bottom.

## Accuracy and testing

All documents were verified for internal consistency and cross-referenced against the actual codebase:

- File links (to `STEAM_APP_REGISTRATION.md`, `STEAM_DEPOT_CONTENTS.md`, `steam-achievements-stats-rich-presence.md`, `platform-notes.md`, `steam-mvp-scope.md`, `steam-triage.md`, `.github/workflows/steam-deploy.yml`, `steam/app_build.vdf.tpl`, `entitlements.plist`, etc.) checked against the actual file tree.
- Compliance gate IDs (G3-01–G3-05, G4-01–G4-05, SR-01–SR-09) cross-checked against `STEAM_COMPLIANCE_AND_RISK_REGISTER.md` and `docs/steam-mvp-scope.md`.
- Environment variable names, Cargo features, Tauri command names, and CloudSettings schema validated against `platform-notes.md`, `steam.rs`, `steam_cloud.py`, and `steam-deploy.yml`.
- macOS entitlements cross-checked against the actual `entitlements.plist` (Hardened Runtime enabled, App Sandbox disabled, JIT and file-access entitlements noted).
- Windows code-signing CI steps verified against `release.yml` (post-build `signtool.exe` automation, not Tauri bundler auto-signing).
- Steam Cloud sync scope and `.nosteamcloudpath` sentinel generation verified against `steam-mvp-scope.md` and the actual lifespan hook in `convsim_core/app.py`.

Subsequent review commits fixed:
- Tauri command handler locations, managed-state construction pattern, and `.nosteamcloudpath` generation site in `STEAM_INTEGRATION.md`.
- Compliance gate mapping (Stage 3 requires SR-01–SR-08 + SR-09 sign-off; Stage 4 requires G4-01–G4-05 re-audit) in `STEAM_STORE_AND_OPERATIONS.md`.
- Broken GitHub anchor link to macOS depot section in `MACOS_SIGNING_AND_NOTARIZATION.md`.
- `steam_cloud_settings.json` schema to match the actual `CloudSettings` model (single field `last_model_id` only; display preferences and UI layout deferred to future versions).
- `set_live_branch` input default documentation (defaults to `beta`, must be cleared for staged uploads).

Closes #232