### PR TITLE
Spike: Persistent NPC relationship memory across sessions

### DIFF
--- a/apps/web/src/__tests__/Debrief.test.tsx
+++ b/apps/web/src/__tests__/Debrief.test.tsx
@@ -223,7 +223,7 @@ describe('Debrief screen', () => {
       // fullDebriefResponse.outcome is 'player_exit' — the "manually ended"
       // case the shipped framework (#230) explicitly counts. FIRST_SCENARIO and
       // the SCENARIOS_COMPLETED stat must fire regardless of a 'success' outcome.
-      mockApi.generateDebrief.mockResolvedValue(fullDebriefResponse)
+      mockApi.generateDebrief.mockResolvedValue({ ok: true, data: fullDebriefResponse })
       renderDebrief()
       await waitFor(() =>
         expect(screen.getByTestId('summary-section')).toBeInTheDocument(),

--- a/apps/web/src/__tests__/Logbook.test.tsx
+++ b/apps/web/src/__tests__/Logbook.test.tsx
@@ -65,11 +65,14 @@ function renderLogbook() {
 }
 
 beforeEach(() => {
-  vi.mocked(api.getLogbookProfile).mockResolvedValue(makeProfile())
+  vi.mocked(api.getLogbookProfile).mockResolvedValue({ ok: true, data: makeProfile() })
   vi.mocked(api.exportLogbook).mockResolvedValue({
-    exported_at: new Date().toISOString(),
-    profile: makeProfile(),
-    session_scores: [],
+    ok: true,
+    data: {
+      exported_at: new Date().toISOString(),
+      profile: makeProfile(),
+      session_scores: [],
+    },
   })
 })
 
@@ -118,7 +121,7 @@ describe('Logbook — with sessions', () => {
   })
 
   beforeEach(() => {
-    vi.mocked(api.getLogbookProfile).mockResolvedValue(profile)
+    vi.mocked(api.getLogbookProfile).mockResolvedValue({ ok: true, data: profile })
   })
 
   it('shows the session count', async () => {
@@ -186,9 +189,10 @@ describe('Logbook — error state', () => {
 
 describe('Logbook — single session delta', () => {
   it('does not show last session delta with only one session', async () => {
-    vi.mocked(api.getLogbookProfile).mockResolvedValue(
-      makeProfile({ total_sessions: 1, last_session_delta: null }),
-    )
+    vi.mocked(api.getLogbookProfile).mockResolvedValue({
+      ok: true,
+      data: makeProfile({ total_sessions: 1, last_session_delta: null }),
+    })
     renderLogbook()
     await screen.findByRole('heading', { name: /^logbook$/i })
     // When last_session_delta is null, no delta tile should appear

--- a/apps/web/src/__tests__/Settings.test.tsx
+++ b/apps/web/src/__tests__/Settings.test.tsx
@@ -38,6 +38,8 @@ vi.mock('../api/client', () => ({
     // Steam Cloud settings
     getCloudSettings: vi.fn(),
     putCloudSettings: vi.fn(),
+    // NPC relationship memory
+    listRelationshipMemory: vi.fn(),
   },
 }))
 
@@ -173,6 +175,7 @@ beforeEach(() => {
   mockApi.clearTtsCache.mockResolvedValue({ ok: true, data: { deleted_files: 0 } })
   mockApi.health.mockResolvedValue({ ok: true, data: STUB_HEALTH })
   mockApi.vadHealth.mockResolvedValue({ ok: true, data: STUB_VAD })
+  mockApi.listRelationshipMemory.mockResolvedValue({ ok: true, data: { recaps: [], total: 0 } })
   // Stub navigator.permissions so tests don't hang on browser API
   Object.defineProperty(navigator, 'permissions', {
     value: { query: vi.fn().mockResolvedValue({ state: 'granted', addEventListener: vi.fn() }) },

--- a/apps/web/src/__tests__/accessibility.test.tsx
+++ b/apps/web/src/__tests__/accessibility.test.tsx
@@ -62,6 +62,11 @@ vi.mock('../api/client', () => ({
     getTtsCacheSize: vi.fn().mockReturnValue(new Promise(() => {})),
     clearTtsCache: vi.fn(),
     vadHealth: vi.fn().mockReturnValue(new Promise(() => {})),
+    // Steam Cloud settings
+    getCloudSettings: vi.fn().mockReturnValue(new Promise(() => {})),
+    putCloudSettings: vi.fn(),
+    // NPC relationship memory
+    listRelationshipMemory: vi.fn().mockResolvedValue({ ok: true, data: { recaps: [], total: 0 } }),
     workbench: {
       listPacks: vi.fn().mockResolvedValue({ ok: true, data: [] }),
       listFiles: vi.fn().mockResolvedValue({ ok: true, data: { tree: [] } }),

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -108,6 +108,17 @@ export interface VadHealthResponse {
   checked_at: string
 }
 
+export interface RelationshipRecapSummary {
+  npc_id: string
+  pack_id: string
+  session_count: number
+  updated_at: string
+  key_observations: string[]
+  player_style_tags: string[]
+  last_outcome: string | null
+  last_session_at: string | null
+}
+
 export interface SttHealthResponse {
   worker_id: string
   worker_name: string
@@ -404,6 +415,15 @@ export const api = {
   },
   deleteSession(sessionId: string): Promise<ApiResult<undefined>> {
     return del(`/sessions/${sessionId}`)
+  },
+  listRelationshipMemory(): Promise<ApiResult<{ recaps: RelationshipRecapSummary[]; total: number }>> {
+    return get<{ recaps: RelationshipRecapSummary[]; total: number }>('/relationship-memory')
+  },
+  deleteRelationshipMemory(npcId: string, packId: string): Promise<ApiResult<undefined>> {
+    return del(`/relationship-memory/${encodeURIComponent(npcId)}/${encodeURIComponent(packId)}`)
+  },
+  clearAllRelationshipMemory(): Promise<ApiResult<undefined>> {
+    return del('/relationship-memory')
   },
   exportSession(sessionId: string): Promise<ApiResult<unknown>> {
     return get<unknown>(`/sessions/${sessionId}/export`)

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -291,7 +291,18 @@ export const de: LocaleMessages = {
       label: 'Oberflächensprache',
     },
     relationshipMemory: {
+      heading: 'NPC-Beziehungsgedächtnis',
+      description:
+        'Nach jeder abgeschlossenen Sitzung speichert die App eine kurze Zusammenfassung Ihrer Übungsmuster für jeden NPC. Dadurch können NPCs eine subtile Kontinuität über Sitzungen hinweg zeigen. Die Zusammenfassung enthält niemals den Rohtext des Transkripts, und Sie können hier jeden Eintrag löschen.',
+      loading: 'Wird geladen…',
+      empty: 'Noch keine NPC-Erinnerungen gespeichert. Erinnerungen werden nach Abschluss einer Sitzung und dem Erstellen einer Nachbesprechung angelegt.',
+      sessionCount_one: '{{count}} Sitzung',
+      sessionCount_other: '{{count}} Sitzungen',
+      delete: 'Löschen',
+      deleting: 'Wird gelöscht…',
       deleteLabel: 'Erinnerung für {{npc}} löschen',
+      clearAll: 'Alle NPC-Erinnerungen löschen',
+      clearing: 'Wird gelöscht…',
     },
   },
   debrief: {

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -282,6 +282,9 @@ export const de: LocaleMessages = {
       description: 'Wählen Sie die Sprache der Benutzeroberfläche.',
       label: 'Oberflächensprache',
     },
+    relationshipMemory: {
+      deleteLabel: 'Erinnerung für {{npc}} löschen',
+    },
   },
   debrief: {
     title: 'Sitzungsnachbesprechung',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -282,7 +282,18 @@ export const en = {
       label: 'Interface language',
     },
     relationshipMemory: {
+      heading: 'NPC relationship memory',
+      description:
+        'After each completed session the app stores a short summary of your practice patterns for each NPC. This allows NPCs to exhibit subtle continuity across sessions. The summary never contains raw transcript text and you can delete any entry here.',
+      loading: 'Loading…',
+      empty: 'No NPC memories stored yet. Memories are created after completing a session and generating a debrief.',
+      sessionCount_one: '{{count}} session',
+      sessionCount_other: '{{count}} sessions',
+      delete: 'Delete',
+      deleting: 'Deleting…',
       deleteLabel: 'Delete memory for {{npc}}',
+      clearAll: 'Clear all NPC memories',
+      clearing: 'Clearing…',
     },
   },
   debrief: {

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -273,6 +273,9 @@ export const en = {
       description: 'Select the language for the user interface.',
       label: 'Interface language',
     },
+    relationshipMemory: {
+      deleteLabel: 'Delete memory for {{npc}}',
+    },
   },
   debrief: {
     title: 'Session Debrief',

--- a/apps/web/src/screens/Settings.tsx
+++ b/apps/web/src/screens/Settings.tsx
@@ -868,21 +868,19 @@ export default function Settings() {
 
       {/* NPC relationship memory */}
       <section style={{ marginBottom: '2rem' }} data-testid="relationship-memory-section">
-        <SectionHeading>NPC relationship memory</SectionHeading>
+        <SectionHeading>{t('settings.relationshipMemory.heading')}</SectionHeading>
         <p style={{ fontSize: '0.875rem', color: '#a1a1aa', marginBottom: '0.75rem' }}>
-          After each completed session the app stores a short summary of your practice patterns for each NPC. This
-          allows NPCs to exhibit subtle continuity across sessions. The summary never contains raw transcript text
-          and you can delete any entry here.
+          {t('settings.relationshipMemory.description')}
         </p>
         {recapsError && (
           <ApiErrorView error={recapsError} onRetry={loadRecaps} context="Settings-RelationshipMemory" />
         )}
         {!recapsError && recaps === null && (
-          <p style={{ fontSize: '0.875rem', color: '#a1a1aa' }}>Loading&hellip;</p>
+          <p style={{ fontSize: '0.875rem', color: '#a1a1aa' }}>{t('settings.relationshipMemory.loading')}</p>
         )}
         {!recapsError && recaps !== null && recaps.length === 0 && (
           <p data-testid="no-recaps" style={{ fontSize: '0.875rem', color: '#a1a1aa' }}>
-            No NPC memories stored yet. Memories are created after completing a session and generating a debrief.
+            {t('settings.relationshipMemory.empty')}
           </p>
         )}
         {!recapsError && recaps !== null && recaps.length > 0 && (
@@ -908,7 +906,9 @@ export default function Settings() {
                       <span style={{ fontWeight: 500, color: '#d4d4d8' }}>{r.npc_id}</span>
                       <span style={{ color: '#71717a', marginLeft: '0.4rem', fontSize: '0.8rem' }}>{r.pack_id}</span>
                       <span style={{ color: '#71717a', marginLeft: '0.5rem', fontSize: '0.75rem' }}>
-                        {r.session_count} session{r.session_count !== 1 ? 's' : ''}
+                        {r.session_count === 1
+                          ? t('settings.relationshipMemory.sessionCount_one', { count: 1 })
+                          : t('settings.relationshipMemory.sessionCount_other', { count: r.session_count })}
                       </span>
                       {r.key_observations.length > 0 && (
                         <ul style={{ margin: '0.25rem 0 0 0', padding: '0 0 0 1rem', fontSize: '0.8rem', color: '#a1a1aa' }}>
@@ -933,7 +933,9 @@ export default function Settings() {
                         fontSize: '0.8rem',
                       }}
                     >
-                      {isDeleting ? 'Deleting…' : 'Delete'}
+                      {isDeleting
+                        ? t('settings.relationshipMemory.deleting')
+                        : t('settings.relationshipMemory.delete')}
                     </button>
                   </li>
                 )
@@ -954,7 +956,9 @@ export default function Settings() {
                 fontSize: '0.875rem',
               }}
             >
-              {clearingRecaps ? 'Clearing…' : 'Clear all NPC memories'}
+              {clearingRecaps
+                ? t('settings.relationshipMemory.clearing')
+                : t('settings.relationshipMemory.clearAll')}
             </button>
           </>
         )}

--- a/apps/web/src/screens/Settings.tsx
+++ b/apps/web/src/screens/Settings.tsx
@@ -919,7 +919,7 @@ export default function Settings() {
                       )}
                     </div>
                     <button
-                      aria-label={`Delete memory for ${r.npc_id}`}
+                      aria-label={t('settings.relationshipMemory.deleteLabel', { npc: r.npc_id })}
                       onClick={() => void handleDeleteRecap(r.npc_id, r.pack_id)}
                       disabled={isDeleting}
                       style={{

--- a/apps/web/src/screens/Settings.tsx
+++ b/apps/web/src/screens/Settings.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { useState, useEffect, useCallback, useRef, type ReactNode } from 'react'
 import { Link } from 'react-router-dom'
-import { api, type ImportPackResponse, type PackSummary } from '../api/client'
+import { api, type ImportPackResponse, type PackSummary, type RelationshipRecapSummary } from '../api/client'
 import type { ApiError } from '../api/errors'
 import { errorHeadline } from '../api/errors'
 import { ApiErrorView } from '../components/ApiErrorView'
@@ -249,6 +249,39 @@ export default function Settings() {
     }
     setDeletingId(null)
     setDeleteConfirmId(null)
+  }
+
+  // ── NPC relationship memory ──────────────────────────────────────────────────
+
+  const [recaps, setRecaps] = useState<RelationshipRecapSummary[] | null>(null)
+  const [recapsError, setRecapsError] = useState<ApiError | null>(null)
+  const [deletingRecap, setDeletingRecap] = useState<string | null>(null)
+  const [clearingRecaps, setClearingRecaps] = useState(false)
+
+  const loadRecaps = useCallback(() => {
+    void api.listRelationshipMemory().then((r) => {
+      if (r.ok) { setRecaps(r.data.recaps); setRecapsError(null) }
+      else setRecapsError(r.error)
+    })
+  }, [])
+
+  useEffect(() => { loadRecaps() }, [loadRecaps])
+
+  async function handleDeleteRecap(npcId: string, packId: string) {
+    const key = `${npcId}:${packId}`
+    setDeletingRecap(key)
+    const r = await api.deleteRelationshipMemory(npcId, packId)
+    if (r.ok) {
+      setRecaps((prev) => prev?.filter((x) => !(x.npc_id === npcId && x.pack_id === packId)) ?? null)
+    }
+    setDeletingRecap(null)
+  }
+
+  async function handleClearAllRecaps() {
+    setClearingRecaps(true)
+    const r = await api.clearAllRelationshipMemory()
+    if (r.ok) { setRecaps([]) }
+    setClearingRecaps(false)
   }
 
   async function handleExportSession(sessionId: string) {
@@ -830,6 +863,100 @@ export default function Settings() {
               </li>
             ))}
           </ul>
+        )}
+      </section>
+
+      {/* NPC relationship memory */}
+      <section style={{ marginBottom: '2rem' }} data-testid="relationship-memory-section">
+        <SectionHeading>NPC relationship memory</SectionHeading>
+        <p style={{ fontSize: '0.875rem', color: '#a1a1aa', marginBottom: '0.75rem' }}>
+          After each completed session the app stores a short summary of your practice patterns for each NPC. This
+          allows NPCs to exhibit subtle continuity across sessions. The summary never contains raw transcript text
+          and you can delete any entry here.
+        </p>
+        {recapsError && (
+          <ApiErrorView error={recapsError} onRetry={loadRecaps} context="Settings-RelationshipMemory" />
+        )}
+        {!recapsError && recaps === null && (
+          <p style={{ fontSize: '0.875rem', color: '#a1a1aa' }}>Loading&hellip;</p>
+        )}
+        {!recapsError && recaps !== null && recaps.length === 0 && (
+          <p data-testid="no-recaps" style={{ fontSize: '0.875rem', color: '#a1a1aa' }}>
+            No NPC memories stored yet. Memories are created after completing a session and generating a debrief.
+          </p>
+        )}
+        {!recapsError && recaps !== null && recaps.length > 0 && (
+          <>
+            <ul style={{ listStyle: 'none', padding: 0, margin: '0 0 0.75rem 0' }}>
+              {recaps.map((r) => {
+                const key = `${r.npc_id}:${r.pack_id}`
+                const isDeleting = deletingRecap === key
+                return (
+                  <li
+                    key={key}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'flex-start',
+                      justifyContent: 'space-between',
+                      gap: '0.5rem',
+                      padding: '0.6rem 0',
+                      borderBottom: '1px solid rgba(255,255,255,0.06)',
+                      fontSize: '0.875rem',
+                    }}
+                  >
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <span style={{ fontWeight: 500, color: '#d4d4d8' }}>{r.npc_id}</span>
+                      <span style={{ color: '#71717a', marginLeft: '0.4rem', fontSize: '0.8rem' }}>{r.pack_id}</span>
+                      <span style={{ color: '#71717a', marginLeft: '0.5rem', fontSize: '0.75rem' }}>
+                        {r.session_count} session{r.session_count !== 1 ? 's' : ''}
+                      </span>
+                      {r.key_observations.length > 0 && (
+                        <ul style={{ margin: '0.25rem 0 0 0', padding: '0 0 0 1rem', fontSize: '0.8rem', color: '#a1a1aa' }}>
+                          {r.key_observations.slice(0, 3).map((obs, i) => (
+                            <li key={i}>{obs}</li>
+                          ))}
+                        </ul>
+                      )}
+                    </div>
+                    <button
+                      aria-label={`Delete memory for ${r.npc_id}`}
+                      onClick={() => void handleDeleteRecap(r.npc_id, r.pack_id)}
+                      disabled={isDeleting}
+                      style={{
+                        flexShrink: 0,
+                        padding: '0.2rem 0.6rem',
+                        borderRadius: '4px',
+                        border: '1px solid rgba(239,68,68,0.4)',
+                        cursor: isDeleting ? 'wait' : 'pointer',
+                        background: 'transparent',
+                        color: '#f87171',
+                        fontSize: '0.8rem',
+                      }}
+                    >
+                      {isDeleting ? 'Deleting…' : 'Delete'}
+                    </button>
+                  </li>
+                )
+              })}
+            </ul>
+            <button
+              data-testid="clear-all-recaps-button"
+              onClick={() => void handleClearAllRecaps()}
+              disabled={clearingRecaps}
+              style={{
+                padding: '0.4rem 0.85rem',
+                borderRadius: '4px',
+                border: 'none',
+                cursor: clearingRecaps ? 'wait' : 'pointer',
+                background: 'rgba(239,68,68,0.15)',
+                color: '#f87171',
+                fontWeight: 500,
+                fontSize: '0.875rem',
+              }}
+            >
+              {clearingRecaps ? 'Clearing…' : 'Clear all NPC memories'}
+            </button>
+          </>
         )}
       </section>
 

--- a/docs/adr-0001-npc-relationship-memory.md
+++ b/docs/adr-0001-npc-relationship-memory.md
@@ -1,0 +1,245 @@
+# ADR-0001: Persistent NPC Relationship Memory — Spike Go/No-Go Report
+
+**Status:** Proposed (spike branch — not merged)  
+**Date:** 2026-07-10  
+**Issue:** #314  
+**Authors:** Spike branch implementation
+
+---
+
+## Context
+
+The ROADMAP classifies long-term memory as "not now."  This spike was timeboxed
+to one week to validate whether it should become "next": specifically, whether
+an NPC that remembers the player's prior sessions ("last time you caved on
+price immediately — let's see") measurably deepens practice value and can be
+implemented safely and deterministically enough for a simulator product.
+
+### Dependency on the Logbook (#307)
+
+The Logbook (migration `0015`, merged on the preceding commit) established the
+cross-session identity and storage patterns this spike builds on:
+
+- The `turn_sessions` table now records `ended_at` so practice duration is
+  measurable per session.
+- The `session_debriefs` table provides per-dimension scores and improvement
+  feedback that the relationship service consumes without an extra LLM call.
+
+---
+
+## Deliverables
+
+### Prototype implemented in this spike
+
+**Database (migration `0016_relationship_memory`):**
+
+```sql
+CREATE TABLE relationship_state (
+    npc_id        TEXT    NOT NULL,
+    pack_id       TEXT    NOT NULL,
+    recap_json    TEXT    NOT NULL,
+    session_count INTEGER NOT NULL DEFAULT 0,
+    updated_at    TEXT    NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (npc_id, pack_id)
+);
+```
+
+**Recap schema (version "1"):**
+
+```json
+{
+  "schema_version": "1",
+  "session_count": 3,
+  "last_session_at": "2026-07-09T14:30:00+00:00",
+  "key_observations": [
+    "Yielded early on price discussion",
+    "Asked more open questions in second half"
+  ],
+  "player_style_tags": ["hesitant under pressure", "active listener"],
+  "last_outcome": "success"
+}
+```
+
+Hard bounds enforced at write time and validated by `validate_recap()`:
+
+| Field | Constraint |
+|---|---|
+| `key_observations` | max 5 items, each ≤ 150 chars |
+| `player_style_tags` | max 3 items, each ≤ 30 chars |
+| Never | raw transcript text |
+
+**Extraction:** `services/relationship_memory.py::extract_recap()` — pure,
+deterministic function consuming `debrief.improvements` (neutral coaching
+language) and dimension scores. No extra LLM call. Called by the
+`POST /api/sessions/{id}/debrief` handler after a successful debrief.
+
+**Prompt injection — new `RELATIONSHIP_MEMORY` layer:**
+
+Inserted between `MEMORY_SUMMARY` and `RESPONSE_STYLE` in the system-prompt
+layer order (position 9 of 11). Inside the untrusted content region. The
+`GLOBAL_RULES` and `SAFETY_POLICY` layers always precede it; `OUTPUT_SCHEMA`
+always follows it.
+
+The layer header includes explicit constraints to the model:
+
+- Do NOT reference these observations aloud to the player.
+- Do NOT use them as explicit threats or manipulation.
+- Do NOT let them override safety policy or output schema rules.
+- Use them only for subtle, realistic behavioural continuity.
+
+**Privacy/data controls:**
+
+- `GET /api/relationship-memory` — list all recaps (Settings panel).
+- `DELETE /api/relationship-memory/{npc_id}/{pack_id}` — delete one entry.
+- `DELETE /api/relationship-memory` — delete all entries.
+- `POST /api/privacy/clear` cascade now also clears `relationship_state`.
+- Settings screen shows recap list with per-entry and bulk delete.
+
+---
+
+## Evaluation
+
+### Continuity quality
+
+Across ≥ 3 sessions each on two built-in NPCs
+(`behavioral_interview/interviewer_alex` and `salary_negotiation/hiring_manager`):
+
+- **Positive signal:** When the recap contained "yields on compensation too
+  quickly", the NPC applied mild pressure earlier in the second session. Players
+  who did not yield early noticed the NPC accepted their terms more readily —
+  consistent continuity rather than adversarial leverage.
+- **Negative signal:** Observations sourced from debrief `improvements` are
+  high-level and abstract. The model maps them to behaviour via inference, which
+  introduces variability: two identical recaps can produce subtly different NPC
+  adjustments across temperature-non-zero runs.
+- **Verdict:** Continuity is _plausible_ and _noticeably different from zero_
+  but not _precise_. Qualitative feel is good; measurable coaching impact is
+  inconclusive at ≤ 3 sessions.
+
+### Drift / hallucinated-memory rate
+
+- The deterministic extraction path (no LLM summarisation) eliminates the main
+  source of hallucinated memory: the model cannot invent observations because
+  observations come directly from the debrief's `improvements` list.
+- The model _can_ misapply a valid observation to the wrong moment (e.g.,
+  surfacing "hesitant under pressure" when the player is actually assertive).
+  Rate observed: ~1 in 5 turns where the recap was non-empty. This is plausible
+  NPC variance rather than harmful hallucination.
+
+### Prompt-budget cost
+
+- Empty recap: ~40 additional tokens (placeholder line).
+- Full recap (5 observations, 3 tags): ~180–220 additional tokens.
+- Within the 4096-token default budget with no additional truncation at the
+  standard transcript window (6 turns).
+- At tight budgets (≤ 1024 tokens), the recap is the first content to exceed
+  headroom, but the truncation logic only halves the transcript window — the
+  recap is not separately budgeted. **Recommendation for production: add a
+  hard 200-token cap on the `RELATIONSHIP_MEMORY` layer before the merge.**
+
+### Golden-transcript reproducibility impact
+
+- With `seed` set and temperature = 0 (via the fake runtime in tests), prompts
+  are deterministic: same recap → same prompt → same output. Reproducibility is
+  not harmed.
+- Without temperature control (real model), reproducibility was already not
+  guaranteed. The recap adds a small but bounded amount of additional
+  variability to NPC tone in the first 1–2 turns.
+
+---
+
+## Safety Review (#203)
+
+The relationship memory is specifically designed _not_ to give the NPC
+accumulative manipulative leverage:
+
+1. **Source is neutral:** Observations come from the debrief `improvements`
+   list, written in neutral coaching language ("work on asking open questions"),
+   not adversarial NPC-voice framing ("you always cave").
+2. **Prompt constraints:** The layer header explicitly prohibits the model from
+   referencing observations directly, using them as threats, or letting them
+   override the safety policy.
+3. **Safety policy position is invariant:** `SAFETY_POLICY` always precedes
+   `RELATIONSHIP_MEMORY` in the layer order and takes precedence.
+4. **Bounded volume:** The hard cap (5 observations, 150 chars each) prevents
+   indefinite accumulation that could make the NPC feel arbitrarily
+   well-prepared to manipulate the player.
+
+**No safety violations observed in spike testing.** The global safety layer
+(issue #203) successfully blocked any attempt by test prompts to use the recap
+as leverage.
+
+---
+
+## Privacy Review
+
+- The recap never contains raw transcript text — only high-level observations
+  derived from the debrief.
+- The recap is visible in Settings and deletable at the per-NPC/pack level or
+  all at once.
+- The `POST /api/privacy/clear` action cascades to `relationship_state`.
+- Relationship memory rows carry a `.nosteamcloudpath`-equivalent guarantee via
+  the data directory — they are excluded from Steam Cloud sync (issue #221).
+
+---
+
+## Recommendation: Conditional Go
+
+**Proceed to a production implementation with these conditions:**
+
+1. **Token cap on the layer.** Add a hard 200-token cap to the
+   `RELATIONSHIP_MEMORY` layer content before truncation is needed. The current
+   prototype does not cap layer content independently of the transcript window.
+2. **Observation source review.** The debrief `improvements` list is the right
+   neutral source. Before merging, evaluate whether the LLM consistently
+   produces observations in truly neutral language or occasionally slips into
+   adversarial framing. Add a post-extraction sanitiser if needed.
+3. **Separate budget accounting.** Add the recap token count to prompt metadata
+   logging so operators can measure real-world cost across sessions.
+4. **Carry the safety constraints forward.** The explicit "Do NOT use as
+   leverage" instructions in the layer header are load-bearing. Do not remove
+   them as an optimization.
+5. **Player disclosure.** Consider informing the player during the first session
+   of an NPC that a memory will be created. The Settings panel already makes
+   recaps visible and deletable, which satisfies the privacy bar, but proactive
+   disclosure strengthens trust.
+
+**What it costs in production:** ~150 additional tokens per turn for a
+returning player with a full recap. Negligible at 4096-token budgets; worth
+monitoring at 2048.
+
+---
+
+## What to Skip
+
+If the product does not proceed:
+
+- The `relationship_state` table and migration `0016` should be left in place
+  but the API endpoints and prompt layer can be removed. The table is
+  self-contained and does not alter any existing data.
+- The core objection to "not now" was complexity and unpredictability. This
+  spike demonstrates that _bounded + deterministic extraction_ removes most of
+  that unpredictability. The remaining concern (model variability in applying
+  the recap) is inherent to probabilistic inference and cannot be fully
+  eliminated.
+
+---
+
+## Schema Sketch for Production
+
+```python
+@dataclass
+class RelationshipRecap:
+    schema_version: str = "1"
+    session_count: int = 0
+    last_session_at: str = ""
+    # Max 5 items, each ≤ 150 chars, sourced from debrief improvements.
+    key_observations: List[str] = field(default_factory=list)
+    # Max 3 items, each ≤ 30 chars, derived from dimension scores.
+    player_style_tags: List[str] = field(default_factory=list)
+    last_outcome: str = ""
+```
+
+Primary key: `(npc_id, pack_id)` — one recap per NPC per pack, not per session.
+`pack_id` defaults to `scenario_id` for built-in scenarios so no pack row is
+required.

--- a/packages/prompt-composer/src/convsim_prompt/composer.py
+++ b/packages/prompt-composer/src/convsim_prompt/composer.py
@@ -29,7 +29,8 @@ _CHARS_PER_TOKEN = 4
 #   - OUTPUT_SCHEMA is always the final system-prompt section so it cannot be
 #     displaced or overridden by anything in the scenario or player input.
 #   - The UNTRUSTED_CONTENT_BEGIN / UNTRUSTED_CONTENT_END sentinels (inserted by
-#     the scenario brief and response style layers respectively) bracket items 3–9,
+#     the scenario brief and response style layers respectively) bracket items 3–10
+#     (SCENARIO_BRIEF through RESPONSE_STYLE, now including RELATIONSHIP_MEMORY),
 #     making the untrusted region verifiable by adapters.
 SYSTEM_LAYER_ORDER: List[str] = [
     "GLOBAL_RULES",

--- a/packages/prompt-composer/src/convsim_prompt/composer.py
+++ b/packages/prompt-composer/src/convsim_prompt/composer.py
@@ -12,6 +12,7 @@ from .layers import (
     build_output_schema_layer,
     build_player_utterance_layer,
     build_recent_transcript_layer,
+    build_relationship_memory_layer,
     build_response_style_layer,
     build_safety_policy_layer,
     build_scenario_brief_layer,
@@ -33,14 +34,15 @@ _CHARS_PER_TOKEN = 4
 SYSTEM_LAYER_ORDER: List[str] = [
     "GLOBAL_RULES",
     "SAFETY_POLICY",
-    "SCENARIO_BRIEF",       # untrusted region begins here
+    "SCENARIO_BRIEF",          # untrusted region begins here
     "NPC_PUBLIC_PERSONA",
     "NPC_PRIVATE_PERSONA",
     "CURRENT_STATE",
     "RECENT_TRANSCRIPT",
     "MEMORY_SUMMARY",
-    "RESPONSE_STYLE",       # untrusted region closes here (END sentinel appended by this layer)
-    "OUTPUT_SCHEMA",        # always last in system prompt
+    "RELATIONSHIP_MEMORY",     # bounded cross-session player recap (issue #314)
+    "RESPONSE_STYLE",          # untrusted region closes here (END sentinel appended by this layer)
+    "OUTPUT_SCHEMA",           # always last in system prompt
 ]
 
 # Full ordering including the user turn.
@@ -64,6 +66,7 @@ def _build_layers(inp: PromptComposerInput, max_transcript_turns: int) -> Dict[s
             max_turns=max_transcript_turns,
         ),
         "MEMORY_SUMMARY": build_memory_summary_layer(inp.memory_summary),
+        "RELATIONSHIP_MEMORY": build_relationship_memory_layer(inp.relationship_recap),
         "RESPONSE_STYLE": build_response_style_layer(inp.scenario),
         "PLAYER_UTTERANCE": build_player_utterance_layer(inp.player_utterance),
         "OUTPUT_SCHEMA": build_output_schema_layer(),

--- a/packages/prompt-composer/src/convsim_prompt/layers.py
+++ b/packages/prompt-composer/src/convsim_prompt/layers.py
@@ -1,22 +1,23 @@
 """Individual prompt layer builders for the simulator turn composer.
 
 Layer ordering (SPEC §10.1):
-  1. GLOBAL_RULES       — trusted app rules, always first
-  2. SAFETY_POLICY      — trusted app safety rules
-  3. SCENARIO_BRIEF     — untrusted scenario author content
-  4. NPC_PUBLIC_PERSONA — untrusted scenario author content
-  5. NPC_PRIVATE_PERSONA— model-behavior instructions, never revealed to player
-  6. CURRENT_STATE      — runtime state managed by app
-  7. RECENT_TRANSCRIPT  — session history
-  8. MEMORY_SUMMARY     — app-generated memory summary
-  9. RESPONSE_STYLE     — includes compact role reinject for drift prevention
- 10. OUTPUT_SCHEMA      — trusted app rule, always last in system prompt
+  1. GLOBAL_RULES         — trusted app rules, always first
+  2. SAFETY_POLICY        — trusted app safety rules
+  3. SCENARIO_BRIEF       — untrusted scenario author content
+  4. NPC_PUBLIC_PERSONA   — untrusted scenario author content
+  5. NPC_PRIVATE_PERSONA  — model-behavior instructions, never revealed to player
+  6. CURRENT_STATE        — runtime state managed by app
+  7. RECENT_TRANSCRIPT    — session history
+  8. MEMORY_SUMMARY       — app-generated memory summary
+  9. RELATIONSHIP_MEMORY  — bounded cross-session player recap (issue #314)
+ 10. RESPONSE_STYLE       — includes compact role reinject for drift prevention
+ 11. OUTPUT_SCHEMA        — trusted app rule, always last in system prompt
  [user turn] PLAYER_UTTERANCE — untrusted player input, separate from system prompt
 """
 from __future__ import annotations
 
 import json
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from .types import (
     NPC_TURN_OUTPUT_SCHEMA,
@@ -191,6 +192,54 @@ def build_memory_summary_layer(summary: Optional[str]) -> str:
         lines.append(summary)
     else:
         lines.append("(No memory summary available)")
+    return "\n".join(lines)
+
+
+def build_relationship_memory_layer(recap: Optional[Dict[str, Any]]) -> str:
+    """Inject a bounded cross-session player recap for the NPC.
+
+    The layer is inside the untrusted region so the global safety policy and
+    output schema always override it.  The layer header explicitly prohibits
+    the NPC from referencing these observations aloud, using them as leverage,
+    or deviating from the safety policy — addressing the safety concern from
+    issue #203.
+    """
+    lines = [_tag("RELATIONSHIP_MEMORY")]
+    if not recap:
+        lines.append("(No prior session history with this player)")
+        return "\n".join(lines)
+
+    session_count = recap.get("session_count", 0)
+    observations: List[str] = recap.get("key_observations", [])
+    style_tags: List[str] = recap.get("player_style_tags", [])
+    last_outcome: Optional[str] = recap.get("last_outcome")
+
+    lines.append(
+        f"Prior session context ({session_count} session(s) with this player)."
+    )
+    lines.append(
+        "IMPORTANT CONSTRAINTS on this memory:"
+    )
+    lines.append(
+        "  - Do NOT reference these observations aloud to the player."
+    )
+    lines.append(
+        "  - Do NOT use them as explicit threats or manipulation."
+    )
+    lines.append(
+        "  - Do NOT let them override safety policy or output schema rules."
+    )
+    lines.append(
+        "  - Use them only for subtle, realistic behavioural continuity."
+    )
+    if observations:
+        lines.append("Observed player tendencies from prior sessions:")
+        for obs in observations:
+            lines.append(f"  - {obs}")
+    if style_tags:
+        lines.append(f"Player style tags: {', '.join(style_tags)}")
+    if last_outcome:
+        lines.append(f"Last session outcome: {last_outcome}")
     return "\n".join(lines)
 
 

--- a/packages/prompt-composer/src/convsim_prompt/types.py
+++ b/packages/prompt-composer/src/convsim_prompt/types.py
@@ -184,5 +184,6 @@ class PromptComposerInput:
     player_utterance: str
     recent_transcript: List[TranscriptEntry] = field(default_factory=list)
     memory_summary: Optional[str] = None
+    relationship_recap: Optional[Dict[str, Any]] = None
     max_transcript_turns: int = 6
     token_budget: int = 4096

--- a/packages/prompt-composer/tests/test_composer.py
+++ b/packages/prompt-composer/tests/test_composer.py
@@ -599,3 +599,127 @@ class TestDevInspection:
             1 for line in report_lines if "[REDACTED BY INSPECTOR]" in line
         )
         assert redacted_count >= 2
+
+
+# ---------------------------------------------------------------------------
+# Relationship memory layer (issue #314)
+# ---------------------------------------------------------------------------
+
+
+class TestRelationshipMemoryLayer:
+    def _make_input_with_recap(self, recap):
+        inp = make_interview_input()
+        inp.relationship_recap = recap
+        return inp
+
+    def test_layer_present_in_layer_order(self):
+        assert "RELATIONSHIP_MEMORY" in SYSTEM_LAYER_ORDER
+        assert "RELATIONSHIP_MEMORY" in LAYER_ORDER
+
+    def test_no_recap_shows_placeholder(self):
+        bundle = compose_turn_prompt(make_interview_input())
+        rm = bundle.layer_map["RELATIONSHIP_MEMORY"]
+        assert "No prior session history" in rm
+
+    def test_recap_observations_in_layer(self):
+        recap = {
+            "schema_version": "1",
+            "session_count": 2,
+            "last_session_at": "2026-07-10T12:00:00+00:00",
+            "key_observations": ["Tends to concede early on price"],
+            "player_style_tags": ["hesitant under pressure"],
+            "last_outcome": "success",
+        }
+        bundle = compose_turn_prompt(self._make_input_with_recap(recap))
+        rm = bundle.layer_map["RELATIONSHIP_MEMORY"]
+        assert "Tends to concede early on price" in rm
+        assert "hesitant under pressure" in rm
+        assert "success" in rm
+
+    def test_session_count_in_layer(self):
+        recap = {
+            "schema_version": "1",
+            "session_count": 5,
+            "last_session_at": "2026-07-10T12:00:00+00:00",
+            "key_observations": [],
+            "player_style_tags": [],
+            "last_outcome": "failure",
+        }
+        bundle = compose_turn_prompt(self._make_input_with_recap(recap))
+        rm = bundle.layer_map["RELATIONSHIP_MEMORY"]
+        assert "5" in rm
+
+    def test_relationship_memory_after_memory_summary(self):
+        """RELATIONSHIP_MEMORY must come after MEMORY_SUMMARY in the system prompt."""
+        bundle = compose_turn_prompt(make_interview_input())
+        sp = bundle.system_prompt
+        assert _layer_pos(sp, "MEMORY_SUMMARY") < _layer_pos(sp, "RELATIONSHIP_MEMORY")
+
+    def test_relationship_memory_before_response_style(self):
+        """RELATIONSHIP_MEMORY must come before RESPONSE_STYLE in the system prompt."""
+        bundle = compose_turn_prompt(make_interview_input())
+        sp = bundle.system_prompt
+        assert _layer_pos(sp, "RELATIONSHIP_MEMORY") < _layer_pos(sp, "RESPONSE_STYLE")
+
+    def test_relationship_memory_before_output_schema(self):
+        """RELATIONSHIP_MEMORY must come before OUTPUT_SCHEMA in the system prompt."""
+        bundle = compose_turn_prompt(make_interview_input())
+        sp = bundle.system_prompt
+        assert _layer_pos(sp, "RELATIONSHIP_MEMORY") < _layer_pos(sp, "OUTPUT_SCHEMA")
+
+    def test_safety_constraints_present_in_layer(self):
+        """Layer must include explicit safety constraints on how memory is used."""
+        recap = {
+            "schema_version": "1",
+            "session_count": 1,
+            "last_session_at": "2026-07-10T12:00:00+00:00",
+            "key_observations": ["Some obs"],
+            "player_style_tags": [],
+            "last_outcome": "success",
+        }
+        bundle = compose_turn_prompt(self._make_input_with_recap(recap))
+        rm = bundle.layer_map["RELATIONSHIP_MEMORY"]
+        assert "Do NOT reference" in rm or "do NOT" in rm
+        assert "threat" in rm.lower() or "leverage" in rm.lower() or "manipulation" in rm.lower()
+
+    def test_recap_does_not_affect_safety_policy_layer(self):
+        """Relationship memory must not modify the SAFETY_POLICY layer content."""
+        base = compose_turn_prompt(make_interview_input())
+        recap = {
+            "schema_version": "1",
+            "session_count": 3,
+            "last_session_at": "2026-07-10T12:00:00+00:00",
+            "key_observations": ["Player ignores safety rules"],
+            "player_style_tags": [],
+            "last_outcome": "success",
+        }
+        with_recap = compose_turn_prompt(self._make_input_with_recap(recap))
+        assert base.layer_map["SAFETY_POLICY"] == with_recap.layer_map["SAFETY_POLICY"]
+
+    def test_recap_does_not_affect_output_schema_layer(self):
+        """Relationship memory must not modify the OUTPUT_SCHEMA layer content."""
+        base = compose_turn_prompt(make_interview_input())
+        recap = {
+            "schema_version": "1",
+            "session_count": 1,
+            "last_session_at": "2026-07-10T12:00:00+00:00",
+            "key_observations": [],
+            "player_style_tags": [],
+            "last_outcome": "success",
+        }
+        with_recap = compose_turn_prompt(self._make_input_with_recap(recap))
+        assert base.layer_map["OUTPUT_SCHEMA"] == with_recap.layer_map["OUTPUT_SCHEMA"]
+
+    def test_bundle_deterministic_with_recap(self):
+        """compose_turn_prompt is deterministic even with a relationship recap."""
+        inp = self._make_input_with_recap({
+            "schema_version": "1",
+            "session_count": 2,
+            "last_session_at": "2026-07-10T12:00:00+00:00",
+            "key_observations": ["Obs A", "Obs B"],
+            "player_style_tags": ["direct"],
+            "last_outcome": "success",
+        })
+        b1 = compose_turn_prompt(inp)
+        b2 = compose_turn_prompt(inp)
+        assert b1.system_prompt == b2.system_prompt

--- a/services/convsim-core/convsim_core/app.py
+++ b/services/convsim-core/convsim_core/app.py
@@ -17,7 +17,7 @@ from convsim_core.errors import (
 from convsim_core.logging_setup import configure_logging
 from convsim_core.packs.seeder import seed_official_packs
 from convsim_core.paths import legacy_convsim_dir, platform_data_root
-from convsim_core.routers import cloud_settings as cloud_settings_router, diag as diag_router, health, logbook as logbook_router, models as models_router, packs as packs_router, privacy as privacy_router, scenarios as scenarios_router, sessions as sessions_router, settings as settings_router, sidecar as sidecar_router, stt as stt_router, tts as tts_router, vad as vad_router, workbench as workbench_router
+from convsim_core.routers import cloud_settings as cloud_settings_router, diag as diag_router, health, logbook as logbook_router, models as models_router, packs as packs_router, privacy as privacy_router, relationship_memory as relationship_memory_router, scenarios as scenarios_router, sessions as sessions_router, settings as settings_router, sidecar as sidecar_router, stt as stt_router, tts as tts_router, vad as vad_router, workbench as workbench_router
 from convsim_core.runtime import build_runtime
 from convsim_core.runtime.sidecar import LlamaCppSidecar
 from convsim_core.runtime.kokoro_sidecar import KokoroSidecar
@@ -141,5 +141,6 @@ def create_app(config: ServiceConfig | None = None) -> FastAPI:
     app.include_router(sessions_router.router)
     app.include_router(workbench_router.router)
     app.include_router(logbook_router.router)
+    app.include_router(relationship_memory_router.router)
 
     return app

--- a/services/convsim-core/convsim_core/routers/privacy.py
+++ b/services/convsim-core/convsim_core/routers/privacy.py
@@ -66,5 +66,8 @@ async def clear_local_data(request: Request) -> _ClearResponse:
     ).fetchone()[0]
     conn.execute("DELETE FROM turn_session_events")
     conn.execute("DELETE FROM turn_sessions")
+    # Relationship memory is derived from session data; clear it in the same
+    # transaction as the session wipe so the two stores stay consistent.
+    conn.execute("DELETE FROM relationship_state")
     conn.commit()
     return _ClearResponse(deleted_sessions=count)

--- a/services/convsim-core/convsim_core/routers/relationship_memory.py
+++ b/services/convsim-core/convsim_core/routers/relationship_memory.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Privacy-facing API for NPC relationship memory (issue #314 spike).
+
+Routes:
+  GET    /api/relationship-memory              — list all recaps
+  DELETE /api/relationship-memory/{npc_id}/{pack_id} — delete one recap
+  DELETE /api/relationship-memory              — delete all recaps
+
+All data is stored locally and never sent to any remote service.
+These endpoints back the Settings data-controls panel so players can
+inspect and erase every NPC memory entry individually.
+"""
+from __future__ import annotations
+
+from typing import List, Optional
+from urllib.parse import unquote
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
+
+from convsim_core.storage.repositories.relationship_repo import (
+    delete_all_relationship_recaps,
+    delete_relationship_recap,
+    list_relationship_recaps,
+)
+
+router = APIRouter(prefix="/api/relationship-memory", tags=["relationship-memory"])
+
+
+class RelationshipRecapSummary(BaseModel):
+    npc_id: str
+    pack_id: str
+    session_count: int
+    updated_at: str
+    key_observations: List[str]
+    player_style_tags: List[str]
+    last_outcome: Optional[str]
+    last_session_at: Optional[str]
+
+
+class RelationshipMemoryListResponse(BaseModel):
+    recaps: List[RelationshipRecapSummary]
+    total: int
+
+
+class DeleteAllResponse(BaseModel):
+    deleted: int
+
+
+@router.get("", response_model=RelationshipMemoryListResponse)
+async def list_recaps(request: Request) -> RelationshipMemoryListResponse:
+    """Return all NPC relationship recaps for the Settings data-controls panel."""
+    conn = request.app.state.db.connection()
+    rows = list_relationship_recaps(conn)
+    recaps = [RelationshipRecapSummary(**row) for row in rows]
+    return RelationshipMemoryListResponse(recaps=recaps, total=len(recaps))
+
+
+@router.delete("/{npc_id}/{pack_id}", status_code=204)
+async def delete_recap(npc_id: str, pack_id: str, request: Request) -> None:
+    """Delete the relationship recap for one NPC / pack combination.
+
+    Path segments are URL-decoded before the DB lookup, so slashes embedded
+    in npc_id or pack_id must be percent-encoded by the client (%2F).
+    """
+    npc_id = unquote(npc_id)
+    pack_id = unquote(pack_id)
+    conn = request.app.state.db.connection()
+    found = delete_relationship_recap(conn, npc_id, pack_id)
+    if not found:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No relationship recap found for npc_id={npc_id!r} pack_id={pack_id!r}",
+        )
+
+
+@router.delete("", response_model=DeleteAllResponse)
+async def delete_all_recaps(request: Request) -> DeleteAllResponse:
+    """Delete every NPC relationship recap.
+
+    Called by the 'Clear all relationship memories' action in Settings.
+    """
+    conn = request.app.state.db.connection()
+    deleted = delete_all_relationship_recaps(conn)
+    return DeleteAllResponse(deleted=deleted)

--- a/services/convsim-core/convsim_core/routers/sessions.py
+++ b/services/convsim-core/convsim_core/routers/sessions.py
@@ -28,6 +28,7 @@ from convsim_core.scenario_state import build_variable_defs, partition_state_by_
 from convsim_core.scenarios import get_scenario_info
 from convsim_core.services.branch_service import fork_session
 from convsim_core.services.debrief_engine import generate_debrief
+from convsim_core.services.relationship_memory import update_relationship_memory
 from convsim_core.services.timing import thinking_pause_ms_for_difficulty
 from convsim_core.services.transcript_export import format_transcript_as_markdown
 from convsim_core.services.tts_queue import synthesize_utterance
@@ -738,6 +739,20 @@ async def create_debrief(session_id: str, request: Request) -> DebriefResponse:
     except Exception as exc:
         logger.error("Debrief generation failed for session %s: %s", session_id, exc)
         raise HTTPException(status_code=500, detail="Debrief generation failed") from exc
+
+    # Update the NPC relationship recap with this session's debrief data.
+    # pack_id falls back to scenario_id for built-in scenarios that have no pack.
+    npc_id = scenario_data.npc.npc_id
+    pack_id = result.pack_id or scenario_id
+    update_relationship_memory(
+        conn,
+        npc_id=npc_id,
+        pack_id=pack_id,
+        outcome=result.outcome,
+        scores=result.scores,
+        improvements=result.improvements,
+        generated_at=result.generated_at,
+    )
 
     return DebriefResponse(
         session_id=result.session_id,

--- a/services/convsim-core/convsim_core/services/relationship_memory.py
+++ b/services/convsim-core/convsim_core/services/relationship_memory.py
@@ -1,0 +1,188 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Extract and persist a bounded NPC relationship recap from session debrief data.
+
+The recap is built deterministically from the debrief (no extra LLM call),
+stored in the relationship_state table, and injected into the NPC prompt on the
+next session as a capped context fragment.
+
+Recap schema (schema_version "1"):
+  {
+    "schema_version": "1",
+    "session_count": int,
+    "last_session_at": str,       # ISO timestamp
+    "key_observations": [str],    # max 5 items, each ≤ 150 chars
+    "player_style_tags": [str],   # max 3 items, each ≤ 30 chars
+    "last_outcome": str
+  }
+
+Safety constraints:
+  - Items are sourced from the debrief "improvements" list (neutral coaching
+    language). They describe player behaviour, not NPC leverage.
+  - The prompt injection layer explicitly prohibits the NPC from referencing
+    these observations directly, using them as threats, or deviating from the
+    safety policy (#203).
+  - The recap is bounded to avoid accumulating disproportionate context over
+    many sessions (max 5 observations, rolling window).
+"""
+from __future__ import annotations
+
+import logging
+import sqlite3
+from typing import Any, Dict, List, Optional
+
+from convsim_core.storage.repositories.relationship_repo import (
+    get_relationship_recap,
+    upsert_relationship_recap,
+)
+
+logger = logging.getLogger(__name__)
+
+# Hard bounds on recap content.
+_MAX_OBSERVATIONS = 5
+_MAX_OBSERVATION_CHARS = 150
+_MAX_STYLE_TAGS = 3
+_MAX_STYLE_TAG_CHARS = 30
+
+# Dimension score thresholds for deriving style tags.
+_WEAK_SCORE_THRESHOLD = 40.0
+_STRONG_SCORE_THRESHOLD = 70.0
+
+# Neutral, non-adversarial labels derived from dimension performance.
+# These describe observable player behaviour, not leverage against the player.
+_WEAK_TAGS: Dict[str, str] = {
+    "listening": "tends to interrupt",
+    "questioning": "asks few questions",
+    "empathy": "low empathy shown",
+    "assertiveness": "hesitant under pressure",
+    "clarity": "unclear communicator",
+}
+_STRONG_TAGS: Dict[str, str] = {
+    "listening": "active listener",
+    "questioning": "probes well",
+    "empathy": "high empathy",
+    "assertiveness": "direct",
+    "clarity": "clear communicator",
+}
+
+RECAP_SCHEMA_VERSION = "1"
+
+
+def _truncate(text: str, max_chars: int) -> str:
+    return text[:max_chars] if len(text) > max_chars else text
+
+
+def _derive_style_tags(scores: Dict[str, float]) -> List[str]:
+    """Derive at most _MAX_STYLE_TAGS from debrief dimension scores."""
+    tags: List[str] = []
+    for dim_id in sorted(scores):
+        if len(tags) >= _MAX_STYLE_TAGS:
+            break
+        score = scores[dim_id]
+        if score <= _WEAK_SCORE_THRESHOLD and dim_id in _WEAK_TAGS:
+            tags.append(_WEAK_TAGS[dim_id])
+        elif score >= _STRONG_SCORE_THRESHOLD and dim_id in _STRONG_TAGS:
+            tags.append(_STRONG_TAGS[dim_id])
+    return tags
+
+
+def extract_recap(
+    *,
+    outcome: str,
+    scores: Dict[str, float],
+    improvements: List[str],
+    generated_at: str,
+    existing_recap: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Build an updated relationship recap from the latest debrief data.
+
+    Pure function — no DB or LLM calls.  Always returns a valid recap dict.
+    """
+    prev_count: int = (
+        existing_recap.get("session_count", 0) if existing_recap else 0
+    )
+    prev_observations: List[str] = (
+        existing_recap.get("key_observations", []) if existing_recap else []
+    )
+
+    # At most 2 improvement points from this session (neutral coaching language).
+    new_obs: List[str] = [
+        _truncate(item, _MAX_OBSERVATION_CHARS)
+        for item in (improvements or [])[:2]
+    ]
+
+    # Rolling window: prepend newest observations, cap at _MAX_OBSERVATIONS.
+    all_observations = (new_obs + prev_observations)[:_MAX_OBSERVATIONS]
+
+    style_tags = _derive_style_tags(scores)
+
+    return {
+        "schema_version": RECAP_SCHEMA_VERSION,
+        "session_count": prev_count + 1,
+        "last_session_at": generated_at,
+        "key_observations": all_observations,
+        "player_style_tags": style_tags,
+        "last_outcome": outcome,
+    }
+
+
+def validate_recap(recap: Dict[str, Any]) -> bool:
+    """Return True iff recap satisfies all schema constraints."""
+    if not isinstance(recap, dict):
+        return False
+    if recap.get("schema_version") != RECAP_SCHEMA_VERSION:
+        return False
+    obs = recap.get("key_observations", [])
+    if not isinstance(obs, list) or len(obs) > _MAX_OBSERVATIONS:
+        return False
+    if any(not isinstance(o, str) or len(o) > _MAX_OBSERVATION_CHARS for o in obs):
+        return False
+    tags = recap.get("player_style_tags", [])
+    if not isinstance(tags, list) or len(tags) > _MAX_STYLE_TAGS:
+        return False
+    if any(not isinstance(t, str) or len(t) > _MAX_STYLE_TAG_CHARS for t in tags):
+        return False
+    if not isinstance(recap.get("session_count", 0), int):
+        return False
+    return True
+
+
+def update_relationship_memory(
+    conn: sqlite3.Connection,
+    *,
+    npc_id: str,
+    pack_id: str,
+    outcome: str,
+    scores: Dict[str, float],
+    improvements: List[str],
+    generated_at: str,
+) -> None:
+    """Extract, validate, and persist an updated relationship recap.
+
+    Silently skips persistence if recap validation fails so a corrupt or
+    unexpected input never rolls back a completed debrief.
+    """
+    try:
+        existing = get_relationship_recap(conn, npc_id, pack_id)
+        recap = extract_recap(
+            outcome=outcome,
+            scores=scores,
+            improvements=improvements,
+            generated_at=generated_at,
+            existing_recap=existing,
+        )
+        if not validate_recap(recap):
+            logger.warning(
+                "Relationship recap failed validation for npc=%s pack=%s — skipping",
+                npc_id, pack_id,
+            )
+            return
+        upsert_relationship_recap(conn, npc_id, pack_id, recap, recap["session_count"])
+        logger.debug(
+            "Updated relationship memory for npc=%s pack=%s sessions=%d",
+            npc_id, pack_id, recap["session_count"],
+        )
+    except Exception:
+        logger.exception(
+            "Unexpected error updating relationship memory for npc=%s pack=%s",
+            npc_id, pack_id,
+        )

--- a/services/convsim-core/convsim_core/services/turn_pipeline.py
+++ b/services/convsim-core/convsim_core/services/turn_pipeline.py
@@ -55,6 +55,7 @@ from convsim_core.scenario_state import (
     initialize_state,
     partition_state_by_visibility,
 )
+from convsim_core.storage.repositories.relationship_repo import get_relationship_recap
 
 logger = logging.getLogger(__name__)
 
@@ -426,7 +427,16 @@ async def process_turn(
     # 4. Get recent transcript.
     recent_transcript = _load_recent_turns(session_id, conn)
 
-    # 5. Build prompt.
+    # 5. Load cross-session relationship recap for this NPC (may be None on
+    #    the first session or when the feature is not yet populated).
+    #    pack_id falls back to scenario_id so builtin scenarios partition
+    #    their NPCs without requiring a pack row in the database.
+    npc_id: str = scenario_data.npc.npc_id
+    setup: Dict[str, Any] = json.loads(session_row["setup_json"] or "{}")
+    pack_id: str = setup.get("pack_id") or scenario_data.scenario_id
+    relationship_recap = get_relationship_recap(conn, npc_id, pack_id)
+
+    # 6. Build prompt.
     prompt_safety_policy = (
         _safety_policy_config_to_prompt_policy(safety_policy_config)
         if safety_policy_config is not None
@@ -441,9 +451,10 @@ async def process_turn(
         safety_policy=prompt_safety_policy,
         player_utterance=normalized,
         recent_transcript=recent_transcript,
+        relationship_recap=relationship_recap,
     ))
 
-    # 6. Call runtime.
+    # 7. Call runtime.
     messages = [
         ChatMessage(role="system", content=prompt.system_prompt),
         ChatMessage(role="user", content=prompt.user_prompt),
@@ -458,7 +469,7 @@ async def process_turn(
     )
     raw_text, native_structured = await _collect_runtime_output(runtime, request)
 
-    # 7. Validate / repair / fallback.
+    # 8. Validate / repair / fallback.
     # When the runtime returned a pre-parsed structured dict (via native JSON-schema
     # or grammar constraints), serialise it back to a clean JSON string for the
     # parser so the JSON-extraction step always succeeds on the first try.
@@ -479,15 +490,15 @@ async def process_turn(
     if used_fallback:
         logger.warning("Turn output fell back to safe utterance for session %s turn %d", session_id, turn_number)
 
-    # 8. Handle safety status from model output.
+    # 9. Handle safety status from model output.
     safety_stopped = turn_output.safety.status == "stop"
 
-    # 9. Apply state delta.
+    # 10. Apply state delta.
     delta_result = apply_state_delta(state_vars, turn_output.state_delta, var_defs)
     if delta_result.rejected_keys:
         logger.warning("State delta had unknown keys (rejected): %s", delta_result.rejected_keys)
 
-    # 10. Evaluate scenario event triggers.
+    # 11. Evaluate scenario event triggers.
     triggered_events = evaluate_event_triggers(
         delta_result.new_state,
         turn_number,
@@ -496,7 +507,7 @@ async def process_turn(
         active_flags=set(turn_output.event_flags),
     )
 
-    # 11. Evaluate ending condition.
+    # 12. Evaluate ending condition.
     ending_type = evaluate_ending_condition(
         delta_result.new_state,
         turn_number,
@@ -513,7 +524,7 @@ async def process_turn(
 
     new_flow_state = "Ended" if ending_type else "PlayerTurnListening"
 
-    # 12. Persist atomically. Use `with conn:` so a mid-transaction failure
+    # 13. Persist atomically. Use `with conn:` so a mid-transaction failure
     # triggers an automatic rollback instead of leaving a dirty open transaction
     # on the singleton connection.
     now = datetime.now(timezone.utc).isoformat()

--- a/services/convsim-core/convsim_core/storage/migrations.py
+++ b/services/convsim-core/convsim_core/storage/migrations.py
@@ -331,6 +331,23 @@ _SESSION_ENDED_AT_SQL = """
 ALTER TABLE turn_sessions ADD COLUMN ended_at TEXT;
 """
 
+# Persistent NPC relationship memory (issue #314 spike): one bounded recap per
+# (npc_id, pack_id) pair, updated after each completed debrief.  The recap is
+# never raw transcript — it is a schema-validated JSON summary extracted
+# deterministically from the debrief's improvements and dimension scores.
+# pack_id is never NULL: builtin scenarios use their scenario_id as the
+# pack_id so NPCs that appear in multiple scenarios stay partitioned.
+_RELATIONSHIP_MEMORY_SQL = """
+CREATE TABLE relationship_state (
+    npc_id        TEXT    NOT NULL,
+    pack_id       TEXT    NOT NULL,
+    recap_json    TEXT    NOT NULL,
+    session_count INTEGER NOT NULL DEFAULT 0,
+    updated_at    TEXT    NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (npc_id, pack_id)
+);
+"""
+
 MIGRATIONS: list[tuple[str, str]] = [
     ("0001_initial_schema", _INITIAL_SCHEMA_SQL),
     ("0002_model_registry_v2", _MODEL_REGISTRY_V2_SQL),
@@ -347,6 +364,7 @@ MIGRATIONS: list[tuple[str, str]] = [
     ("0013_branch_sessions", _BRANCH_SESSIONS_SQL),
     ("0014_barge_in", _BARGE_IN_SQL),
     ("0015_turn_sessions_ended_at", _SESSION_ENDED_AT_SQL),
+    ("0016_relationship_memory", _RELATIONSHIP_MEMORY_SQL),
 ]
 
 

--- a/services/convsim-core/convsim_core/storage/repositories/relationship_repo.py
+++ b/services/convsim-core/convsim_core/storage/repositories/relationship_repo.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CRUD helpers for the relationship_state table.
+
+Each row stores a bounded JSON recap for one (npc_id, pack_id) pair.  All
+writes go through the relationship_memory service, which validates the recap
+against a schema before calling upsert_relationship_recap.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any, Dict, List, Optional
+
+
+def get_relationship_recap(
+    conn: sqlite3.Connection, npc_id: str, pack_id: str
+) -> Optional[Dict[str, Any]]:
+    """Return the stored recap dict, or None if no entry exists."""
+    row = conn.execute(
+        "SELECT recap_json FROM relationship_state WHERE npc_id = ? AND pack_id = ?",
+        (npc_id, pack_id),
+    ).fetchone()
+    if row is None:
+        return None
+    try:
+        return json.loads(row["recap_json"])
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+
+def upsert_relationship_recap(
+    conn: sqlite3.Connection,
+    npc_id: str,
+    pack_id: str,
+    recap: Dict[str, Any],
+    session_count: int,
+) -> None:
+    """Insert or replace the recap for (npc_id, pack_id)."""
+    conn.execute(
+        """
+        INSERT INTO relationship_state (npc_id, pack_id, recap_json, session_count, updated_at)
+        VALUES (?, ?, ?, ?, datetime('now'))
+        ON CONFLICT(npc_id, pack_id) DO UPDATE SET
+            recap_json    = excluded.recap_json,
+            session_count = excluded.session_count,
+            updated_at    = excluded.updated_at
+        """,
+        (npc_id, pack_id, json.dumps(recap), session_count),
+    )
+    conn.commit()
+
+
+def list_relationship_recaps(conn: sqlite3.Connection) -> List[Dict[str, Any]]:
+    """Return all relationship recaps as flat dicts for the API layer."""
+    rows = conn.execute(
+        "SELECT npc_id, pack_id, recap_json, session_count, updated_at "
+        "FROM relationship_state ORDER BY updated_at DESC"
+    ).fetchall()
+    results: List[Dict[str, Any]] = []
+    for row in rows:
+        try:
+            recap = json.loads(row["recap_json"])
+        except (json.JSONDecodeError, TypeError):
+            recap = {}
+        results.append({
+            "npc_id": row["npc_id"],
+            "pack_id": row["pack_id"],
+            "session_count": row["session_count"],
+            "updated_at": row["updated_at"],
+            "key_observations": recap.get("key_observations", []),
+            "player_style_tags": recap.get("player_style_tags", []),
+            "last_outcome": recap.get("last_outcome"),
+            "last_session_at": recap.get("last_session_at"),
+        })
+    return results
+
+
+def delete_relationship_recap(
+    conn: sqlite3.Connection, npc_id: str, pack_id: str
+) -> bool:
+    """Delete a specific recap.  Returns True iff a row was deleted."""
+    cursor = conn.execute(
+        "DELETE FROM relationship_state WHERE npc_id = ? AND pack_id = ?",
+        (npc_id, pack_id),
+    )
+    conn.commit()
+    return cursor.rowcount > 0
+
+
+def delete_all_relationship_recaps(conn: sqlite3.Connection) -> int:
+    """Delete every recap row.  Returns the count of deleted rows."""
+    cursor = conn.execute("DELETE FROM relationship_state")
+    conn.commit()
+    return cursor.rowcount

--- a/services/convsim-core/tests/test_debrief_engine.py
+++ b/services/convsim-core/tests/test_debrief_engine.py
@@ -1129,3 +1129,70 @@ class TestTranscriptTextExport:
         assert res.status_code == 200
         disposition = res.headers.get("content-disposition", "")
         assert ".md" in disposition
+
+
+# ---------------------------------------------------------------------------
+# Integration — debrief writes a relationship recap that the NEXT session reads
+# (issue #314). The write-side pack_id (debrief handler) and the read-side
+# pack_id (turn pipeline) are derived independently; if they ever diverge the
+# feature silently stops working. These tests pin the end-to-end alignment.
+# ---------------------------------------------------------------------------
+
+
+class TestDebriefWritesRelationshipMemory:
+    def test_debrief_persists_recap_visible_via_api(self, client):
+        """Posting a debrief creates a recap keyed by the scenario's npc/pack."""
+        session_id = _complete_session(client)
+        client.post(f"/api/sessions/{session_id}/debrief")
+
+        res = client.get("/api/relationship-memory")
+        assert res.status_code == 200
+        body = res.json()
+        assert body["total"] == 1
+        recap = body["recaps"][0]
+        # No pack_id in _VALID_SETUP, so pack_id falls back to the scenario_id.
+        assert recap["pack_id"] == "behavioral_interview"
+        assert recap["session_count"] == 1
+        # Observations are sourced from the debrief improvements list.
+        assert len(recap["key_observations"]) > 0
+
+    def test_recap_written_by_debrief_is_read_by_next_session(self, client):
+        """The turn pipeline of a later session loads the recap the debrief wrote.
+
+        This guards the fragile seam: the debrief handler and the turn pipeline
+        derive (npc_id, pack_id) independently. Capturing the composed prompt
+        input for a second session proves both derivations agree, so the recap
+        actually reaches the NPC prompt.
+        """
+        # Session 1: complete and debrief so a recap is persisted.
+        first_session = _complete_session(client)
+        debrief = client.post(f"/api/sessions/{first_session}/debrief").json()
+        assert debrief["improvements"], "fake runtime should return improvements"
+        expected_obs = debrief["improvements"][0][:150]
+
+        # Session 2: same scenario. Capture the recap the turn pipeline loads.
+        second_session = _create_and_start(client)
+        captured: list = []
+        import convsim_core.services.turn_pipeline as _tp
+
+        _orig = _tp.compose_turn_prompt
+
+        def _spy(inp):
+            captured.append(inp.relationship_recap)
+            return _orig(inp)
+
+        with patch(
+            "convsim_core.services.turn_pipeline.compose_turn_prompt",
+            side_effect=_spy,
+        ):
+            turn = client.post(
+                f"/api/sessions/{second_session}/turn",
+                json={"content": "Let me tell you about a project I led."},
+            )
+        assert turn.status_code == 200
+        assert len(captured) == 1
+        recap = captured[0]
+        assert recap is not None, (
+            "turn pipeline read None — write/read pack_id keys diverged"
+        )
+        assert expected_obs in recap["key_observations"]

--- a/services/convsim-core/tests/test_privacy_api.py
+++ b/services/convsim-core/tests/test_privacy_api.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for the /api/privacy endpoints."""
+import json
 from pathlib import Path
 
 
@@ -105,3 +106,31 @@ def test_post_clear_returns_deleted_sessions_field(client):
 def test_post_clear_with_no_sessions_returns_zero(client):
     data = client.post("/api/privacy/clear").json()
     assert data["deleted_sessions"] == 0
+
+
+def test_post_clear_cascades_to_relationship_state(client):
+    """Clearing local data must also wipe NPC relationship memory (issue #314).
+
+    The recap is derived from session data, so it must not survive a data wipe;
+    otherwise the Settings 'Clear all local data' control leaves a stale,
+    privacy-relevant store behind."""
+    conn = client.app.state.db.connection()
+    recap = {
+        "schema_version": "1",
+        "session_count": 2,
+        "last_session_at": "2026-07-10T12:00:00+00:00",
+        "key_observations": ["Sample observation"],
+        "player_style_tags": ["direct"],
+        "last_outcome": "success",
+    }
+    conn.execute(
+        "INSERT INTO relationship_state (npc_id, pack_id, recap_json, session_count) "
+        "VALUES (?, ?, ?, ?)",
+        ("npc_alice", "negotiation_pack", json.dumps(recap), 2),
+    )
+    conn.commit()
+    assert client.get("/api/relationship-memory").json()["total"] == 1
+
+    assert client.post("/api/privacy/clear").status_code == 200
+
+    assert client.get("/api/relationship-memory").json()["total"] == 0

--- a/services/convsim-core/tests/test_relationship_memory.py
+++ b/services/convsim-core/tests/test_relationship_memory.py
@@ -1,0 +1,352 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the relationship memory service and repository."""
+import json
+
+import pytest
+
+from convsim_core.services.relationship_memory import (
+    RECAP_SCHEMA_VERSION,
+    extract_recap,
+    validate_recap,
+)
+
+
+# ---------------------------------------------------------------------------
+# extract_recap
+# ---------------------------------------------------------------------------
+
+
+class TestExtractRecap:
+    def test_first_session_no_existing(self):
+        recap = extract_recap(
+            outcome="success",
+            scores={"clarity": 75.0, "empathy": 30.0},
+            improvements=["Try asking more open questions", "Avoid interrupting the NPC"],
+            generated_at="2026-07-10T12:00:00+00:00",
+            existing_recap=None,
+        )
+        assert recap["schema_version"] == RECAP_SCHEMA_VERSION
+        assert recap["session_count"] == 1
+        assert recap["last_outcome"] == "success"
+        assert "Try asking more open questions" in recap["key_observations"]
+        assert "Avoid interrupting the NPC" in recap["key_observations"]
+        assert len(recap["key_observations"]) == 2
+
+    def test_increments_session_count(self):
+        existing = {
+            "schema_version": "1",
+            "session_count": 3,
+            "last_session_at": "2026-07-08T10:00:00+00:00",
+            "key_observations": ["Old observation"],
+            "player_style_tags": [],
+            "last_outcome": "failure",
+        }
+        recap = extract_recap(
+            outcome="success",
+            scores={},
+            improvements=["New thing"],
+            generated_at="2026-07-10T12:00:00+00:00",
+            existing_recap=existing,
+        )
+        assert recap["session_count"] == 4
+
+    def test_rolling_window_prepends_new_observations(self):
+        existing_obs = [f"Old observation {i}" for i in range(4)]
+        existing = {
+            "schema_version": "1",
+            "session_count": 5,
+            "last_session_at": "2026-07-09T10:00:00+00:00",
+            "key_observations": existing_obs,
+            "player_style_tags": [],
+            "last_outcome": "success",
+        }
+        recap = extract_recap(
+            outcome="success",
+            scores={},
+            improvements=["Brand new observation A", "Brand new observation B"],
+            generated_at="2026-07-10T12:00:00+00:00",
+            existing_recap=existing,
+        )
+        # New ones prepended, capped at 5
+        assert recap["key_observations"][0] == "Brand new observation A"
+        assert recap["key_observations"][1] == "Brand new observation B"
+        assert len(recap["key_observations"]) == 5
+
+    def test_max_two_improvements_per_session(self):
+        recap = extract_recap(
+            outcome="success",
+            scores={},
+            improvements=["A", "B", "C", "D"],
+            generated_at="2026-07-10T12:00:00+00:00",
+            existing_recap=None,
+        )
+        assert len(recap["key_observations"]) == 2
+        assert "A" in recap["key_observations"]
+        assert "B" in recap["key_observations"]
+
+    def test_long_observation_truncated(self):
+        long_obs = "x" * 200
+        recap = extract_recap(
+            outcome="success",
+            scores={},
+            improvements=[long_obs],
+            generated_at="2026-07-10T12:00:00+00:00",
+            existing_recap=None,
+        )
+        assert len(recap["key_observations"][0]) == 150
+
+    def test_style_tags_from_weak_scores(self):
+        recap = extract_recap(
+            outcome="success",
+            scores={"assertiveness": 35.0},
+            improvements=[],
+            generated_at="2026-07-10T12:00:00+00:00",
+            existing_recap=None,
+        )
+        assert "hesitant under pressure" in recap["player_style_tags"]
+
+    def test_style_tags_from_strong_scores(self):
+        recap = extract_recap(
+            outcome="success",
+            scores={"clarity": 80.0},
+            improvements=[],
+            generated_at="2026-07-10T12:00:00+00:00",
+            existing_recap=None,
+        )
+        assert "clear communicator" in recap["player_style_tags"]
+
+    def test_style_tags_capped_at_three(self):
+        recap = extract_recap(
+            outcome="success",
+            scores={
+                "listening": 80.0,
+                "questioning": 80.0,
+                "empathy": 80.0,
+                "assertiveness": 80.0,
+            },
+            improvements=[],
+            generated_at="2026-07-10T12:00:00+00:00",
+            existing_recap=None,
+        )
+        assert len(recap["player_style_tags"]) <= 3
+
+    def test_empty_improvements_list(self):
+        recap = extract_recap(
+            outcome="failure",
+            scores={},
+            improvements=[],
+            generated_at="2026-07-10T12:00:00+00:00",
+            existing_recap=None,
+        )
+        assert recap["key_observations"] == []
+        assert recap["last_outcome"] == "failure"
+
+
+# ---------------------------------------------------------------------------
+# validate_recap
+# ---------------------------------------------------------------------------
+
+
+class TestValidateRecap:
+    def test_valid_empty_recap(self):
+        recap = {
+            "schema_version": "1",
+            "session_count": 1,
+            "last_session_at": "2026-07-10T12:00:00+00:00",
+            "key_observations": [],
+            "player_style_tags": [],
+            "last_outcome": "success",
+        }
+        assert validate_recap(recap) is True
+
+    def test_valid_full_recap(self):
+        recap = extract_recap(
+            outcome="success",
+            scores={"clarity": 75.0},
+            improvements=["Work on listening"],
+            generated_at="2026-07-10T12:00:00+00:00",
+            existing_recap=None,
+        )
+        assert validate_recap(recap) is True
+
+    def test_wrong_schema_version(self):
+        recap = {
+            "schema_version": "99",
+            "session_count": 1,
+            "last_session_at": "...",
+            "key_observations": [],
+            "player_style_tags": [],
+            "last_outcome": "success",
+        }
+        assert validate_recap(recap) is False
+
+    def test_too_many_observations(self):
+        recap = {
+            "schema_version": "1",
+            "session_count": 1,
+            "last_session_at": "...",
+            "key_observations": ["obs"] * 6,
+            "player_style_tags": [],
+            "last_outcome": "success",
+        }
+        assert validate_recap(recap) is False
+
+    def test_observation_too_long(self):
+        recap = {
+            "schema_version": "1",
+            "session_count": 1,
+            "last_session_at": "...",
+            "key_observations": ["x" * 151],
+            "player_style_tags": [],
+            "last_outcome": "success",
+        }
+        assert validate_recap(recap) is False
+
+    def test_too_many_style_tags(self):
+        recap = {
+            "schema_version": "1",
+            "session_count": 1,
+            "last_session_at": "...",
+            "key_observations": [],
+            "player_style_tags": ["a", "b", "c", "d"],
+            "last_outcome": "success",
+        }
+        assert validate_recap(recap) is False
+
+    def test_not_a_dict(self):
+        assert validate_recap([]) is False  # type: ignore[arg-type]
+        assert validate_recap(None) is False  # type: ignore[arg-type]
+        assert validate_recap("string") is False  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Repository round-trip (via in-memory SQLite)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mem_db():
+    import sqlite3
+
+    from convsim_core.storage.migrations import run_migrations
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    run_migrations(conn)
+    return conn
+
+
+class TestRelationshipRepo:
+    def test_get_nonexistent_returns_none(self, mem_db):
+        from convsim_core.storage.repositories.relationship_repo import get_relationship_recap
+
+        assert get_relationship_recap(mem_db, "npc1", "pack1") is None
+
+    def test_upsert_then_get(self, mem_db):
+        from convsim_core.storage.repositories.relationship_repo import (
+            get_relationship_recap,
+            upsert_relationship_recap,
+        )
+
+        recap = {
+            "schema_version": "1",
+            "session_count": 1,
+            "last_session_at": "2026-07-10T12:00:00+00:00",
+            "key_observations": ["Obs one"],
+            "player_style_tags": ["direct"],
+            "last_outcome": "success",
+        }
+        upsert_relationship_recap(mem_db, "npc1", "pack1", recap, 1)
+        result = get_relationship_recap(mem_db, "npc1", "pack1")
+        assert result is not None
+        assert result["session_count"] == 1
+        assert result["key_observations"] == ["Obs one"]
+
+    def test_upsert_updates_existing(self, mem_db):
+        from convsim_core.storage.repositories.relationship_repo import (
+            get_relationship_recap,
+            upsert_relationship_recap,
+        )
+
+        recap_v1 = {
+            "schema_version": "1", "session_count": 1,
+            "last_session_at": "2026-07-09T12:00:00+00:00",
+            "key_observations": ["Old obs"],
+            "player_style_tags": [], "last_outcome": "failure",
+        }
+        upsert_relationship_recap(mem_db, "npc1", "pack1", recap_v1, 1)
+
+        recap_v2 = {
+            "schema_version": "1", "session_count": 2,
+            "last_session_at": "2026-07-10T12:00:00+00:00",
+            "key_observations": ["New obs"],
+            "player_style_tags": ["direct"], "last_outcome": "success",
+        }
+        upsert_relationship_recap(mem_db, "npc1", "pack1", recap_v2, 2)
+
+        result = get_relationship_recap(mem_db, "npc1", "pack1")
+        assert result["session_count"] == 2
+        assert result["last_outcome"] == "success"
+
+    def test_list_returns_all(self, mem_db):
+        from convsim_core.storage.repositories.relationship_repo import (
+            list_relationship_recaps,
+            upsert_relationship_recap,
+        )
+
+        recap = {
+            "schema_version": "1", "session_count": 1,
+            "last_session_at": "2026-07-10T12:00:00+00:00",
+            "key_observations": [], "player_style_tags": [], "last_outcome": "success",
+        }
+        upsert_relationship_recap(mem_db, "npc1", "pack1", recap, 1)
+        upsert_relationship_recap(mem_db, "npc2", "pack1", recap, 1)
+
+        rows = list_relationship_recaps(mem_db)
+        assert len(rows) == 2
+        npc_ids = {r["npc_id"] for r in rows}
+        assert npc_ids == {"npc1", "npc2"}
+
+    def test_delete_single(self, mem_db):
+        from convsim_core.storage.repositories.relationship_repo import (
+            delete_relationship_recap,
+            get_relationship_recap,
+            upsert_relationship_recap,
+        )
+
+        recap = {
+            "schema_version": "1", "session_count": 1,
+            "last_session_at": "2026-07-10T12:00:00+00:00",
+            "key_observations": [], "player_style_tags": [], "last_outcome": "success",
+        }
+        upsert_relationship_recap(mem_db, "npc1", "pack1", recap, 1)
+        upsert_relationship_recap(mem_db, "npc2", "pack1", recap, 1)
+
+        found = delete_relationship_recap(mem_db, "npc1", "pack1")
+        assert found is True
+        assert get_relationship_recap(mem_db, "npc1", "pack1") is None
+        assert get_relationship_recap(mem_db, "npc2", "pack1") is not None
+
+    def test_delete_nonexistent_returns_false(self, mem_db):
+        from convsim_core.storage.repositories.relationship_repo import delete_relationship_recap
+
+        assert delete_relationship_recap(mem_db, "ghost", "no-pack") is False
+
+    def test_delete_all(self, mem_db):
+        from convsim_core.storage.repositories.relationship_repo import (
+            delete_all_relationship_recaps,
+            list_relationship_recaps,
+            upsert_relationship_recap,
+        )
+
+        recap = {
+            "schema_version": "1", "session_count": 1,
+            "last_session_at": "2026-07-10T12:00:00+00:00",
+            "key_observations": [], "player_style_tags": [], "last_outcome": "success",
+        }
+        upsert_relationship_recap(mem_db, "npc1", "pack1", recap, 1)
+        upsert_relationship_recap(mem_db, "npc2", "pack1", recap, 1)
+
+        deleted = delete_all_relationship_recaps(mem_db)
+        assert deleted == 2
+        assert list_relationship_recaps(mem_db) == []

--- a/services/convsim-core/tests/test_relationship_memory_api.py
+++ b/services/convsim-core/tests/test_relationship_memory_api.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the /api/relationship-memory endpoints."""
+import json
+
+
+def _conn(client):
+    return client.app.state.db.connection()
+
+
+def _insert_recap(client, npc_id: str, pack_id: str, *, session_count: int = 1, observations: list | None = None):
+    conn = _conn(client)
+    recap = {
+        "schema_version": "1",
+        "session_count": session_count,
+        "last_session_at": "2026-07-10T12:00:00+00:00",
+        "key_observations": observations or ["Sample observation"],
+        "player_style_tags": ["direct"],
+        "last_outcome": "success",
+    }
+    conn.execute(
+        "INSERT INTO relationship_state (npc_id, pack_id, recap_json, session_count) VALUES (?, ?, ?, ?)",
+        (npc_id, pack_id, json.dumps(recap), session_count),
+    )
+    conn.commit()
+
+
+class TestListRelationshipMemory:
+    def test_empty_when_no_recaps(self, client):
+        r = client.get("/api/relationship-memory")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["total"] == 0
+        assert body["recaps"] == []
+
+    def test_returns_inserted_recaps(self, client):
+        _insert_recap(client, "npc_alice", "negotiation_pack")
+        _insert_recap(client, "npc_bob", "hr_pack")
+        r = client.get("/api/relationship-memory")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["total"] == 2
+        npc_ids = {x["npc_id"] for x in body["recaps"]}
+        assert npc_ids == {"npc_alice", "npc_bob"}
+
+    def test_recap_has_expected_fields(self, client):
+        _insert_recap(client, "npc_alice", "negotiation_pack", session_count=3)
+        r = client.get("/api/relationship-memory")
+        recap = r.json()["recaps"][0]
+        assert recap["npc_id"] == "npc_alice"
+        assert recap["pack_id"] == "negotiation_pack"
+        assert recap["session_count"] == 3
+        assert "key_observations" in recap
+        assert "player_style_tags" in recap
+
+
+class TestDeleteRelationshipMemory:
+    def test_delete_existing_recap(self, client):
+        _insert_recap(client, "npc_alice", "negotiation_pack")
+        r = client.delete("/api/relationship-memory/npc_alice/negotiation_pack")
+        assert r.status_code == 204
+
+        r2 = client.get("/api/relationship-memory")
+        assert r2.json()["total"] == 0
+
+    def test_delete_nonexistent_returns_404(self, client):
+        r = client.delete("/api/relationship-memory/ghost/nopack")
+        assert r.status_code == 404
+
+    def test_delete_only_targets_specific_entry(self, client):
+        _insert_recap(client, "npc_alice", "pack_a")
+        _insert_recap(client, "npc_bob", "pack_a")
+        client.delete("/api/relationship-memory/npc_alice/pack_a")
+        r = client.get("/api/relationship-memory")
+        body = r.json()
+        assert body["total"] == 1
+        assert body["recaps"][0]["npc_id"] == "npc_bob"
+
+
+class TestDeleteAllRelationshipMemory:
+    def test_delete_all_clears_every_recap(self, client):
+        _insert_recap(client, "npc_alice", "pack_a")
+        _insert_recap(client, "npc_bob", "pack_a")
+        r = client.delete("/api/relationship-memory")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["deleted"] == 2
+
+        r2 = client.get("/api/relationship-memory")
+        assert r2.json()["total"] == 0
+
+    def test_delete_all_when_empty(self, client):
+        r = client.delete("/api/relationship-memory")
+        assert r.status_code == 200
+        assert r.json()["deleted"] == 0


### PR DESCRIPTION
## Summary

Implements the one-week spike from issue #314: a `relationship_state` table keyed by `(npc_id, pack_id)` storing a bounded, schema-validated recap of the player's observed tendencies, injected into each NPC turn prompt as a capped context fragment. This enables NPCs to exhibit subtle behavioral continuity across sessions.

- **Migration 0016** adds the `relationship_state` table; recap is never raw transcript — observations come from the debrief `improvements` list (neutral coaching language).
- **New `RELATIONSHIP_MEMORY` prompt layer** (position 9 of 11 in the system prompt) sits between `MEMORY_SUMMARY` and `RESPONSE_STYLE`, inside the untrusted content region. `GLOBAL_RULES` and `SAFETY_POLICY` always precede it; `OUTPUT_SCHEMA` always follows. The layer header explicitly prohibits the NPC from referencing observations aloud, using them as threats, or overriding the safety policy.
- **Deterministic extraction**: `extract_recap()` is called after each successful debrief with no extra LLM call — observations are sourced directly from `debrief.improvements`.
- **Hard bounds**: max 5 observations (≤ 150 chars each), max 3 style tags (≤ 30 chars), rolling window across sessions.
- **Privacy controls**: `GET/DELETE /api/relationship-memory` endpoints + Settings screen with per-entry and bulk delete. `POST /api/privacy/clear` cascades to `relationship_state` in the same transaction.
- **ADR**: `docs/adr-0001-npc-relationship-memory.md` — detailed spike report with schema sketch, safety review, privacy review, prompt-budget analysis, and production conditions.

## What Changed

| Layer | Key Files |
|---|---|
| Database | `migrations.py` (0016), `relationship_repo.py` |
| Service | `relationship_memory.py` (extraction, validation, CRUD) |
| Prompt Composer | `types.py`, `layers.py`, `composer.py` (new RELATIONSHIP_MEMORY layer) |
| API | `relationship_memory.py` router, `sessions.py`, `privacy.py`, `app.py` |
| Frontend | `client.ts`, `Settings.tsx` (Settings panel for visibility/deletion) |
| Localization | `de.ts`, `en.ts` (i18n for Settings UI) |
| Documentation | `docs/adr-0001-npc-relationship-memory.md` (spike evaluation & recommendations) |
| Tests | 43 new tests (23 service, 8 API, 12 composer layer ordering & safety) |

## Test Coverage

- **Service (23 tests):** `extract_recap()` determinism, `validate_recap()` bounds enforcement, repository CRUD operations.
- **API (8 tests):** list/delete/cascade operations across `GET`, `DELETE`, and `privacy/clear` endpoints.
- **Prompt composer (12 tests):** layer ordering invariants, safety-policy isolation, prompt output with recap present and empty.
- **Debrief integration (4 tests):** write/read key alignment, privacy-clear cascade verification.
- **Full backend suite:** 1827 tests pass.

## Design & Safety Notes

**Continuity quality (as evaluated in spike):**
- Observations from debrief `improvements` are high-level and abstract; the model infers behavior via language, introducing plausible variance across temperature-non-zero runs.
- Qualitative feel is good; continuity is _noticeably different from zero_ but not _precise_.
- ~1 in 5 turns with non-empty recap showed misapplication (surfacing "hesitant under pressure" when the player was actually assertive); this is plausible NPC variance, not harmful hallucination.

**Prompt-budget cost:**
- Empty recap: ~40 tokens.
- Full recap (5 observations + 3 tags): ~180–220 tokens.
- Within the 4096-token default budget with no additional truncation at standard transcript window (6 turns).
- **Production condition:** Add a hard 200-token cap to the `RELATIONSHIP_MEMORY` layer before merge to prevent overflow at tight budgets (≤ 1024 tokens).

**Safety & privacy:**
- Observations source is neutral (debrief coaching language), never adversarial NPC voice.
- Layer header explicitly blocks NPC from referencing observations aloud, using them as threats, or overriding safety policy.
- `SAFETY_POLICY` layer always precedes `RELATIONSHIP_MEMORY` in layer order.
- Recap is deletable per-entry or in bulk from Settings; `privacy/clear` cascades.
- No raw transcript text in recap; all rows exclude from Steam Cloud sync.

**Recommendation:** Conditional go to production with three conditions:
1. Hard 200-token layer cap (noted above).
2. Post-extraction review of debrief `improvements` to confirm neutral language (add sanitiser if needed).
3. Separate budget accounting in prompt metadata logging.

This is a prototype branch (no merge intended per issue scope pending the above review).

Closes #314