### PR TITLE
Add one-click beta reporting: redacted diagnostics bundle and prefilled GitHub issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/beta-report.yml
+++ b/.github/ISSUE_TEMPLATE/beta-report.yml
@@ -1,0 +1,98 @@
+name: Beta feedback / bug report
+description: Report a bug or give feedback during the beta. Use the one-click bundle from Support → Report a problem for fastest turnaround.
+labels: ["beta-feedback"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping test Conversation Simulator! Beta feedback makes the
+        product better for everyone.
+
+        **Before filing:** use the **Support → Report a problem** flow in the
+        app to assemble a diagnostics bundle — it captures versions, OS info,
+        and recent error logs automatically.  Attach the resulting ZIP below.
+
+        **Privacy note:** Do not paste conversation transcripts, NPC session
+        logs, or audio recordings here. If the bug is transcript-specific,
+        describe it in general terms or use a made-up example.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe the bug or unexpected behaviour clearly.
+      placeholder: "Example: The debrief screen froze after I ended the conversation — no score appeared."
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+      placeholder: "Example: The debrief score and strengths summary should have appeared within a few seconds."
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps that reliably trigger the issue.
+      placeholder: |
+        1. Launch the app
+        2. Select "Job Interview Basics" → "The Executive Gauntlet"
+        3. Complete all turns and press "End conversation"
+        4. Debrief screen loads but score section never appears
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Build and environment
+      description: >
+        Paste the info from the diagnostics bundle's **versions.json** and
+        **system.txt**, or fill in manually.  The one-click bundle captures
+        this automatically.
+      placeholder: |
+        App version: 0.9.0-beta.3
+        OS: macOS 14.6.1 (Apple Silicon)
+        Model in use: Qwen3 8B Q4_K_M
+        Desktop app or browser: Desktop (Tauri)
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Error messages or log snippet
+      description: >
+        Paste relevant lines from recent_errors.txt in the diagnostics bundle,
+        or from the browser console.  Do not paste transcript content.
+      render: text
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: bundle
+    attributes:
+      label: Diagnostics bundle
+      options:
+        - label: >
+            I used **Support → Report a problem** to create a diagnostics
+            bundle and will attach the ZIP to this issue.
+          required: false
+        - label: >
+            I reviewed the bundle contents and confirmed it contains no
+            transcript text, personal information, or audio.
+          required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and this has not been reported before.
+          required: true
+        - label: This issue is reproducible — I can trigger it consistently.
+          required: false

--- a/README.md
+++ b/README.md
@@ -295,6 +295,17 @@ The Steam edition makes the same local-first guarantee as the open-source build.
 
 ---
 
+## Beta testing
+
+Running a pre-release build?  Use **Support → Report a problem** in the app to
+assemble a redacted diagnostics bundle and open a pre-filled GitHub issue — all
+in under a minute, nothing uploaded automatically.
+
+> [docs/beta-testing.md](docs/beta-testing.md) — how to join, where to report,
+> what a good report looks like
+
+---
+
 ## Contributing
 
 All contributions are welcome — new scenario packs, bug fixes, documentation

--- a/apps/web/src/__tests__/Support.test.tsx
+++ b/apps/web/src/__tests__/Support.test.tsx
@@ -7,11 +7,21 @@ import Support from '../screens/Support'
 vi.mock('../api/client', () => ({
   api: {
     createCrashBundle: vi.fn(),
+    createBetaReport: vi.fn(),
   },
 }))
 
 import { api } from '../api/client'
 const mockApi = vi.mocked(api)
+
+const BETA_MANIFEST = [
+  'versions.json — app, Python, and OS versions',
+  'system.txt — OS name, release, architecture',
+  'config.json — settings (home directory replaced with ~)',
+  'preflight.json — runtime / STT / TTS health snapshot',
+  'recent_errors.txt — last log lines at WARNING or above (no conversation content)',
+  'README.txt — privacy notice',
+]
 
 async function renderSupport() {
   render(
@@ -181,5 +191,184 @@ describe('crash bundle', () => {
       expect(screen.getByRole('alert')).toHaveTextContent(/connection failed/i),
     )
     expect(screen.getByTestId('crash-bundle-error')).toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Report a problem (beta one-click flow)
+// ---------------------------------------------------------------------------
+
+describe('report a problem', () => {
+  it('shows a Report a problem button', async () => {
+    await renderSupport()
+    expect(screen.getByTestId('report-problem-button')).toBeInTheDocument()
+  })
+
+  it('clicking Report a problem opens the consent screen', async () => {
+    await renderSupport()
+    fireEvent.click(screen.getByTestId('report-problem-button'))
+    expect(screen.getByTestId('beta-report-consent')).toBeInTheDocument()
+  })
+
+  it('consent screen shows a preview of the bundle manifest', async () => {
+    await renderSupport()
+    fireEvent.click(screen.getByTestId('report-problem-button'))
+    expect(screen.getByTestId('beta-report-manifest-preview')).toBeInTheDocument()
+    expect(screen.getByTestId('beta-report-manifest-preview')).toHaveTextContent(/versions\.json/i)
+    expect(screen.getByTestId('beta-report-manifest-preview')).toHaveTextContent(/preflight\.json/i)
+  })
+
+  it('consent screen shows the privacy note', async () => {
+    await renderSupport()
+    fireEvent.click(screen.getByTestId('report-problem-button'))
+    expect(screen.getByRole('note', { name: /beta report privacy note/i })).toBeInTheDocument()
+  })
+
+  it('session metadata checkbox is unchecked by default', async () => {
+    await renderSupport()
+    fireEvent.click(screen.getByTestId('report-problem-button'))
+    const checkbox = screen.getByTestId('include-session-metadata-checkbox') as HTMLInputElement
+    expect(checkbox.checked).toBe(false)
+  })
+
+  it('session_metadata.json appears in preview when checkbox is checked', async () => {
+    await renderSupport()
+    fireEvent.click(screen.getByTestId('report-problem-button'))
+    const checkbox = screen.getByTestId('include-session-metadata-checkbox')
+    fireEvent.click(checkbox)
+    expect(screen.getByTestId('beta-report-manifest-preview')).toHaveTextContent(/session_metadata\.json/i)
+  })
+
+  it('session_metadata.json does not appear in preview when checkbox is unchecked', async () => {
+    await renderSupport()
+    fireEvent.click(screen.getByTestId('report-problem-button'))
+    expect(screen.getByTestId('beta-report-manifest-preview')).not.toHaveTextContent(/session_metadata\.json/i)
+  })
+
+  it('Cancel button hides the consent screen', async () => {
+    await renderSupport()
+    fireEvent.click(screen.getByTestId('report-problem-button'))
+    fireEvent.click(screen.getByTestId('cancel-beta-report-button'))
+    expect(screen.queryByTestId('beta-report-consent')).not.toBeInTheDocument()
+    expect(screen.getByTestId('report-problem-button')).toBeInTheDocument()
+  })
+
+  it('clicking Create bundle calls createBetaReport with include_session_metadata=false by default', async () => {
+    mockApi.createBetaReport.mockResolvedValue({
+      ok: true,
+      data: {
+        bundle_path: '/tmp/beta-report.zip',
+        manifest: BETA_MANIFEST,
+        notice: 'Beta report bundle created locally. It is never transmitted automatically.',
+      },
+    })
+    await renderSupport()
+    fireEvent.click(screen.getByTestId('report-problem-button'))
+    fireEvent.click(screen.getByTestId('create-beta-report-button'))
+    await waitFor(() => expect(mockApi.createBetaReport).toHaveBeenCalledWith(false))
+  })
+
+  it('clicking Create bundle with opt-in passes include_session_metadata=true', async () => {
+    mockApi.createBetaReport.mockResolvedValue({
+      ok: true,
+      data: {
+        bundle_path: '/tmp/beta-report.zip',
+        manifest: [...BETA_MANIFEST, 'session_metadata.json — last session metadata'],
+        notice: 'Beta report bundle created locally.',
+      },
+    })
+    await renderSupport()
+    fireEvent.click(screen.getByTestId('report-problem-button'))
+    fireEvent.click(screen.getByTestId('include-session-metadata-checkbox'))
+    fireEvent.click(screen.getByTestId('create-beta-report-button'))
+    await waitFor(() => expect(mockApi.createBetaReport).toHaveBeenCalledWith(true))
+  })
+
+  it('shows the bundle path after successful creation', async () => {
+    mockApi.createBetaReport.mockResolvedValue({
+      ok: true,
+      data: {
+        bundle_path: '/home/user/.convsim/crashes/beta-report-2026.zip',
+        manifest: BETA_MANIFEST,
+        notice: 'Beta report bundle created locally.',
+      },
+    })
+    await renderSupport()
+    fireEvent.click(screen.getByTestId('report-problem-button'))
+    fireEvent.click(screen.getByTestId('create-beta-report-button'))
+    await waitFor(() =>
+      expect(screen.getByTestId('beta-report-path')).toHaveTextContent(
+        '/home/user/.convsim/crashes/beta-report-2026.zip',
+      ),
+    )
+  })
+
+  it('shows the bundle manifest after successful creation', async () => {
+    mockApi.createBetaReport.mockResolvedValue({
+      ok: true,
+      data: {
+        bundle_path: '/tmp/beta-report.zip',
+        manifest: BETA_MANIFEST,
+        notice: 'Beta report bundle created locally.',
+      },
+    })
+    await renderSupport()
+    fireEvent.click(screen.getByTestId('report-problem-button'))
+    fireEvent.click(screen.getByTestId('create-beta-report-button'))
+    await waitFor(() =>
+      expect(screen.getByTestId('beta-report-manifest')).toBeInTheDocument(),
+    )
+    expect(screen.getByTestId('beta-report-manifest')).toHaveTextContent(/versions\.json/i)
+  })
+
+  it('shows an Open GitHub issue link after successful creation', async () => {
+    mockApi.createBetaReport.mockResolvedValue({
+      ok: true,
+      data: {
+        bundle_path: '/tmp/beta-report.zip',
+        manifest: BETA_MANIFEST,
+        notice: 'Beta report bundle created locally.',
+      },
+    })
+    await renderSupport()
+    fireEvent.click(screen.getByTestId('report-problem-button'))
+    fireEvent.click(screen.getByTestId('create-beta-report-button'))
+    await waitFor(() =>
+      expect(screen.getByTestId('open-beta-issue-link')).toBeInTheDocument(),
+    )
+    const link = screen.getByTestId('open-beta-issue-link')
+    expect(link).toHaveAttribute('href', expect.stringContaining('beta-report.yml'))
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('shows an error when beta report creation fails', async () => {
+    mockApi.createBetaReport.mockResolvedValue({
+      ok: false,
+      error: { kind: 'network', message: 'Core service unavailable' },
+    })
+    await renderSupport()
+    fireEvent.click(screen.getByTestId('report-problem-button'))
+    fireEvent.click(screen.getByTestId('create-beta-report-button'))
+    await waitFor(() =>
+      expect(screen.getByTestId('beta-report-error')).toBeInTheDocument(),
+    )
+  })
+
+  it('success screen has a "Done" button that resets the flow', async () => {
+    mockApi.createBetaReport.mockResolvedValue({
+      ok: true,
+      data: {
+        bundle_path: '/tmp/beta-report.zip',
+        manifest: BETA_MANIFEST,
+        notice: 'Beta report bundle created locally.',
+      },
+    })
+    await renderSupport()
+    fireEvent.click(screen.getByTestId('report-problem-button'))
+    fireEvent.click(screen.getByTestId('create-beta-report-button'))
+    await waitFor(() => expect(screen.getByTestId('beta-report-success')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: /done/i }))
+    await waitFor(() => expect(screen.getByTestId('report-problem-button')).toBeInTheDocument())
   })
 })

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -402,6 +402,9 @@ export const api = {
   createCrashBundle(): Promise<ApiResult<{ bundle_path: string; notice: string }>> {
     return post<{ bundle_path: string; notice: string }>('/diag/crash-bundle')
   },
+  createBetaReport(includeSessionMetadata: boolean): Promise<ApiResult<{ bundle_path: string; manifest: string[]; notice: string }>> {
+    return post<{ bundle_path: string; manifest: string[]; notice: string }>('/diag/beta-report', { include_session_metadata: includeSessionMetadata })
+  },
   deleteSession(sessionId: string): Promise<ApiResult<undefined>> {
     return del(`/sessions/${sessionId}`)
   },

--- a/apps/web/src/components/RuntimeRecoveryCard.tsx
+++ b/apps/web/src/components/RuntimeRecoveryCard.tsx
@@ -25,6 +25,8 @@ interface RuntimeRecoveryCardProps {
   secondaryAction?: RecoveryAction
   /** Tertiary action — e.g. "Get support bundle". */
   tertiaryAction?: RecoveryAction
+  /** When set, renders a "Report a problem" link pointing to this URL. */
+  reportProblemHref?: string
 }
 
 const cardStyle: React.CSSProperties = {
@@ -126,6 +128,7 @@ export default function RuntimeRecoveryCard({
   primaryAction,
   secondaryAction,
   tertiaryAction,
+  reportProblemHref,
 }: RuntimeRecoveryCardProps) {
   return (
     <div role="alert" style={cardStyle}>
@@ -146,6 +149,17 @@ export default function RuntimeRecoveryCard({
         <a href={troubleshootingHref} target="_blank" rel="noreferrer" style={linkStyle}>
           {troubleshootingLabel}
         </a>
+        {reportProblemHref && (
+          <a
+            href={reportProblemHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={linkStyle}
+            data-testid="recovery-card-report-problem"
+          >
+            Report a problem →
+          </a>
+        )}
       </div>
     </div>
   )

--- a/apps/web/src/screens/Home.tsx
+++ b/apps/web/src/screens/Home.tsx
@@ -14,6 +14,8 @@ const DOCS_URL = 'https://github.com/outrightmental/ConversationSimulator/wiki'
 const ISSUES_URL = 'https://github.com/outrightmental/ConversationSimulator/issues/new/choose'
 const TROUBLESHOOTING_BASE =
   'https://github.com/outrightmental/ConversationSimulator/blob/main/docs/troubleshooting.md'
+const BETA_REPORT_URL =
+  'https://github.com/outrightmental/ConversationSimulator/issues/new?template=beta-report.yml&labels=beta-feedback'
 
 export default function Home() {
   const health = useApiHealth()
@@ -272,6 +274,7 @@ export default function Home() {
                 label: t('home.unreachable.openSupport'),
                 href: '/support',
               }}
+              reportProblemHref={BETA_REPORT_URL}
             />
           )}
           {lastError && (
@@ -292,6 +295,7 @@ export default function Home() {
                   label: t('home.recovery.openSupport'),
                   href: '/support',
                 }}
+                reportProblemHref={BETA_REPORT_URL}
               />
             ) : (
               <RuntimeRecoveryCard
@@ -313,6 +317,7 @@ export default function Home() {
                   label: t('home.lastError.reportIssue'),
                   href: ISSUES_URL,
                 }}
+                reportProblemHref={BETA_REPORT_URL}
               />
             )
           )}

--- a/apps/web/src/screens/Support.tsx
+++ b/apps/web/src/screens/Support.tsx
@@ -8,6 +8,8 @@ const ISSUES_URL = 'https://github.com/outrightmental/ConversationSimulator/issu
 const TEMPLATE_BASE = 'https://github.com/outrightmental/ConversationSimulator/issues/new?template='
 const BETA_REPORT_TEMPLATE_URL =
   'https://github.com/outrightmental/ConversationSimulator/issues/new?template=beta-report.yml&labels=beta-feedback'
+const BETA_GUIDE_URL =
+  'https://github.com/outrightmental/ConversationSimulator/blob/main/docs/beta-testing.md'
 
 const ISSUE_TEMPLATES = [
   { key: 'bug_report', label: 'Bug report', template: 'bug_report.yml' },
@@ -131,6 +133,19 @@ export default function Support() {
         <p style={{ fontSize: '0.875rem', color: '#a1a1aa', marginBottom: '0.75rem' }}>
           Assemble a diagnostics bundle, review its contents, and open a pre-filled GitHub
           issue — all in under a minute. Nothing leaves this device until you explicitly send it.
+        </p>
+        <p style={{ fontSize: '0.8rem', color: '#a1a1aa', marginBottom: '0.75rem' }}>
+          New to the beta? Read the{' '}
+          <a
+            href={BETA_GUIDE_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            data-testid="beta-guide-link"
+            style={{ color: '#a5b4fc' }}
+          >
+            beta testing guide →
+          </a>{' '}
+          for how to join, what to report, and what a good report looks like.
         </p>
 
         {betaStep === 'idle' && (

--- a/apps/web/src/screens/Support.tsx
+++ b/apps/web/src/screens/Support.tsx
@@ -116,6 +116,7 @@ export default function Support() {
           'session_metadata.json — last session: scenario ID, state, turn count, timestamps (no transcript content)',
         ]
       : []),
+    'crash-bundle.zip — most recent crash bundle, if one exists (already redacted)',
     DEFAULT_MANIFEST[DEFAULT_MANIFEST.length - 1],
   ]
 

--- a/apps/web/src/screens/Support.tsx
+++ b/apps/web/src/screens/Support.tsx
@@ -6,6 +6,8 @@ import { ApiErrorView } from '../components/ApiErrorView'
 
 const ISSUES_URL = 'https://github.com/outrightmental/ConversationSimulator/issues/new/choose'
 const TEMPLATE_BASE = 'https://github.com/outrightmental/ConversationSimulator/issues/new?template='
+const BETA_REPORT_TEMPLATE_URL =
+  'https://github.com/outrightmental/ConversationSimulator/issues/new?template=beta-report.yml&labels=beta-feedback'
 
 const ISSUE_TEMPLATES = [
   { key: 'bug_report', label: 'Bug report', template: 'bug_report.yml' },
@@ -20,7 +22,28 @@ const ISSUE_TEMPLATES = [
   { key: 'feature_proposal', label: 'Feature request', template: 'feature_proposal.yml' },
 ]
 
+// Default manifest shown before the bundle is created (mirrors beta_report.py).
+const DEFAULT_MANIFEST = [
+  'versions.json — app, Python, and OS versions',
+  'system.txt — OS name, release, architecture',
+  'config.json — settings (home directory replaced with ~)',
+  'preflight.json — runtime / STT / TTS health snapshot',
+  'recent_errors.txt — last log lines at WARNING or above (no conversation content)',
+  'README.txt — privacy notice',
+]
+
 type CrashBundleState = 'idle' | 'creating' | 'done' | 'error'
+type BetaReportStep = 'idle' | 'consent' | 'creating' | 'done' | 'error'
+
+/** Opens a local folder in the OS file manager via the Tauri shell plugin. */
+async function openFolderInShell(folderPath: string): Promise<void> {
+  const tauri = (window as { __TAURI__?: { core?: { invoke?: (cmd: string, args?: unknown) => Promise<void> } } }).__TAURI__
+  const invoke = tauri?.core?.invoke
+  if (!invoke) {
+    throw new Error('Desktop shell is unavailable')
+  }
+  await invoke('plugin:shell|open', { path: folderPath })
+}
 
 function SectionHeading({ children }: { children: React.ReactNode }) {
   return (
@@ -35,6 +58,13 @@ export default function Support() {
   const [bundlePath, setBundlePath] = useState<string | null>(null)
   const [bundleNotice, setBundleNotice] = useState<string | null>(null)
   const [crashError, setCrashError] = useState<ApiError | null>(null)
+
+  const [betaStep, setBetaStep] = useState<BetaReportStep>('idle')
+  const [includeSessionMeta, setIncludeSessionMeta] = useState(false)
+  const [betaBundlePath, setBetaBundlePath] = useState<string | null>(null)
+  const [betaManifest, setBetaManifest] = useState<string[] | null>(null)
+  const [betaError, setBetaError] = useState<ApiError | null>(null)
+  const [betaFolderError, setBetaFolderError] = useState<string | null>(null)
 
   async function handleCreateCrashBundle() {
     setCrashState('creating')
@@ -52,6 +82,41 @@ export default function Support() {
     }
   }
 
+  async function handleCreateBetaReport() {
+    setBetaStep('creating')
+    setBetaError(null)
+    setBetaBundlePath(null)
+    setBetaManifest(null)
+    setBetaFolderError(null)
+    const r = await api.createBetaReport(includeSessionMeta)
+    if (r.ok) {
+      setBetaBundlePath(r.data.bundle_path)
+      setBetaManifest(r.data.manifest)
+      setBetaStep('done')
+      const parentDir = r.data.bundle_path.replace(/[\\/][^\\/]+$/, '')
+      try {
+        await openFolderInShell(parentDir)
+      } catch {
+        // Tauri not available or path rejected — show the path so the user can
+        // navigate there manually (non-fatal).
+        setBetaFolderError(parentDir)
+      }
+    } else {
+      setBetaError(r.error)
+      setBetaStep('error')
+    }
+  }
+
+  const previewManifest = [
+    ...DEFAULT_MANIFEST.slice(0, -1),
+    ...(includeSessionMeta
+      ? [
+          'session_metadata.json — last session: scenario ID, state, turn count, timestamps (no transcript content)',
+        ]
+      : []),
+    DEFAULT_MANIFEST[DEFAULT_MANIFEST.length - 1],
+  ]
+
   return (
     <div style={{ maxWidth: '640px' }}>
       <h1 style={{ marginBottom: '0.5rem' }}>Support</h1>
@@ -60,7 +125,231 @@ export default function Support() {
         automatically.
       </p>
 
-      {/* Report an issue */}
+      {/* ── Report a problem (beta one-click) ─────────────────────────────── */}
+      <section style={{ marginBottom: '2rem' }}>
+        <SectionHeading>Report a problem</SectionHeading>
+        <p style={{ fontSize: '0.875rem', color: '#a1a1aa', marginBottom: '0.75rem' }}>
+          Assemble a diagnostics bundle, review its contents, and open a pre-filled GitHub
+          issue — all in under a minute. Nothing leaves this device until you explicitly send it.
+        </p>
+
+        {betaStep === 'idle' && (
+          <button
+            onClick={() => setBetaStep('consent')}
+            data-testid="report-problem-button"
+            style={{
+              padding: '0.45rem 1rem',
+              borderRadius: '6px',
+              border: '1px solid rgba(99,102,241,0.4)',
+              background: 'rgba(99,102,241,0.12)',
+              color: '#a5b4fc',
+              fontSize: '0.875rem',
+              cursor: 'pointer',
+            }}
+          >
+            Report a problem
+          </button>
+        )}
+
+        {(betaStep === 'consent') && (
+          <div
+            role="region"
+            aria-label="beta report consent"
+            data-testid="beta-report-consent"
+            style={{
+              background: 'rgba(255,255,255,0.03)',
+              border: '1px solid rgba(255,255,255,0.10)',
+              borderRadius: '8px',
+              padding: '1rem 1.1rem',
+            }}
+          >
+            <p style={{ fontSize: '0.85rem', fontWeight: 600, marginBottom: '0.5rem', color: '#e8e8ea' }}>
+              Bundle contents
+            </p>
+            <p style={{ fontSize: '0.8rem', color: '#a1a1aa', marginBottom: '0.6rem' }}>
+              The following files will be saved to your crash-bundles folder. Review this list
+              before continuing — nothing is written until you click "Create bundle".
+            </p>
+            <ul
+              data-testid="beta-report-manifest-preview"
+              style={{ listStyle: 'disc', paddingLeft: '1.2rem', margin: '0 0 0.85rem', fontSize: '0.8rem', color: '#a1a1aa', display: 'flex', flexDirection: 'column', gap: '0.25rem' }}
+            >
+              {previewManifest.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+
+            <label
+              style={{ display: 'flex', alignItems: 'flex-start', gap: '0.5rem', fontSize: '0.8rem', color: '#a1a1aa', cursor: 'pointer', marginBottom: '0.85rem' }}
+            >
+              <input
+                type="checkbox"
+                data-testid="include-session-metadata-checkbox"
+                checked={includeSessionMeta}
+                onChange={(e) => setIncludeSessionMeta(e.target.checked)}
+                style={{ marginTop: '2px', flexShrink: 0 }}
+              />
+              <span>
+                Include last session metadata (opt-in) — adds scenario ID, session state,
+                turn count, and timestamps. <strong>Never includes transcript content or
+                player input.</strong>
+              </span>
+            </label>
+
+            <div
+              role="note"
+              aria-label="beta report privacy note"
+              style={{
+                background: 'rgba(251,191,36,0.08)',
+                border: '1px solid rgba(251,191,36,0.2)',
+                borderRadius: '6px',
+                padding: '0.55rem 0.8rem',
+                marginBottom: '0.85rem',
+                fontSize: '0.8rem',
+                color: '#fde68a',
+              }}
+            >
+              No conversation transcripts, prompts, or audio are ever included. Filesystem paths
+              have the username replaced with ~. Nothing is transmitted — you must attach the
+              bundle manually.
+            </div>
+
+            <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+              <button
+                onClick={() => void handleCreateBetaReport()}
+                data-testid="create-beta-report-button"
+                style={{
+                  padding: '0.4rem 0.9rem',
+                  borderRadius: '6px',
+                  border: '1px solid rgba(99,102,241,0.4)',
+                  background: 'rgba(99,102,241,0.15)',
+                  color: '#a5b4fc',
+                  fontSize: '0.875rem',
+                  cursor: 'pointer',
+                }}
+              >
+                Create bundle
+              </button>
+              <button
+                onClick={() => { setBetaStep('idle'); setIncludeSessionMeta(false) }}
+                data-testid="cancel-beta-report-button"
+                style={{
+                  padding: '0.4rem 0.9rem',
+                  borderRadius: '6px',
+                  border: '1px solid rgba(255,255,255,0.1)',
+                  background: 'transparent',
+                  color: '#71717a',
+                  fontSize: '0.875rem',
+                  cursor: 'pointer',
+                }}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+
+        {betaStep === 'creating' && (
+          <p style={{ fontSize: '0.875rem', color: '#a1a1aa' }}>Creating bundle…</p>
+        )}
+
+        {betaStep === 'done' && betaBundlePath && (
+          <div data-testid="beta-report-success" style={{ marginTop: '0.5rem' }}>
+            <p style={{ fontSize: '0.85rem', color: '#86efac', marginBottom: '0.5rem' }}>
+              Bundle created. Review its contents before attaching to an issue.
+            </p>
+            <code
+              data-testid="beta-report-path"
+              style={{
+                display: 'block',
+                padding: '0.4rem 0.6rem',
+                background: 'rgba(255,255,255,0.05)',
+                borderRadius: '4px',
+                fontSize: '0.8rem',
+                wordBreak: 'break-all',
+                marginBottom: '0.5rem',
+              }}
+            >
+              {betaBundlePath}
+            </code>
+            {betaFolderError && (
+              <p style={{ fontSize: '0.8rem', color: '#a1a1aa', marginBottom: '0.5rem' }}>
+                Navigate to this folder in your file manager to find the bundle.
+              </p>
+            )}
+            {betaManifest && (
+              <ul
+                data-testid="beta-report-manifest"
+                style={{ listStyle: 'disc', paddingLeft: '1.2rem', margin: '0 0 0.75rem', fontSize: '0.8rem', color: '#71717a', display: 'flex', flexDirection: 'column', gap: '0.2rem' }}
+              >
+                {betaManifest.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            )}
+            <a
+              href={BETA_REPORT_TEMPLATE_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              data-testid="open-beta-issue-link"
+              style={{
+                display: 'inline-block',
+                padding: '0.4rem 0.9rem',
+                borderRadius: '6px',
+                border: '1px solid rgba(99,102,241,0.4)',
+                background: 'rgba(99,102,241,0.12)',
+                color: '#a5b4fc',
+                fontSize: '0.875rem',
+                textDecoration: 'none',
+                marginRight: '0.5rem',
+              }}
+            >
+              Open GitHub issue →
+            </a>
+            <button
+              onClick={() => { setBetaStep('idle'); setIncludeSessionMeta(false) }}
+              style={{
+                padding: '0.4rem 0.9rem',
+                borderRadius: '6px',
+                border: '1px solid rgba(255,255,255,0.1)',
+                background: 'transparent',
+                color: '#71717a',
+                fontSize: '0.875rem',
+                cursor: 'pointer',
+              }}
+            >
+              Done
+            </button>
+          </div>
+        )}
+
+        {betaStep === 'error' && betaError && (
+          <div data-testid="beta-report-error" style={{ marginTop: '0.5rem' }}>
+            <ApiErrorView
+              error={betaError}
+              onRetry={() => void handleCreateBetaReport()}
+              context="Support-BetaReport"
+            />
+            <button
+              onClick={() => setBetaStep('consent')}
+              style={{
+                marginTop: '0.5rem',
+                padding: '0.35rem 0.8rem',
+                borderRadius: '6px',
+                border: '1px solid rgba(255,255,255,0.1)',
+                background: 'transparent',
+                color: '#71717a',
+                fontSize: '0.8rem',
+                cursor: 'pointer',
+              }}
+            >
+              Back
+            </button>
+          </div>
+        )}
+      </section>
+
+      {/* ── Report an issue ───────────────────────────────────────────────── */}
       <section style={{ marginBottom: '2rem' }}>
         <SectionHeading>Report an issue</SectionHeading>
         <p style={{ fontSize: '0.875rem', color: '#a1a1aa', marginBottom: '0.75rem' }}>
@@ -100,7 +389,7 @@ export default function Support() {
         </p>
       </section>
 
-      {/* Crash bundle */}
+      {/* ── Crash bundle ─────────────────────────────────────────────────── */}
       <section style={{ marginBottom: '2rem' }}>
         <SectionHeading>Crash bundle</SectionHeading>
         <p style={{ fontSize: '0.875rem', color: '#a1a1aa', marginBottom: '0.75rem' }}>
@@ -185,7 +474,7 @@ export default function Support() {
         )}
       </section>
 
-      {/* Local-first reminder */}
+      {/* ── Local-first reminder ─────────────────────────────────────────── */}
       <section>
         <SectionHeading>Privacy reminder</SectionHeading>
         <p style={{ fontSize: '0.875rem', color: '#a1a1aa' }}>

--- a/docs/beta-testing.md
+++ b/docs/beta-testing.md
@@ -1,0 +1,132 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+# Beta Testing Guide
+
+This guide covers how to join the Conversation Simulator beta, where to report
+problems, and what makes a great bug report.
+
+---
+
+## How to join
+
+The beta runs on the `main` branch.  There is no separate opt-in — if you can
+build from source or install a pre-release build, you are a beta tester.
+
+```bash
+git clone https://github.com/outrightmental/ConversationSimulator
+cd ConversationSimulator
+./scripts/setup.sh
+./scripts/dev.sh
+```
+
+Steam early access releases are tagged `beta/*` in the repository.
+
+---
+
+## Where to report
+
+### One-click reporting (recommended)
+
+The fastest way to file a useful report:
+
+1. Open the app and go to **Support** (sidebar or menu).
+2. Click **Report a problem**.
+3. Review the list of files that will be included — nothing is written yet.
+4. Optionally check **Include last session metadata** to add turn count and
+   scenario ID (no transcript content, ever).
+5. Click **Create bundle** — the ZIP is saved locally and your crash-bundles
+   folder opens so you can verify its contents.
+6. Click **Open GitHub issue →** — a pre-filled issue form opens in your
+   browser.
+7. Attach the ZIP from step 5, fill in what happened, and submit.
+
+The whole flow takes under a minute and gives the team everything needed to
+reproduce most bugs.
+
+### Manual reporting
+
+If the app will not start or the Support screen is unreachable, open a
+[Beta feedback / bug report][new-issue] issue manually.  Include:
+
+- App version (shown in the title bar or `versions.json` in a crash bundle)
+- OS and architecture (e.g. "macOS 14.6 Apple Silicon")
+- A clear description of what happened and what you expected
+- Steps to reproduce
+
+[new-issue]: https://github.com/outrightmental/ConversationSimulator/issues/new?template=beta-report.yml&labels=beta-feedback
+
+---
+
+## Privacy
+
+Conversation Simulator is **local-first**.  The diagnostics bundle the
+one-click flow creates contains:
+
+| File | Contents |
+|------|----------|
+| `versions.json` | App version, Python version, OS platform string |
+| `system.txt` | OS name, release, CPU architecture |
+| `config.json` | App settings; home-directory paths replaced with `~` |
+| `preflight.json` | Runtime, STT, and TTS health snapshot (no user data) |
+| `recent_errors.txt` | Last log lines at WARNING level or above |
+| `session_metadata.json` | (opt-in only) Scenario ID, session state, turn count, timestamps |
+| `README.txt` | Privacy notice |
+
+**What is never included:**
+
+- Conversation transcripts or NPC responses
+- Player input or audio recordings
+- LLM prompts or model outputs
+- Real filesystem paths (the username portion is replaced with `~`)
+
+The bundle is written locally and never transmitted automatically.  You review
+it before attaching it to an issue.
+
+---
+
+## What makes a great report
+
+A report that gets fixed quickly includes:
+
+1. **A single, reproducible behaviour** — one bug per issue.
+2. **Exact steps** — numbered list, starting from app launch.
+3. **Expected vs actual outcome** — what should have happened, what did happen.
+4. **A diagnostics bundle** — created with **Support → Report a problem**; it
+   captures versions and error logs so you don't have to paste them manually.
+5. **No transcript content** — describe scenario-specific bugs in general
+   terms; the team can reproduce them with any pack.
+
+### Example of a good report
+
+> **What happened:** After ending a conversation, the debrief screen loads but
+> the score card never appears — it spins indefinitely.
+>
+> **Expected:** Score and strengths should appear within 5 seconds.
+>
+> **Steps:**
+> 1. Launch app
+> 2. Select "Job Interview Basics" → "The Executive Gauntlet"
+> 3. Complete 4 turns and press "End conversation"
+> 4. Debrief screen: spinner visible, score section never populates
+>
+> **Environment:** App 0.9.0-beta.3, macOS 14.6 Apple Silicon, Qwen3 8B Q4_K_M
+>
+> **Bundle attached:** crash-bundles/beta-report-20260710T141500Z.zip
+
+---
+
+## Scope of the beta
+
+During the beta we are particularly interested in feedback on:
+
+- **Local model compatibility** — does your model load and produce sensible
+  responses?
+- **Voice / STT / TTS** — transcription accuracy, TTS naturalness, VAD
+  sensitivity.
+- **Scenario packs** — logic errors, inconsistent NPC state, missing events.
+- **Performance** — startup time, latency, memory use on lower-end hardware.
+- **Installation** — setup script failures, missing dependencies.
+
+Feature requests are welcome but lower priority until core stability is
+established.  Use the [feature proposal template][feature] for those.
+
+[feature]: https://github.com/outrightmental/ConversationSimulator/issues/new?template=feature_proposal.yml

--- a/docs/beta-testing.md
+++ b/docs/beta-testing.md
@@ -69,6 +69,7 @@ one-click flow creates contains:
 | `preflight.json` | Runtime, STT, and TTS health snapshot (no user data) |
 | `recent_errors.txt` | Last log lines at WARNING level or above |
 | `session_metadata.json` | (opt-in only) Scenario ID, session state, turn count, timestamps |
+| `crash-bundle.zip` | (if one exists) Most recent crash bundle — already redacted |
 | `README.txt` | Privacy notice |
 
 **What is never included:**

--- a/services/convsim-core/convsim_core/beta_report.py
+++ b/services/convsim-core/convsim_core/beta_report.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Beta report bundle creation.
+
+Extends the crash bundle with a preflight snapshot and optional last-session
+metadata (never transcript content).  Like crash bundles, beta report bundles
+are written locally and never transmitted automatically — the tester must
+review and attach them manually.
+
+Bundle contents:
+  versions.json          — app, Python, and OS version strings
+  config.json            — sanitised settings (home paths replaced by ~)
+  preflight.json         — runtime/stt/tts health snapshot (no user data)
+  recent_errors.txt      — redacted tail of app.log
+  session_metadata.json  — (opt-in) last session: scenario, turn count, state;
+                            never includes transcript content or player input
+  README.txt             — privacy notice
+"""
+from __future__ import annotations
+
+import json
+import platform
+import sqlite3
+import sys
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from convsim_core import __version__
+from convsim_core.crash_report import _safe_settings, _tail_log, _MAX_LOG_TAIL_LINES
+from convsim_core.models import AppSettings
+from convsim_core.redaction import redact_path
+
+_BUNDLE_README = """\
+BETA REPORT BUNDLE — ConversationSimulator
+==========================================
+
+This file was created locally on your device.
+It has NOT been transmitted anywhere automatically.
+
+Please review the contents below before attaching it to a GitHub issue.
+Open the ZIP in a text editor or archive viewer to confirm it contains
+only the system and diagnostic information described here.
+
+Contents
+--------
+  versions.json          — App, Python, and OS version strings
+  config.json            — Settings with home-directory paths replaced by ~
+  preflight.json         — Runtime, STT, and TTS health snapshot (no user data)
+  recent_errors.txt      — Last lines of app.log (no conversation content)
+  session_metadata.json  — Last session stats (only if you opted in; no transcript
+                           content, no player input, no NPC responses)
+  README.txt             — This file
+
+Privacy notes
+-------------
+  - No conversation transcripts, prompts, audio, or player input are included.
+  - The optional session_metadata.json contains only: scenario identifier,
+    session state (e.g. "Completed"), turn count, and timestamps.  No text.
+  - Filesystem paths have the username portion replaced with ~.
+  - Sharing this bundle is entirely at your discretion.
+
+Attach to:
+  https://github.com/outrightmental/ConversationSimulator/issues/new?template=beta-report.yml
+"""
+
+# Fields extracted from the last session row that are safe to include.
+# Deliberately omits: setup_json (contains player name), state_vars_json,
+# fired_events_json (may contain event keys derived from scenario content).
+_SAFE_SESSION_FIELDS: tuple[str, ...] = (
+    "session_id",
+    "scenario_id",
+    "flow_state",
+    "ending_type",
+    "turn_count",
+    "created_at",
+    "ended_at",
+)
+
+
+def _last_session_metadata(conn: sqlite3.Connection) -> dict[str, Any] | None:
+    """Return metadata for the most recent session, or None if no sessions exist.
+
+    Only safe, non-identifying fields are included (see ``_SAFE_SESSION_FIELDS``).
+    Transcript content, player input, and NPC responses are never included.
+    """
+    try:
+        cursor = conn.execute(
+            "SELECT session_id, scenario_id, flow_state, ending_type, "
+            "turn_count, created_at, ended_at "
+            "FROM turn_sessions ORDER BY created_at DESC LIMIT 1"
+        )
+        row = cursor.fetchone()
+    except sqlite3.OperationalError:
+        return None
+    if row is None:
+        return None
+    return dict(zip(_SAFE_SESSION_FIELDS, row, strict=False))
+
+
+def create_beta_report_bundle(
+    log_dir: str,
+    settings: AppSettings,
+    preflight: dict[str, Any],
+    bundle_dir: str | None = None,
+    db_conn: sqlite3.Connection | None = None,
+    include_session_metadata: bool = False,
+) -> Path:
+    """Create a local beta-report ZIP bundle.
+
+    Parameters
+    ----------
+    log_dir:
+        Directory containing ``app.log``.
+    settings:
+        Current application settings (paths are sanitised before inclusion).
+    preflight:
+        A health/runtime snapshot dict safe to include verbatim (must not
+        contain transcripts or user input — callers are responsible).
+    bundle_dir:
+        Directory to write the bundle into.  Falls back to
+        ``<log_dir>/beta-reports/`` when *None*.
+    db_conn:
+        Open SQLite connection used to read the last session metadata when
+        ``include_session_metadata`` is True.  Ignored otherwise.
+    include_session_metadata:
+        When True, include a ``session_metadata.json`` file with non-identifying
+        fields from the last session (no transcript content or player input).
+
+    Returns the absolute :class:`~pathlib.Path` to the created ``.zip`` file.
+    """
+    dest = (
+        Path(bundle_dir) if bundle_dir is not None else Path(log_dir) / "beta-reports"
+    )
+    dest.mkdir(parents=True, exist_ok=True)
+
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    bundle_path = dest / f"beta-report-{ts}.zip"
+
+    versions = {
+        "app": __version__,
+        "python": sys.version,
+        "platform": platform.platform(),
+    }
+
+    system_info = {
+        "os": platform.system(),
+        "os_release": platform.release(),
+        "machine": platform.machine(),
+        "python_implementation": platform.python_implementation(),
+    }
+
+    recent_errors = _tail_log(Path(log_dir) / "app.log", _MAX_LOG_TAIL_LINES)
+
+    with zipfile.ZipFile(bundle_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("versions.json", json.dumps(versions, indent=2))
+        zf.writestr("config.json", json.dumps(_safe_settings(settings), indent=2))
+        zf.writestr("preflight.json", json.dumps(preflight, indent=2))
+        zf.writestr("recent_errors.txt", recent_errors)
+        zf.writestr("system.txt", json.dumps(system_info, indent=2))
+
+        if include_session_metadata and db_conn is not None:
+            meta = _last_session_metadata(db_conn)
+            zf.writestr(
+                "session_metadata.json",
+                json.dumps(meta, indent=2) if meta is not None else "null",
+            )
+
+        zf.writestr("README.txt", _BUNDLE_README)
+
+    return bundle_path
+
+
+def beta_report_manifest(include_session_metadata: bool) -> list[str]:
+    """Return the list of files that will be included in the bundle.
+
+    Used by the UI consent screen so the tester sees exactly what the bundle
+    will contain before it is written to disk.
+    """
+    files = [
+        "versions.json — app, Python, and OS versions",
+        "system.txt — OS name, release, architecture",
+        "config.json — settings (home directory replaced with ~)",
+        "preflight.json — runtime / STT / TTS health snapshot",
+        "recent_errors.txt — last log lines at WARNING or above (no conversation content)",
+    ]
+    if include_session_metadata:
+        files.append(
+            "session_metadata.json — last session: scenario ID, state, turn count,"
+            " timestamps (no transcript content or player input)"
+        )
+    files.append("README.txt — privacy notice")
+    return files

--- a/services/convsim-core/convsim_core/beta_report.py
+++ b/services/convsim-core/convsim_core/beta_report.py
@@ -47,6 +47,7 @@ only the system and diagnostic information described here.
 Contents
 --------
   versions.json          — App, Python, and OS version strings
+  system.txt             — OS name, release, architecture, Python implementation
   config.json            — Settings with home-directory paths replaced by ~
   preflight.json         — Runtime, STT, and TTS health snapshot (no user data)
   recent_errors.txt      — Last lines of app.log (no conversation content)

--- a/services/convsim-core/convsim_core/beta_report.py
+++ b/services/convsim-core/convsim_core/beta_report.py
@@ -29,7 +29,6 @@ from typing import Any
 from convsim_core import __version__
 from convsim_core.crash_report import _safe_settings, _tail_log, _MAX_LOG_TAIL_LINES
 from convsim_core.models import AppSettings
-from convsim_core.redaction import redact_path
 
 _BUNDLE_README = """\
 BETA REPORT BUNDLE — ConversationSimulator

--- a/services/convsim-core/convsim_core/beta_report.py
+++ b/services/convsim-core/convsim_core/beta_report.py
@@ -52,6 +52,8 @@ Contents
   recent_errors.txt      — Last lines of app.log (no conversation content)
   session_metadata.json  — Last session stats (only if you opted in; no transcript
                            content, no player input, no NPC responses)
+  crash-bundle.zip       — Most recent crash bundle, if one exists (already
+                           redacted the same way as this bundle)
   README.txt             — This file
 
 Privacy notes
@@ -112,6 +114,21 @@ def _redact_paths(value: Any) -> Any:
     return value
 
 
+def latest_crash_bundle(bundle_dir: str | Path) -> Path | None:
+    """Return the most recent ``crash-*.zip`` in *bundle_dir*, or None.
+
+    Crash bundles (see :mod:`convsim_core.crash_report`) are written to the same
+    directory as beta reports and named ``crash-<UTC timestamp>.zip``, so the
+    lexicographically greatest name is also the newest.  Beta-report ZIPs use a
+    ``beta-report-`` prefix and are therefore never matched.
+    """
+    directory = Path(bundle_dir)
+    if not directory.is_dir():
+        return None
+    candidates = sorted(p for p in directory.glob("crash-*.zip") if p.is_file())
+    return candidates[-1] if candidates else None
+
+
 def _last_session_metadata(conn: sqlite3.Connection) -> dict[str, Any] | None:
     """Return metadata for the most recent session, or None if no sessions exist.
 
@@ -139,6 +156,7 @@ def create_beta_report_bundle(
     bundle_dir: str | None = None,
     db_conn: sqlite3.Connection | None = None,
     include_session_metadata: bool = False,
+    crash_bundle_path: Path | None = None,
 ) -> Path:
     """Create a local beta-report ZIP bundle.
 
@@ -162,6 +180,10 @@ def create_beta_report_bundle(
     include_session_metadata:
         When True, include a ``session_metadata.json`` file with non-identifying
         fields from the last session (no transcript content or player input).
+    crash_bundle_path:
+        When provided and the file exists, the crash bundle is embedded as
+        ``crash-bundle.zip``.  Crash bundles are already redacted, so this adds
+        no new sensitive data.  Use :func:`latest_crash_bundle` to locate it.
 
     Returns the absolute :class:`~pathlib.Path` to the created ``.zip`` file.
     """
@@ -202,16 +224,23 @@ def create_beta_report_bundle(
                 json.dumps(meta, indent=2) if meta is not None else "null",
             )
 
+        if crash_bundle_path is not None and crash_bundle_path.is_file():
+            zf.write(crash_bundle_path, arcname="crash-bundle.zip")
+
         zf.writestr("README.txt", _BUNDLE_README)
 
     return bundle_path
 
 
-def beta_report_manifest(include_session_metadata: bool) -> list[str]:
+def beta_report_manifest(
+    include_session_metadata: bool, include_crash_bundle: bool = False
+) -> list[str]:
     """Return the list of files that will be included in the bundle.
 
     Used by the UI consent screen so the tester sees exactly what the bundle
-    will contain before it is written to disk.
+    will contain before it is written to disk.  ``include_crash_bundle`` should
+    reflect whether a crash bundle actually exists (see
+    :func:`latest_crash_bundle`) so the preview matches the real contents.
     """
     files = [
         "versions.json — app, Python, and OS versions",
@@ -224,6 +253,10 @@ def beta_report_manifest(include_session_metadata: bool) -> list[str]:
         files.append(
             "session_metadata.json — last session: scenario ID, state, turn count,"
             " timestamps (no transcript content or player input)"
+        )
+    if include_crash_bundle:
+        files.append(
+            "crash-bundle.zip — most recent crash bundle (already redacted)"
         )
     files.append("README.txt — privacy notice")
     return files

--- a/services/convsim-core/convsim_core/beta_report.py
+++ b/services/convsim-core/convsim_core/beta_report.py
@@ -18,6 +18,7 @@ Bundle contents:
 from __future__ import annotations
 
 import json
+import os
 import platform
 import sqlite3
 import sys
@@ -29,6 +30,8 @@ from typing import Any
 from convsim_core import __version__
 from convsim_core.crash_report import _safe_settings, _tail_log, _MAX_LOG_TAIL_LINES
 from convsim_core.models import AppSettings
+
+_HOME_PREFIX: str = str(Path.home())
 
 _BUNDLE_README = """\
 BETA REPORT BUNDLE — ConversationSimulator
@@ -77,6 +80,38 @@ _SAFE_SESSION_FIELDS: tuple[str, ...] = (
 )
 
 
+def _redact_home_in_text(text: str) -> str:
+    """Replace the home-directory prefix with ``~`` anywhere it appears.
+
+    Unlike :func:`convsim_core.redaction.redact_path`, which only redacts a
+    string that *is* an absolute path, this also catches paths embedded inside
+    larger strings — e.g. an STT health ``message`` such as
+    ``"STT model not found at '/home/alice/.convsim/...'"``.  The prefix is only
+    replaced when followed by a path separator so unrelated strings that merely
+    share the prefix (e.g. ``/home/alice-backup``) are left intact.
+    """
+    if not _HOME_PREFIX:
+        return text
+    return text.replace(_HOME_PREFIX + os.sep, "~" + os.sep)
+
+
+def _redact_paths(value: Any) -> Any:
+    """Recursively redact home-directory prefixes in any string values.
+
+    The preflight snapshot embeds health fields such as ``stt.model_path`` and
+    error ``message`` strings that contain absolute paths — these leak the OS
+    username unless redacted.  Non-path strings are returned unchanged, so this
+    is safe to apply blanket across the whole snapshot.
+    """
+    if isinstance(value, str):
+        return _redact_home_in_text(value)
+    if isinstance(value, dict):
+        return {k: _redact_paths(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_redact_paths(v) for v in value]
+    return value
+
+
 def _last_session_metadata(conn: sqlite3.Connection) -> dict[str, Any] | None:
     """Return metadata for the most recent session, or None if no sessions exist.
 
@@ -114,8 +149,10 @@ def create_beta_report_bundle(
     settings:
         Current application settings (paths are sanitised before inclusion).
     preflight:
-        A health/runtime snapshot dict safe to include verbatim (must not
-        contain transcripts or user input — callers are responsible).
+        A health/runtime snapshot dict.  Home-directory prefixes in any string
+        values are redacted to ``~`` before writing, so it is safe to pass the
+        raw health payload; callers remain responsible for ensuring it contains
+        no transcripts or user input.
     bundle_dir:
         Directory to write the bundle into.  Falls back to
         ``<log_dir>/beta-reports/`` when *None*.
@@ -154,7 +191,7 @@ def create_beta_report_bundle(
     with zipfile.ZipFile(bundle_path, "w", zipfile.ZIP_DEFLATED) as zf:
         zf.writestr("versions.json", json.dumps(versions, indent=2))
         zf.writestr("config.json", json.dumps(_safe_settings(settings), indent=2))
-        zf.writestr("preflight.json", json.dumps(preflight, indent=2))
+        zf.writestr("preflight.json", json.dumps(_redact_paths(preflight), indent=2))
         zf.writestr("recent_errors.txt", recent_errors)
         zf.writestr("system.txt", json.dumps(system_info, indent=2))
 

--- a/services/convsim-core/convsim_core/routers/diag.py
+++ b/services/convsim-core/convsim_core/routers/diag.py
@@ -2,10 +2,15 @@
 """Diagnostics endpoints for local log-folder access and crash-bundle creation."""
 import logging
 from pathlib import Path
+from typing import Any
 
 from fastapi import APIRouter, Request
 from pydantic import BaseModel
 
+from convsim_core.beta_report import (
+    beta_report_manifest,
+    create_beta_report_bundle,
+)
 from convsim_core.crash_report import create_crash_bundle
 from convsim_core.redaction import redact_path
 
@@ -18,6 +23,12 @@ _BUNDLE_NOTICE = (
     "Review the contents and attach it to a GitHub issue manually."
 )
 
+_BETA_REPORT_NOTICE = (
+    "Beta report bundle created locally. "
+    "It is never transmitted automatically. "
+    "Review the contents, then attach it to a GitHub issue manually."
+)
+
 
 class _LogsFolderResponse(BaseModel):
     logs_folder: str
@@ -25,6 +36,16 @@ class _LogsFolderResponse(BaseModel):
 
 class _CrashBundleResponse(BaseModel):
     bundle_path: str
+    notice: str
+
+
+class _BetaReportRequest(BaseModel):
+    include_session_metadata: bool = False
+
+
+class _BetaReportResponse(BaseModel):
+    bundle_path: str
+    manifest: list[str]
     notice: str
 
 
@@ -53,3 +74,47 @@ async def post_crash_bundle(request: Request) -> _CrashBundleResponse:
     )
     logger.info("Crash bundle created at %s", redact_path(str(bundle_path)))
     return _CrashBundleResponse(bundle_path=str(bundle_path), notice=_BUNDLE_NOTICE)
+
+
+@router.post("/beta-report", response_model=_BetaReportResponse)
+async def post_beta_report(
+    body: _BetaReportRequest, request: Request
+) -> _BetaReportResponse:
+    """Create a local beta-report bundle for attaching to a GitHub issue.
+
+    Extends the crash bundle with a preflight health snapshot and an optional
+    last-session metadata entry (never includes transcript content or player
+    input).  The bundle is written locally and never transmitted automatically.
+    """
+    config = request.app.state.service_config
+    settings = request.app.state.app_settings
+
+    # Build a safe preflight snapshot from the health state already in memory.
+    # We read from app.state directly (no HTTP call) to keep this path offline.
+    runtime_health = await request.app.state.runtime.health()
+    stt_health = await request.app.state.stt_worker.health()
+    tts_health = await request.app.state.tts_worker.health()
+    preflight: dict[str, Any] = {
+        "runtime": runtime_health.model_dump() if hasattr(runtime_health, "model_dump") else str(runtime_health),
+        "stt": stt_health.model_dump() if hasattr(stt_health, "model_dump") else str(stt_health),
+        "tts": tts_health.model_dump() if hasattr(tts_health, "model_dump") else str(tts_health),
+    }
+
+    db_conn = request.app.state.db.connection() if body.include_session_metadata else None
+
+    bundle_path = create_beta_report_bundle(
+        log_dir=config.log_dir,
+        settings=settings,
+        preflight=preflight,
+        bundle_dir=config.crash_bundles_dir,
+        db_conn=db_conn,
+        include_session_metadata=body.include_session_metadata,
+    )
+
+    manifest = beta_report_manifest(body.include_session_metadata)
+    logger.info("Beta report bundle created at %s", redact_path(str(bundle_path)))
+    return _BetaReportResponse(
+        bundle_path=str(bundle_path),
+        manifest=manifest,
+        notice=_BETA_REPORT_NOTICE,
+    )

--- a/services/convsim-core/convsim_core/routers/diag.py
+++ b/services/convsim-core/convsim_core/routers/diag.py
@@ -89,8 +89,9 @@ async def post_beta_report(
     config = request.app.state.service_config
     settings = request.app.state.app_settings
 
-    # Build a safe preflight snapshot from the health state already in memory.
-    # We read from app.state directly (no HTTP call) to keep this path offline.
+    # Build a safe preflight snapshot from the in-process health checkers.
+    # These probe the local sidecars over loopback only (e.g. llama-server on
+    # 127.0.0.1); no request ever leaves the machine, keeping this path offline.
     runtime_health = await request.app.state.runtime.health()
     stt_health = await request.app.state.stt_worker.health()
     tts_health = await request.app.state.tts_worker.health()

--- a/services/convsim-core/convsim_core/routers/diag.py
+++ b/services/convsim-core/convsim_core/routers/diag.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel
 from convsim_core.beta_report import (
     beta_report_manifest,
     create_beta_report_bundle,
+    latest_crash_bundle,
 )
 from convsim_core.crash_report import create_crash_bundle
 from convsim_core.redaction import redact_path
@@ -103,6 +104,10 @@ async def post_beta_report(
 
     db_conn = request.app.state.db.connection() if body.include_session_metadata else None
 
+    # Embed the most recent crash bundle (#288) when one exists — it is written
+    # to the same directory and already redacted, so it adds no new sensitive data.
+    crash_bundle_path = latest_crash_bundle(config.crash_bundles_dir)
+
     bundle_path = create_beta_report_bundle(
         log_dir=config.log_dir,
         settings=settings,
@@ -110,9 +115,13 @@ async def post_beta_report(
         bundle_dir=config.crash_bundles_dir,
         db_conn=db_conn,
         include_session_metadata=body.include_session_metadata,
+        crash_bundle_path=crash_bundle_path,
     )
 
-    manifest = beta_report_manifest(body.include_session_metadata)
+    manifest = beta_report_manifest(
+        body.include_session_metadata,
+        include_crash_bundle=crash_bundle_path is not None,
+    )
     logger.info("Beta report bundle created at %s", redact_path(str(bundle_path)))
     return _BetaReportResponse(
         bundle_path=str(bundle_path),

--- a/services/convsim-core/tests/test_diag.py
+++ b/services/convsim-core/tests/test_diag.py
@@ -201,6 +201,42 @@ def test_post_beta_report_written_to_crash_bundles_dir(client):
     assert bundle_path.parent == crash_bundles_dir
 
 
+def test_beta_report_preflight_redacts_home_paths(tmp_path):
+    """Home-directory prefixes in the preflight snapshot must be redacted.
+
+    The STT health payload embeds an absolute model path (and error messages
+    reference it) that leak the OS username unless redacted — this asserts the
+    bundle honours its own privacy promise for preflight.json.
+    """
+    from convsim_core.beta_report import create_beta_report_bundle
+    from convsim_core.models import AppSettings
+
+    home = str(Path.home())
+    leaky_path = f"{home}/.convsim/models/stt/ggml-base.en.bin"
+    preflight = {
+        "runtime": {"runtime_id": "fake", "status": "ready"},
+        "stt": {
+            "worker_id": "whisper",
+            "model_path": leaky_path,
+            "message": f"STT model not found at {leaky_path!r}.",
+        },
+        "tts": {"worker_id": "piper", "status": "ready"},
+    }
+
+    bundle_path = create_beta_report_bundle(
+        log_dir=str(tmp_path),
+        settings=AppSettings(data_dir=str(tmp_path), log_dir=str(tmp_path)),
+        preflight=preflight,
+        bundle_dir=str(tmp_path),
+    )
+
+    with zipfile.ZipFile(bundle_path) as zf:
+        raw = zf.read("preflight.json").decode("utf-8")
+
+    assert home not in raw, f"preflight.json leaked home prefix: {raw}"
+    assert "~/.convsim/models/stt/ggml-base.en.bin" in raw
+
+
 def test_post_beta_report_makes_no_outbound_network_calls(client):
     """Creating a beta report must not make any outbound (non-loopback) calls.
 

--- a/services/convsim-core/tests/test_diag.py
+++ b/services/convsim-core/tests/test_diag.py
@@ -282,3 +282,47 @@ def test_post_beta_report_makes_no_outbound_network_calls(client):
     assert attempts == [], (
         f"Beta report endpoint made {len(attempts)} outbound network call(s): {attempts}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Crash-bundle embedding (#288 — "crash bundle if present")
+# ---------------------------------------------------------------------------
+
+def test_beta_report_omits_crash_bundle_when_none_present(client):
+    """With no crash bundle on disk, the beta report must not contain one."""
+    data = client.post("/api/diag/beta-report", json={}).json()
+    with zipfile.ZipFile(data["bundle_path"]) as zf:
+        names = zf.namelist()
+    assert "crash-bundle.zip" not in names
+    assert not any("crash-bundle" in item for item in data["manifest"])
+
+
+def test_beta_report_embeds_existing_crash_bundle(client):
+    """When a crash bundle exists, the beta report embeds it and lists it."""
+    # Create a crash bundle first — it lands in crash_bundles_dir.
+    crash = client.post("/api/diag/crash-bundle").json()
+    assert Path(crash["bundle_path"]).name.startswith("crash-")
+
+    data = client.post("/api/diag/beta-report", json={}).json()
+    with zipfile.ZipFile(data["bundle_path"]) as zf:
+        names = zf.namelist()
+        embedded = zf.read("crash-bundle.zip")
+    assert "crash-bundle.zip" in names
+    assert any("crash-bundle" in item for item in data["manifest"])
+    # The embedded entry is a real ZIP with the same bytes as the crash bundle.
+    assert embedded == Path(crash["bundle_path"]).read_bytes()
+
+
+def test_latest_crash_bundle_picks_newest(tmp_path):
+    """latest_crash_bundle returns the newest crash-*.zip and ignores others."""
+    from convsim_core.beta_report import latest_crash_bundle
+
+    assert latest_crash_bundle(tmp_path) is None
+    (tmp_path / "crash-20260101T000000Z.zip").write_text("old")
+    (tmp_path / "crash-20260709T120000Z.zip").write_text("new")
+    # A beta-report ZIP in the same dir must never be selected.
+    (tmp_path / "beta-report-20260709T130000Z.zip").write_text("beta")
+
+    latest = latest_crash_bundle(tmp_path)
+    assert latest is not None
+    assert latest.name == "crash-20260709T120000Z.zip"

--- a/services/convsim-core/tests/test_diag.py
+++ b/services/convsim-core/tests/test_diag.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for the /api/diag endpoints."""
 import json
+import socket
 import zipfile
 from pathlib import Path
 
@@ -89,4 +90,159 @@ def test_post_crash_bundle_written_to_crash_bundles_dir(client):
     bundle_path = Path(data["bundle_path"]).resolve()
     assert bundle_path.parent == crash_bundles_dir, (
         f"crash bundle written to {bundle_path.parent}, not crash_bundles_dir {crash_bundles_dir}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# /api/diag/beta-report
+# ---------------------------------------------------------------------------
+
+def test_post_beta_report_returns_200(client):
+    response = client.post("/api/diag/beta-report", json={})
+    assert response.status_code == 200
+
+
+def test_post_beta_report_returns_bundle_path(client):
+    data = client.post("/api/diag/beta-report", json={}).json()
+    assert "bundle_path" in data
+    assert isinstance(data["bundle_path"], str)
+
+
+def test_post_beta_report_file_exists(client):
+    data = client.post("/api/diag/beta-report", json={}).json()
+    assert Path(data["bundle_path"]).exists()
+
+
+def test_post_beta_report_is_valid_zip(client):
+    data = client.post("/api/diag/beta-report", json={}).json()
+    assert zipfile.is_zipfile(data["bundle_path"])
+
+
+def test_post_beta_report_contains_required_files(client):
+    data = client.post("/api/diag/beta-report", json={}).json()
+    with zipfile.ZipFile(data["bundle_path"]) as zf:
+        names = zf.namelist()
+    assert "versions.json" in names
+    assert "config.json" in names
+    assert "preflight.json" in names
+    assert "recent_errors.txt" in names
+    assert "system.txt" in names
+    assert "README.txt" in names
+
+
+def test_post_beta_report_no_session_metadata_by_default(client):
+    data = client.post("/api/diag/beta-report", json={}).json()
+    with zipfile.ZipFile(data["bundle_path"]) as zf:
+        names = zf.namelist()
+    assert "session_metadata.json" not in names
+
+
+def test_post_beta_report_with_session_metadata_opt_in(client):
+    data = client.post(
+        "/api/diag/beta-report", json={"include_session_metadata": True}
+    ).json()
+    with zipfile.ZipFile(data["bundle_path"]) as zf:
+        names = zf.namelist()
+    assert "session_metadata.json" in names
+
+
+def test_post_beta_report_session_metadata_is_null_when_no_sessions(client):
+    data = client.post(
+        "/api/diag/beta-report", json={"include_session_metadata": True}
+    ).json()
+    with zipfile.ZipFile(data["bundle_path"]) as zf:
+        meta = json.loads(zf.read("session_metadata.json"))
+    assert meta is None
+
+
+def test_post_beta_report_preflight_has_runtime_key(client):
+    data = client.post("/api/diag/beta-report", json={}).json()
+    with zipfile.ZipFile(data["bundle_path"]) as zf:
+        preflight = json.loads(zf.read("preflight.json"))
+    assert "runtime" in preflight
+
+
+def test_post_beta_report_versions_has_app(client):
+    data = client.post("/api/diag/beta-report", json={}).json()
+    with zipfile.ZipFile(data["bundle_path"]) as zf:
+        versions = json.loads(zf.read("versions.json"))
+    assert "app" in versions
+
+
+def test_post_beta_report_returns_manifest(client):
+    data = client.post("/api/diag/beta-report", json={}).json()
+    assert "manifest" in data
+    assert isinstance(data["manifest"], list)
+    assert len(data["manifest"]) > 0
+
+
+def test_post_beta_report_manifest_excludes_session_metadata_by_default(client):
+    data = client.post("/api/diag/beta-report", json={}).json()
+    assert not any("session_metadata" in item for item in data["manifest"])
+
+
+def test_post_beta_report_manifest_includes_session_metadata_when_opted_in(client):
+    data = client.post(
+        "/api/diag/beta-report", json={"include_session_metadata": True}
+    ).json()
+    assert any("session_metadata" in item for item in data["manifest"])
+
+
+def test_post_beta_report_notice_mentions_local(client):
+    data = client.post("/api/diag/beta-report", json={}).json()
+    notice = data["notice"].lower()
+    assert "local" in notice or "manually" in notice
+
+
+def test_post_beta_report_written_to_crash_bundles_dir(client):
+    crash_bundles_dir = Path(client.app.state.service_config.crash_bundles_dir).resolve()
+    data = client.post("/api/diag/beta-report", json={}).json()
+    bundle_path = Path(data["bundle_path"]).resolve()
+    assert bundle_path.parent == crash_bundles_dir
+
+
+def test_post_beta_report_makes_no_outbound_network_calls(client):
+    """Creating a beta report must not make any outbound (non-loopback) calls.
+
+    This extends the issue #218 guard suite to cover the beta report path.
+    """
+    _LOOPBACK = frozenset({"localhost", "::1", "[::1]", "0.0.0.0", "::"})
+
+    def _is_local(family, address) -> bool:
+        if family == getattr(socket, "AF_UNIX", object()):
+            return True
+        if not isinstance(address, tuple) or not address:
+            return True
+        host = str(address[0]).lower()
+        if host in _LOOPBACK or host.endswith(".localhost"):
+            return True
+        return host.startswith("127.")
+
+    attempts: list = []
+    orig_connect = socket.socket.connect
+    orig_connect_ex = socket.socket.connect_ex
+
+    def guarded_connect(self, address, *args, **kwargs):  # noqa: ANN001
+        if not _is_local(self.family, address):
+            attempts.append(address)
+            raise OSError(f"Outbound call blocked: {address!r}")
+        return orig_connect(self, address, *args, **kwargs)
+
+    def guarded_connect_ex(self, address, *args, **kwargs):  # noqa: ANN001
+        if not _is_local(self.family, address):
+            attempts.append(address)
+            raise OSError(f"Outbound call blocked: {address!r}")
+        return orig_connect_ex(self, address, *args, **kwargs)
+
+    socket.socket.connect = guarded_connect
+    socket.socket.connect_ex = guarded_connect_ex
+    try:
+        response = client.post("/api/diag/beta-report", json={})
+    finally:
+        socket.socket.connect = orig_connect
+        socket.socket.connect_ex = orig_connect_ex
+
+    assert response.status_code == 200, response.text
+    assert attempts == [], (
+        f"Beta report endpoint made {len(attempts)} outbound network call(s): {attempts}"
     )


### PR DESCRIPTION
## Summary

Adds a one-click beta reporting flow with a redacted, locally-written diagnostics bundle. Testers can consent to create and review the bundle contents before attaching to a GitHub issue. Includes prefilled issue template, opt-in session metadata (scenario/flow state only—never transcripts), and a privacy guide.

## What changed

### Backend (`convsim_core`)

- **`convsim_core/beta_report.py`** (new) — `create_beta_report_bundle()` assembles a ZIP in the crash-bundles directory containing `versions.json`, `system.txt`, `config.json`, `preflight.json` (runtime/STT/TTS health snapshot read directly from `app.state`, no outbound calls), `recent_errors.txt` (redacted log tail via the existing `_tail_log` helper), optional `session_metadata.json` (last session: scenario ID, flow state, turn count, timestamps—never transcript content), optional embedded crash bundle, and `README.txt`. `beta_report_manifest()` returns the file list shown in the UI consent screen.
- **`convsim_core/routers/diag.py`** — new `POST /api/diag/beta-report` endpoint. Accepts `{ include_session_metadata: bool }` (default false). Returns `{ bundle_path, manifest, notice }`. Reads health state from in-process `app.state`—zero outbound HTTP calls. Automatically embeds the most recent crash bundle when present.

### Frontend (`apps/web`)

- **`api/client.ts`** — adds `api.createBetaReport(includeSessionMetadata)` calling the new endpoint.
- **`screens/Support.tsx`** — new "Report a problem" section with a two-step consent flow: (1) click button → consent screen shows the exact manifest preview before writing anything; (2) opt-in checkbox for session metadata (off by default); (3) privacy note; (4) "Create bundle" writes the ZIP and opens the folder via Tauri shell; (5) success screen shows the path, manifest, and an "Open GitHub issue →" link prefilled with `beta-report.yml`.
- **`components/RuntimeRecoveryCard.tsx`** — adds optional `reportProblemHref` prop that renders a "Report a problem →" link in the action row.
- **`screens/Home.tsx`** — all three degraded-state cards (`showUnreachable`, port-conflict, last-error) now pass `BETA_REPORT_URL` to `reportProblemHref`.

### Issue template and docs

- **`.github/ISSUE_TEMPLATE/beta-report.yml`** — new template (opened by the "Open GitHub issue →" button) with fields for observed/expected behaviour, repro steps, build info from the bundle, and a checklist for attaching the ZIP.
- **`docs/beta-testing.md`** (new) — how to join the beta, step-by-step one-click reporting walkthrough, privacy table for each bundle file, what makes a good report, and feedback scope.
- **`README.md`** — new "Beta testing" section (before Contributing) linking to `docs/beta-testing.md`.

## How it was tested

- **Python**: 20 new tests in `services/convsim-core/tests/test_diag.py` cover the `/api/diag/beta-report` endpoint: ZIP validity, required files, opt-in session metadata (present/absent), preflight key presence, manifest shape, socket-level network-guard assertion (endpoint makes zero non-loopback connections), embedded crash-bundle handling, and path redaction. All 33 diag tests pass.
- **TypeScript**: 15 new tests in `apps/web/src/__tests__/Support.test.tsx` cover the full consent flow — button visibility, manifest preview with/without session metadata, privacy note, checkbox state, `createBetaReport` called with correct argument, bundle path and manifest display on success, GitHub link attributes, error rendering, and "Done" reset. All 1,075 frontend tests pass.

Closes #302