### PR TITLE
Add Steam beta verification checklists for macOS, Linux, Steam Deck and aggregate report template

### DIFF
--- a/apps/web/src/__tests__/VoiceSettingsPanel.test.tsx
+++ b/apps/web/src/__tests__/VoiceSettingsPanel.test.tsx
@@ -125,8 +125,7 @@ describe('voice readiness cards', () => {
 
   it('shows Microphone as ready when permission is granted', async () => {
     render(<VoiceSettingsPanel />)
-    await waitFor(() => expect(screen.getByTestId('readiness-mic')).toBeInTheDocument())
-    expect(screen.getByTestId('readiness-mic')).toHaveTextContent('permission granted')
+    await waitFor(() => expect(screen.getByTestId('readiness-mic')).toHaveTextContent('permission granted'))
   })
 
   it('shows STT as unavailable when health reports stt_ready=false', async () => {

--- a/docs/QA_STEAM_PLATFORM_MATRIX.md
+++ b/docs/QA_STEAM_PLATFORM_MATRIX.md
@@ -351,6 +351,14 @@ Signed: ___________________________ (tester)
 Countersigned: ___________________________ (maintainer, if PARTIAL or for Stage 4)
 ```
 
+### Aggregate beta verification report
+
+After all per-platform sign-offs above are complete, combine them into the
+aggregate beta verification report using the template in
+[`docs/STEAM_BETA_VERIFICATION_REPORT.md`](STEAM_BETA_VERIFICATION_REPORT.md).
+The completed report must be attached to the release GitHub issue before the
+Stage 3 gate (G3-06) can be declared PASS.
+
 ### Steam review sign-off (Stage 4 public release)
 
 Before opening the Stage 4 gate, the publishing owner must complete the
@@ -380,9 +388,11 @@ Notes            :
 
 - [steam-mvp-scope.md](steam-mvp-scope.md) — feature requirements and pass/fail gates (G2–G4)
 - [STEAM_ROADMAP.md](STEAM_ROADMAP.md) — release principles, release train, Steam Deck verification checklist
-- [release-checklist.md](release-checklist.md) — Parts A–D platform smoke matrix
+- [STEAM_BETA_VERIFICATION_REPORT.md](STEAM_BETA_VERIFICATION_REPORT.md) — aggregate signed-off beta verification report template (all four platforms)
+- [release-checklist.md](release-checklist.md) — Parts A–D platform smoke matrix; Parts E (Windows), G (macOS), H (Linux/SteamOS), I (Steam Deck), J (sign-off) for Steam beta verification
 - [performance.md](performance.md) — hardware tier definitions and latency guidance
 - [platform-notes.md](platform-notes.md) — platform-specific build and install details
+- [linux-steamos-requirements.md](linux-steamos-requirements.md) — glibc requirements, SteamOS hardware profile, AppImage behavior
 - [privacy.md](privacy.md) — local-first promise and data handling
 - [network-security.md](network-security.md) — runtime network enforcement
 - [voice-smoke-tests.md](voice-smoke-tests.md) — STT/TTS smoke test procedures

--- a/docs/STEAM_BETA_VERIFICATION_REPORT.md
+++ b/docs/STEAM_BETA_VERIFICATION_REPORT.md
@@ -1,0 +1,316 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+# Steam Beta Verification Report
+
+> **Purpose:** Signed-off aggregate report produced after completing the
+> Steam beta client verification across all required platforms (Windows, macOS,
+> Linux, Steam Deck).  One completed copy of this report must be attached to
+> the release GitHub issue before the Stage 3 gate (G3-06) can be declared PASS,
+> and before Valve's Steam Deck Verified review (G4-02) is requested.
+>
+> **When to use:** Complete this report after all four platform-specific
+> checklists in `docs/release-checklist.md` (Parts E, G, H, I) are finished
+> for the release candidate build.
+>
+> **How to file:** Copy this template, fill it in, and either attach it as a
+> file to the release GitHub issue or paste it as a comment with the title
+> "Steam beta verification report — vX.Y.Z".
+
+---
+
+## Report header
+
+```
+Build version         : vX.Y.Z  (or Steam build ID)
+Steam branch verified : beta
+Build date            : YYYY-MM-DD
+Release issue         : https://github.com/outrightmental/ConversationSimulator/issues/NNN
+Verification period   : YYYY-MM-DD to YYYY-MM-DD
+Publishing owner      :
+Report date           : YYYY-MM-DD
+```
+
+---
+
+## Prerequisites
+
+The following dependent issues must be resolved or have an accepted waiver
+before this verification can proceed:
+
+| Label | Issue | Status |
+|-------|-------|--------|
+| `ci-steam-beta-deploy` | [CI] Add SteamPipe deploy workflow to Steam beta branch | [ ] Closed / [ ] Waiver |
+| `ci-signing-notarization-malware` | [CI] Add code signing, macOS notarization, and malware-scan hooks | [ ] Closed / [ ] Waiver |
+| `steam-cloud-nonsensitive` | [Steamworks] Configure Steam Cloud for non-sensitive settings only | [ ] Closed / [ ] Waiver |
+| `steam-achievements-stats-presence` | [Steamworks] Add achievements, stats, and rich presence | [ ] Closed / [ ] Waiver |
+| `steam-store-assets-trailer` | [Steamworks] Prepare Steam store page copy, capsules, screenshots, and trailer | [ ] Closed / [ ] Waiver |
+| `qa-automation-e2e` | [QA] Add packaged-app smoke tests and end-to-end scripted playthroughs | [ ] Closed / [ ] Waiver |
+
+---
+
+## Part 1 — Windows verification (release-checklist.md Part E)
+
+**Tester:**
+**Machine:**
+**Date:**
+
+| Step | Result |
+|------|--------|
+| E.1 SmartScreen / Authenticode — no warning on signed build | [ ] PASS / [ ] FAIL / [ ] SKIP |
+| E.2 First-run model wizard | [ ] PASS / [ ] FAIL / [ ] SKIP |
+| E.3 Text scenario and debrief | [ ] PASS / [ ] FAIL / [ ] SKIP |
+| E.4 Log verification | [ ] PASS / [ ] FAIL / [ ] SKIP |
+| E.5 Uninstall behavior | [ ] PASS / [ ] FAIL / [ ] SKIP |
+| E.6 Reinstall behavior | [ ] PASS / [ ] FAIL / [ ] SKIP |
+| E.7 Depot content audit | [ ] PASS / [ ] FAIL / [ ] SKIP |
+| E.8 Offline play after model download | [ ] PASS / [ ] FAIL / [ ] SKIP |
+| E.9 Privacy controls | [ ] PASS / [ ] FAIL / [ ] SKIP |
+| E.10 Steam Cloud exclusions (Part B.11) | [ ] PASS / [ ] FAIL / [ ] SKIP |
+| E.11 Support bundle flow | [ ] PASS / [ ] FAIL / [ ] SKIP |
+| E.12 Achievements / stats / rich presence | [ ] PASS / [ ] FAIL / [ ] N/A |
+
+**Windows platform result:**
+- [ ] PASS — all required steps passed; no blocking issues
+- [ ] PARTIAL — failures noted (see blockers below); maintainer waiver required
+- [ ] FAIL — one or more blocking issues remain open
+
+```
+Hardware
+  CPU  :
+  RAM  :
+  GPU  :
+  OS   :  Windows 10 / 11 build NNNNN
+  Model tested : Qwen3 4B Q4_K_M / other
+  Hardware tier : [ ] Minimum  [ ] Starter  [ ] Recommended
+
+First-token latency : ___ s   [ ] Within threshold  [ ] Exceeds threshold
+Notes:
+  -
+```
+
+---
+
+## Part 2 — macOS verification (release-checklist.md Part G)
+
+**Tester:**
+**Machine:**
+**Date:**
+
+| Step | Result |
+|------|--------|
+| G.1 Gatekeeper / notarization — no dialog on clean install | [ ] PASS / [ ] FAIL / [ ] SKIP |
+| G.2 Fresh install from Steam | [ ] PASS / [ ] FAIL / [ ] SKIP |
+| G.3 First-run model wizard | [ ] PASS / [ ] FAIL / [ ] SKIP |
+| G.4 Text scenario and debrief | [ ] PASS / [ ] FAIL / [ ] SKIP |
+| G.5 Offline play after model download | [ ] PASS / [ ] FAIL / [ ] SKIP |
+| G.6 Privacy controls | [ ] PASS / [ ] FAIL / [ ] SKIP |
+| G.7 Steam Cloud exclusions (Part B.11) | [ ] PASS / [ ] FAIL / [ ] SKIP |
+| G.8 Support bundle flow | [ ] PASS / [ ] FAIL / [ ] SKIP |
+| G.9 Achievements / stats / rich presence | [ ] PASS / [ ] FAIL / [ ] N/A |
+| G.10 Log verification | [ ] PASS / [ ] FAIL / [ ] SKIP |
+| G.11 Uninstall and reinstall behavior | [ ] PASS / [ ] FAIL / [ ] SKIP |
+
+**macOS platform result:**
+- [ ] PASS
+- [ ] PARTIAL — failures noted; waiver required
+- [ ] FAIL
+
+```
+Hardware
+  CPU / chip  :  Apple M__ / Intel Core i__
+  RAM         :
+  OS          :  macOS 13 / 14 / 15
+  Architecture:  arm64 / x86-64
+  Model tested: Qwen3 4B Q4_K_M / other
+  Hardware tier: [ ] Minimum  [ ] Starter  [ ] Recommended
+
+spctl output  : accepted / rejected / error
+codesign exit : 0 / non-zero
+First-token latency : ___ s   [ ] Within threshold  [ ] Exceeds threshold
+Notes:
+  -
+```
+
+---
+
+## Part 3 — Linux verification (release-checklist.md Part H)
+
+**Tester:**
+**Machine:**
+**Date:**
+
+| Step | Result |
+|------|--------|
+| H.1 Executable permissions and glibc ≥ 2.35 confirmed | [ ] PASS / [ ] FAIL / [ ] SKIP |
+| H.2 Fresh install from Steam | [ ] PASS / [ ] FAIL / [ ] SKIP |
+| H.3 First-run model wizard | [ ] PASS / [ ] FAIL / [ ] SKIP |
+| H.4 Text scenario and debrief | [ ] PASS / [ ] FAIL / [ ] SKIP |
+| H.5 Offline play after model download | [ ] PASS / [ ] FAIL / [ ] SKIP |
+| H.6 Privacy controls | [ ] PASS / [ ] FAIL / [ ] SKIP |
+| H.7 Steam Cloud exclusions (Part B.11) | [ ] PASS / [ ] FAIL / [ ] SKIP |
+| H.8 Support bundle flow | [ ] PASS / [ ] FAIL / [ ] SKIP |
+| H.9 Achievements / stats / rich presence | [ ] PASS / [ ] FAIL / [ ] N/A |
+| H.10 Log verification | [ ] PASS / [ ] FAIL / [ ] SKIP |
+| H.11 FUSE / AppImage notes documented | [ ] Done / [ ] N/A |
+
+**Linux platform result:**
+- [ ] PASS
+- [ ] PARTIAL — failures noted; waiver required
+- [ ] FAIL
+
+```
+Hardware
+  CPU     :
+  RAM     :
+  GPU     :
+  OS      :  Ubuntu 22.04 / 24.04 / Fedora 40 / other
+  glibc   :  x.xx (output of `ldd --version`)
+  Model tested: Qwen3 4B Q4_K_M / other
+  Hardware tier: [ ] Minimum  [ ] Starter  [ ] Recommended
+
+FUSE status :  FUSE 2 present / absent (used --appimage-extract-and-run)
+First-token latency : ___ s   [ ] Within threshold  [ ] Exceeds threshold
+Notes:
+  -
+```
+
+---
+
+## Part 4 — Steam Deck verification (release-checklist.md Part I)
+
+**Tester:**
+**Device:**  Steam Deck [ ] LCD / [ ] OLED
+**SteamOS version:**
+**Date:**
+
+| Step | Result |
+|------|--------|
+| I.1 Install from Steam library in Gaming Mode | [ ] PASS / [ ] FAIL |
+| I.2 First-run model wizard (controller-only) | [ ] PASS / [ ] FAIL |
+| I.3 TC-11 controller-only full session (all 13 steps) | [ ] PASS / [ ] PARTIAL / [ ] FAIL |
+| I.4 Offline play under SteamOS | [ ] PASS / [ ] FAIL |
+| I.5 Privacy controls and support bundle (controller-only) | [ ] PASS / [ ] FAIL |
+| I.6 Steam Cloud exclusions | [ ] PASS / [ ] FAIL |
+| I.7 Achievements / stats / rich presence | [ ] PASS / [ ] FAIL / [ ] N/A |
+| I.8 Battery impact documented (target < 15 W) | [ ] Done |
+| I.9 All Steam Deck Verified sign-off items checked | [ ] PASS / [ ] FAIL |
+
+**TC-11 detail (any FAIL steps):**
+
+```
+(list any TC-11 steps that failed, with description)
+-
+```
+
+**Steam Deck platform result:**
+- [ ] PASS — all required steps passed; Deck Verified criteria met
+- [ ] PARTIAL — failures noted; waiver required before G4-02 request
+- [ ] FAIL — Deck Verified cannot be requested until blockers resolved
+
+```
+Battery draw (observed)  : ___ W average
+Fan behavior             : silent / intermittent / sustained
+Model load time          : ___ s  (target ≤ 90 s)
+First-token latency      : ___ s  (target ≤ 30 s)
+Notes:
+  -
+```
+
+---
+
+## Part 5 — Platform-specific blocker log
+
+List every session-ending bug, data-loss bug, or privacy regression found during
+Parts E, G, H, and I.  Each entry must have a corresponding GitHub issue with
+the labels `beta-testing` and the appropriate `platform:*` label.
+
+| # | Platform | Description | GitHub issue | Status |
+|---|----------|-------------|-------------|--------|
+| 1 | | | | |
+| 2 | | | | |
+| 3 | | | | |
+
+> Add rows as needed.  "Status" values: `Open`, `Closed`, `Waived (see notes)`.
+
+**All session-ending / data-loss / privacy-regression blockers resolved or waived:**
+- [ ] Yes — gate G3-06 may be declared PASS
+- [ ] No — gate blocked; see open issues above
+
+---
+
+## Part 6 — CI gate confirmation
+
+All automated gates must be green on the build commit before this report is
+filed.
+
+| Gate | Workflow | Result |
+|------|----------|--------|
+| Part A CI gates | `ci.yml` | [ ] PASS / [ ] FAIL |
+| Release smoke — Windows | `release-smoke.yml` | [ ] PASS / [ ] FAIL |
+| Release smoke — macOS | `release-smoke.yml` | [ ] PASS / [ ] FAIL |
+| Release smoke — Linux | `release-smoke.yml` | [ ] PASS / [ ] FAIL |
+| Artifact inspection (all platforms) | `steam-deploy.yml` | [ ] PASS / [ ] FAIL |
+
+CI run link: _______________________________________________
+
+---
+
+## Aggregate sign-off
+
+```
+=== Steam Beta Verification Report — Aggregate Sign-Off ===
+
+Build version      : vX.Y.Z
+Steam branch       : beta
+Steam App ID       : ___________________________
+Build submitted    : ___________________________  (SteamPipe build ID)
+Verification date  : YYYY-MM-DD
+
+--- Platform results ---
+Windows            : [ ] PASS  [ ] PARTIAL  [ ] FAIL
+macOS (Apple Si.)  : [ ] PASS  [ ] PARTIAL  [ ] FAIL
+macOS (Intel)      : [ ] PASS  [ ] PARTIAL  [ ] FAIL
+Linux (x86-64)     : [ ] PASS  [ ] PARTIAL  [ ] FAIL
+Steam Deck         : [ ] PASS  [ ] PARTIAL  [ ] FAIL  [ ] Deferred to Stage 4
+
+--- Blocker status ---
+Open blocking issues (GitHub #):
+  -
+  -
+All blockers resolved or waived: [ ] Yes  [ ] No
+
+--- Gate outcomes ---
+G3-06 (beta session verification)      : [ ] PASS  [ ] PARTIAL  [ ] FAIL
+G4-02 (Steam Deck Verified — Stage 4)  : [ ] PASS  [ ] Pending Valve review  [ ] FAIL
+
+--- Overall result ---
+[ ] PASS — all required platforms passed; no unresolved blocking issues
+[ ] PARTIAL — failures noted above; requires maintainer countersignature
+[ ] FAIL — one or more blocking issues remain; gate cannot open
+
+Signed: ___________________________ (tester / QA lead)
+
+Countersigned: ___________________________ (publishing owner — required for
+               PARTIAL or Stage 4 gate decisions)
+Date: YYYY-MM-DD
+
+Additional notes:
+  -
+```
+
+---
+
+## Links
+
+- [`docs/release-checklist.md`](release-checklist.md) — Parts E (Windows),
+  G (macOS), H (Linux/SteamOS), I (Steam Deck), and J (sign-off) contain the
+  step-by-step platform checklists this report summarises
+- [`docs/QA_STEAM_PLATFORM_MATRIX.md`](QA_STEAM_PLATFORM_MATRIX.md) — full QA
+  test case matrix (TC-01 through TC-11) and per-platform hardware tiers
+- [`docs/steam-mvp-scope.md`](steam-mvp-scope.md) — gate definitions G3-06 and
+  G4-02
+- [`publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md`](../publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md)
+  — compliance checklists SR-01 through SR-08 and risk register
+- [`docs/linux-steamos-requirements.md`](linux-steamos-requirements.md) —
+  glibc requirements, SteamOS hardware profile, and performance targets
+- [`docs/platform-notes.md`](platform-notes.md) — macOS signing, Gatekeeper,
+  and system requirements

--- a/docs/STEAM_BETA_VERIFICATION_REPORT.md
+++ b/docs/STEAM_BETA_VERIFICATION_REPORT.md
@@ -55,7 +55,7 @@ before this verification can proceed:
 
 | Step | Result |
 |------|--------|
-| E.1 SmartScreen / Authenticode — no warning on signed build | [ ] PASS / [ ] FAIL / [ ] SKIP |
+| E.1 Fresh install from Steam — no SmartScreen / AV warning on signed build | [ ] PASS / [ ] FAIL / [ ] SKIP |
 | E.2 First-run model wizard | [ ] PASS / [ ] FAIL / [ ] SKIP |
 | E.3 Text scenario and debrief | [ ] PASS / [ ] FAIL / [ ] SKIP |
 | E.4 Log verification | [ ] PASS / [ ] FAIL / [ ] SKIP |

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -496,9 +496,13 @@ Navigate to **Settings → Support** (or the Help / Support screen).
 ### E.12 Achievements, stats, and rich presence (if included in build)
 
 > Skip this step if the build was not compiled with `--features steam`.
-> Steam features are present only when the Tauri command `get_steam_status`
-> returns `{"enabled": true, ...}`.  Check `GET /api/health` for the
-> `steam` field, or look for `[steam] Steam initialised` in the startup log.
+> Steam features are active only when the Tauri command `get_steam_status`
+> returns `is_steam_enabled: true` in its `SteamStatus` payload
+> (`{"is_steam_enabled": ..., "launched_by_steam": ..., "app_id": ...,
+> "persona_name": ...}`).  `is_steam_enabled` is `true` only when the build
+> includes the `steam` Cargo feature **and** the app was launched from a
+> running Steam client.  As a UI cross-check, the Settings → Steam Cloud
+> panel shows an "active" indicator whenever the app is `launched_by_steam`.
 
 - [ ] Completing a scored session triggers the expected achievement notification
   (Steam overlay toast or in-app indicator)
@@ -732,7 +736,7 @@ Navigate to **Settings → Support**.
 
 ### G.9 Achievements, stats, and rich presence (if included in build)
 
-> Skip if `get_steam_status` returns `{"enabled": false}`.
+> Skip if `get_steam_status` returns `is_steam_enabled: false` (see E.12).
 
 - [ ] Completing a scored session triggers an achievement notification
 - [ ] Steam overlay (Shift+Tab) reflects the unlocked achievement
@@ -854,7 +858,7 @@ Navigate to **Settings → Support**.
 
 ### H.9 Achievements, stats, and rich presence (if included in build)
 
-> Skip if `get_steam_status` returns `{"enabled": false}`.
+> Skip if `get_steam_status` returns `is_steam_enabled: false` (see E.12).
 
 - [ ] Completing a scored session triggers an achievement notification
 - [ ] Steam overlay (Shift+Tab) reflects the unlocked achievement
@@ -965,7 +969,7 @@ done
 
 ### I.7 Achievements, stats, and rich presence (if included in build)
 
-> Skip if `get_steam_status` returns `{"enabled": false}`.
+> Skip if `get_steam_status` returns `is_steam_enabled: false` (see E.12).
 
 - [ ] Achievement notification appears after a scored session (on-screen toast
   or Steam overlay notification visible from Gaming Mode)

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -890,8 +890,8 @@ Gaming Mode.  This is required for the Stage 4 gate G4-02 (Steam Deck Verified).
 
 All steps must be completable without a keyboard or mouse: use the D-pad,
 A/B/X/Y buttons, left stick, right trackpad, and the Steam on-screen keyboard
-only.  See `docs/QA_STEAM_PLATFORM_MATRIX.md §3` for the full controller
-navigation checklist (TC-11) that these steps exercise.
+only.  See `docs/QA_STEAM_PLATFORM_MATRIX.md §3` for the Steam Deck
+verification checklist and §4 for the TC-11 test case that these steps exercise.
 
 ### I.1 Install from Steam library
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -480,8 +480,8 @@ Complete B.11 on this Windows machine before checking the items below.
 - [ ] B.11 Steam Cloud sync verification completed (Windows)
 - [ ] `steam_cloud_settings.json` contains only `last_model_id` — no transcripts,
   audio paths, or session content
-- [ ] `.nosteamcloudpath` markers present in `db\`, `logs\`, `models\llm\`,
-  `packs\`, `exports\`, `cache\`, and `crashes\` subdirectories
+- [ ] `.nosteamcloudpath` markers present in `data\`, `db\`, `logs\`,
+  `models\llm\`, `packs\`, `exports\`, `cache\`, and `crashes\` subdirectories
 
 ### E.11 Support bundle flow
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -450,6 +450,64 @@ Before submitting the depot to Valve, run the audit locally:
 - [ ] No `.env`, `__pycache__\`, or `.venv\` directories in the depot
 - [ ] Installer is Authenticode-signed (verify with `signtool.exe verify /pa /v <file>`)
 
+### E.8 Offline play after model download
+
+Block all outbound network access (Windows Firewall or disconnect the network
+adapter) after the model has been downloaded and verified, then start a session.
+
+- [ ] Session starts and runs normally with no network connection
+- [ ] No error or network-related warning appears in the UI
+- [ ] Push-to-talk (if voice is enabled) still functions locally
+- [ ] Reconnecting the network does not trigger any sync or phone-home behavior
+
+### E.9 Privacy controls
+
+Navigate to **Settings → Privacy** (or the Privacy section of Settings).
+
+- [ ] Transcript history view is accessible and lists the sessions played above
+- [ ] "Clear all local data" button is present and functional
+- [ ] Local data path (`%LOCALAPPDATA%\outrightmental\convsim\`) is displayed in the UI
+- [ ] Clearing data removes all sessions from the session library without requiring
+  file-manager navigation
+- [ ] After clearing, `GET /api/health` shows `privacy.telemetry_enabled: false`
+- [ ] No outbound telemetry call is observed before or after clearing data
+
+### E.10 Steam Cloud exclusions
+
+See **Part B.11** for the full Steam Cloud sync verification procedure.
+Complete B.11 on this Windows machine before checking the items below.
+
+- [ ] B.11 Steam Cloud sync verification completed (Windows)
+- [ ] `steam_cloud_settings.json` contains only `last_model_id` — no transcripts,
+  audio paths, or session content
+- [ ] `.nosteamcloudpath` markers present in `db\`, `logs\`, `models\llm\`,
+  `packs\`, `exports\`, `cache\`, and `crashes\` subdirectories
+
+### E.11 Support bundle flow
+
+Navigate to **Settings → Support** (or the Help / Support screen).
+
+- [ ] Log directory path is shown or linked in the UI
+- [ ] User can copy the log path without file-manager navigation
+- [ ] Opening the log directory via the UI shows `%LOCALAPPDATA%\outrightmental\convsim\logs\`
+- [ ] Log files contain startup events and session lifecycle info with no raw
+  conversation text or NPC responses
+
+### E.12 Achievements, stats, and rich presence (if included in build)
+
+> Skip this step if the build was not compiled with `--features steam`.
+> Steam features are present only when the Tauri command `get_steam_status`
+> returns `{"enabled": true, ...}`.  Check `GET /api/health` for the
+> `steam` field, or look for `[steam] Steam initialised` in the startup log.
+
+- [ ] Completing a scored session triggers the expected achievement notification
+  (Steam overlay toast or in-app indicator)
+- [ ] Steam overlay (Shift+Tab) shows the unlocked achievement in the
+  overlay's achievement list
+- [ ] Rich presence text in the Steam Friends list reflects the current
+  scenario or session state
+- [ ] No outbound HTTP calls outside the Steamworks SDK are observed during play
+
 ---
 
 ## Part F — Packaged-app smoke (desktop build)
@@ -580,6 +638,413 @@ grep -r "player_turn\|npc_turn\|content.*:" "${TMPDIR:-/tmp}"/convsim-release-sm
 
 ---
 
+## Part G — macOS Steam beta install verification
+
+Run this checklist on a **clean macOS machine** (fresh Steam library, no prior
+Conversation Simulator data) before declaring the macOS Stage 3 gate open.
+It is the macOS equivalent of Part E.
+
+Minimum hardware: macOS 13 Ventura or newer, Apple Silicon (arm64) or Intel
+(x86-64).  See `docs/platform-notes.md` for system requirements.
+
+### G.1 Gatekeeper and notarization
+
+Install the app from the Steam client and attempt to launch it on a fresh macOS
+profile where the app has never been opened before.
+
+- [ ] Steam installs the macOS app without errors (no Python, Node.js, or Rust prompts)
+- [ ] The `.app` bundle opens from the Steam Play button **without** a Gatekeeper
+  "unverified developer" dialog (notarised + stapled build)
+- [ ] `spctl --assess --verbose "ConversationSimulator.app"` exits 0 and prints
+  `accepted` (run in Terminal on the installed `.app`)
+- [ ] `codesign --verify --deep --strict "ConversationSimulator.app"` exits 0
+- [ ] No persistent security exception in System Settings → Privacy & Security
+  is required after first launch
+
+### G.2 Fresh install from Steam
+
+- [ ] Tauri window opens and displays the home screen
+- [ ] No terminal window is visible (convsim-core runs as a hidden child process)
+- [ ] `~/Library/Application Support/com.outrightmental.convsim/` is created on
+  first launch; no data written before the first-run wizard is dismissed
+
+### G.3 First-run model wizard
+
+- [ ] Wizard is shown before the main scenario library is accessible
+- [ ] All six mandatory disclosure fields are visible:
+  model name, source URL, license, download size, SHA-256 checksum,
+  destination path on disk
+- [ ] Download button is inactive until the player confirms disclosure
+- [ ] Destination path shown is under
+  `~/Library/Application Support/com.outrightmental.convsim/models/`
+- [ ] Download completes; SHA-256 is verified; model status changes to `loaded`
+
+### G.4 Text scenario and debrief
+
+Select **Job Interview Basics → Behavioral Interview** and run a session.
+
+- [ ] Scenario library loads and all five official packs are listed
+- [ ] Session starts without errors; NPC opening line is delivered
+- [ ] Player can submit a text turn; NPC responds within 60 seconds (CPU-only)
+- [ ] Session ends cleanly via the Stop / End Session button
+- [ ] Debrief screen loads with rubric scores and an export option
+- [ ] Exporting the transcript saves a file under
+  `~/Library/Application Support/com.outrightmental.convsim/exports/`
+
+### G.5 Offline play after model download
+
+Disconnect the network (Wi-Fi off or Airplane mode) after the model is
+downloaded and verified.
+
+- [ ] Session starts and runs normally with no network connection
+- [ ] No error or network-related warning appears
+- [ ] Reconnecting to the network does not trigger any sync or phone-home behavior
+
+### G.6 Privacy controls
+
+Navigate to **Settings → Privacy**.
+
+- [ ] Transcript history view lists the sessions played above
+- [ ] "Clear all local data" button is present and functional
+- [ ] Local data path (`~/Library/Application Support/com.outrightmental.convsim/`)
+  is displayed in the UI
+- [ ] Clearing data removes all sessions without requiring Finder navigation
+- [ ] `telemetry_enabled` is `false` in `GET /api/health`
+
+### G.7 Steam Cloud exclusions
+
+See **Part B.11** for the full Steam Cloud sync verification procedure.
+
+- [ ] B.11 Steam Cloud sync verification completed (macOS)
+- [ ] `steam_cloud_settings.json` at the data root contains only `last_model_id`
+- [ ] `.nosteamcloudpath` markers present in `data/`, `db/`, `logs/`,
+  `models/llm/`, `packs/`, `exports/`, `cache/`, and `crashes/`
+
+### G.8 Support bundle flow
+
+Navigate to **Settings → Support**.
+
+- [ ] Log directory path is shown or linked in the UI
+- [ ] Opening the log directory via the UI reveals
+  `~/Library/Application Support/com.outrightmental.convsim/logs/`
+- [ ] Log files contain startup events and session lifecycle info with no raw
+  conversation text
+
+### G.9 Achievements, stats, and rich presence (if included in build)
+
+> Skip if `get_steam_status` returns `{"enabled": false}`.
+
+- [ ] Completing a scored session triggers an achievement notification
+- [ ] Steam overlay (Shift+Tab) reflects the unlocked achievement
+- [ ] Rich presence text updates to reflect the current session state
+- [ ] No outbound HTTP calls outside the Steamworks SDK observed during play
+
+### G.10 Log verification
+
+```bash
+ls -la "$HOME/Library/Application Support/com.outrightmental.convsim/logs/"
+```
+
+- [ ] Log files present in the macOS data directory
+- [ ] Logs contain no API keys, tokens, or raw conversation content
+- [ ] No stale `~/.convsim/` directory was created (macOS platform path only)
+
+### G.11 Uninstall and reinstall behavior
+
+Uninstall via **Steam → right-click → Manage → Uninstall**, then reinstall.
+
+- [ ] Uninstall completes; the Steam library directory for the app is removed
+- [ ] User data under `~/Library/Application Support/com.outrightmental.convsim/`
+  is **preserved** (Steam uninstallers must not touch Application Support)
+- [ ] Downloaded model weights survive the uninstall
+- [ ] After reinstall, **no first-run wizard** appears — the app detects existing
+  user data and goes directly to the main screen
+- [ ] Session history and downloaded model detected as `loaded` (no re-download)
+
+---
+
+## Part H — Linux / SteamOS Steam beta install verification
+
+Run this checklist on a **clean Ubuntu 22.04 or SteamOS 3.x machine** with
+no prior Conversation Simulator install.  It is the Linux equivalent of Part E.
+
+### H.1 Executable permissions and dependency verification
+
+```bash
+# After Steam installs the app:
+INSTALL_DIR="$HOME/.steam/steam/steamapps/common/ConversationSimulator"
+ls -la "$INSTALL_DIR"
+
+# Check the AppImage is executable:
+file "$INSTALL_DIR/ConversationSimulator.AppImage"   # should say "ELF 64-bit" or "AppImage"
+
+# Confirm glibc version meets the ≥ 2.35 requirement:
+ldd --version | head -1
+```
+
+- [ ] AppImage file is present in the Steam install directory
+- [ ] AppImage has the executable bit set (`-rwxr-xr-x`)
+- [ ] `ldd --version` reports glibc ≥ 2.35 (Ubuntu 22.04 ships 2.35; SteamOS 3.x ships 2.37+)
+- [ ] No additional package install prompts appear (WebKitGTK and GTK 3 bundled
+  in AppImage)
+- [ ] On Ubuntu 22.04 without FUSE 2: AppImage runs with `--appimage-extract-and-run`
+  flag or after `sudo apt-get install libfuse2`
+
+### H.2 Fresh install from Steam
+
+- [ ] Tauri window opens and displays the home screen
+- [ ] No terminal window visible (convsim-core runs as hidden child process)
+- [ ] `~/.local/share/convsim/` or `~/.config/com.outrightmental.convsim/` is
+  created on first launch (platform-native data directory; confirm in startup log)
+
+### H.3 First-run model wizard
+
+- [ ] Wizard is shown before the main scenario library is accessible
+- [ ] All six mandatory disclosure fields visible (name, source, license, size,
+  SHA-256, destination path)
+- [ ] Download button inactive until disclosure confirmed
+- [ ] Destination path shown is under `~/.local/share/convsim/models/`
+- [ ] Download completes; SHA-256 verified; model status changes to `loaded`
+
+### H.4 Text scenario and debrief
+
+Select **Job Interview Basics → Behavioral Interview** and run a session.
+
+- [ ] All five official packs listed in the scenario library
+- [ ] Session starts; NPC opening line delivered
+- [ ] Player text turn submitted; NPC responds within 60 seconds (CPU-only)
+- [ ] Session ends cleanly; debrief screen loads with rubric scores and export option
+- [ ] Exported transcript saved under `~/.local/share/convsim/exports/`
+
+### H.5 Offline play after model download
+
+Disable the network interface (`nmcli networking off` or unplug ethernet) after
+model download.
+
+- [ ] Session runs normally with no network
+- [ ] No error or network-related warning in the UI
+- [ ] Restoring network does not trigger phone-home or sync behavior
+
+### H.6 Privacy controls
+
+Navigate to **Settings → Privacy**.
+
+- [ ] Transcript history view lists played sessions
+- [ ] "Clear all local data" button present and functional
+- [ ] Local data path displayed in the UI
+- [ ] Clearing data removes sessions without terminal navigation
+- [ ] `telemetry_enabled` is `false` in `GET /api/health`
+
+### H.7 Steam Cloud exclusions
+
+See **Part B.11** for the full Steam Cloud sync verification procedure.
+
+- [ ] B.11 Steam Cloud sync verification completed (Linux)
+- [ ] `steam_cloud_settings.json` at the data root contains only `last_model_id`
+- [ ] `.nosteamcloudpath` markers present in all required subdirectories
+
+### H.8 Support bundle flow
+
+Navigate to **Settings → Support**.
+
+- [ ] Log directory path shown or linked in the UI
+- [ ] Opening via the UI confirms logs in `~/.local/share/convsim/logs/`
+- [ ] Log files contain diagnostic context with no raw conversation text
+
+### H.9 Achievements, stats, and rich presence (if included in build)
+
+> Skip if `get_steam_status` returns `{"enabled": false}`.
+
+- [ ] Completing a scored session triggers an achievement notification
+- [ ] Steam overlay (Shift+Tab) reflects the unlocked achievement
+- [ ] Rich presence text updates in the Steam Friends list
+- [ ] No outbound HTTP calls outside the Steamworks SDK during play
+
+### H.10 Log verification
+
+```bash
+ls -la ~/.local/share/convsim/logs/
+```
+
+- [ ] Log files present
+- [ ] No API keys, tokens, or raw conversation content in logs
+- [ ] No stale `~/.convsim/` directory (platform-native path only)
+
+### H.11 FUSE and AppImage behavior notes
+
+> Document any FUSE-related issues encountered during this verification.
+
+| Issue | Resolution | Documented |
+|-------|-----------|-----------|
+| FUSE 2 not present | Run with `--appimage-extract-and-run` or `apt install libfuse2` | [ ] |
+| AppImage not executable | `chmod +x ConversationSimulator.AppImage` | [ ] |
+| WebKit / GTK missing | Should not occur (bundled); document if observed | [ ] |
+
+---
+
+## Part I — Steam Deck beta verification
+
+Run this checklist on **physical Steam Deck hardware** running SteamOS 3.x in
+Gaming Mode.  This is required for the Stage 4 gate G4-02 (Steam Deck Verified).
+
+All steps must be completable without a keyboard or mouse: use the D-pad,
+A/B/X/Y buttons, left stick, right trackpad, and the Steam on-screen keyboard
+only.  See `docs/QA_STEAM_PLATFORM_MATRIX.md §3` for the full controller
+navigation checklist (TC-11) that these steps exercise.
+
+### I.1 Install from Steam library
+
+In Gaming Mode on the Steam Deck:
+
+- [ ] App is listed in the Steam library after the beta key is redeemed
+- [ ] Install completes from the Steam Play button without switching to Desktop Mode
+- [ ] App launches in Gaming Mode from the library tile
+
+### I.2 First-run model wizard (controller-only)
+
+- [ ] Wizard appears before the main scenario library
+- [ ] Model Manager UI is fully navigable with D-pad and A/B/X/Y buttons
+- [ ] On-screen keyboard appears automatically when any text field is focused
+  (tester name or search field)
+- [ ] Download button can be reached and activated via controller alone
+- [ ] Download completes; model status changes to `loaded` at the expected
+  SteamOS latency (see `docs/linux-steamos-requirements.md` — target ≤ 90 s
+  for Qwen3 4B Q4_K_M on Steam Deck hardware)
+
+### I.3 Controller-only full session (TC-11)
+
+Complete all 13 steps of TC-11 from `docs/QA_STEAM_PLATFORM_MATRIX.md §4`
+using the controller alone.
+
+| TC-11 step | Result |
+|-----------|--------|
+| 11.1 Launch and reach Home screen | [ ] PASS / [ ] FAIL |
+| 11.2 Navigate Home with D-pad / left stick | [ ] PASS / [ ] FAIL |
+| 11.3 Navigate to Scenario Library | [ ] PASS / [ ] FAIL |
+| 11.4 Select scenario without keyboard/mouse | [ ] PASS / [ ] FAIL |
+| 11.5 On-screen keyboard for text field | [ ] PASS / [ ] FAIL |
+| 11.6 Start voice session; R1 triggers push-to-talk | [ ] PASS / [ ] FAIL / [ ] N/A |
+| 11.7 Submit text turn via on-screen keyboard | [ ] PASS / [ ] FAIL |
+| 11.8 End session; reach Debrief screen | [ ] PASS / [ ] FAIL |
+| 11.9 Navigate Debrief; check readability at 1280×800 | [ ] PASS / [ ] FAIL |
+| 11.10 Navigate Model Manager, Settings, Support, Workbench | [ ] PASS / [ ] FAIL |
+| 11.11 DebugDrawer excluded from focus ring (dev build) | [ ] PASS / [ ] N/A |
+| 11.12 Steam overlay opens / closes without breaking session | [ ] PASS / [ ] FAIL |
+| 11.13 Quit via controller; no orphaned processes | [ ] PASS / [ ] FAIL |
+
+### I.4 Offline play under SteamOS
+
+After model download, switch to Airplane Mode (Steam Deck Quick Access → Network).
+
+- [ ] Session runs normally with no network
+- [ ] No error or network-related warning in the UI (controller-accessible)
+- [ ] TC-09 offline smoke criteria met on SteamOS hardware
+
+### I.5 Privacy controls and support bundle
+
+Navigate to **Settings → Privacy** and **Settings → Support** via controller.
+
+- [ ] Privacy controls navigable without keyboard/mouse
+- [ ] "Clear all local data" button reachable and functional via controller
+- [ ] Support screen log path visible and readable at 1280×800
+
+### I.6 Steam Cloud exclusions
+
+```bash
+# In Desktop Mode — Konsole:
+cat "$HOME/.local/share/convsim/steam_cloud_settings.json"
+for d in data db logs models/llm packs exports cache crashes; do
+    echo "$d: $(ls "$HOME/.local/share/convsim/$d/.nosteamcloudpath" 2>/dev/null \
+      && echo PRESENT || echo MISSING)"
+done
+```
+
+- [ ] `steam_cloud_settings.json` contains only `last_model_id`
+- [ ] `.nosteamcloudpath` present in all required subdirectories
+
+### I.7 Achievements, stats, and rich presence (if included in build)
+
+> Skip if `get_steam_status` returns `{"enabled": false}`.
+
+- [ ] Achievement notification appears after a scored session (on-screen toast
+  or Steam overlay notification visible from Gaming Mode)
+- [ ] Rich presence text visible in the Steam Friends list on another device
+- [ ] No outbound HTTP calls outside Steamworks SDK during play
+
+### I.8 Battery impact documentation
+
+Run a 15-minute text session while monitoring battery draw.  Use the Steam Deck
+performance overlay (Quick Access → Performance) to observe average wattage.
+
+- [ ] Average battery draw during sustained text inference: ___ W
+  (target: < 15 W — see `docs/linux-steamos-requirements.md §SteamOS`)
+- [ ] Fan behavior during inference: [ ] Silent / [ ] Intermittent spin / [ ] Sustained
+- [ ] Result documented in the beta verification report
+
+### I.9 Steam Deck Verified sign-off requirements
+
+These items are required for Valve to grant the Verified tier (G4-02).
+
+- [ ] All TC-11 steps above show PASS (no FAIL results)
+- [ ] On-screen keyboard appeared automatically for every text field
+- [ ] No required action hidden behind a mouse-only hover state
+- [ ] All text readable at 1280×800 from couch distance without zooming
+- [ ] Every interactive element had a visible focus ring during controller navigation
+- [ ] Default controller config (`steam/controller_config.vdf`) loaded automatically
+  (confirm via Steam Input overlay)
+- [ ] Push-to-talk (R1) does not conflict with Steam overlay (Shift+Tab)
+- [ ] App exits cleanly and returns to the Steam library home
+- [ ] Battery draw documented (I.8 above)
+
+---
+
+## Part J — Steam beta verification sign-off
+
+Complete this section after Parts E, G, H, and I are all finished for the
+release candidate build.  This section gates **G3-06** (private beta sign-off)
+and contributes evidence for **G4-02** (Steam Deck Verified).
+
+### J.1 Minimum tester coverage
+
+A minimum of five testers must complete at least one full text session and view
+the debrief screen before G3-06 can be declared PASS.  At least one tester must
+be on each required platform.
+
+| Platform | Required testers | Status |
+|----------|-----------------|--------|
+| Windows 10 / 11 (x86-64) | ≥ 2 | TBD |
+| macOS — Apple Silicon | ≥ 1 | TBD |
+| macOS — Intel | ≥ 1 | TBD |
+| Linux (x86-64) | ≥ 1 | TBD |
+| Steam Deck (SteamOS 3.x, Gaming Mode) | ≥ 1 | TBD for G4-02 |
+
+### J.2 Platform-specific blocker tracking
+
+Any session-ending bug, data-loss bug, or privacy regression found during Parts
+E, G, H, or I must be filed as a GitHub issue with the label `beta-testing`
+before the gate can be declared.
+
+Use the label `platform:windows`, `platform:macos`, `platform:linux`, or
+`platform:steam-deck` to identify the affected platform.  Child issues should
+reference this issue as a blocker.
+
+- [ ] All session-ending, data-loss, and privacy-regression bugs are filed
+- [ ] All filed blockers are either closed or have a documented maintainer waiver
+  before G3-06 is declared PASS
+
+### J.3 Beta verification report
+
+Produce and file the signed-off beta verification report using the template in
+`docs/STEAM_BETA_VERIFICATION_REPORT.md`.  The completed report must be
+attached to the release issue before the Stage 3 gate is declared open.
+
+- [ ] `docs/STEAM_BETA_VERIFICATION_REPORT.md` filled out for this build
+- [ ] All four platform sign-offs completed (or PARTIAL with documented waiver)
+- [ ] Report attached to the release GitHub issue or linked from the release PR
+- [ ] Publishing owner has countersigned the aggregate sign-off section
+
+---
+
 ## Smoke log
 
 Fill this in for each manual release smoke run.
@@ -629,6 +1094,13 @@ When a subsystem fails, the output labels the failing step:
 | `[e2e-playthrough]` | E2E playthrough | Full playthrough broken in packaged-env mode; official packs not loading |
 | `[artifact-inspect]` | Artifact inspection | Version not stamped; icon missing; forbidden file in depot; permission bit wrong |
 | `[workbench]` | Creator workbench | Pack import/export or file API broken; workbench route error |
+| `[steam-beta]` | Steam beta verification | Platform-specific install, OS trust state, or Steam-client-specific regression; see Parts E / G / H / I |
 
 CI artifacts for failed runs are uploaded to GitHub Actions under the job name
 `release-smoke-<platform>` and retained for 7 days.
+
+Steam beta verification failures (Parts E, G, H, I) must be filed as GitHub
+issues with the label `beta-testing` and the appropriate `platform:*` label
+before the Stage 3 gate (G3-06) can be declared PASS.  See Part J for the
+complete sign-off process and `docs/STEAM_BETA_VERIFICATION_REPORT.md` for the
+report template.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -794,8 +794,9 @@ ldd --version | head -1
 
 - [ ] Tauri window opens and displays the home screen
 - [ ] No terminal window visible (convsim-core runs as hidden child process)
-- [ ] `~/.local/share/convsim/` or `~/.config/com.outrightmental.convsim/` is
-  created on first launch (platform-native data directory; confirm in startup log)
+- [ ] `~/.local/share/convsim/` (or `$XDG_DATA_HOME/convsim` when `XDG_DATA_HOME`
+  is set) is created on first launch (platform-native data directory; confirm in
+  startup log)
 
 ### H.3 First-run model wizard
 

--- a/publishing/STEAM_STORE_AND_OPERATIONS.md
+++ b/publishing/STEAM_STORE_AND_OPERATIONS.md
@@ -155,6 +155,12 @@ until every item is checked.
 - [ ] Smoke matrix from [`docs/release-checklist.md`](../docs/release-checklist.md)
       has been run and passed on Windows 10/11, macOS 13+, Linux x86-64, and
       Steam Deck.
+- [ ] Steam beta verification (Parts E, G, H, I, J of
+      [`docs/release-checklist.md`](../docs/release-checklist.md)) is complete and
+      the signed-off
+      [`docs/STEAM_BETA_VERIFICATION_REPORT.md`](../docs/STEAM_BETA_VERIFICATION_REPORT.md)
+      for the launch build is attached to the release issue (SR-09 / G3-06
+      deliverable).
 - [ ] Steam Deck Verified tier checklist from
       [`docs/STEAM_ROADMAP.md`](../docs/STEAM_ROADMAP.md#steam-deck-verification-checklist)
       has been submitted to Valve and verified.
@@ -245,4 +251,5 @@ for the full policy.
 - [`docs/steam-triage.md`](../docs/steam-triage.md) — issue triage flow, SLA targets, privacy handling
 - [`docs/steam-mvp-scope.md`](../docs/steam-mvp-scope.md) — feature requirements and pass/fail release gates
 - [`docs/STEAM_ROADMAP.md`](../docs/STEAM_ROADMAP.md) — release principles and release train
-- [`docs/release-checklist.md`](../docs/release-checklist.md) — platform smoke matrix
+- [`docs/release-checklist.md`](../docs/release-checklist.md) — platform smoke matrix and Steam beta verification (Parts E/G/H/I/J)
+- [`docs/STEAM_BETA_VERIFICATION_REPORT.md`](../docs/STEAM_BETA_VERIFICATION_REPORT.md) — aggregate signed-off beta verification report template (all four platforms)


### PR DESCRIPTION
## Summary

Implements the QA verification process for running the Steam beta client on all required platforms (Windows, macOS, Linux, Steam Deck) before the Stage 3 and Stage 4 release gates can be declared. Adds comprehensive per-platform Steam beta checklists to the release checklist, a new aggregate signed-off beta verification report template, and updates related reference documentation.

## What changed

### `docs/release-checklist.md`

**Extended Part E (Windows Steam verification)** with five new steps:
- E.8 — Offline play after model download (firewall/network-off test)
- E.9 — Privacy controls (transcript history, clear-all-data, telemetry defaults)
- E.10 — Steam Cloud exclusions (references Part B.11; verifies `last_model_id`-only sync and `.nosteamcloudpath` markers)
- E.11 — Support bundle flow (log directory visible and accessible from the UI)
- E.12 — Achievements, stats, and rich presence (conditional on `--features steam` build)

**Added Part G — macOS Steam beta install verification:** mirrors Part E for macOS with a Gatekeeper/notarization trust-state check (`spctl --assess`, `codesign --verify`), fresh Steam install, first-run model wizard, scenario play, debrief, offline play, privacy controls, Steam Cloud, support bundle, achievements, log verification, and uninstall/reinstall behavior.

**Added Part H — Linux / SteamOS Steam beta install verification:** executable permissions and glibc ≥ 2.35 dependency check (required for AppImage on Ubuntu 22.04+/SteamOS 3.x), fresh Steam install, model wizard, scenario play, debrief, offline play, privacy controls, Steam Cloud, support bundle, achievements, log verification, and FUSE/AppImage behavior documentation table.

**Added Part I — Steam Deck beta verification:** Gaming Mode install from the Steam library, controller-only model wizard, TC-11 13-step controller walkthrough table (referencing `docs/QA_STEAM_PLATFORM_MATRIX.md §4`), offline play under SteamOS, privacy and support controls navigable by controller, Steam Cloud exclusions, achievements, battery impact documentation (target < 15 W), and all Steam Deck Verified sign-off requirements for gate G4-02.

**Added Part J — Steam beta verification sign-off:** minimum tester coverage table (≥ 5 testers, ≥ 1 per platform), platform-specific blocker tracking with GitHub label guidance (`beta-testing` + `platform:*`), and the step to produce and file the aggregate beta verification report.

**Updated Failure reference table** with a `[steam-beta]` label pointing to Parts E/G/H/I and the blocker filing process.

### `docs/STEAM_BETA_VERIFICATION_REPORT.md` (new file)

Aggregate signed-off beta verification report template covering all four platforms. Contains:
- Report header (build version, branch, dates, publishing owner)
- Prerequisites checklist linking the six blocked-by roadmap issues
- Per-platform result tables for Windows (Part E), macOS (Part G), Linux (Part H), and Steam Deck (Part I) with PASS / PARTIAL / FAIL outcomes and hardware capture fields
- Platform-specific blocker log table (GitHub issue number, platform, status)
- CI gate confirmation (ci.yml, release-smoke.yml, steam-deploy.yml)
- Aggregate sign-off block with tester signature and publishing-owner countersignature (required for PARTIAL results or Stage 4 decisions)

### `docs/QA_STEAM_PLATFORM_MATRIX.md`

- Added cross-reference in §7 pointing from per-platform sign-off templates to the new aggregate report template.
- Updated §8 Links to include `STEAM_BETA_VERIFICATION_REPORT.md` and `linux-steamos-requirements.md`; expanded the `release-checklist.md` link description to name the new parts (E, G, H, I, J).

### `publishing/STEAM_STORE_AND_OPERATIONS.md`

- Updated the launch checklist to explicitly require Steam beta verification (Parts E, G, H, I, J) completion and the signed-off `STEAM_BETA_VERIFICATION_REPORT.md` attached to the release issue (SR-09 / G3-06 deliverable).
- Updated the reference links section to include both the main release checklist and the aggregate report template.

### `apps/web/src/__tests__/VoiceSettingsPanel.test.tsx`

Fixed a flaky test condition: consolidated the readiness-mic check to wait for the text content "permission granted" in a single `waitFor()` call instead of checking element existence separately, preventing race conditions on async state updates.

## How it was tested

These are primarily documentation and process changes with one test fix:
- All existing automated CI gates (pytest, vitest, cargo check, release-smoke, artifact inspection) remain unchanged.
- The new checklist steps map directly to existing test cases (TC-01 through TC-11 in QA_STEAM_PLATFORM_MATRIX.md) and existing automated coverage (`tests/acceptance/`, `tests/e2e/`, `tests/artifact/`, Part B.11 Steam Cloud verification).
- The VoiceSettingsPanel test fix eliminates a race condition by combining assertion and wait into a single `waitFor()` block.

## Release gate impact

- Parts E, G, H, I, and J are required before G3-06 (beta session verification) can be declared PASS.
- Part I and the Steam Deck section of the aggregate report are required before requesting Valve's G4-02 (Steam Deck Verified) review.
- The completed `STEAM_BETA_VERIFICATION_REPORT.md` must be attached to the release GitHub issue as the signed-off deliverable.

Closes #239