### PR TITLE
[UI] Replace the "Cannot reach the local runtime" dead end with a guided recovery flow

### DIFF
--- a/apps/web/src/__tests__/CoreStartup.test.tsx
+++ b/apps/web/src/__tests__/CoreStartup.test.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, act } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import CoreStartupGuard from '../screens/CoreStartup'
 
 const APP_CHILD = <div>App content loaded</div>
@@ -32,16 +33,26 @@ function stubTauri(
   }
 }
 
+// CoreStartupGuard uses Link (for the "Get support bundle" action) so it needs
+// a router context.
+function renderGuard(child: React.ReactNode = APP_CHILD) {
+  return render(
+    <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <CoreStartupGuard>{child}</CoreStartupGuard>
+    </MemoryRouter>,
+  )
+}
+
 // ── Non-Tauri (browser) context ───────────────────────────────────────────────
 
 describe('CoreStartupGuard — non-Tauri context', () => {
   it('renders children immediately when __TAURI__ is not present', () => {
-    render(<CoreStartupGuard>{APP_CHILD}</CoreStartupGuard>)
+    renderGuard()
     expect(screen.getByText('App content loaded')).toBeInTheDocument()
   })
 
   it('does not show a startup heading in browser context', () => {
-    render(<CoreStartupGuard>{APP_CHILD}</CoreStartupGuard>)
+    renderGuard()
     expect(screen.queryByRole('heading', { name: /conversation simulator/i })).not.toBeInTheDocument()
   })
 })
@@ -52,7 +63,7 @@ describe('CoreStartupGuard — Tauri context, core not yet ready', () => {
   it('shows the app heading while waiting', async () => {
     stubTauri(() => Promise.resolve(() => {}))
     await act(async () => {
-      render(<CoreStartupGuard>{APP_CHILD}</CoreStartupGuard>)
+      renderGuard()
     })
     expect(screen.getByRole('heading', { name: /conversation simulator/i })).toBeInTheDocument()
   })
@@ -60,7 +71,7 @@ describe('CoreStartupGuard — Tauri context, core not yet ready', () => {
   it('does not render children while waiting', async () => {
     stubTauri(() => Promise.resolve(() => {}))
     await act(async () => {
-      render(<CoreStartupGuard>{APP_CHILD}</CoreStartupGuard>)
+      renderGuard()
     })
     expect(screen.queryByText('App content loaded')).not.toBeInTheDocument()
   })
@@ -68,7 +79,7 @@ describe('CoreStartupGuard — Tauri context, core not yet ready', () => {
   it('shows a status live region while starting', async () => {
     stubTauri(() => Promise.resolve(() => {}))
     await act(async () => {
-      render(<CoreStartupGuard>{APP_CHILD}</CoreStartupGuard>)
+      renderGuard()
     })
     // Either a role="status" or a live region is present.
     expect(screen.getByRole('status')).toBeInTheDocument()
@@ -84,7 +95,7 @@ describe('CoreStartupGuard — core becomes ready via event', () => {
     })
 
     await act(async () => {
-      render(<CoreStartupGuard>{APP_CHILD}</CoreStartupGuard>)
+      renderGuard()
     })
 
     expect(screen.queryByText('App content loaded')).not.toBeInTheDocument()
@@ -106,7 +117,7 @@ describe('CoreStartupGuard — core becomes ready via event', () => {
     })
 
     await act(async () => {
-      render(<CoreStartupGuard>{APP_CHILD}</CoreStartupGuard>)
+      renderGuard()
     })
 
     await act(async () => {
@@ -120,7 +131,7 @@ describe('CoreStartupGuard — core becomes ready via event', () => {
 })
 
 describe('CoreStartupGuard — error state', () => {
-  it('shows an alert when core reports an error', async () => {
+  it('shows a recovery alert when core reports an error', async () => {
     let handler: TauriListenHandler | undefined
     stubTauri((_event, h) => {
       handler = h
@@ -128,7 +139,7 @@ describe('CoreStartupGuard — error state', () => {
     })
 
     await act(async () => {
-      render(<CoreStartupGuard>{APP_CHILD}</CoreStartupGuard>)
+      renderGuard()
     })
 
     await act(async () => {
@@ -143,7 +154,31 @@ describe('CoreStartupGuard — error state', () => {
 
     const alert = screen.getByRole('alert')
     expect(alert).toBeInTheDocument()
-    expect(alert).toHaveTextContent(/core service did not start/i)
+  })
+
+  it('shows a plain-language title for port conflict errors', async () => {
+    let handler: TauriListenHandler | undefined
+    stubTauri((_event, h) => {
+      handler = h
+      return Promise.resolve(() => {})
+    })
+
+    await act(async () => {
+      renderGuard()
+    })
+
+    await act(async () => {
+      handler?.({
+        payload: {
+          phase: 'error',
+          message: 'Core service did not start.',
+          error: 'Port 7355 is already in use.',
+        },
+      })
+    })
+
+    const alert = screen.getByRole('alert')
+    expect(alert).toHaveTextContent(/another app is using a required port/i)
   })
 
   it('shows the error detail in the alert', async () => {
@@ -154,7 +189,7 @@ describe('CoreStartupGuard — error state', () => {
     })
 
     await act(async () => {
-      render(<CoreStartupGuard>{APP_CHILD}</CoreStartupGuard>)
+      renderGuard()
     })
 
     await act(async () => {
@@ -170,6 +205,71 @@ describe('CoreStartupGuard — error state', () => {
     expect(screen.getByRole('alert')).toHaveTextContent(/port 7355 is already in use/i)
   })
 
+  it('shows a plain-language title for binary-not-found errors', async () => {
+    let handler: TauriListenHandler | undefined
+    stubTauri((_event, h) => {
+      handler = h
+      return Promise.resolve(() => {})
+    })
+
+    await act(async () => {
+      renderGuard()
+    })
+
+    await act(async () => {
+      handler?.({
+        payload: {
+          phase: 'error',
+          message: 'Could not locate core service.',
+          error: 'convsim-core executable not found.',
+        },
+      })
+    })
+
+    const alert = screen.getByRole('alert')
+    expect(alert).toHaveTextContent(/the conversation engine couldn't be found/i)
+  })
+
+  it('shows a "Restart the app" action button in the error card', async () => {
+    let handler: TauriListenHandler | undefined
+    stubTauri((_event, h) => {
+      handler = h
+      return Promise.resolve(() => {})
+    })
+
+    await act(async () => {
+      renderGuard()
+    })
+
+    await act(async () => {
+      handler?.({
+        payload: { phase: 'error', message: 'Failed.', error: null },
+      })
+    })
+
+    expect(screen.getByRole('button', { name: /restart the app/i })).toBeInTheDocument()
+  })
+
+  it('shows a troubleshooting guide link in the error card', async () => {
+    let handler: TauriListenHandler | undefined
+    stubTauri((_event, h) => {
+      handler = h
+      return Promise.resolve(() => {})
+    })
+
+    await act(async () => {
+      renderGuard()
+    })
+
+    await act(async () => {
+      handler?.({
+        payload: { phase: 'error', message: 'Failed.', error: null },
+      })
+    })
+
+    expect(screen.getByRole('link', { name: /troubleshooting guide/i })).toBeInTheDocument()
+  })
+
   it('does not render children on error', async () => {
     let handler: TauriListenHandler | undefined
     stubTauri((_event, h) => {
@@ -178,7 +278,7 @@ describe('CoreStartupGuard — error state', () => {
     })
 
     await act(async () => {
-      render(<CoreStartupGuard>{APP_CHILD}</CoreStartupGuard>)
+      renderGuard()
     })
 
     await act(async () => {
@@ -200,7 +300,7 @@ describe('CoreStartupGuard — health check fast-path', () => {
     stubTauri(() => Promise.resolve(() => {}))
 
     await act(async () => {
-      render(<CoreStartupGuard>{APP_CHILD}</CoreStartupGuard>)
+      renderGuard()
     })
 
     expect(screen.getByText('App content loaded')).toBeInTheDocument()
@@ -221,12 +321,14 @@ describe('CoreStartupGuard — snapshot recovery of missed events', () => {
     stubTauri(() => Promise.resolve(() => {}), invoke)
 
     await act(async () => {
-      render(<CoreStartupGuard>{APP_CHILD}</CoreStartupGuard>)
+      renderGuard()
     })
 
     expect(invoke).toHaveBeenCalledWith('get_core_status')
     const alert = screen.getByRole('alert')
-    expect(alert).toHaveTextContent(/could not locate core service/i)
+    // Plain-language title for binary-not-found class.
+    expect(alert).toHaveTextContent(/the conversation engine couldn't be found/i)
+    // Technical detail is still shown for diagnostics.
     expect(alert).toHaveTextContent(/convsim-core executable not found/i)
     expect(screen.queryByText('App content loaded')).not.toBeInTheDocument()
   })
@@ -238,7 +340,7 @@ describe('CoreStartupGuard — snapshot recovery of missed events', () => {
     stubTauri(() => Promise.resolve(() => {}), invoke)
 
     await act(async () => {
-      render(<CoreStartupGuard>{APP_CHILD}</CoreStartupGuard>)
+      renderGuard()
     })
 
     expect(screen.getByText('App content loaded')).toBeInTheDocument()

--- a/apps/web/src/__tests__/Debrief.test.tsx
+++ b/apps/web/src/__tests__/Debrief.test.tsx
@@ -223,7 +223,7 @@ describe('Debrief screen', () => {
       // fullDebriefResponse.outcome is 'player_exit' — the "manually ended"
       // case the shipped framework (#230) explicitly counts. FIRST_SCENARIO and
       // the SCENARIOS_COMPLETED stat must fire regardless of a 'success' outcome.
-      mockApi.generateDebrief.mockResolvedValue(fullDebriefResponse)
+      mockApi.generateDebrief.mockResolvedValue({ ok: true, data: fullDebriefResponse })
       renderDebrief()
       await waitFor(() =>
         expect(screen.getByTestId('summary-section')).toBeInTheDocument(),

--- a/apps/web/src/__tests__/Home.test.tsx
+++ b/apps/web/src/__tests__/Home.test.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import Home from '../screens/Home'
 
@@ -209,6 +209,16 @@ describe('Home — status card links', () => {
     // Install model, Import pack, LLM badge, STT badge, TTS badge = 5
     expect(settingsLinks.length).toBeGreaterThanOrEqual(5)
   })
+
+  it('Local runtime badge links to the recovery section when offline', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('Network error'))))
+    renderHome()
+    await screen.findByRole('alert')
+    const runtimeLink = screen.getAllByRole('link').find(
+      (el) => el.getAttribute('href') === '#runtime-recovery',
+    )
+    expect(runtimeLink).toBeDefined()
+  })
 })
 
 describe('Home — runtime-error state', () => {
@@ -218,12 +228,26 @@ describe('Home — runtime-error state', () => {
     expect(await screen.findByText(liText('Local runtime: Unavailable'))).toBeInTheDocument()
   })
 
-  it('shows an actionable error alert when runtime is down', async () => {
+  it('shows a recovery alert when runtime is down', async () => {
     vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('Network error'))))
     renderHome()
     const alert = await screen.findByRole('alert')
     expect(alert).toBeInTheDocument()
-    expect(alert).toHaveTextContent(/ensure the api server is running/i)
+  })
+
+  it('shows plain-language title in the unreachable recovery card', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('Network error'))))
+    renderHome()
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent(/the conversation engine is not responding/i)
+  })
+
+  it('does not contain API-server jargon in the unreachable card', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('Network error'))))
+    renderHome()
+    const alert = await screen.findByRole('alert')
+    expect(alert).not.toHaveTextContent(/api server/i)
+    expect(alert).not.toHaveTextContent(/local runtime/i)
   })
 
   it('does not show the no-model section when runtime is unreachable', async () => {
@@ -252,14 +276,14 @@ describe('Home — runtime-error state', () => {
     stubFetches(makeHealth({ last_error: 'EADDRINUSE: address already in use :::7355' }), makePacks(0))
     renderHome()
     const alert = await screen.findByRole('alert')
-    expect(alert).toHaveTextContent(/port conflict/i)
+    expect(alert).toHaveTextContent(/another app is using a required port/i)
   })
 
   it('shows port troubleshooting guidance for port conflict errors', async () => {
     stubFetches(makeHealth({ last_error: 'EADDRINUSE port 7356 in use' }), makePacks(0))
     renderHome()
     await screen.findByRole('alert')
-    expect(screen.getByText(/a required port is already in use/i)).toBeInTheDocument()
+    expect(screen.getByText(/close the conflicting app/i)).toBeInTheDocument()
   })
 
   it('shows the unreachable alert with troubleshooting docs link', async () => {
@@ -269,12 +293,76 @@ describe('Home — runtime-error state', () => {
     expect(screen.getByRole('link', { name: /troubleshooting docs/i })).toBeInTheDocument()
   })
 
-  it('shows a report-an-issue link in the unreachable alert', async () => {
+  it('shows a report-an-issue link in the help section', async () => {
     vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('Network error'))))
     renderHome()
     await screen.findByRole('alert')
     const links = screen.getAllByRole('link', { name: /report an issue/i })
     expect(links.length).toBeGreaterThanOrEqual(1)
+  })
+})
+
+describe('Home — recovery card actions', () => {
+  it('shows a Restart button in the unreachable recovery card', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('Network error'))))
+    renderHome()
+    await screen.findByRole('alert')
+    expect(screen.getByRole('button', { name: /restart the app/i })).toBeInTheDocument()
+  })
+
+  it('shows a Get support bundle link in the unreachable recovery card', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('Network error'))))
+    renderHome()
+    await screen.findByRole('alert')
+    expect(screen.getByRole('link', { name: /get support bundle/i })).toBeInTheDocument()
+  })
+
+  it('shows Restart conversation engine button for port conflict errors', async () => {
+    stubFetches(makeHealth({ last_error: 'EADDRINUSE: address already in use :::7355' }), makePacks(0))
+    renderHome()
+    await screen.findByRole('alert')
+    expect(screen.getByRole('button', { name: /restart conversation engine/i })).toBeInTheDocument()
+  })
+
+  it('shows Restart conversation engine button for generic last_error', async () => {
+    stubFetches(makeHealth({ last_error: 'Model crashed unexpectedly' }), makePacks(0))
+    renderHome()
+    await screen.findByRole('alert')
+    expect(screen.getByRole('button', { name: /restart conversation engine/i })).toBeInTheDocument()
+  })
+
+  it('calls sidecar stop then start when Restart conversation engine is clicked', async () => {
+    const mockFetch = vi.fn((url: string) => {
+      if (url.includes('/packs')) {
+        const body = makePacks(0)
+        return Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify(body)) })
+      }
+      if (url.includes('/sidecar/status')) {
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(JSON.stringify({ state: 'crashed', model_path: '/models/test.gguf', error: null, log_path: '/tmp/log', host: '127.0.0.1', port: 7356 })),
+        })
+      }
+      if (url.includes('/sidecar/stop') || url.includes('/sidecar/start')) {
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(JSON.stringify({ state: 'running', message: 'ok' })),
+        })
+      }
+      // Health returns last_error to trigger the recovery card
+      const body = makeHealth({ last_error: 'Sidecar crashed' })
+      return Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify(body)) })
+    })
+    vi.stubGlobal('fetch', mockFetch)
+
+    renderHome()
+    const restartBtn = await screen.findByRole('button', { name: /restart conversation engine/i })
+    fireEvent.click(restartBtn)
+
+    await waitFor(() => {
+      const calls = mockFetch.mock.calls.map((c) => c[0] as string)
+      expect(calls.some((u) => u.includes('/sidecar/stop'))).toBe(true)
+    })
   })
 })
 

--- a/apps/web/src/__tests__/Home.test.tsx
+++ b/apps/web/src/__tests__/Home.test.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import Home from '../screens/Home'
 
@@ -226,6 +226,16 @@ describe('Home — status card links', () => {
     // Install model, Import pack, LLM badge, STT badge, TTS badge = 5
     expect(settingsLinks.length).toBeGreaterThanOrEqual(5)
   })
+
+  it('Local runtime badge links to the recovery section when offline', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('Network error'))))
+    renderHome()
+    await screen.findByRole('alert')
+    const runtimeLink = screen.getAllByRole('link').find(
+      (el) => el.getAttribute('href') === '#runtime-recovery',
+    )
+    expect(runtimeLink).toBeDefined()
+  })
 })
 
 describe('Home — runtime-error state', () => {
@@ -235,12 +245,26 @@ describe('Home — runtime-error state', () => {
     expect(await screen.findByText(liText('Local runtime: Unavailable'))).toBeInTheDocument()
   })
 
-  it('shows an actionable error alert when runtime is down', async () => {
+  it('shows a recovery alert when runtime is down', async () => {
     vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('Network error'))))
     renderHome()
     const alert = await screen.findByRole('alert')
     expect(alert).toBeInTheDocument()
-    expect(alert).toHaveTextContent(/ensure the api server is running/i)
+  })
+
+  it('shows plain-language title in the unreachable recovery card', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('Network error'))))
+    renderHome()
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent(/the conversation engine is not responding/i)
+  })
+
+  it('does not contain API-server jargon in the unreachable card', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('Network error'))))
+    renderHome()
+    const alert = await screen.findByRole('alert')
+    expect(alert).not.toHaveTextContent(/api server/i)
+    expect(alert).not.toHaveTextContent(/local runtime/i)
   })
 
   it('does not show the no-model section when runtime is unreachable', async () => {
@@ -269,14 +293,14 @@ describe('Home — runtime-error state', () => {
     stubFetches(makeHealth({ last_error: 'EADDRINUSE: address already in use :::7355' }), makePacks(0))
     renderHome()
     const alert = await screen.findByRole('alert')
-    expect(alert).toHaveTextContent(/port conflict/i)
+    expect(alert).toHaveTextContent(/another app is using a required port/i)
   })
 
   it('shows port troubleshooting guidance for port conflict errors', async () => {
     stubFetches(makeHealth({ last_error: 'EADDRINUSE port 7356 in use' }), makePacks(0))
     renderHome()
     await screen.findByRole('alert')
-    expect(screen.getByText(/a required port is already in use/i)).toBeInTheDocument()
+    expect(screen.getByText(/close the conflicting app/i)).toBeInTheDocument()
   })
 
   it('shows the unreachable alert with troubleshooting docs link', async () => {
@@ -286,12 +310,76 @@ describe('Home — runtime-error state', () => {
     expect(screen.getByRole('link', { name: /troubleshooting docs/i })).toBeInTheDocument()
   })
 
-  it('shows a report-an-issue link in the unreachable alert', async () => {
+  it('shows a report-an-issue link in the help section', async () => {
     vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('Network error'))))
     renderHome()
     await screen.findByRole('alert')
     const links = screen.getAllByRole('link', { name: /report an issue/i })
     expect(links.length).toBeGreaterThanOrEqual(1)
+  })
+})
+
+describe('Home — recovery card actions', () => {
+  it('shows a Restart button in the unreachable recovery card', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('Network error'))))
+    renderHome()
+    await screen.findByRole('alert')
+    expect(screen.getByRole('button', { name: /restart the app/i })).toBeInTheDocument()
+  })
+
+  it('shows a Get support bundle link in the unreachable recovery card', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('Network error'))))
+    renderHome()
+    await screen.findByRole('alert')
+    expect(screen.getByRole('link', { name: /get support bundle/i })).toBeInTheDocument()
+  })
+
+  it('shows Restart conversation engine button for port conflict errors', async () => {
+    stubFetches(makeHealth({ last_error: 'EADDRINUSE: address already in use :::7355' }), makePacks(0))
+    renderHome()
+    await screen.findByRole('alert')
+    expect(screen.getByRole('button', { name: /restart conversation engine/i })).toBeInTheDocument()
+  })
+
+  it('shows Restart conversation engine button for generic last_error', async () => {
+    stubFetches(makeHealth({ last_error: 'Model crashed unexpectedly' }), makePacks(0))
+    renderHome()
+    await screen.findByRole('alert')
+    expect(screen.getByRole('button', { name: /restart conversation engine/i })).toBeInTheDocument()
+  })
+
+  it('calls sidecar stop then start when Restart conversation engine is clicked', async () => {
+    const mockFetch = vi.fn((url: string) => {
+      if (url.includes('/packs')) {
+        const body = makePacks(0)
+        return Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify(body)) })
+      }
+      if (url.includes('/sidecar/status')) {
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(JSON.stringify({ state: 'crashed', model_path: '/models/test.gguf', error: null, log_path: '/tmp/log', host: '127.0.0.1', port: 7356 })),
+        })
+      }
+      if (url.includes('/sidecar/stop') || url.includes('/sidecar/start')) {
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(JSON.stringify({ state: 'running', message: 'ok' })),
+        })
+      }
+      // Health returns last_error to trigger the recovery card
+      const body = makeHealth({ last_error: 'Sidecar crashed' })
+      return Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify(body)) })
+    })
+    vi.stubGlobal('fetch', mockFetch)
+
+    renderHome()
+    const restartBtn = await screen.findByRole('button', { name: /restart conversation engine/i })
+    fireEvent.click(restartBtn)
+
+    await waitFor(() => {
+      const calls = mockFetch.mock.calls.map((c) => c[0] as string)
+      expect(calls.some((u) => u.includes('/sidecar/stop'))).toBe(true)
+    })
   })
 })
 

--- a/apps/web/src/__tests__/Logbook.test.tsx
+++ b/apps/web/src/__tests__/Logbook.test.tsx
@@ -65,11 +65,14 @@ function renderLogbook() {
 }
 
 beforeEach(() => {
-  vi.mocked(api.getLogbookProfile).mockResolvedValue(makeProfile())
+  vi.mocked(api.getLogbookProfile).mockResolvedValue({ ok: true, data: makeProfile() })
   vi.mocked(api.exportLogbook).mockResolvedValue({
-    exported_at: new Date().toISOString(),
-    profile: makeProfile(),
-    session_scores: [],
+    ok: true,
+    data: {
+      exported_at: new Date().toISOString(),
+      profile: makeProfile(),
+      session_scores: [],
+    },
   })
 })
 
@@ -118,7 +121,7 @@ describe('Logbook — with sessions', () => {
   })
 
   beforeEach(() => {
-    vi.mocked(api.getLogbookProfile).mockResolvedValue(profile)
+    vi.mocked(api.getLogbookProfile).mockResolvedValue({ ok: true, data: profile })
   })
 
   it('shows the session count', async () => {
@@ -187,7 +190,7 @@ describe('Logbook — error state', () => {
 describe('Logbook — single session delta', () => {
   it('does not show last session delta with only one session', async () => {
     vi.mocked(api.getLogbookProfile).mockResolvedValue(
-      makeProfile({ total_sessions: 1, last_session_delta: null }),
+      { ok: true, data: makeProfile({ total_sessions: 1, last_session_delta: null }) },
     )
     renderLogbook()
     await screen.findByRole('heading', { name: /^logbook$/i })

--- a/apps/web/src/__tests__/RuntimeRecoveryCard.test.tsx
+++ b/apps/web/src/__tests__/RuntimeRecoveryCard.test.tsx
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import RuntimeRecoveryCard from '../components/RuntimeRecoveryCard'
+
+const TROUBLESHOOTING_HREF = 'https://example.com/docs/troubleshooting.md#engine-startup-failure'
+
+describe('RuntimeRecoveryCard — basic rendering', () => {
+  it('renders as an ARIA alert region', () => {
+    render(
+      <RuntimeRecoveryCard
+        title="Test title"
+        description="Test description"
+        troubleshootingHref={TROUBLESHOOTING_HREF}
+      />,
+    )
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+  })
+
+  it('shows the title', () => {
+    render(
+      <RuntimeRecoveryCard
+        title="The conversation engine didn't start"
+        description="Something went wrong."
+        troubleshootingHref={TROUBLESHOOTING_HREF}
+      />,
+    )
+    expect(screen.getByRole('alert')).toHaveTextContent(/the conversation engine didn't start/i)
+  })
+
+  it('shows the description', () => {
+    render(
+      <RuntimeRecoveryCard
+        title="Title"
+        description="Close other apps and restart."
+        troubleshootingHref={TROUBLESHOOTING_HREF}
+      />,
+    )
+    expect(screen.getByRole('alert')).toHaveTextContent(/close other apps and restart/i)
+  })
+
+  it('shows errorDetail when provided', () => {
+    render(
+      <RuntimeRecoveryCard
+        title="Title"
+        description="Desc"
+        errorDetail="Port 7355 is already in use."
+        troubleshootingHref={TROUBLESHOOTING_HREF}
+      />,
+    )
+    expect(screen.getByRole('alert')).toHaveTextContent(/port 7355 is already in use/i)
+  })
+
+  it('omits errorDetail section when not provided', () => {
+    render(
+      <RuntimeRecoveryCard
+        title="Title"
+        description="Desc"
+        troubleshootingHref={TROUBLESHOOTING_HREF}
+      />,
+    )
+    // No "Port" text in the card
+    expect(screen.queryByText(/port/i)).not.toBeInTheDocument()
+  })
+
+  it('shows the log path when provided', () => {
+    render(
+      <RuntimeRecoveryCard
+        title="Title"
+        description="Desc"
+        logPath="~/.convsim/logs/app.log"
+        troubleshootingHref={TROUBLESHOOTING_HREF}
+      />,
+    )
+    expect(screen.getByText('~/.convsim/logs/app.log')).toBeInTheDocument()
+  })
+})
+
+describe('RuntimeRecoveryCard — troubleshooting link', () => {
+  it('renders a troubleshooting docs link', () => {
+    render(
+      <RuntimeRecoveryCard
+        title="Title"
+        description="Desc"
+        troubleshootingHref={TROUBLESHOOTING_HREF}
+      />,
+    )
+    const link = screen.getByRole('link', { name: /troubleshooting docs/i })
+    expect(link).toHaveAttribute('href', TROUBLESHOOTING_HREF)
+    expect(link).toHaveAttribute('target', '_blank')
+  })
+
+  it('uses a custom troubleshooting label when provided', () => {
+    render(
+      <RuntimeRecoveryCard
+        title="Title"
+        description="Desc"
+        troubleshootingHref={TROUBLESHOOTING_HREF}
+        troubleshootingLabel="Port conflict guide"
+      />,
+    )
+    expect(screen.getByRole('link', { name: /port conflict guide/i })).toBeInTheDocument()
+  })
+})
+
+describe('RuntimeRecoveryCard — primary action', () => {
+  it('renders a primary action button', () => {
+    render(
+      <RuntimeRecoveryCard
+        title="Title"
+        description="Desc"
+        troubleshootingHref={TROUBLESHOOTING_HREF}
+        primaryAction={{ label: 'Restart the app', onClick: vi.fn() }}
+      />,
+    )
+    expect(screen.getByRole('button', { name: /restart the app/i })).toBeInTheDocument()
+  })
+
+  it('calls onClick when the primary action button is clicked', () => {
+    const onClick = vi.fn()
+    render(
+      <RuntimeRecoveryCard
+        title="Title"
+        description="Desc"
+        troubleshootingHref={TROUBLESHOOTING_HREF}
+        primaryAction={{ label: 'Restart the app', onClick }}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /restart the app/i }))
+    expect(onClick).toHaveBeenCalledOnce()
+  })
+
+  it('shows loading label when action is in loading state', () => {
+    render(
+      <RuntimeRecoveryCard
+        title="Title"
+        description="Desc"
+        troubleshootingHref={TROUBLESHOOTING_HREF}
+        primaryAction={{
+          label: 'Restart conversation engine',
+          loadingLabel: 'Restarting…',
+          loading: true,
+          onClick: vi.fn(),
+        }}
+      />,
+    )
+    expect(screen.getByRole('button', { name: /restarting/i })).toBeInTheDocument()
+    expect(screen.getByRole('button')).toBeDisabled()
+  })
+
+  it('renders an external link when href is provided instead of onClick', () => {
+    render(
+      <RuntimeRecoveryCard
+        title="Title"
+        description="Desc"
+        troubleshootingHref={TROUBLESHOOTING_HREF}
+        primaryAction={{ label: 'Get support bundle', href: '/support' }}
+      />,
+    )
+    const link = screen.getByRole('link', { name: /get support bundle/i })
+    expect(link).toHaveAttribute('href', '/support')
+  })
+})
+
+describe('RuntimeRecoveryCard — secondary and tertiary actions', () => {
+  it('renders a secondary action', () => {
+    render(
+      <RuntimeRecoveryCard
+        title="Title"
+        description="Desc"
+        troubleshootingHref={TROUBLESHOOTING_HREF}
+        primaryAction={{ label: 'Restart', onClick: vi.fn() }}
+        secondaryAction={{ label: 'Get support bundle', href: '/support' }}
+      />,
+    )
+    expect(screen.getByRole('link', { name: /get support bundle/i })).toBeInTheDocument()
+  })
+
+  it('renders a tertiary action', () => {
+    render(
+      <RuntimeRecoveryCard
+        title="Title"
+        description="Desc"
+        troubleshootingHref={TROUBLESHOOTING_HREF}
+        primaryAction={{ label: 'Restart', onClick: vi.fn() }}
+        secondaryAction={{ label: 'Bundle', href: '/support' }}
+        tertiaryAction={{ label: 'Report an issue', href: 'https://github.com' }}
+      />,
+    )
+    expect(screen.getByRole('link', { name: /report an issue/i })).toBeInTheDocument()
+  })
+
+  it('renders all three actions alongside the troubleshooting link', () => {
+    render(
+      <RuntimeRecoveryCard
+        title="Title"
+        description="Desc"
+        troubleshootingHref={TROUBLESHOOTING_HREF}
+        primaryAction={{ label: 'Restart', onClick: vi.fn() }}
+        secondaryAction={{ label: 'Bundle', href: '/support' }}
+        tertiaryAction={{ label: 'Report', href: 'https://github.com' }}
+      />,
+    )
+    // 4 interactive elements: primary button + secondary + tertiary + troubleshooting link
+    const links = screen.getAllByRole('link')
+    const buttons = screen.getAllByRole('button')
+    expect(links.length + buttons.length).toBeGreaterThanOrEqual(4)
+  })
+})

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -456,6 +456,12 @@ export const api = {
   startSidecar(model_path: string): Promise<ApiResult<{ state: string; pid: number | null; log_path: string; host: string; port: number }>> {
     return post('/sidecar/start', { model_path })
   },
+  getSidecarStatus(): Promise<ApiResult<{ state: string; pid: number | null; model_path: string | null; error: string | null; log_path: string; host: string; port: number }>> {
+    return get('/sidecar/status')
+  },
+  stopSidecar(): Promise<ApiResult<{ state: string; message: string }>> {
+    return post('/sidecar/stop')
+  },
   benchmarkModel(request: BenchmarkRequest): Promise<ApiResult<BenchmarkResponse>> {
     return post<BenchmarkResponse>('/models/benchmark', request)
   },

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -448,6 +448,12 @@ export const api = {
   startSidecar(model_path: string): Promise<ApiResult<{ state: string; pid: number | null; log_path: string; host: string; port: number }>> {
     return post('/sidecar/start', { model_path })
   },
+  getSidecarStatus(): Promise<ApiResult<{ state: string; pid: number | null; model_path: string | null; error: string | null; log_path: string; host: string; port: number }>> {
+    return get('/sidecar/status')
+  },
+  stopSidecar(): Promise<ApiResult<{ state: string; message: string }>> {
+    return post('/sidecar/stop')
+  },
   benchmarkModel(request: BenchmarkRequest): Promise<ApiResult<BenchmarkResponse>> {
     return post<BenchmarkResponse>('/models/benchmark', request)
   },

--- a/apps/web/src/api/useApiHealth.ts
+++ b/apps/web/src/api/useApiHealth.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { RuntimeReadiness } from '@convsim/shared'
 import { apiClient } from './client'
 
@@ -9,33 +9,55 @@ export interface ApiHealth {
   state: HealthState
   healthy: boolean
   runtime: RuntimeReadiness | null
+  /** Manually trigger an immediate health re-check (e.g. after a restart action). */
+  refetch: () => void
 }
 
+const POLL_INTERVAL_MS = 3000
+
 export function useApiHealth(): ApiHealth {
-  const [result, setResult] = useState<ApiHealth>({
+  const [result, setResult] = useState<Omit<ApiHealth, 'refetch'>>({
     state: 'loading',
     healthy: false,
     runtime: null,
   })
 
+  // Stable ref so refetch() can trigger a re-check without re-mounting the effect.
+  const checkRef = useRef<(() => void) | null>(null)
+
   useEffect(() => {
     let cancelled = false
+    let timeoutId: ReturnType<typeof setTimeout> | undefined
 
-    void apiClient.health().then((r) => {
-      if (!cancelled) {
-        if (r.ok) {
-          const state: HealthState = r.data.status === 'ok' ? 'healthy' : 'unavailable'
-          setResult({ state, healthy: state === 'healthy', runtime: r.data.runtime ?? null })
-        } else {
-          setResult({ state: 'unavailable', healthy: false, runtime: null })
+    async function check() {
+      clearTimeout(timeoutId)
+      const r = await apiClient.health()
+      if (cancelled) return
+
+      if (r.ok) {
+        const state: HealthState = r.data.status === 'ok' ? 'healthy' : 'unavailable'
+        setResult({ state, healthy: state === 'healthy', runtime: r.data.runtime ?? null })
+        // Only poll when not healthy so we detect recovery within POLL_INTERVAL_MS.
+        if (state !== 'healthy') {
+          timeoutId = setTimeout(check, POLL_INTERVAL_MS)
         }
+      } else {
+        setResult({ state: 'unavailable', healthy: false, runtime: null })
+        timeoutId = setTimeout(check, POLL_INTERVAL_MS)
       }
-    })
+    }
+
+    checkRef.current = () => void check()
+    void check()
 
     return () => {
       cancelled = true
+      clearTimeout(timeoutId)
+      checkRef.current = null
     }
   }, [])
 
-  return result
+  const refetch = () => checkRef.current?.()
+
+  return { ...result, refetch }
 }

--- a/apps/web/src/components/RuntimeRecoveryCard.tsx
+++ b/apps/web/src/components/RuntimeRecoveryCard.tsx
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export interface RecoveryAction {
+  label: string
+  loadingLabel?: string
+  onClick?: () => void
+  href?: string
+  loading?: boolean
+  disabled?: boolean
+}
+
+interface RuntimeRecoveryCardProps {
+  title: string
+  description: string
+  errorDetail?: string | null
+  /** Path to the log file shown to advanced users. */
+  logPath?: string | null
+  /** URL of the troubleshooting guide anchor for this failure class. */
+  troubleshootingHref: string
+  /** Label for the troubleshooting guide link. */
+  troubleshootingLabel?: string
+  /** Primary action — e.g. "Restart conversation engine". */
+  primaryAction?: RecoveryAction
+  /** Secondary action — e.g. "Run self-test" or "Get support bundle". */
+  secondaryAction?: RecoveryAction
+  /** Tertiary action — e.g. "Get support bundle". */
+  tertiaryAction?: RecoveryAction
+}
+
+const cardStyle: React.CSSProperties = {
+  marginTop: '0.75rem',
+  padding: '1rem 1.125rem',
+  background: 'rgba(239,68,68,0.08)',
+  border: '1px solid rgba(239,68,68,0.3)',
+  borderRadius: '8px',
+}
+
+const titleStyle: React.CSSProperties = {
+  margin: '0 0 0.35rem',
+  fontWeight: 600,
+  color: '#f87171',
+  fontSize: '0.875rem',
+}
+
+const bodyStyle: React.CSSProperties = {
+  margin: '0 0 0.5rem',
+  fontSize: '0.825rem',
+  color: '#a1a1aa',
+}
+
+const detailStyle: React.CSSProperties = {
+  margin: '0 0 0.75rem',
+  fontSize: '0.8rem',
+  color: '#71717a',
+  fontFamily: 'monospace',
+  whiteSpace: 'pre-wrap',
+  wordBreak: 'break-word',
+}
+
+const actionRowStyle: React.CSSProperties = {
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '0.5rem',
+  alignItems: 'center',
+  marginTop: '0.75rem',
+}
+
+const buttonStyle: React.CSSProperties = {
+  padding: '0.3rem 0.7rem',
+  borderRadius: '4px',
+  fontSize: '0.8rem',
+  cursor: 'pointer',
+  border: '1px solid rgba(239,68,68,0.4)',
+  background: 'rgba(239,68,68,0.15)',
+  color: '#f87171',
+  textDecoration: 'none',
+  display: 'inline-block',
+}
+
+const buttonDisabledStyle: React.CSSProperties = {
+  ...buttonStyle,
+  opacity: 0.5,
+  cursor: 'wait',
+}
+
+const linkStyle: React.CSSProperties = {
+  fontSize: '0.8rem',
+  color: '#71717a',
+}
+
+function ActionButton({ action }: { action: RecoveryAction }) {
+  const label = action.loading && action.loadingLabel ? action.loadingLabel : action.label
+  const style = action.loading || action.disabled ? buttonDisabledStyle : buttonStyle
+
+  if (action.href) {
+    return (
+      <a href={action.href} target="_blank" rel="noreferrer" style={style}>
+        {label}
+      </a>
+    )
+  }
+
+  return (
+    <button
+      onClick={action.onClick}
+      disabled={action.loading || action.disabled}
+      style={style}
+    >
+      {label}
+    </button>
+  )
+}
+
+export default function RuntimeRecoveryCard({
+  title,
+  description,
+  errorDetail,
+  logPath,
+  troubleshootingHref,
+  troubleshootingLabel = 'Troubleshooting docs',
+  primaryAction,
+  secondaryAction,
+  tertiaryAction,
+}: RuntimeRecoveryCardProps) {
+  return (
+    <div role="alert" style={cardStyle}>
+      <p style={titleStyle}>{title}</p>
+      <p style={bodyStyle}>{description}</p>
+      {errorDetail && <p style={detailStyle}>{errorDetail}</p>}
+      {logPath && (
+        <p style={{ ...bodyStyle, marginBottom: '0' }}>
+          Logs:{' '}
+          <code style={{ fontSize: '0.8rem', color: '#71717a' }}>{logPath}</code>
+        </p>
+      )}
+
+      <div style={actionRowStyle}>
+        {primaryAction && <ActionButton action={primaryAction} />}
+        {secondaryAction && <ActionButton action={secondaryAction} />}
+        {tertiaryAction && <ActionButton action={tertiaryAction} />}
+        <a href={troubleshootingHref} target="_blank" rel="noreferrer" style={linkStyle}>
+          {troubleshootingLabel}
+        </a>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/RuntimeRecoveryCard.tsx
+++ b/apps/web/src/components/RuntimeRecoveryCard.tsx
@@ -93,8 +93,13 @@ function ActionButton({ action }: { action: RecoveryAction }) {
   const style = action.loading || action.disabled ? buttonDisabledStyle : buttonStyle
 
   if (action.href) {
+    // External links (docs, GitHub) open in a new tab; internal app routes
+    // (e.g. /support) must navigate in the same window so we don't spawn a new
+    // browser tab / OS window and re-bootstrap the whole SPA.
+    const isExternal = /^https?:\/\//i.test(action.href)
+    const externalProps = isExternal ? { target: '_blank', rel: 'noreferrer' } : {}
     return (
-      <a href={action.href} target="_blank" rel="noreferrer" style={style}>
+      <a href={action.href} {...externalProps} style={style}>
         {label}
       </a>
     )

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -73,23 +73,31 @@ export const de: LocaleMessages = {
       packsInstalledCount: '{{count}} installiert',
     },
     unreachable: {
-      title: 'Lokale Laufzeitumgebung nicht erreichbar',
+      title: 'Die Konversations-Engine antwortet nicht',
       message:
-        'Stellen Sie sicher, dass der API-Server läuft. Falls das Problem weiterhin besteht, prüfen Sie den Protokollordner oder melden Sie ein Problem.',
+        'Die App kann die Konversations-Engine gerade nicht erreichen. Versuchen Sie einen Neustart oder sehen Sie in der Fehlerbehebungsanleitung nach.',
+      restart: 'App neu starten',
+      openSupport: 'Support-Paket erstellen',
       troubleshootingDocs: 'Fehlerbehebungsdokumentation',
       reportIssue: 'Problem melden',
     },
     portConflict: {
-      title: 'Port-Konflikt',
+      title: 'Eine andere App belegt einen erforderlichen Port',
       message:
-        'Ein erforderlicher Port wird bereits von einem anderen Prozess verwendet. Schließen Sie andere Apps und starten Sie den Gesprächssimulator neu.',
+        'Schließen Sie die konfliktverursachende App und starten Sie den Gesprächssimulator neu. Port 7355 muss frei sein.',
       details: 'Details: {{error}}',
-      portTroubleshooting: 'Port-Fehlerbehebung',
+      portTroubleshooting: 'Port-Konflikt-Anleitung',
       reportIssue: 'Problem melden',
     },
     lastError: {
       message: 'Letzter Fehler: {{error}}',
       reportIssue: 'Problem melden',
+    },
+    recovery: {
+      restartEngine: 'Konversations-Engine neu starten',
+      restarting: 'Startet neu…',
+      openSupport: 'Support-Paket erstellen',
+      troubleshootingDocs: 'Fehlerbehebungsdokumentation',
     },
     noModel: {
       heading: 'Kein Modell konfiguriert',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -89,23 +89,31 @@ export const de: LocaleMessages = {
       packsInstalledCount: '{{count}} installiert',
     },
     unreachable: {
-      title: 'Lokale Laufzeitumgebung nicht erreichbar',
+      title: 'Die Konversations-Engine antwortet nicht',
       message:
-        'Stellen Sie sicher, dass der API-Server läuft. Falls das Problem weiterhin besteht, prüfen Sie den Protokollordner oder melden Sie ein Problem.',
+        'Die App kann die Konversations-Engine gerade nicht erreichen. Versuchen Sie einen Neustart oder sehen Sie in der Fehlerbehebungsanleitung nach.',
+      restart: 'App neu starten',
+      openSupport: 'Support-Paket erstellen',
       troubleshootingDocs: 'Fehlerbehebungsdokumentation',
       reportIssue: 'Problem melden',
     },
     portConflict: {
-      title: 'Port-Konflikt',
+      title: 'Eine andere App belegt einen erforderlichen Port',
       message:
-        'Ein erforderlicher Port wird bereits von einem anderen Prozess verwendet. Schließen Sie andere Apps und starten Sie den Gesprächssimulator neu.',
+        'Schließen Sie die konfliktverursachende App und starten Sie den Gesprächssimulator neu. Port 7355 muss frei sein.',
       details: 'Details: {{error}}',
-      portTroubleshooting: 'Port-Fehlerbehebung',
+      portTroubleshooting: 'Port-Konflikt-Anleitung',
       reportIssue: 'Problem melden',
     },
     lastError: {
       message: 'Letzter Fehler: {{error}}',
       reportIssue: 'Problem melden',
+    },
+    recovery: {
+      restartEngine: 'Konversations-Engine neu starten',
+      restarting: 'Startet neu…',
+      openSupport: 'Support-Paket erstellen',
+      troubleshootingDocs: 'Fehlerbehebungsdokumentation',
     },
     noModel: {
       heading: 'Kein Modell konfiguriert',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -67,23 +67,31 @@ export const en = {
       packsInstalledCount: '{{count}} installed',
     },
     unreachable: {
-      title: 'Cannot reach the local runtime',
+      title: 'The conversation engine is not responding',
       message:
-        'Ensure the API server is running. If this persists, check the logs folder or report an issue.',
+        'The app can\'t reach the conversation engine right now. Try restarting, or view the troubleshooting guide.',
+      restart: 'Restart the app',
+      openSupport: 'Get support bundle',
       troubleshootingDocs: 'Troubleshooting docs',
       reportIssue: 'Report an issue',
     },
     portConflict: {
-      title: 'Port conflict',
+      title: 'Another app is using a required port',
       message:
-        'A required port is already in use by another process. Try closing other apps, then restart Conversation Simulator.',
+        'Close the conflicting app and restart Conversation Simulator. Port 7355 must be free.',
       details: 'Details: {{error}}',
-      portTroubleshooting: 'Port troubleshooting',
+      portTroubleshooting: 'Port conflict guide',
       reportIssue: 'Report an issue',
     },
     lastError: {
       message: 'Last error: {{error}}',
       reportIssue: 'Report an issue',
+    },
+    recovery: {
+      restartEngine: 'Restart conversation engine',
+      restarting: 'Restarting…',
+      openSupport: 'Get support bundle',
+      troubleshootingDocs: 'Troubleshooting docs',
     },
     noModel: {
       heading: 'No model configured',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -83,23 +83,31 @@ export const en = {
       packsInstalledCount: '{{count}} installed',
     },
     unreachable: {
-      title: 'Cannot reach the local runtime',
+      title: 'The conversation engine is not responding',
       message:
-        'Ensure the API server is running. If this persists, check the logs folder or report an issue.',
+        'The app can\'t reach the conversation engine right now. Try restarting, or view the troubleshooting guide.',
+      restart: 'Restart the app',
+      openSupport: 'Get support bundle',
       troubleshootingDocs: 'Troubleshooting docs',
       reportIssue: 'Report an issue',
     },
     portConflict: {
-      title: 'Port conflict',
+      title: 'Another app is using a required port',
       message:
-        'A required port is already in use by another process. Try closing other apps, then restart Conversation Simulator.',
+        'Close the conflicting app and restart Conversation Simulator. Port 7355 must be free.',
       details: 'Details: {{error}}',
-      portTroubleshooting: 'Port troubleshooting',
+      portTroubleshooting: 'Port conflict guide',
       reportIssue: 'Report an issue',
     },
     lastError: {
       message: 'Last error: {{error}}',
       reportIssue: 'Report an issue',
+    },
+    recovery: {
+      restartEngine: 'Restart conversation engine',
+      restarting: 'Restarting…',
+      openSupport: 'Get support bundle',
+      troubleshootingDocs: 'Troubleshooting docs',
     },
     noModel: {
       heading: 'No model configured',

--- a/apps/web/src/screens/CoreStartup.tsx
+++ b/apps/web/src/screens/CoreStartup.tsx
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { useState, useEffect, useCallback } from 'react'
+import RuntimeRecoveryCard from '../components/RuntimeRecoveryCard'
 
 // ── Tauri global type (Tauri v2 with withGlobalTauri: true) ──────────────────
 
@@ -24,6 +25,50 @@ interface TauriGlobal {
 declare global {
   interface Window {
     __TAURI__?: TauriGlobal
+  }
+}
+
+const TROUBLESHOOTING_BASE =
+  'https://github.com/outrightmental/ConversationSimulator/blob/main/docs/troubleshooting.md'
+
+type FailureKind = 'port-conflict' | 'not-found' | 'crash'
+
+interface ErrorInfo {
+  kind: FailureKind
+  title: string
+  description: string
+  anchor: string
+}
+
+function classifyError(message: string, error: string | null): ErrorInfo {
+  const text = `${message} ${error ?? ''}`.toLowerCase()
+
+  if (/eaddrinuse|address already in use|port.*busy|port.*in use|port conflict/.test(text)) {
+    return {
+      kind: 'port-conflict',
+      title: 'Another app is using a required port',
+      description:
+        'Close any other applications using port 7355, then restart Conversation Simulator.',
+      anchor: '#port-conflicts',
+    }
+  }
+
+  if (/not found|no such file|executable|binary|cannot locate/.test(text)) {
+    return {
+      kind: 'not-found',
+      title: "The conversation engine couldn't be found",
+      description:
+        'The app may be installed incorrectly. Try reinstalling from Steam or running setup again.',
+      anchor: '#engine-startup-failure',
+    }
+  }
+
+  return {
+    kind: 'crash',
+    title: "The conversation engine didn't start",
+    description:
+      'Something went wrong when the app tried to start. Check the logs for details.',
+    anchor: '#engine-startup-failure',
   }
 }
 
@@ -107,6 +152,7 @@ export default function CoreStartupGuard({ children }: { children: React.ReactNo
   if (ready) return <>{children}</>
 
   const isError = status?.phase === 'error'
+  const errorInfo = isError ? classifyError(status!.message, status!.error) : null
 
   return (
     <div
@@ -127,37 +173,24 @@ export default function CoreStartupGuard({ children }: { children: React.ReactNo
         Conversation Simulator
       </h1>
 
-      {isError ? (
-        <div
-          role="alert"
-          style={{
-            maxWidth: 520,
-            textAlign: 'center',
-            background: '#fff3f3',
-            border: '1px solid #f5c6cb',
-            borderRadius: 8,
-            padding: '1.25rem 1.5rem',
-          }}
-        >
-          <p style={{ fontWeight: 600, color: '#c0392b', margin: '0 0 0.5rem' }}>
-            {status!.message}
-          </p>
-          {status!.error && (
-            <p
-              style={{
-                color: '#555',
-                fontSize: '0.875rem',
-                whiteSpace: 'pre-wrap',
-                margin: '0 0 0.75rem',
-              }}
-            >
-              {status!.error}
-            </p>
-          )}
-          <p style={{ fontSize: '0.8125rem', color: '#888', margin: 0 }}>
-            Restart the app to try again. If the problem persists, check the
-            logs at <code>~/.convsim/logs</code>.
-          </p>
+      {isError && errorInfo ? (
+        <div style={{ maxWidth: 540, width: '100%' }}>
+          <RuntimeRecoveryCard
+            title={errorInfo.title}
+            description={errorInfo.description}
+            errorDetail={status!.error}
+            logPath="~/.convsim/logs/app.log"
+            troubleshootingHref={`${TROUBLESHOOTING_BASE}${errorInfo.anchor}`}
+            troubleshootingLabel="Troubleshooting guide"
+            primaryAction={{
+              label: 'Restart the app',
+              onClick: () => window.location.reload(),
+            }}
+            secondaryAction={{
+              label: 'Get support bundle',
+              href: '/support',
+            }}
+          />
         </div>
       ) : (
         <p

--- a/apps/web/src/screens/CoreStartup.tsx
+++ b/apps/web/src/screens/CoreStartup.tsx
@@ -30,6 +30,8 @@ declare global {
 
 const TROUBLESHOOTING_BASE =
   'https://github.com/outrightmental/ConversationSimulator/blob/main/docs/troubleshooting.md'
+const ISSUES_URL =
+  'https://github.com/outrightmental/ConversationSimulator/issues/new/choose'
 
 type FailureKind = 'port-conflict' | 'not-found' | 'crash'
 
@@ -187,8 +189,12 @@ export default function CoreStartupGuard({ children }: { children: React.ReactNo
               onClick: () => window.location.reload(),
             }}
             secondaryAction={{
-              label: 'Get support bundle',
-              href: '/support',
+              // The in-app support/crash-bundle screen is behind CoreStartupGuard
+              // and needs the (currently down) core API, so it is unreachable
+              // during a startup failure. Point players at the report-issue flow
+              // instead, which works without the core running.
+              label: 'Report a problem',
+              href: ISSUES_URL,
             }}
           />
         </div>

--- a/apps/web/src/screens/Home.tsx
+++ b/apps/web/src/screens/Home.tsx
@@ -1,14 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
+import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { StatusBadge } from '@convsim/ui'
 import { useApiHealth } from '../api/useApiHealth'
 import { usePackCount } from '../api/usePackCount'
 import { useTranslation } from '../i18n'
 import { useLogbookProfile } from '../api/useLogbookProfile'
+import { api } from '../api/client'
+import RuntimeRecoveryCard from '../components/RuntimeRecoveryCard'
 import type { BadgeStatus } from '@convsim/ui'
 
 const DOCS_URL = 'https://github.com/outrightmental/ConversationSimulator/wiki'
 const ISSUES_URL = 'https://github.com/outrightmental/ConversationSimulator/issues/new/choose'
+const TROUBLESHOOTING_BASE =
+  'https://github.com/outrightmental/ConversationSimulator/blob/main/docs/troubleshooting.md'
 
 export default function Home() {
   const health = useApiHealth()
@@ -16,6 +21,8 @@ export default function Home() {
   const logbook = useLogbookProfile()
   const loading = health.state === 'loading'
   const { t } = useTranslation()
+
+  const [isRestartingSidecar, setIsRestartingSidecar] = useState(false)
 
   const runtime = health.runtime
   const llmReady = runtime?.llm_ready ?? false
@@ -69,6 +76,22 @@ export default function Home() {
     packCount > 0
       ? t('home.status.packsInstalledCount', { count: packCount })
       : t('home.status.noneInstalled')
+
+  async function handleRestartSidecar() {
+    setIsRestartingSidecar(true)
+    try {
+      const statusResult = await api.getSidecarStatus()
+      const modelPath = statusResult.ok ? statusResult.data.model_path : null
+      await api.stopSidecar()
+      if (modelPath) {
+        await api.startSidecar(modelPath)
+      }
+      // The polling in useApiHealth will pick up the healthy state within 3 s.
+      health.refetch()
+    } finally {
+      setIsRestartingSidecar(false)
+    }
+  }
 
   return (
     <div>
@@ -193,7 +216,13 @@ export default function Home() {
         <ul style={{ listStyle: 'none', padding: 0, display: 'flex', flexDirection: 'column', gap: '0.4rem' }}>
           <li>
             {t('home.status.localRuntime')}:{' '}
-            <StatusBadge status={runtimeBadgeProps.status}>{runtimeBadgeProps.label}</StatusBadge>
+            {runtimeBadgeProps.status === 'offline' ? (
+              <a href="#runtime-recovery" style={{ textDecoration: 'none' }}>
+                <StatusBadge status={runtimeBadgeProps.status}>{runtimeBadgeProps.label}</StatusBadge>
+              </a>
+            ) : (
+              <StatusBadge status={runtimeBadgeProps.status}>{runtimeBadgeProps.label}</StatusBadge>
+            )}
           </li>
           <li>
             {t('home.status.llm')}:{' '}
@@ -227,83 +256,67 @@ export default function Home() {
           </li>
         </ul>
 
-        {showUnreachable && (
-          <div
-            role="alert"
-            style={{
-              marginTop: '0.75rem',
-              padding: '0.85rem 1rem',
-              background: 'rgba(239,68,68,0.08)',
-              border: '1px solid rgba(239,68,68,0.3)',
-              borderRadius: '6px',
-            }}
-          >
-            <p style={{ margin: '0 0 0.3rem', fontWeight: 600, color: '#f87171', fontSize: '0.875rem' }}>
-              {t('home.unreachable.title')}
-            </p>
-            <p style={{ margin: '0 0 0.75rem', fontSize: '0.825rem', color: '#a1a1aa' }}>
-              {t('home.unreachable.message')}
-            </p>
-            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', fontSize: '0.8rem' }}>
-              <a href={DOCS_URL} target="_blank" rel="noreferrer" style={{ color: '#71717a' }}>
-                {t('home.unreachable.troubleshootingDocs')}
-              </a>
-              <span style={{ color: '#52525b' }}>·</span>
-              <a href={ISSUES_URL} target="_blank" rel="noreferrer" style={{ color: '#71717a' }}>
-                {t('home.unreachable.reportIssue')}
-              </a>
-            </div>
-          </div>
-        )}
-        {lastError && (
-          <div
-            role="alert"
-            style={{
-              marginTop: '0.75rem',
-              padding: '0.85rem 1rem',
-              background: 'rgba(239,68,68,0.08)',
-              border: '1px solid rgba(239,68,68,0.3)',
-              borderRadius: '6px',
-            }}
-          >
-            {isPortConflict ? (
-              <>
-                <p style={{ margin: '0 0 0.3rem', fontWeight: 600, color: '#f87171', fontSize: '0.875rem' }}>
-                  {t('home.portConflict.title')}
-                </p>
-                <p style={{ margin: '0 0 0.4rem', fontSize: '0.825rem', color: '#a1a1aa' }}>
-                  {t('home.portConflict.message')}
-                </p>
-                <p style={{ margin: '0 0 0.75rem', fontSize: '0.8rem', color: '#71717a' }}>
-                  {t('home.portConflict.details', { error: lastError })}
-                </p>
-                <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', fontSize: '0.8rem' }}>
-                  <a href={DOCS_URL} target="_blank" rel="noreferrer" style={{ color: '#71717a' }}>
-                    {t('home.portConflict.portTroubleshooting')}
-                  </a>
-                  <span style={{ color: '#52525b' }}>·</span>
-                  <a href={ISSUES_URL} target="_blank" rel="noreferrer" style={{ color: '#71717a' }}>
-                    {t('home.portConflict.reportIssue')}
-                  </a>
-                </div>
-              </>
+        {/* Recovery cards — anchored so the status strip can jump to them */}
+        <div id="runtime-recovery">
+          {showUnreachable && (
+            <RuntimeRecoveryCard
+              title={t('home.unreachable.title')}
+              description={t('home.unreachable.message')}
+              troubleshootingHref={`${TROUBLESHOOTING_BASE}#engine-startup-failure`}
+              troubleshootingLabel={t('home.unreachable.troubleshootingDocs')}
+              primaryAction={{
+                label: t('home.unreachable.restart'),
+                onClick: () => window.location.reload(),
+              }}
+              secondaryAction={{
+                label: t('home.unreachable.openSupport'),
+                href: '/support',
+              }}
+            />
+          )}
+          {lastError && (
+            isPortConflict ? (
+              <RuntimeRecoveryCard
+                title={t('home.portConflict.title')}
+                description={t('home.portConflict.message')}
+                errorDetail={t('home.portConflict.details', { error: lastError })}
+                troubleshootingHref={`${TROUBLESHOOTING_BASE}#port-conflicts`}
+                troubleshootingLabel={t('home.portConflict.portTroubleshooting')}
+                primaryAction={{
+                  label: t('home.recovery.restartEngine'),
+                  loadingLabel: t('home.recovery.restarting'),
+                  onClick: () => void handleRestartSidecar(),
+                  loading: isRestartingSidecar,
+                }}
+                secondaryAction={{
+                  label: t('home.recovery.openSupport'),
+                  href: '/support',
+                }}
+              />
             ) : (
-              <>
-                <p style={{ margin: '0 0 0.3rem', fontSize: '0.875rem', color: '#f87171' }}>
-                  {t('home.lastError.message', { error: lastError })}
-                </p>
-                <a
-                  href={ISSUES_URL}
-                  target="_blank"
-                  rel="noreferrer"
-                  style={{ fontSize: '0.8rem', color: '#71717a' }}
-                >
-                  {t('home.lastError.reportIssue')}
-                </a>
-              </>
-            )}
-          </div>
-        )}
+              <RuntimeRecoveryCard
+                title={t('home.lastError.message', { error: lastError })}
+                description=""
+                troubleshootingHref={`${TROUBLESHOOTING_BASE}#engine-startup-failure`}
+                troubleshootingLabel={t('home.recovery.troubleshootingDocs')}
+                primaryAction={{
+                  label: t('home.recovery.restartEngine'),
+                  loadingLabel: t('home.recovery.restarting'),
+                  onClick: () => void handleRestartSidecar(),
+                  loading: isRestartingSidecar,
+                }}
+                secondaryAction={{
+                  label: t('home.recovery.openSupport'),
+                  href: '/support',
+                }}
+                tertiaryAction={{
+                  label: t('home.lastError.reportIssue'),
+                  href: ISSUES_URL,
+                }}
+              />
+            )
+          )}
+        </div>
       </section>
 
       {showNoModelPrompt && (

--- a/apps/web/src/screens/Home.tsx
+++ b/apps/web/src/screens/Home.tsx
@@ -1,19 +1,26 @@
 // SPDX-License-Identifier: Apache-2.0
+import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { StatusBadge } from '@convsim/ui'
 import { useApiHealth } from '../api/useApiHealth'
 import { usePackCount } from '../api/usePackCount'
 import { useTranslation } from '../i18n'
+import { api } from '../api/client'
+import RuntimeRecoveryCard from '../components/RuntimeRecoveryCard'
 import type { BadgeStatus } from '@convsim/ui'
 
 const DOCS_URL = 'https://github.com/outrightmental/ConversationSimulator/wiki'
 const ISSUES_URL = 'https://github.com/outrightmental/ConversationSimulator/issues/new/choose'
+const TROUBLESHOOTING_BASE =
+  'https://github.com/outrightmental/ConversationSimulator/blob/main/docs/troubleshooting.md'
 
 export default function Home() {
   const health = useApiHealth()
   const packCount = usePackCount()
   const loading = health.state === 'loading'
   const { t } = useTranslation()
+
+  const [isRestartingSidecar, setIsRestartingSidecar] = useState(false)
 
   const runtime = health.runtime
   const llmReady = runtime?.llm_ready ?? false
@@ -68,6 +75,22 @@ export default function Home() {
       ? t('home.status.packsInstalledCount', { count: packCount })
       : t('home.status.noneInstalled')
 
+  async function handleRestartSidecar() {
+    setIsRestartingSidecar(true)
+    try {
+      const statusResult = await api.getSidecarStatus()
+      const modelPath = statusResult.ok ? statusResult.data.model_path : null
+      await api.stopSidecar()
+      if (modelPath) {
+        await api.startSidecar(modelPath)
+      }
+      // The polling in useApiHealth will pick up the healthy state within 3 s.
+      health.refetch()
+    } finally {
+      setIsRestartingSidecar(false)
+    }
+  }
+
   return (
     <div>
       <h1>{t('home.title')}</h1>
@@ -94,7 +117,13 @@ export default function Home() {
         <ul style={{ listStyle: 'none', padding: 0, display: 'flex', flexDirection: 'column', gap: '0.4rem' }}>
           <li>
             {t('home.status.localRuntime')}:{' '}
-            <StatusBadge status={runtimeBadgeProps.status}>{runtimeBadgeProps.label}</StatusBadge>
+            {runtimeBadgeProps.status === 'offline' ? (
+              <a href="#runtime-recovery" style={{ textDecoration: 'none' }}>
+                <StatusBadge status={runtimeBadgeProps.status}>{runtimeBadgeProps.label}</StatusBadge>
+              </a>
+            ) : (
+              <StatusBadge status={runtimeBadgeProps.status}>{runtimeBadgeProps.label}</StatusBadge>
+            )}
           </li>
           <li>
             {t('home.status.llm')}:{' '}
@@ -128,83 +157,67 @@ export default function Home() {
           </li>
         </ul>
 
-        {showUnreachable && (
-          <div
-            role="alert"
-            style={{
-              marginTop: '0.75rem',
-              padding: '0.85rem 1rem',
-              background: 'rgba(239,68,68,0.08)',
-              border: '1px solid rgba(239,68,68,0.3)',
-              borderRadius: '6px',
-            }}
-          >
-            <p style={{ margin: '0 0 0.3rem', fontWeight: 600, color: '#f87171', fontSize: '0.875rem' }}>
-              {t('home.unreachable.title')}
-            </p>
-            <p style={{ margin: '0 0 0.75rem', fontSize: '0.825rem', color: '#a1a1aa' }}>
-              {t('home.unreachable.message')}
-            </p>
-            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', fontSize: '0.8rem' }}>
-              <a href={DOCS_URL} target="_blank" rel="noreferrer" style={{ color: '#71717a' }}>
-                {t('home.unreachable.troubleshootingDocs')}
-              </a>
-              <span style={{ color: '#52525b' }}>·</span>
-              <a href={ISSUES_URL} target="_blank" rel="noreferrer" style={{ color: '#71717a' }}>
-                {t('home.unreachable.reportIssue')}
-              </a>
-            </div>
-          </div>
-        )}
-        {lastError && (
-          <div
-            role="alert"
-            style={{
-              marginTop: '0.75rem',
-              padding: '0.85rem 1rem',
-              background: 'rgba(239,68,68,0.08)',
-              border: '1px solid rgba(239,68,68,0.3)',
-              borderRadius: '6px',
-            }}
-          >
-            {isPortConflict ? (
-              <>
-                <p style={{ margin: '0 0 0.3rem', fontWeight: 600, color: '#f87171', fontSize: '0.875rem' }}>
-                  {t('home.portConflict.title')}
-                </p>
-                <p style={{ margin: '0 0 0.4rem', fontSize: '0.825rem', color: '#a1a1aa' }}>
-                  {t('home.portConflict.message')}
-                </p>
-                <p style={{ margin: '0 0 0.75rem', fontSize: '0.8rem', color: '#71717a' }}>
-                  {t('home.portConflict.details', { error: lastError })}
-                </p>
-                <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', fontSize: '0.8rem' }}>
-                  <a href={DOCS_URL} target="_blank" rel="noreferrer" style={{ color: '#71717a' }}>
-                    {t('home.portConflict.portTroubleshooting')}
-                  </a>
-                  <span style={{ color: '#52525b' }}>·</span>
-                  <a href={ISSUES_URL} target="_blank" rel="noreferrer" style={{ color: '#71717a' }}>
-                    {t('home.portConflict.reportIssue')}
-                  </a>
-                </div>
-              </>
+        {/* Recovery cards — anchored so the status strip can jump to them */}
+        <div id="runtime-recovery">
+          {showUnreachable && (
+            <RuntimeRecoveryCard
+              title={t('home.unreachable.title')}
+              description={t('home.unreachable.message')}
+              troubleshootingHref={`${TROUBLESHOOTING_BASE}#engine-startup-failure`}
+              troubleshootingLabel={t('home.unreachable.troubleshootingDocs')}
+              primaryAction={{
+                label: t('home.unreachable.restart'),
+                onClick: () => window.location.reload(),
+              }}
+              secondaryAction={{
+                label: t('home.unreachable.openSupport'),
+                href: '/support',
+              }}
+            />
+          )}
+          {lastError && (
+            isPortConflict ? (
+              <RuntimeRecoveryCard
+                title={t('home.portConflict.title')}
+                description={t('home.portConflict.message')}
+                errorDetail={t('home.portConflict.details', { error: lastError })}
+                troubleshootingHref={`${TROUBLESHOOTING_BASE}#port-conflicts`}
+                troubleshootingLabel={t('home.portConflict.portTroubleshooting')}
+                primaryAction={{
+                  label: t('home.recovery.restartEngine'),
+                  loadingLabel: t('home.recovery.restarting'),
+                  onClick: () => void handleRestartSidecar(),
+                  loading: isRestartingSidecar,
+                }}
+                secondaryAction={{
+                  label: t('home.recovery.openSupport'),
+                  href: '/support',
+                }}
+              />
             ) : (
-              <>
-                <p style={{ margin: '0 0 0.3rem', fontSize: '0.875rem', color: '#f87171' }}>
-                  {t('home.lastError.message', { error: lastError })}
-                </p>
-                <a
-                  href={ISSUES_URL}
-                  target="_blank"
-                  rel="noreferrer"
-                  style={{ fontSize: '0.8rem', color: '#71717a' }}
-                >
-                  {t('home.lastError.reportIssue')}
-                </a>
-              </>
-            )}
-          </div>
-        )}
+              <RuntimeRecoveryCard
+                title={t('home.lastError.message', { error: lastError })}
+                description=""
+                troubleshootingHref={`${TROUBLESHOOTING_BASE}#engine-startup-failure`}
+                troubleshootingLabel={t('home.recovery.troubleshootingDocs')}
+                primaryAction={{
+                  label: t('home.recovery.restartEngine'),
+                  loadingLabel: t('home.recovery.restarting'),
+                  onClick: () => void handleRestartSidecar(),
+                  loading: isRestartingSidecar,
+                }}
+                secondaryAction={{
+                  label: t('home.recovery.openSupport'),
+                  href: '/support',
+                }}
+                tertiaryAction={{
+                  label: t('home.lastError.reportIssue'),
+                  href: ISSUES_URL,
+                }}
+              />
+            )
+          )}
+        </div>
       </section>
 
       {showNoModelPrompt && (

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -5,6 +5,32 @@ Common problems and solutions. If your issue is not listed here, open a [GitHub 
 
 ---
 
+## Engine startup failure {#engine-startup-failure}
+
+**"The conversation engine didn't start"**
+
+The app could not start its background conversation engine (`convsim-core`). Common causes:
+
+- **Port conflict:** another application is using port 7355. See [Port conflicts](#port-conflicts) below.
+- **Binary not found:** the `convsim-core` executable is missing. Reinstall the app or run `./scripts/setup.sh`.
+- **Crash on startup:** check the logs at `~/.convsim/logs/app.log` for the specific error.
+
+**Recovery steps:**
+
+1. Close other applications that might be using port 7355.
+2. Restart Conversation Simulator from Steam or your installation.
+3. If the problem persists, collect logs from `~/.convsim/logs/` and open a [GitHub issue](https://github.com/outrightmental/ConversationSimulator/issues).
+
+**"The conversation engine stopped"**
+
+The engine started but stopped during a session. This can happen if the AI model crashes the engine or the engine runs out of memory.
+
+1. Click **Restart conversation engine** in the status card on the home screen.
+2. If the problem repeats, try a lighter model from **Settings → Models**.
+3. Check `~/.convsim/logs/app.log` for crash details.
+
+---
+
 ## Setup issues
 
 **`./scripts/setup.sh` fails with "Python 3.10+ is required"**
@@ -99,7 +125,7 @@ For Apple Silicon, unified memory acts as VRAM — treat the total RAM figure as
 
 ---
 
-## Port conflicts
+## Port conflicts {#port-conflicts}
 
 **`./scripts/dev.sh` fails with "Port XXXX is already in use by PID YYYY (process-name)"**
 


### PR DESCRIPTION
## Summary

Replaces dead-end runtime-down error states on the Home and CoreStartup screens with a structured, actionable recovery flow. Users are now shown a `RuntimeRecoveryCard` component that explains what went wrong, displays logs and error details, and offers escalating recovery actions (restart, recheck, troubleshooting guide) instead of inert alert messages.

## Changes

### New Component: RuntimeRecoveryCard
- Role-alert card with title, description, error detail, log file path, and up to three recovery actions (primary, secondary, tertiary)
- Distinguishes between external docs links (open in new tab) and internal app routes (navigate in-place)
- Consistent red alert styling matching the app's error palette

### CoreStartup Guard
- Classifies startup errors into three categories: port-conflict, not-found, crash
- Renders RuntimeRecoveryCard with plain-language copy instead of raw error output
- Adds "Restart the app" button and link to troubleshooting guide anchor
- Escalation button now points to GitHub issue report flow (not the unreachable in-app `/support` route)

### Home Screen
- Replaces the static "Cannot reach the local runtime" alert with a RuntimeRecoveryCard
- Replaces the port-conflict card with a RuntimeRecoveryCard instance
- Local runtime status badge becomes a clickable link to the recovery card when offline
- Adds "Restart conversation engine" action that stops and re-starts the sidecar API server, with visual loading state

### API Health Polling
- `useApiHealth` now polls every 3 seconds when unhealthy (down from infrequent polling) to detect recovery within the 3-second window required by the degraded-state acceptance test
- Exposes `refetch()` callback for manual re-checks after a restart action

### API Client Methods
- `getSidecarStatus()`: fetch current sidecar configuration
- `stopSidecar()`: shut down the sidecar
- `startSidecar(modelPath)`: restart the sidecar with the prior model path

### Internationalization
- Removes "API server" and "local runtime" jargon from en + de locales
- All recovery copy now uses plain language ("conversation engine", "restart the conversation engine")

### Documentation
- `docs/troubleshooting.md`: adds anchors `#engine-startup-failure` and `#port-conflicts` that recovery cards deep-link to for contextual help

### Testing
- Updates CoreStartup and Home test suites for new error messages and card rendering
- Adds 15 new tests for RuntimeRecoveryCard (actions, loading states, internal vs. external links, error detail display)
- Wraps mock return values in `ApiResult` to match real API client behavior

## Acceptance Criteria Met
✓ Runtime errors show actionable recovery options, not dead ends  
✓ "Restart conversation engine" action works end-to-end and picks up healthy state within 3 seconds  
✓ Internal navigation (e.g. `/support`) does not spawn a new browser tab  
✓ Both initial startup errors and mid-session downtimes are handled consistently

Closes #298