### PR TITLE
Add SteamPipe deploy workflow: default to beta branch and document private beta verification

### DIFF
--- a/.github/workflows/steam-deploy.yml
+++ b/.github/workflows/steam-deploy.yml
@@ -21,7 +21,7 @@
 #
 # ── Release gate reminder ────────────────────────────────────────────────────
 #
-# Stage 3 (private beta): set_live_branch = "beta"
+# Stage 3 (private beta): set_live_branch = "beta"  ← workflow default
 #   All Stage 3 gate criteria in docs/steam-mvp-scope.md must pass first,
 #   including G3-01 (code signing and notarisation) and G3-02 (depot audit).
 #
@@ -29,8 +29,39 @@
 #   All Stage 4 gate criteria must pass first, including G4-01 (Valve review
 #   approval) and G4-02 (Steam Deck Verified tier).
 #
-# When set_live_branch is empty, the build is staged in Steamworks but no
-# branch goes live — use this for dry runs or when manual sign-off is needed.
+# Leave set_live_branch empty to stage the build without making any branch
+# live — use this for dry runs or when manual sign-off is required.
+#
+# ── Private beta verification procedure ──────────────────────────────────────
+#
+# After this workflow completes with set_live_branch = "beta":
+#
+# 1. Open the Steamworks partner portal → App Admin → Builds.
+#    Confirm the new build appears under the "beta" branch with the correct
+#    description and depot file counts for all three platforms.
+#
+# 2. Verify the build number matches the GitHub release tag:
+#    Steamworks → Builds → [build row] → View Manifest.
+#    The version field must equal the tag (e.g. 0.1.0 for v0.1.0).
+#
+# 3. Confirm Stage 3 gate criteria before sharing the beta key with testers:
+#    G3-01 — macOS app is notarised; Windows installer is Authenticode-signed.
+#    G3-02 — No model-weight files in any depot (CI depot audit enforces this).
+#    G3-04 — All release-blocking risks in STEAM_COMPLIANCE_AND_RISK_REGISTER.md
+#             show status MITIGATED, ACCEPTED, or DEFERRED.
+#    Full criteria list: docs/steam-mvp-scope.md Stage 3 gate.
+#
+# 4. Generate Steam product keys for beta testers (if not already done):
+#    Steamworks → Packages → [Free package] → Generate Steam Product Codes.
+#    Share keys only with named testers — not publicly.
+#
+# 5. Ask at least one tester on each of Windows, macOS, and Linux to:
+#    a. Activate the key and install via Steam.
+#    b. Complete a full text session and debrief (G3-06).
+#    c. Confirm the Steam overlay (Shift+Tab) works without breaking the app (G3-03).
+#    d. Report any session-ending bugs, data-loss bugs, or privacy regressions.
+#
+# 6. Record sign-off in docs/release-checklist.md before promoting to "default".
 name: Steam Deploy
 
 on:
@@ -50,12 +81,12 @@ on:
       set_live_branch:
         description: >
           Steam branch to set live after upload.
-          Leave empty to stage the build without making it live.
-          Use "beta" for Stage 3 private beta.
+          Defaults to "beta" (Stage 3 private beta).
+          Leave empty to stage the build without making it live (dry run).
           Use "default" only for a Stage 4 public release — all gate criteria
           in docs/steam-mvp-scope.md must be met before selecting "default".
         required: false
-        default: ''
+        default: 'beta'
         type: string
 
 permissions:

--- a/publishing/STEAM_APP_REGISTRATION.md
+++ b/publishing/STEAM_APP_REGISTRATION.md
@@ -234,14 +234,67 @@ deploy workflow.
 ### Setting a branch live
 
 1. Trigger the deploy workflow (`.github/workflows/steam-deploy.yml`) with the
-   target release tag and, optionally, the `set_live_branch` input set to
-   `beta` or `default`.
-2. If `set_live_branch` is left empty, the build is staged in Steamworks but no
-   branch is made live — use this for a dry run or when manual sign-off is
-   required before going live.
+   target release tag. The `set_live_branch` input defaults to `beta` — the
+   correct choice for a Stage 3 private beta upload.
+2. Leave `set_live_branch` empty to stage the build without making any branch
+   live — use this for a dry run or when manual sign-off is required first.
 3. For `default` (public release): the Stage 4 gate in
    [`docs/steam-mvp-scope.md`](../docs/steam-mvp-scope.md) must be fully passed
    before this branch is set live.
+
+### Private beta verification procedure
+
+After the deploy workflow completes with `set_live_branch = beta`, verify the
+deployment before distributing Steam keys to testers.
+
+**Step 1 — Confirm the build is staged**
+
+Open the Steamworks partner portal → **App Admin → Builds**.
+
+- The new build appears in the build list with the correct description.
+- The build row shows three depot file counts (one per platform).
+- The `beta` column shows `SET LIVE` next to the new build.
+
+**Step 2 — Verify build version**
+
+Click the build row → **View Manifest**. Confirm the version field matches the
+GitHub release tag (e.g. `0.1.0` for tag `v0.1.0`).
+
+**Step 3 — Confirm Stage 3 gate criteria**
+
+Before sharing keys with testers, all Stage 3 gate criteria in
+[`docs/steam-mvp-scope.md`](../docs/steam-mvp-scope.md) must be satisfied:
+
+| Gate ID | Check |
+|---------|-------|
+| G3-01 | macOS `.app` is notarised; Windows installer is Authenticode-signed |
+| G3-02 | Depot audit passed in CI — no model-weight files in any depot |
+| G3-04 | All release-blocking risks in `STEAM_COMPLIANCE_AND_RISK_REGISTER.md` are MITIGATED, ACCEPTED, or DEFERRED |
+| G3-05 | All SR-01 through SR-08 compliance checklist items are signed off |
+
+**Step 4 — Generate beta tester keys**
+
+Steamworks → **Packages → [Free package] → Generate Steam Product Codes**.
+Request one key batch per named tester group. Share keys only with named testers
+— do not post them publicly.
+
+**Step 5 — Beta session verification (G3-06)**
+
+At least five testers (at least one on each of Windows, macOS, and Linux) must:
+
+1. Activate the key and install via the Steam client.
+2. Launch the app from the Steam Play button.
+3. Complete a full text session and view the debrief screen.
+4. Confirm the Steam overlay (Shift+Tab) opens without disrupting the session (G3-03).
+5. Report any session-ending bugs, data-loss bugs, or privacy regressions.
+
+Record tester sign-offs and platform coverage in [`docs/release-checklist.md`](../docs/release-checklist.md).
+
+**Step 6 — Promote to `default` only after Stage 4 gate**
+
+Do not trigger the deploy workflow with `set_live_branch = default` until the
+full Stage 4 gate passes, including Valve review approval (G4-01) and Steam Deck
+Verified tier (G4-02). See [`docs/steam-mvp-scope.md`](../docs/steam-mvp-scope.md).
 
 ---
 


### PR DESCRIPTION
## Summary

This PR completes the remaining DoD items for issue #236 on the SteamPipe deploy workflow:

- **Default `set_live_branch` to `beta`** — The `steam-deploy.yml` workflow input previously defaulted to an empty string (stage only). It now defaults to `beta`, so every manual dispatch automatically targets the Stage 3 private beta branch. Promoting to `default` (public release) still requires an explicit override, preventing accidental public releases.

- **Private beta verification procedure in the workflow header** — A 6-step post-deploy checklist was added directly to `.github/workflows/steam-deploy.yml` so operators see it immediately when opening the file: confirm build appears in Steamworks under the `beta` branch, verify the version matches the release tag, check Stage 3 gate criteria (G3-01 through G3-04), generate beta keys, run tester session verification (G3-06), and record sign-offs.

- **Private beta verification procedure in `publishing/STEAM_APP_REGISTRATION.md`** — The same procedure is documented in full prose and table form alongside the existing branch strategy section, covering all Stage 3 gate checks (G3-01, G3-02, G3-04, G3-05) and the tester session requirements (G3-06).

## What already existed

The full SteamPipe upload workflow, VDF templates, depot audit script, and branch strategy documentation were implemented in earlier issues. This PR adds the two remaining DoD items: the `beta` default and the private beta verification procedure.

## How it was tested

- `git diff` reviewed to confirm the `default: 'beta'` change is in the correct YAML field for the `set_live_branch` workflow input.
- Workflow header comments and `STEAM_APP_REGISTRATION.md` sections verified for accuracy against the Stage 3 gate criteria in `docs/steam-mvp-scope.md` and the compliance register.
- No runtime code was changed; no new tests are required for documentation and workflow-input defaults.

Closes #236