### PR TITLE
Complete Steam review checklist and launch operations runbook

### DIFF
--- a/publishing/BETA_FEEDBACK_AND_LAUNCH_RISKS.md
+++ b/publishing/BETA_FEEDBACK_AND_LAUNCH_RISKS.md
@@ -1,0 +1,188 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+# Private Beta Feedback Summary and Accepted Launch Risks
+
+> **Purpose:** Record the private beta tester feedback collected during Stage 3,
+> summarise what was fixed, what was deferred, and document all risks formally
+> accepted for the v1 public launch. This document is the sign-off evidence for
+> gate SR-09 (private beta sign-off) and feeds directly into the known-issues
+> table in [`publishing/LAUNCH_DAY_RUNBOOK.md`](LAUNCH_DAY_RUNBOOK.md).
+>
+> **Audience:** Platform team, launch commander, Outright Mental. Outright Mental
+> must review and sign the [Accepted risks sign-off](#accepted-risks-sign-off)
+> section before the `default` branch is set live.
+>
+> **When to complete:** After the Stage 3 beta verification report is signed off
+> and before the Stage 4 gate check in the launch day runbook.
+
+---
+
+## Beta tester coverage
+
+Record each tester who participated in the private beta and the platforms they
+covered. The minimum coverage requirement is ≥ 5 testers with ≥ 1 per platform
+(gate G3-06 / SR-09).
+
+| Tester ID | Platform(s) tested | Sessions completed | Sign-off date |
+|-----------|-------------------|-------------------|--------------|
+| *(tester-01)* | Windows 11 | | |
+| *(tester-02)* | macOS 14 (Apple Silicon) | | |
+| *(tester-03)* | Linux (Ubuntu 24.04) | | |
+| *(tester-04)* | Steam Deck (SteamOS 3.x) | | |
+| *(tester-05)* | Windows 10 | | |
+| *(add rows as needed)* | | | |
+
+**Total testers:** ___  
+**Windows coverage:** ___  
+**macOS coverage:** ___  
+**Linux / SteamOS coverage:** ___  
+**Steam Deck coverage:** ___
+
+Tester identity is kept within the team. Do not publish individual tester
+names or contact details.
+
+---
+
+## Feedback summary
+
+### How feedback was collected
+
+- One-click redacted diagnostics bundle via the in-app "Send beta report" button
+  (see [`docs/beta-testing.md`](../docs/beta-testing.md) and
+  `services/convsim-core/convsim_core/beta_report.py`).
+- Manual GitHub issues filed by testers using the
+  `.github/ISSUE_TEMPLATE/beta-report.yml` template.
+- Direct tester communication recorded by the platform lead.
+
+### Aggregate feedback statistics
+
+| Category | Reports received | Fixed before launch | Deferred | Won't fix |
+|----------|-----------------|--------------------|---------|---------:|
+| Platform / installation | | | | |
+| Session flow / NPC behaviour | | | | |
+| Model download and management | | | | |
+| Voice / microphone | | | | |
+| Steam Deck / controller | | | | |
+| Privacy / data handling | | | | |
+| UI / UX | | | | |
+| Performance | | | | |
+| Other | | | | |
+| **Total** | | | | |
+
+### Themes from feedback
+
+Document the top 3–5 themes that emerged across multiple testers. These inform
+both the accepted risks below and future post-launch milestones.
+
+1. *(summarise after beta)*
+2. *(summarise after beta)*
+3. *(summarise after beta)*
+
+### What was fixed
+
+List GitHub issues fixed as a result of private beta feedback that are included
+in the launch build.
+
+| Issue | Description | Platform | Fix included in tag |
+|-------|-------------|----------|-------------------|
+| *(#nnn)* | | | |
+
+### What was deferred
+
+List GitHub issues filed during private beta that are **not** fixed in the
+launch build and are deferred to a post-launch milestone. Each deferred item
+must appear in the accepted risks table or the known-issues table in
+[`publishing/LAUNCH_DAY_RUNBOOK.md`](LAUNCH_DAY_RUNBOOK.md).
+
+| Issue | Description | Platform | Deferred to milestone | Severity |
+|-------|-------------|----------|----------------------|---------|
+| *(#nnn)* | | | | |
+
+---
+
+## Accepted launch risks
+
+These risks are formally accepted by Outright Mental as present at public
+launch. Each risk must have a mitigation or workaround documented and must not
+be a release-blocking risk that is `OPEN` in the compliance register.
+
+For compliance register risks (e.g. AU-01, SP-01), the `Status` column in
+[`publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md`](STEAM_COMPLIANCE_AND_RISK_REGISTER.md)
+must be updated to `ACCEPTED` once this sign-off is complete.
+
+### Functional risks accepted for v1
+
+| Risk ID | Description | Mitigation / workaround | Player impact | Tracking |
+|---------|-------------|------------------------|--------------|---------|
+| AR-01 | *(document accepted functional risks here)* | | | |
+
+### Platform risks accepted for v1
+
+| Risk ID | Description | Platform | Mitigation / workaround | Tracking |
+|---------|-------------|---------|------------------------|---------|
+| AP-01 | *(document accepted platform risks here)* | | | |
+
+### Known limitations documented for players
+
+These limitations are communicated to players via the store page, in-app text,
+or the Steam community hub FAQ. They are not bugs — they are intentional
+constraints of the v1 release.
+
+| Limitation | How communicated | Notes |
+|-----------|-----------------|-------|
+| Model weights are not included in the installer; the player must download a model before starting a session | Onboarding wizard, first-launch screen, store page system requirements | By design — avoids model license distribution restrictions |
+| Voice input requires an external USB or Bluetooth microphone on Steam Deck | Steam store page (system requirements), Steam Deck installation note | AU-03; text-only mode available without a microphone |
+| No cloud sync of conversations or transcripts; progress does not transfer between machines | Store page, in-app privacy screen | Local-first by design; only `steam_cloud_settings.json` syncs |
+| Community pack import requires manual file placement; no in-app pack browser | In-app Settings → Packs screen | Pack browser deferred to post-launch Stage 5 |
+| *(add further known limitations here)* | | |
+
+---
+
+## Accepted risks sign-off
+
+All parties listed below must sign this section before the launch day runbook
+proceeds to the Stage 4 gate check.
+
+| Role | Name | Signature / date | Notes |
+|------|------|-----------------|-------|
+| Launch commander (Outright Mental) | | | |
+| Platform lead | | | |
+| Privacy fast-path owner | | | |
+
+By signing, each party confirms:
+
+1. They have reviewed the beta feedback summary and the accepted risks table.
+2. They agree that the accepted risks are tolerable for a free public release
+   and that adequate mitigations or workarounds are in place.
+3. They understand that compliance register risks marked `ACCEPTED` here will
+   be updated to `ACCEPTED` status in
+   [`publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md`](STEAM_COMPLIANCE_AND_RISK_REGISTER.md).
+4. No `OPEN` release-blocking risk in the compliance register is being silently
+   ignored — every such risk is either `MITIGATED`, `ACCEPTED` with sign-off
+   here, or `DEFERRED` with a post-launch milestone assigned.
+
+---
+
+## Post-launch risk monitoring
+
+After launch, the following risks require active monitoring during the 72-hour
+window defined in [`publishing/LAUNCH_DAY_RUNBOOK.md`](LAUNCH_DAY_RUNBOOK.md):
+
+| Risk | Monitor via | Escalation if triggered |
+|------|------------|------------------------|
+| Privacy regression (any data leaving the machine) | Steam reviews, GitHub issues — privacy fast-path keywords | Immediate rollback; notify launch commander |
+| Microphone permission crash (AU-01) | GitHub issues `label:steam+platform-bug`, Steam reviews | Hotfix or patch deployment within 48 hours |
+| Steam Deck controller navigation blocking home screen (SP-02 related) | GitHub issues `label:steam+platform-bug` | Patch or rollback within 24 hours |
+| Valve review rejection risk materialising post-launch | Steamworks notices, Valve developer support email | Launch commander escalation; consult legal |
+
+---
+
+## Links
+
+- [`publishing/LAUNCH_DAY_RUNBOOK.md`](LAUNCH_DAY_RUNBOOK.md) — launch-day operations and known issues table
+- [`publishing/ROLLBACK_AND_SUPPORT_MESSAGING.md`](ROLLBACK_AND_SUPPORT_MESSAGING.md) — rollback procedure and player messaging
+- [`publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md`](STEAM_COMPLIANCE_AND_RISK_REGISTER.md) — full compliance risk register (update status after sign-off)
+- [`docs/STEAM_BETA_VERIFICATION_REPORT.md`](../docs/STEAM_BETA_VERIFICATION_REPORT.md) — aggregate beta verification report (SR-09)
+- [`docs/QA_STEAM_PLATFORM_MATRIX.md`](../docs/QA_STEAM_PLATFORM_MATRIX.md) — QA test matrix and tester sign-offs
+- [`docs/beta-testing.md`](../docs/beta-testing.md) — beta tester guide (diagnostics bundle, reporting)
+- [`docs/steam-triage.md`](../docs/steam-triage.md) — triage routing and SLA policy
+- [`docs/steam-mvp-scope.md`](../docs/steam-mvp-scope.md) — Stage 3 and Stage 4 gate criteria

--- a/publishing/LAUNCH_DAY_RUNBOOK.md
+++ b/publishing/LAUNCH_DAY_RUNBOOK.md
@@ -1,0 +1,342 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+# Launch Day Runbook
+
+> **Purpose:** Detailed operations checklist for the public release of
+> Conversation Simulator on Steam. Covers the sequence from Valve approval
+> through branch promotion, public announcement, support monitoring, rollback
+> criteria, known issues, and triage owner assignments.
+>
+> **Audience:** Platform team, Outright Mental staff. One person from each
+> group listed in [Triage owners](#triage-owners) must be available on launch
+> day and for the following 72 hours.
+>
+> **Prerequisite:** The Steam review submission has been completed and Valve
+> has approved the store page (gate G4-01). All Stage 4 gate criteria in
+> [`docs/steam-mvp-scope.md`](../docs/steam-mvp-scope.md) must be met before
+> setting the `default` branch live.
+
+---
+
+## Triage owners
+
+Assign a named person to each role before launch day. Each owner must confirm
+their availability for the 72-hour post-launch monitoring window.
+
+| Role | Owner | Contact | Escalation |
+|------|-------|---------|-----------|
+| **Launch commander** | *(assign before launch)* | | Account holder at Outright Mental |
+| **Platform lead** (GitHub issues, CI, Steam) | | | Launch commander |
+| **Privacy fast-path** (any privacy/data report) | | | Launch commander — escalate within 30 minutes |
+| **Content / pack** (NPC behaviour, scenario bugs) | | | Platform lead |
+| **Support communications** (player-facing replies, Steam discussion board) | | | Platform lead |
+| **On-call (after-hours)** | | | Platform lead → launch commander |
+
+The launch commander has final say on any rollback decision. The privacy
+fast-path owner must be reachable by phone (not just Slack or email) for the
+first 24 hours after launch.
+
+---
+
+## T−24 hours: Final checks
+
+Complete the day before the scheduled launch.
+
+### Build verification
+
+- [ ] The launch build is staged in Steamworks App Admin → Builds with all three
+      platform depots and is **not** yet live on `default`.
+- [ ] Build description in Steamworks matches the release tag (e.g. `v0.3.0`).
+- [ ] Depot audit has been run clean on the launch build: all three platform
+      content directories exited 0 from `scripts/depot-audit.sh` (SR-08).
+- [ ] The signed-off
+      [`docs/STEAM_BETA_VERIFICATION_REPORT.md`](../docs/STEAM_BETA_VERIFICATION_REPORT.md)
+      for the launch build is attached to the release issue (G3-06 / SR-09).
+
+### Store page
+
+- [ ] Store page has been reviewed in the Steamworks preview since Valve approval:
+      no placeholder text, no wrong screenshots, no pricing shown.
+- [ ] Release date field shows the correct launch date (not `Coming Soon`).
+- [ ] All five screenshots show the current build UI.
+- [ ] `Free to Play` label and "Free" button are visible in the store page preview.
+
+### CI and infrastructure
+
+- [ ] All CI workflows are green on the release tag commit.
+- [ ] GitHub Discussions or the Steam discussion board is enabled and configured.
+- [ ] GitHub issue templates for Steam reports are present (`.github/ISSUE_TEMPLATE/steam_*.yml`).
+- [ ] Launch commander and platform lead have Steamworks partner portal access
+      confirmed (can log in now, not on launch day).
+
+### Announcement content
+
+Draft the announcement before launch day so it can be posted within minutes of
+setting the app live:
+
+- [ ] Steam announcement post drafted in Steamworks → Community Hub → Post Announcement.
+- [ ] Announcement saved as a draft (do not publish yet).
+- [ ] Outright Mental has approved the announcement text.
+- [ ] Any external announcement (social media, mailing list) is queued and ready
+      to publish, coordinated with the Steam announcement.
+
+### Known issues
+
+Complete the known issues table in the [Known issues](#known-issues) section
+of this document before T−24.
+
+---
+
+## Launch sequence
+
+Run these steps in order. Each step has a hard dependency on the previous one.
+
+### Step 1 — Confirm all Stage 4 gates are green (T−2 hours)
+
+Work through the full Stage 4 gate list in
+[`docs/steam-mvp-scope.md`](../docs/steam-mvp-scope.md#stage-4-gates-public-release):
+
+| Gate | Check |
+|------|-------|
+| G4-01 | Valve store page approval received (email from Valve) |
+| G4-02 | Steam Deck Verified status confirmed in Steamworks |
+| G4-03 | Full release checklist (Parts A–J in [`docs/release-checklist.md`](../docs/release-checklist.md)) passed on all four platforms |
+| G4-04 | Store page copy accurate: no therapy/diagnosis language, no implied marketplace |
+| G4-05 | Voice smoke test passed on all required platforms |
+
+If any gate is not green, **do not proceed**. Resolve the gate failure or
+escalate to the launch commander.
+
+### Step 2 — Set the beta branch live (if not already done at Stage 3)
+
+If the `beta` branch is not already live from Stage 3:
+
+1. Trigger the deploy workflow (`.github/workflows/steam-deploy.yml`) with the
+   launch tag and `set_live_branch: beta`.
+2. Confirm the build is live on `beta` in Steamworks App Admin → Builds.
+3. Install from a fresh Steam account on at least one machine per platform to
+   verify the `beta` depot is reachable.
+
+- [ ] `beta` branch is live and verified.
+
+### Step 3 — Set the default branch live (launch)
+
+This is the point of no return. The `default` branch immediately serves all
+new installs.
+
+1. Trigger the deploy workflow with the launch tag and `set_live_branch: default`.
+2. Approve the workflow run in the `steam-release` environment (requires a
+   reviewer with the required-reviewer role).
+3. Wait for the workflow to complete successfully.
+
+- [ ] Workflow completed with exit code 0.
+- [ ] `default` branch shows the launch build in Steamworks App Admin → Builds.
+
+### Step 4 — Verify CDN propagation (T+15 minutes)
+
+Wait 10–15 minutes for the Steam CDN to propagate the new build.
+
+- [ ] The app store page is publicly visible (not returning 404).
+- [ ] The install button reads `Play Game` (not `Purchase` or `Pre-purchase`).
+- [ ] The price shown is `Free`.
+- [ ] Release date shown on the page matches today's date.
+
+### Step 5 — End-to-end install verification
+
+Install from a **fresh Steam account** (not the partner or build account) on
+each required platform. Do not skip this step — CDN propagation issues and
+package configuration errors sometimes only appear on non-partner accounts.
+
+- [ ] Windows 10 or 11: fresh install, app launches, reaches home screen.
+- [ ] macOS 13+: fresh install, Gatekeeper passes, app launches.
+- [ ] Linux / SteamOS: fresh install, app launches, reaches home screen.
+- [ ] Steam Deck (Gaming Mode): fresh install, app launches via Gaming Mode.
+
+### Step 6 — Publish announcement
+
+After Step 5 is complete and all platform installs are verified:
+
+1. Publish the Steam announcement in Steamworks → Community Hub.
+2. Publish any queued external announcements (social media, mailing list).
+3. Record the announcement times in the [Launch log](#launch-log).
+
+- [ ] Steam announcement published.
+- [ ] External announcements published.
+
+### Step 7 — Begin 72-hour monitoring
+
+Immediately after announcement, all triage owners switch to active monitoring.
+See [Support monitoring](#support-monitoring) below.
+
+- [ ] All triage owners notified that monitoring has started.
+- [ ] Monitoring cadence established (see schedule below).
+
+---
+
+## Support monitoring
+
+During the first 72 hours after public launch, monitor all signals on the
+schedule below. All findings are logged in the [Launch log](#launch-log).
+
+### Monitoring schedule
+
+| Window | Cadence | Owner |
+|--------|---------|-------|
+| Hours 0–24 | Check every 30 minutes | Platform lead (on-call during off-hours) |
+| Hours 24–48 | Check every 2 hours | Platform lead |
+| Hours 48–72 | Check every 4 hours | Platform lead |
+| After 72 hours | Standard GitHub issue triage cadence | Platform lead |
+
+### Signals to monitor
+
+| Signal | Where to check | Escalation threshold |
+|--------|---------------|---------------------|
+| Steam review sentiment | Steamworks App Admin → Reviews | Any review mentioning unexpected network activity, "sent my data", "privacy", "recording", or similar — **escalate to privacy fast-path owner immediately** |
+| GitHub Steam issue queue | GitHub Issues, filter `label:steam` | Any `severity:critical` label — 24-hour response SLA; privacy fast-path if content matches the privacy keywords |
+| Steam discussion board | Community Hub → Discussions | Any thread with more than 5 upvotes or a privacy/data concern — respond within 4 hours |
+| Steamworks stats | App Admin → Stats | Abnormal install failure rate or any stat that implies connection errors during play |
+| Known issue reports | GitHub Issues | Compare against the [Known issues](#known-issues) table — triage as `wont-fix` / `tracked` / `escalate` accordingly |
+
+### Privacy fast-path (mandatory)
+
+Any report — in GitHub Issues, Steam reviews, Steam Discussions, or email —
+containing the words "transcripts", "sent my data", "network", "uploaded",
+"privacy", or "recording" triggers the privacy fast-path:
+
+1. **Immediately** notify the privacy fast-path owner by phone.
+2. Privacy fast-path owner notifies the launch commander within 30 minutes.
+3. Do not ask the reporter to paste conversation content in a public thread.
+4. Investigate using the reporter's description only. If a code path is
+   suspected, reproduce locally in a test environment.
+5. If the risk is confirmed as a live privacy regression: initiate rollback
+   (see [Rollback](#rollback)) before any public communication.
+6. If the risk is not confirmed: reply to the reporter within 4 hours with a
+   factual explanation of the local-first architecture.
+
+See [`docs/steam-triage.md`](../docs/steam-triage.md) for the full triage
+routing and SLA policy.
+
+---
+
+## Rollback
+
+### When to roll back
+
+Roll back to the previous beta build if **any** of the following are true:
+
+| Trigger | Severity |
+|---------|---------|
+| Confirmed privacy regression: conversation data leaving the machine | **Immediate — do not wait** |
+| App crashes on launch on any required platform for >10% of reported installs | Critical |
+| Steam Deck in Gaming Mode cannot reach the home screen | Critical |
+| Confirmed data loss: session transcripts deleted without player action | Critical |
+| Score-breaking bug that renders a core session flow uncompletable | High — rollback within 24 hours if no hotfix is ready |
+| Store page live but showing incorrect content or pricing | High — fix in Steamworks (no rollback required) |
+
+Minor cosmetic bugs, translation issues, and single-user edge cases do not
+warrant a rollback unless they are the tip of a larger regression.
+
+### Rollback procedure
+
+1. Open **Steamworks App Admin → Builds**.
+2. Find the previous known-good build (the build that was live on `beta` during
+   Stage 3).
+3. Click **Set Live** → select branch `default`.
+4. Confirm the rollback in Steamworks.
+5. Wait 10–15 minutes for CDN propagation, then verify the previous build is
+   live by installing from a fresh account.
+6. Open a `severity:critical` GitHub issue:
+   - Title: `[Rollback] vX.Y.Z reverted — <brief reason>`
+   - Labels: `steam`, `platform-bug`, `severity:critical`
+   - Body: the affected platform(s), the trigger, the build ID rolled back to,
+     and the build ID rolled back from.
+7. Notify all triage owners of the rollback.
+8. If the rollback was triggered by a privacy regression, notify the launch
+   commander immediately and draft the player support message from
+   [`publishing/ROLLBACK_AND_SUPPORT_MESSAGING.md`](ROLLBACK_AND_SUPPORT_MESSAGING.md).
+
+For the full rollback runbook and player-facing support message templates, see
+[`publishing/ROLLBACK_AND_SUPPORT_MESSAGING.md`](ROLLBACK_AND_SUPPORT_MESSAGING.md).
+
+### Do not re-promote
+
+Do not re-promote the rolled-back build until:
+
+- The defect is identified and fixed in source.
+- The fixed build has passed the depot audit (SR-08).
+- The platform lead and launch commander have both signed off.
+- For a privacy regression: an independent review of the fix must confirm the
+  regression is resolved before re-promoting.
+
+---
+
+## Known issues
+
+Document all known issues accepted for launch before T−24. Update this table
+with any new issues found during the 72-hour monitoring window.
+
+For accepted launch risks from the private beta, see
+[`publishing/BETA_FEEDBACK_AND_LAUNCH_RISKS.md`](BETA_FEEDBACK_AND_LAUNCH_RISKS.md).
+
+| # | Issue | Affected platform | Severity | Workaround | Tracking issue | Resolution target |
+|---|-------|------------------|----------|-----------|---------------|------------------|
+| 1 | *(document known issues here before launch)* | | | | | |
+
+### How to classify
+
+| Label | Meaning |
+|-------|---------|
+| `known-issue-v1` | Accepted for launch; not blocking; tracked for a future patch |
+| `wont-fix` | Accepted forever; documented here for player support use |
+| `severity:critical` | Must trigger rollback if found live (see [Rollback](#rollback)) |
+
+---
+
+## Issue routing at a glance
+
+Use these labels in GitHub Issues. The full triage flow is in
+[`docs/steam-triage.md`](../docs/steam-triage.md).
+
+| Reporter describes | Labels | Owner |
+|--------------------|--------|-------|
+| App does not launch, crashes, Steam overlay broken, controller broken, Steam Deck crash | `steam` + `platform-bug` | Platform lead |
+| Model download fails, checksum mismatch, model not loading | `steam` + `model-install` | Platform lead |
+| NPC gives wrong response, scoring incorrect, scenario broken | `steam` + `pack-bug` | Content / pack owner |
+| Unexpected network activity, "sent my data", privacy concern | `steam` + `privacy` + `safety` | **Privacy fast-path — escalate immediately** |
+| Creator Workbench crash, pack import fails | `steam` + `creator-workbench` | Platform lead |
+| Compliment / general feedback | No label needed | Support communications owner — respond and thank |
+
+---
+
+## Launch log
+
+Record the timeline of key events during the launch.
+
+| Time (UTC) | Event | Owner |
+|------------|-------|-------|
+| | Stage 4 gate check complete — all green | |
+| | `beta` branch confirmed live | |
+| | `default` branch set live | |
+| | CDN propagation verified | |
+| | Fresh-account install verified on Windows | |
+| | Fresh-account install verified on macOS | |
+| | Fresh-account install verified on Linux | |
+| | Fresh-account install verified on Steam Deck | |
+| | Steam announcement published | |
+| | External announcements published | |
+| | 72-hour monitoring window opened | |
+| | 72-hour monitoring window closed | |
+
+Add additional rows for any incidents, rollbacks, or escalations.
+
+---
+
+## Links
+
+- [`publishing/STEAM_REVIEW_SUBMISSION.md`](STEAM_REVIEW_SUBMISSION.md) — Steamworks store review submission runbook
+- [`publishing/ROLLBACK_AND_SUPPORT_MESSAGING.md`](ROLLBACK_AND_SUPPORT_MESSAGING.md) — rollback procedure and player support messages
+- [`publishing/BETA_FEEDBACK_AND_LAUNCH_RISKS.md`](BETA_FEEDBACK_AND_LAUNCH_RISKS.md) — private beta feedback summary and accepted launch risks
+- [`publishing/STEAM_PUBLISHING_AND_DEPLOYMENT.md`](STEAM_PUBLISHING_AND_DEPLOYMENT.md) — SteamPipe build and deploy runbook
+- [`publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md`](STEAM_COMPLIANCE_AND_RISK_REGISTER.md) — compliance checklist and risk register
+- [`docs/steam-triage.md`](../docs/steam-triage.md) — full triage routing and SLA policy
+- [`docs/steam-mvp-scope.md`](../docs/steam-mvp-scope.md) — Stage 4 gate criteria
+- [`docs/release-checklist.md`](../docs/release-checklist.md) — platform smoke matrix and beta verification

--- a/publishing/LAUNCH_DAY_RUNBOOK.md
+++ b/publishing/LAUNCH_DAY_RUNBOOK.md
@@ -93,7 +93,7 @@ Run these steps in order. Each step has a hard dependency on the previous one.
 ### Step 1 — Confirm all Stage 4 gates are green (T−2 hours)
 
 Work through the full Stage 4 gate list in
-[`docs/steam-mvp-scope.md`](../docs/steam-mvp-scope.md#stage-4-gates-public-release):
+[`docs/steam-mvp-scope.md`](../docs/steam-mvp-scope.md#stage-4-gate--public-free-steam-release):
 
 | Gate | Check |
 |------|-------|

--- a/publishing/ROLLBACK_AND_SUPPORT_MESSAGING.md
+++ b/publishing/ROLLBACK_AND_SUPPORT_MESSAGING.md
@@ -237,9 +237,10 @@ transmitted to our servers or any third party during normal play.
 [**If an incident is being investigated, add:**]
 We are currently investigating a reported issue and will post an update here
 once we have a clear picture of what happened. Until then, you can review your
-local data at `~/.convsim/` (macOS / Linux) or
-`%LOCALAPPDATA%\outrightmental\convsim\` (Windows), and you can delete it at
-any time from Settings → Privacy → Clear all data.
+local data at `~/Library/Application Support/com.outrightmental.convsim/`
+(macOS), `~/.local/share/convsim/` (Linux / Steam Deck, or `$XDG_DATA_HOME/convsim`
+if set), or `%LOCALAPPDATA%\outrightmental\convsim\` (Windows), and you can
+delete it at any time from Settings → Privacy → Clear all data.
 
 ---
 

--- a/publishing/ROLLBACK_AND_SUPPORT_MESSAGING.md
+++ b/publishing/ROLLBACK_AND_SUPPORT_MESSAGING.md
@@ -1,0 +1,290 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+# Rollback and Support Messaging
+
+> **Purpose:** Define the rollback path from the current live build back to the
+> previous known-good beta build, and provide the player-facing support messages
+> to use when a rollback occurs or when players ask about incidents.
+>
+> **Audience:** Platform team member performing the rollback, support
+> communications owner drafting player messages, launch commander authorising
+> the rollback decision.
+>
+> **Related document:** The launch-day rollback decision criteria and trigger
+> thresholds are in
+> [`publishing/LAUNCH_DAY_RUNBOOK.md` — Rollback](LAUNCH_DAY_RUNBOOK.md#rollback).
+> The SteamPipe branch operations are in
+> [`publishing/STEAM_PUBLISHING_AND_DEPLOYMENT.md`](STEAM_PUBLISHING_AND_DEPLOYMENT.md).
+
+---
+
+## Rollback path overview
+
+The rollback target is the **previous build that was live on the `beta` branch**
+during Stage 3. This build has been verified against the full Steam beta
+verification matrix (all four platforms) and its sign-off is recorded in
+[`docs/STEAM_BETA_VERIFICATION_REPORT.md`](../docs/STEAM_BETA_VERIFICATION_REPORT.md).
+
+There is no automated rollback. The platform team member must perform the steps
+below manually in the Steamworks partner portal.
+
+| State | Description |
+|-------|-------------|
+| **Pre-rollback (broken)** | Current `default` build — the launch build with the defect |
+| **Rollback target (known good)** | Previous `beta` build — Stage 3 verified build |
+
+### Before rolling back
+
+Confirm the following before starting:
+
+- [ ] The launch commander has authorised the rollback.
+- [ ] The defect is confirmed to affect the live `default` build (not just a
+      test environment).
+- [ ] The rollback target build ID is identified in Steamworks App Admin → Builds
+      (record it below before proceeding).
+
+**Broken build ID / version:** ___________  
+**Rollback target build ID / version:** ___________
+
+---
+
+## Rollback procedure
+
+### Step 1 — Identify the rollback target
+
+1. Open **Steamworks partner portal** → App Admin → Builds.
+2. Locate the previous known-good build in the build history. This is the build
+   that was previously set live on the `beta` branch during Stage 3.
+3. Note the build ID (six-digit number visible in the build row) and the build
+   description.
+
+If there is uncertainty about which build is the correct rollback target, check
+the signed-off
+[`docs/STEAM_BETA_VERIFICATION_REPORT.md`](../docs/STEAM_BETA_VERIFICATION_REPORT.md)
+for the build version recorded there — that version is the last formally verified
+build.
+
+### Step 2 — Set the rollback target live on `default`
+
+1. In the Steamworks Builds list, click the row for the rollback target build.
+2. Under **Set build live on branch**, select `default`.
+3. Click **Set Live**.
+4. Steamworks will show a confirmation dialog. Confirm the action.
+
+This immediately queues the rollback build for all players on the `default`
+branch. The change propagates to the Steam CDN within 10–15 minutes.
+
+### Step 3 — Verify the rollback
+
+1. Wait 10–15 minutes for CDN propagation.
+2. From a non-partner Steam account, install or update the game and confirm the
+   version shown in the app matches the rollback target version.
+3. Run a basic smoke check: launch the app, start a text session, verify the
+   debrief screen is reachable.
+
+- [ ] Rollback build live and verified.
+
+### Step 4 — Open a critical GitHub issue
+
+Open a new GitHub issue immediately after the rollback is confirmed:
+
+- **Title:** `[Rollback] <affected version> reverted on default — <brief reason>`
+- **Labels:** `steam`, `platform-bug`, `severity:critical`
+- **Body must include:**
+  - The defect that triggered the rollback (one paragraph, factual)
+  - The build rolled back from (version and Steamworks build ID)
+  - The build rolled back to (version and Steamworks build ID)
+  - The time the rollback was initiated (UTC)
+  - The time the rollback was verified live (UTC)
+  - The owner assigned to investigating and fixing the defect
+  - A checkbox for: "Do not re-promote the broken build until this issue is
+    closed with a fix."
+
+### Step 5 — Communicate to players (see templates below)
+
+Post the appropriate player-facing message using the templates in the
+[Support messaging](#support-messaging) section. Posting must happen within
+30 minutes of the rollback being confirmed live.
+
+### Step 6 — Notify all triage owners
+
+Send an internal notification to all triage owners listed in
+[`publishing/LAUNCH_DAY_RUNBOOK.md` — Triage owners](LAUNCH_DAY_RUNBOOK.md#triage-owners)
+with:
+
+- Which build is now live on `default`
+- The GitHub issue number tracking the defect
+- The current status of the investigation
+
+---
+
+## Re-promotion criteria
+
+Do not re-promote the broken build — or any build based on it — to `default`
+until all of the following are satisfied:
+
+- [ ] The root cause of the defect is identified and fixed in source.
+- [ ] The fixed build has passed `scripts/depot-audit.sh` on all three platforms.
+- [ ] For a **privacy regression**: the fix has been independently reviewed by a
+      second engineer who confirms the regression is resolved.
+- [ ] The fixed build has passed a targeted smoke test on the affected platform(s).
+- [ ] The launch commander and platform lead have both signed off on the fix.
+- [ ] The GitHub issue opened in Step 4 is closed with a reference to the fixed
+      build tag.
+
+---
+
+## Support messaging
+
+Use these templates for player-facing communication when a rollback occurs or
+when players report an incident. All messages must be reviewed and approved by
+Outright Mental before posting to a public Steam channel.
+
+### Template: Rollback notice (Steam community post)
+
+Use this template for a Steam Community Hub announcement post after a rollback.
+
+---
+
+**Subject:** Brief update on today's release
+
+We pushed an update to Conversation Simulator earlier today and quickly
+identified an issue affecting [**describe the symptom in plain language, e.g.
+"some players on Windows 10"**]. We've reverted to the previous stable version
+while we investigate.
+
+**What this means for you:**
+- If you have already installed today's update, Steam will automatically
+  downgrade to the stable version the next time you open the Steam client.
+- If you haven't installed yet, you'll get the stable version directly.
+
+No conversation data, transcripts, or settings are affected by this update.
+Everything stays on your machine.
+
+We'll post another update here once a fixed version is available. Thank you
+for your patience — and for any reports you sent our way.
+
+— The Conversation Simulator team
+
+---
+
+### Template: Privacy incident notice (Steam community post)
+
+Use this template **only** if the rollback was triggered by a confirmed privacy
+regression (conversation data leaving a player's machine). Do not speculate
+or use this template for non-privacy issues. This message must be approved by
+the launch commander and by Outright Mental legal before posting.
+
+---
+
+**Subject:** Important update about data handling
+
+We identified a defect in today's release of Conversation Simulator that could
+have caused [**describe specifically what happened — e.g. "session metadata to
+be written to a location outside the app's data directory"**]. We have reverted
+to the previous stable version while we fix this.
+
+**What you should know:**
+- Conversation Simulator is designed so that your practice sessions stay
+  entirely on your machine. Today's defect is an unintended deviation from
+  that design.
+- [**Include specifics about scope if known — e.g. "This affected users who
+  completed a voice session since the update was released (approximately
+  HH:MM–HH:MM UTC today)."**]
+- [**State whether any data actually left the machine, or whether the risk was
+  potential but unconfirmed.**]
+- We have reverted the update. The stable version does not contain this defect.
+
+If you have any concerns about your data, you can clear all local session data
+at any time from Settings → Privacy → Clear all data.
+
+We apologise for this. We take the local-first promise seriously and we will
+post a full explanation of what happened and what we fixed once the corrected
+version is available.
+
+— The Conversation Simulator team
+
+---
+
+### Template: Issue acknowledgement (GitHub issue reply)
+
+Use this template when replying to a player who has filed a GitHub issue about
+a defect that is already being investigated.
+
+---
+
+Thank you for reporting this. We're aware of the issue and it's being
+investigated. I've tagged this report as `tracked` so it feeds into the fix.
+
+> **Note:** Please don't include conversation transcripts or personal details
+> in this issue. If we need more information, we'll ask specifically for
+> diagnostics that exclude personal content.
+
+We'll update this issue when a fix is ready. If you'd like to be notified,
+use the **Subscribe** button at the bottom of the issue.
+
+---
+
+### Template: "Is my data safe?" reply (Steam discussion or GitHub)
+
+Use this template when a player asks whether their data was affected by an
+incident, even before a full investigation is complete.
+
+---
+
+Your conversation data is stored locally on your machine and is never
+transmitted to our servers or any third party during normal play.
+
+[**If an incident is being investigated, add:**]
+We are currently investigating a reported issue and will post an update here
+once we have a clear picture of what happened. Until then, you can review your
+local data at `~/.convsim/` (macOS / Linux) or
+`%LOCALAPPDATA%\outrightmental\convsim\` (Windows), and you can delete it at
+any time from Settings → Privacy → Clear all data.
+
+---
+
+### Template: "What happened?" post-incident summary
+
+Use this template once the investigation is complete and a fixed version is
+available. Post it as a Steam Community Hub announcement.
+
+---
+
+**Subject:** What happened, what we fixed, and what's next
+
+Earlier this week we rolled back a Conversation Simulator update due to
+[**describe the incident briefly**]. Here's what we found and what we've done.
+
+**What happened**
+
+[**Plain-language explanation of the root cause. One to two paragraphs. Avoid
+technical jargon where possible.**]
+
+**What we fixed**
+
+[**Describe the fix. One paragraph.**]
+
+**Who was affected and how**
+
+[**Be specific. E.g.: "Players who completed a voice session between HH:MM and
+HH:MM UTC on DATE." If no data left any machine, say so clearly.**]
+
+**The fix is now live**
+
+Version [X.Y.Z] is now available on Steam. It replaces the reverted build.
+Steam will update automatically the next time you open the client.
+
+If you have any further concerns, please open a new GitHub issue or post in
+this discussion.
+
+— The Conversation Simulator team
+
+---
+
+## Links
+
+- [`publishing/LAUNCH_DAY_RUNBOOK.md`](LAUNCH_DAY_RUNBOOK.md) — rollback trigger criteria and launch day operations
+- [`publishing/STEAM_PUBLISHING_AND_DEPLOYMENT.md`](STEAM_PUBLISHING_AND_DEPLOYMENT.md) — SteamPipe branch promotion and troubleshooting
+- [`publishing/BETA_FEEDBACK_AND_LAUNCH_RISKS.md`](BETA_FEEDBACK_AND_LAUNCH_RISKS.md) — accepted launch risks and beta feedback summary
+- [`docs/steam-triage.md`](../docs/steam-triage.md) — issue triage routing and SLA policy
+- [`docs/STEAM_BETA_VERIFICATION_REPORT.md`](../docs/STEAM_BETA_VERIFICATION_REPORT.md) — last known-good verified build reference

--- a/publishing/STEAM_REVIEW_SUBMISSION.md
+++ b/publishing/STEAM_REVIEW_SUBMISSION.md
@@ -1,0 +1,355 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+# Steam Review Submission Runbook
+
+> **Purpose:** Step-by-step instructions for preparing and submitting
+> Conversation Simulator to Valve for store review. Covers all Steamworks portal
+> configuration that must be complete before submission: store page, assets,
+> system requirements, depots, packages, free product settings, content survey
+> (IARC), and release date settings.
+>
+> **Audience:** Platform team member or Outright Mental staff with Steamworks
+> partner portal Developer access. The account holder must approve store copy and
+> content ratings before submission.
+>
+> **Prerequisite:** All Stage 4 release gates in
+> [`docs/steam-mvp-scope.md`](../docs/steam-mvp-scope.md) and all compliance
+> checklist items SR-01 through SR-09 in
+> [`publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md`](STEAM_COMPLIANCE_AND_RISK_REGISTER.md)
+> must be complete before proceeding.
+
+---
+
+## Pre-submission gate check
+
+Confirm **all** of the following before opening the Steamworks submission form.
+No single item may be skipped.
+
+| Gate | Reference | Status |
+|------|-----------|--------|
+| G4-01: Valve store page approval pending (this runbook completes this gate) | [`docs/steam-mvp-scope.md`](../docs/steam-mvp-scope.md) | Proceed |
+| G4-02: Steam Deck Verified tier submitted to Valve | [`docs/STEAM_ROADMAP.md`](../docs/STEAM_ROADMAP.md) | |
+| G4-03: Full release checklist run and passed on all four platforms | [`docs/release-checklist.md`](../docs/release-checklist.md) | |
+| G4-04: Store page accuracy confirmed (no therapy/diagnosis/legal claims; no implied marketplace) | [`publishing/STEAM_STORE_PAGE.md`](STEAM_STORE_PAGE.md) | |
+| G4-05: Voice smoke test on all platforms passes | [`docs/steam-mvp-scope.md`](../docs/steam-mvp-scope.md) | |
+| SR-09: Private beta sign-off complete (≥5 testers, all SR-01–SR-08 items passed) | [`publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md`](STEAM_COMPLIANCE_AND_RISK_REGISTER.md) | |
+| Beta verification report signed off for the launch build | [`docs/STEAM_BETA_VERIFICATION_REPORT.md`](../docs/STEAM_BETA_VERIFICATION_REPORT.md) | |
+| All release-blocking risks MITIGATED, ACCEPTED, or DEFERRED | [`publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md`](STEAM_COMPLIANCE_AND_RISK_REGISTER.md) | |
+| Launch build staged in Steamworks (not yet live on `default`) | [`publishing/STEAM_PUBLISHING_AND_DEPLOYMENT.md`](STEAM_PUBLISHING_AND_DEPLOYMENT.md) | |
+
+---
+
+## 1. Store page copy
+
+Navigate to **Steamworks App Admin → Store Page → Basic Info**.
+
+### 1.1 App name and developer fields
+
+- [ ] App name: `Conversation Simulator` (no version suffix).
+- [ ] Developer field: `Outright Mental`.
+- [ ] Publisher field: `Outright Mental`.
+- [ ] Franchise field: leave empty.
+
+### 1.2 Short description
+
+Enter the approved short description exactly as written in
+[`publishing/STEAM_STORE_PAGE.md` — Short description](STEAM_STORE_PAGE.md#short-description).
+Limit is 300 characters. Do not truncate or paraphrase the approved copy.
+
+- [ ] Short description entered, ≤ 300 characters.
+- [ ] No language claiming therapy, diagnosis, or legal advice.
+- [ ] No implied paid content or marketplace.
+
+### 1.3 Long description
+
+Enter the approved HTML long description from
+[`publishing/STEAM_STORE_PAGE.md` — Long description](STEAM_STORE_PAGE.md#long-description)
+using the Steamworks rich text editor.
+
+- [ ] Long description entered in HTML format.
+- [ ] All section headers, bullet lists, and privacy statement text preserved.
+- [ ] Free edition wording block included verbatim.
+- [ ] Outright Mental sponsorship statement included.
+- [ ] Store page reviewed in Steamworks preview mode for formatting errors.
+
+### 1.4 System requirements
+
+Enter minimum and recommended system requirements exactly as specified in
+[`publishing/STEAM_STORE_PAGE.md` — System requirements](STEAM_STORE_PAGE.md#system-requirements).
+
+**Windows:**
+
+- [ ] Minimum: OS, CPU, RAM, storage, and notes entered.
+- [ ] Recommended: OS, CPU, RAM, storage, and notes entered.
+
+**macOS:**
+
+- [ ] Minimum: OS version, CPU, RAM, storage, and Apple Silicon note entered.
+- [ ] Recommended: OS version, CPU, RAM, storage entered.
+
+**Linux / Steam Deck:**
+
+- [ ] Minimum: OS/glibc version, CPU, RAM, storage entered.
+- [ ] Recommended: OS, CPU, RAM, storage entered.
+- [ ] Steam Deck note about USB microphone requirement entered.
+
+### 1.5 Genres and tags
+
+- [ ] Primary genre set to: **Simulation**.
+- [ ] Secondary genre set to: **Casual**.
+- [ ] User-defined tags applied: `Simulation`, `Casual`, `Education`,
+      `Singleplayer`, `Local Only` (or nearest available equivalent).
+- [ ] No genres or tags imply multiplayer, online features, or purchased DLC.
+
+### 1.6 Languages
+
+- [ ] Supported languages set to English (interface, full audio, subtitles).
+- [ ] Do not claim support for additional languages unless the pack content and
+      UI have been verified in those languages for the launch build.
+
+### 1.7 Age disclosures and content warnings
+
+Enter the age disclosure and content warning text from
+[`publishing/STEAM_STORE_PAGE.md` — Age disclosures](STEAM_STORE_PAGE.md#age-disclosures-and-content-warnings).
+
+- [ ] Age disclosure text entered in the appropriate Steamworks field.
+- [ ] Content warning text entered.
+- [ ] No content is rated more restrictively than the approved copy warrants.
+
+---
+
+## 2. Store assets
+
+Navigate to **Steamworks App Admin → Store Page → Graphical Assets**.
+
+All assets must have been reviewed and approved by Outright Mental before upload.
+Specifications for each asset are in
+[`publishing/STEAM_ASSETS_SPEC.md`](STEAM_ASSETS_SPEC.md).
+
+### 2.1 Capsule art (required for submission)
+
+- [ ] Header capsule (460 × 215 px) uploaded. No blurry upscale; no real human faces.
+- [ ] Small capsule (231 × 87 px) uploaded.
+- [ ] Library capsule (600 × 900 px) uploaded.
+- [ ] Main capsule / library hero (3840 × 1240 px) uploaded.
+
+### 2.2 Screenshots (minimum 5 required)
+
+- [ ] At least 5 screenshots uploaded at 1920 × 1080 px.
+- [ ] At least 3 of the 5 screenshots show actual in-app gameplay from the current launch build (not an earlier alpha).
+- [ ] Screenshots do not show real player data, real transcripts, or real names.
+- [ ] Screenshots do not show placeholder or development UI elements.
+- [ ] All NPCs visible in screenshots are fictional characters from official packs.
+
+### 2.3 Gameplay trailer
+
+- [ ] Gameplay trailer uploaded (MP4, H.264, 30–120 seconds).
+- [ ] Trailer reviewed and approved by Outright Mental.
+- [ ] Trailer audio does not contain real player voice recordings.
+- [ ] Trailer does not imply features not present in the launch build.
+
+### 2.4 Page background (optional)
+
+- [ ] If a background is uploaded, it is 1438 × 810 px and approved by Outright Mental.
+
+### 2.5 Achievement icons
+
+- [ ] Achievement icons (64 × 64 px and 32 × 32 px, one pair per achievement)
+      uploaded for all five achievements defined in
+      [`docs/steam-achievements-stats-rich-presence.md`](../docs/steam-achievements-stats-rich-presence.md).
+
+---
+
+## 3. Free product configuration
+
+Navigate to **Steamworks App Admin → Pricing & Availability**.
+
+- [ ] Base price is set to `Free to Play`. No numeric price appears.
+- [ ] No paid package exists under this App ID.
+- [ ] No DLC package exists under this App ID.
+- [ ] The free default package (created automatically by Valve) is visible in
+      **Steamworks → Packages** and contains all three platform depots:
+      Windows, macOS, and Linux.
+- [ ] The free default package does **not** have a purchase price.
+- [ ] Confirm there is no "Set up pricing" link on the store admin page — this
+      link appears only if the app is not yet configured as free.
+
+---
+
+## 4. Depots and packages
+
+Navigate to **Steamworks App Admin → SteamPipe → Depots**.
+
+- [ ] Three depots exist: Windows x86-64, macOS (Universal), Linux x86-64 / SteamOS.
+- [ ] Depot IDs match the values in
+      [`publishing/STEAM_APP_REGISTRATION.md` — Identifiers](STEAM_APP_REGISTRATION.md#identifiers)
+      and the GitHub repository variables `STEAM_DEPOT_WINDOWS_ID`,
+      `STEAM_DEPOT_MACOS_ID`, `STEAM_DEPOT_LINUX_ID`.
+- [ ] Each depot's platform filter is set correctly (Windows / macOS / Linux).
+- [ ] No fourth depot has been created (no shared-data depot in v1).
+- [ ] The launch build is staged and visible in **App Admin → Builds** with all
+      three depots present. The staged build must not yet be set live on
+      `default`.
+- [ ] Depot audit has been run on the staged build: all three platform directories
+      passed `scripts/depot-audit.sh` with exit code 0 (SR-08).
+
+Navigate to **Steamworks → Packages**.
+
+- [ ] The free default package contains all three platform depots.
+- [ ] Free package ID is recorded in
+      [`publishing/STEAM_APP_REGISTRATION.md` — Identifiers](STEAM_APP_REGISTRATION.md#identifiers).
+
+---
+
+## 5. Steam Cloud
+
+Navigate to **Steamworks App Admin → Steam Cloud**.
+
+- [ ] Byte quota per user: 64 KB.
+- [ ] File count per user: 5.
+- [ ] Include pattern `steam_cloud_settings.json` (non-recursive) is configured.
+- [ ] All eight exclusion patterns are configured as specified in
+      [`publishing/STEAM_APP_REGISTRATION.md` — Steam Cloud configuration](STEAM_APP_REGISTRATION.md#steam-cloud-configuration).
+- [ ] Steam Cloud verification (B.11) in
+      [`docs/release-checklist.md`](../docs/release-checklist.md) has been completed on the staged build.
+
+---
+
+## 6. Content survey (IARC questionnaire)
+
+Navigate to **Steamworks App Admin → Store Page → Content Survey**.
+
+The IARC (International Age Rating Coalition) questionnaire determines the age
+rating labels shown on the store page. Answers must accurately reflect the
+content of the launch build. Do not understate content to obtain a more
+favourable rating.
+
+### 6.1 Questionnaire answers
+
+Answer all IARC questions based on the content present in the v1 launch build:
+
+| Question category | Answer for Conversation Simulator |
+|-------------------|-----------------------------------|
+| Violence | **No** — no combat, no graphic violence, no blood. |
+| Language | **Mild language** — NPC dialogue may contain occasional mild profanity in authentic conversational contexts (e.g. a frustrated manager NPC). No severe profanity in official packs. |
+| Sexual content | **None** — no sexual or romantic content. Dating-confidence scenario content is social and conversational only, capped at PG-13, and ships in a later pack. |
+| Fear / horror | **None** — no horror elements. |
+| Gambling | **None** — no gambling, no simulated gambling. |
+| Drug / alcohol | **None** — no drug or alcohol depictions in official packs. |
+| Online features | **None** — no online multiplayer, no user-generated content submission, no online purchases. The app runs offline. |
+| In-app purchases | **No** — the app is free with no in-app purchases. |
+| User interaction | **None** — no user-to-user interaction; all AI characters are local. |
+
+### 6.2 Expected IARC rating
+
+The answers above should produce a **PEGI 3 / Everyone** (E) rating or equivalent
+regional ratings. If the questionnaire produces a higher rating (e.g. PEGI 12 or
+T), review whether the answers match the actual content and consult Outright Mental
+before submitting.
+
+- [ ] IARC questionnaire completed.
+- [ ] Resulting content descriptors reviewed and approved by Outright Mental.
+- [ ] Content descriptors applied to the store page (displayed below the app title).
+- [ ] Rating labels do not conflict with the approved store page copy.
+
+---
+
+## 7. Release date settings
+
+Navigate to **Steamworks App Admin → Store Page → Basic Info**.
+
+- [ ] Release date field is set. Options:
+  - Use a specific date (e.g. `16 July 2026`) if the date has been confirmed by
+    Outright Mental and Valve approval is expected before that date.
+  - Use `Coming Soon` until the exact date is confirmed with Valve.
+  - Use `Q3 2026` (or the appropriate quarter) if the month is known but the day
+    is not confirmed.
+- [ ] The release date shown on the store page has been approved by Outright Mental.
+- [ ] If `Coming Soon` is showing, confirm the release date setting will be updated
+      to the exact date once the Valve review is approved.
+- [ ] Release state is set to `Released` in Steamworks only **after** the store
+      page has received Valve approval and the `default` branch is set live.
+
+> **Note:** Setting the release date to a specific date before Valve approval
+> creates a commitment that may not be honoured if review takes longer than
+> expected. Coordinate with Outright Mental before committing to a date.
+
+---
+
+## 8. Achievements and stats
+
+Navigate to **Steamworks App Admin → Stats & Achievements**.
+
+- [ ] Five achievements defined as specified in
+      [`docs/steam-achievements-stats-rich-presence.md`](../docs/steam-achievements-stats-rich-presence.md).
+- [ ] Achievement icons uploaded (64 × 64 px and 32 × 32 px for each).
+- [ ] Achievement names and descriptions match approved copy.
+- [ ] Stats API data verified working on the beta build (achievement unlock tested in-game).
+
+---
+
+## 9. Store page review checklist (pre-submission)
+
+Run the full store page review checklist in
+[`publishing/STEAM_STORE_PAGE.md` — Store page review checklist](STEAM_STORE_PAGE.md#store-page-review-checklist)
+before submitting to Valve.
+
+- [ ] Store page review checklist in `STEAM_STORE_PAGE.md` completed.
+- [ ] All sign-off rows in the sign-off table at the bottom of `STEAM_STORE_PAGE.md`
+      are completed with reviewer name and date.
+
+---
+
+## 10. Submit for Valve review
+
+Navigate to **Steamworks App Admin → Publish → Review and Publish**.
+
+- [ ] All sections above are complete. No placeholder copy, missing assets, or
+      unanswered content survey questions remain.
+- [ ] Click **Submit for Review**. Valve will review within 3–5 business days
+      (typical for first-time submissions; may take longer).
+- [ ] Record the submission date in the sign-off block below.
+- [ ] Notify Outright Mental that the app has been submitted.
+
+### What to expect from Valve
+
+| Outcome | Action |
+|---------|--------|
+| Valve approves the store page | Proceed to the launch-day runbook in [`publishing/LAUNCH_DAY_RUNBOOK.md`](LAUNCH_DAY_RUNBOOK.md). |
+| Valve requests changes to store copy | Update the copy in `STEAM_STORE_PAGE.md` (with Outright Mental approval), apply the changes in Steamworks, and resubmit. |
+| Valve requests changes to assets | Produce updated assets per `STEAM_ASSETS_SPEC.md`, apply, and resubmit. |
+| Valve rejects for content policy reasons | Log the rejection as risk SP-01 progressing in the compliance register; engage with Valve developer support; do not resubmit without resolving the stated concern. |
+
+---
+
+## Submission sign-off
+
+| Item | Owner | Date | Notes |
+|------|-------|------|-------|
+| Pre-submission gate check complete | | | |
+| Store copy entered and approved | | | |
+| All capsule assets uploaded | | | |
+| All screenshots uploaded | | | |
+| Gameplay trailer uploaded | | | |
+| System requirements entered | | | |
+| Genres and tags confirmed | | | |
+| Free product configuration verified | | | |
+| Depots and packages confirmed | | | |
+| Steam Cloud configuration confirmed | | | |
+| IARC content survey complete | | | |
+| Release date setting confirmed | | | |
+| Achievements configured | | | |
+| Store page review checklist complete | | | |
+| Submitted to Valve for review | | | |
+
+---
+
+## Links
+
+- [`publishing/STEAM_STORE_PAGE.md`](STEAM_STORE_PAGE.md) — canonical store copy and store page review checklist
+- [`publishing/STEAM_ASSETS_SPEC.md`](STEAM_ASSETS_SPEC.md) — capsule art, screenshots, and trailer brief
+- [`publishing/STEAM_APP_REGISTRATION.md`](STEAM_APP_REGISTRATION.md) — depot IDs, package configuration, Steam Cloud
+- [`publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md`](STEAM_COMPLIANCE_AND_RISK_REGISTER.md) — risk register (SR-09, SP-01)
+- [`publishing/LAUNCH_DAY_RUNBOOK.md`](LAUNCH_DAY_RUNBOOK.md) — what to do after Valve approves
+- [`docs/steam-mvp-scope.md`](../docs/steam-mvp-scope.md) — Stage 4 gate criteria
+- [`docs/STEAM_BETA_VERIFICATION_REPORT.md`](../docs/STEAM_BETA_VERIFICATION_REPORT.md) — signed beta verification report (SR-09 deliverable)
+- [`docs/steam-achievements-stats-rich-presence.md`](../docs/steam-achievements-stats-rich-presence.md) — achievements and stats portal setup

--- a/publishing/STEAM_REVIEW_SUBMISSION.md
+++ b/publishing/STEAM_REVIEW_SUBMISSION.md
@@ -241,10 +241,14 @@ Answer all IARC questions based on the content present in the v1 launch build:
 
 ### 6.2 Expected IARC rating
 
-The answers above should produce a **PEGI 3 / Everyone** (E) rating or equivalent
-regional ratings. If the questionnaire produces a higher rating (e.g. PEGI 12 or
-T), review whether the answers match the actual content and consult Outright Mental
-before submitting.
+Because the official packs contain mild language for workplace and social
+conflict scenarios, the answers above are expected to produce a rating in the
+**ESRB E10+ / Teen** and **PEGI 7 / 12** range (or the equivalent regional
+ratings) — see the expected rating outcome table in
+[`publishing/STEAM_STORE_PAGE.md` — IARC / Steam content questionnaire answers](STEAM_STORE_PAGE.md#iarc--steam-content-questionnaire-answers).
+An 18+ age gate is **not** expected and must not be requested. If Valve assigns
+a rating higher than **PEGI 12 / ESRB T**, review whether the answers match the
+actual content and consult Outright Mental before accepting the rating.
 
 - [ ] IARC questionnaire completed.
 - [ ] Resulting content descriptors reviewed and approved by Outright Mental.

--- a/publishing/STEAM_REVIEW_SUBMISSION.md
+++ b/publishing/STEAM_REVIEW_SUBMISSION.md
@@ -109,7 +109,7 @@ Enter minimum and recommended system requirements exactly as specified in
 ### 1.7 Age disclosures and content warnings
 
 Enter the age disclosure and content warning text from
-[`publishing/STEAM_STORE_PAGE.md` — Age disclosures](STEAM_STORE_PAGE.md#age-disclosures-and-content-warnings).
+[`publishing/STEAM_STORE_PAGE.md` — Age and content disclosures](STEAM_STORE_PAGE.md#age-and-content-disclosures).
 
 - [ ] Age disclosure text entered in the appropriate Steamworks field.
 - [ ] Content warning text entered.

--- a/publishing/STEAM_STORE_AND_OPERATIONS.md
+++ b/publishing/STEAM_STORE_AND_OPERATIONS.md
@@ -26,6 +26,10 @@
 | Risk register and compliance checklists (SR-01 through SR-09) | [`publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md`](STEAM_COMPLIANCE_AND_RISK_REGISTER.md) |
 | Depot contents and exclusions | [`publishing/STEAM_DEPOT_CONTENTS.md`](STEAM_DEPOT_CONTENTS.md) |
 | SteamPipe build, CI deploy, and troubleshooting | [`publishing/STEAM_PUBLISHING_AND_DEPLOYMENT.md`](STEAM_PUBLISHING_AND_DEPLOYMENT.md) |
+| **Steam review submission runbook** (store page, assets, content survey, release date, IARC) | [`publishing/STEAM_REVIEW_SUBMISSION.md`](STEAM_REVIEW_SUBMISSION.md) |
+| **Launch day runbook** (branch promotion, announcement, monitoring, rollback, known issues, triage owners) | [`publishing/LAUNCH_DAY_RUNBOOK.md`](LAUNCH_DAY_RUNBOOK.md) |
+| **Private beta feedback summary and accepted launch risks** | [`publishing/BETA_FEEDBACK_AND_LAUNCH_RISKS.md`](BETA_FEEDBACK_AND_LAUNCH_RISKS.md) |
+| **Rollback path and player support messaging** | [`publishing/ROLLBACK_AND_SUPPORT_MESSAGING.md`](ROLLBACK_AND_SUPPORT_MESSAGING.md) |
 | Steam API integration and fallback behaviour | [`docs/STEAM_INTEGRATION.md`](../docs/STEAM_INTEGRATION.md) |
 | macOS signing and notarisation | [`publishing/MACOS_SIGNING_AND_NOTARIZATION.md`](MACOS_SIGNING_AND_NOTARIZATION.md) |
 | Windows Authenticode signing | [`publishing/WINDOWS_CODE_SIGNING.md`](WINDOWS_CODE_SIGNING.md) |
@@ -120,6 +124,15 @@ before submitting to Valve.
 
 ## Launch operations
 
+> **Detailed runbook:** The complete launch-day operations sequence — including
+> branch promotion, announcement, support monitoring, rollback procedure, known
+> issues, and triage owner assignments — is in
+> [`publishing/LAUNCH_DAY_RUNBOOK.md`](LAUNCH_DAY_RUNBOOK.md). The Steamworks
+> store review submission procedure (content survey, IARC questionnaire, release
+> date settings) is in
+> [`publishing/STEAM_REVIEW_SUBMISSION.md`](STEAM_REVIEW_SUBMISSION.md).
+> The summary below is a condensed reference.
+
 ### Pre-launch checklist (Stage 4 gate)
 
 Complete these steps in the order listed. Do not set the `default` branch live
@@ -147,8 +160,16 @@ until every item is checked.
 - [ ] Gameplay trailer uploaded and approved.
 - [ ] All capsule art uploaded: header, small, library, main.
 - [ ] Genres and tags set correctly (primary: Simulation; secondary: Casual).
-- [ ] IARC questionnaire complete; content descriptors applied (Mild Language only).
-- [ ] Store page has been submitted to Valve and received approval.
+- [ ] IARC content survey complete; resulting content descriptors reviewed and
+      approved by Outright Mental (see
+      [`publishing/STEAM_REVIEW_SUBMISSION.md` — Content survey](STEAM_REVIEW_SUBMISSION.md#6-content-survey-iarc-questionnaire)).
+- [ ] Release date field set correctly — specific date if confirmed; otherwise a
+      quarter or `Coming Soon` (see
+      [`publishing/STEAM_REVIEW_SUBMISSION.md` — Release date](STEAM_REVIEW_SUBMISSION.md#7-release-date-settings)).
+- [ ] Steam Cloud configured in Steamworks portal; B.11 sync verification passed.
+- [ ] Store page has been submitted to Valve and received approval (see full
+      submission checklist in
+      [`publishing/STEAM_REVIEW_SUBMISSION.md`](STEAM_REVIEW_SUBMISSION.md)).
 
 #### Platform and QA
 
@@ -177,20 +198,26 @@ until every item is checked.
 
 ### Launch day
 
-1. **Set the beta branch live first** (if not already done at Stage 3):
+The full step-by-step launch sequence — including Stage 4 gate confirmation,
+branch promotion, announcement, fresh-account install verification, and
+monitoring setup — is in
+[`publishing/LAUNCH_DAY_RUNBOOK.md`](LAUNCH_DAY_RUNBOOK.md). Use that document
+as the live checklist on launch day. The condensed sequence is:
+
+1. **Stage 4 gate check** — all G4-01 through G4-05 criteria must be green before proceeding.
+2. **Set the beta branch live first** (if not already done at Stage 3):
    trigger the deploy workflow with `set_live_branch: beta`.
-2. Confirm beta builds install correctly on at least one machine per platform
+3. Confirm beta builds install correctly on at least one machine per platform
    via a fresh Steam install (log out, remove game, reinstall).
-3. **Set the default branch live:**
+4. **Set the default branch live:**
    trigger the deploy workflow with `set_live_branch: default` and the launch tag.
-4. Wait 10–15 minutes for Steam CDN propagation.
-5. Verify the app is publicly visible on its store page and that the install
+5. Wait 10–15 minutes for Steam CDN propagation.
+6. Verify the app is publicly visible on its store page and that the install
    button is active and set to `Free`.
-6. Install from a fresh account (not the partner account) on each required
+7. Install from a fresh account (not the partner account) on each required
    platform to confirm end-to-end installation.
-7. Confirm all Stage 4 gates (G4-01 through G4-05 in
-   [`docs/steam-mvp-scope.md`](../docs/steam-mvp-scope.md)) remain satisfied on
-   the shipped build, then begin the post-launch monitoring below.
+8. **Publish the announcement** — Steam community post and any external channels.
+9. Begin the 72-hour post-launch monitoring window.
 
 ### Post-launch monitoring
 
@@ -239,6 +266,10 @@ for the full policy.
 
 ## Links
 
+- [`publishing/STEAM_REVIEW_SUBMISSION.md`](STEAM_REVIEW_SUBMISSION.md) — Steamworks store review submission runbook (store page, assets, content survey, release date)
+- [`publishing/LAUNCH_DAY_RUNBOOK.md`](LAUNCH_DAY_RUNBOOK.md) — launch-day operations (branch promotion, announcement, monitoring, rollback, triage owners)
+- [`publishing/BETA_FEEDBACK_AND_LAUNCH_RISKS.md`](BETA_FEEDBACK_AND_LAUNCH_RISKS.md) — private beta feedback summary and accepted launch risks
+- [`publishing/ROLLBACK_AND_SUPPORT_MESSAGING.md`](ROLLBACK_AND_SUPPORT_MESSAGING.md) — rollback path and player support message templates
 - [`publishing/STEAM_STORE_PAGE.md`](STEAM_STORE_PAGE.md) — canonical store copy, system requirements, genres/tags, age disclosures, store review checklist, sign-off table
 - [`publishing/STEAM_ASSETS_SPEC.md`](STEAM_ASSETS_SPEC.md) — capsule art, screenshot, and trailer production briefs
 - [`publishing/STEAM_APP_REGISTRATION.md`](STEAM_APP_REGISTRATION.md) — app identity, depot IDs, CI credentials, branch strategy, partner permissions


### PR DESCRIPTION
Closes #241

## What changed

Adds four new publishing documents and updates the existing `STEAM_STORE_AND_OPERATIONS.md` to complete all five items in the issue's definition of done.

### New documents

**`publishing/STEAM_REVIEW_SUBMISSION.md`** — Steamworks store page submission runbook  
Step-by-step checklist for completing every required Steamworks portal setting before submitting to Valve for review: app name and copy, system requirements, genres/tags, languages, age disclosures, capsule art and screenshots, gameplay trailer, free-product configuration, depot and package verification, Steam Cloud setup, IARC content survey (with recommended answers for the v1 build), release date settings, achievements, and a pre-submission gate table gating on all Stage 4 criteria and SR-09.

**`publishing/LAUNCH_DAY_RUNBOOK.md`** — Launch day operations  
Full launch-day checklist with: named triage owner assignments (launch commander, platform lead, privacy fast-path owner, content owner, support communications, on-call); T−24 preparation steps; the seven-step launch sequence (Stage 4 gate check → beta branch verification → default branch live → CDN propagation → fresh-account install on all four platforms → announcement publication → monitoring start); 72-hour monitoring schedule and signal table; privacy fast-path escalation procedure; rollback decision trigger thresholds; known-issues table; and GitHub issue routing at a glance.

**`publishing/BETA_FEEDBACK_AND_LAUNCH_RISKS.md`** — Private beta feedback summary and accepted launch risks  
Template for recording private beta tester coverage (satisfying the ≥5 testers / ≥1 per platform requirement for SR-09/G3-06), aggregate feedback statistics by category, themes, fixed vs deferred issue lists, accepted functional and platform risk tables, known limitations communicated to players, and a formal sign-off block that gates launch on Outright Mental approval.

**`publishing/ROLLBACK_AND_SUPPORT_MESSAGING.md`** — Rollback path and support messaging  
Complete rollback procedure (identify previous known-good beta build → set live on `default` in Steamworks → CDN verify → open severity:critical GitHub issue → communicate); re-promotion criteria; and a set of five approved player-facing message templates: rollback notice, privacy incident notice, GitHub issue acknowledgement, data-safety reply, and post-incident summary.

### Updated document

**`publishing/STEAM_STORE_AND_OPERATIONS.md`**  
Document map expanded with the four new entries; pre-launch checklist adds IARC content survey and release date settings items, and a Steam Cloud portal verification item; launch-day section updated to reference the new runbook with the announcement and monitoring steps made explicit; links section updated.

## Follow-up fixes

Three bugfix commits address documentation errors discovered during review:

- **IARC expected-rating guidance** — corrected recommended rating range in `STEAM_REVIEW_SUBMISSION.md` section 6.2 to match the canonical store page; the original guidance would have halted a valid submission on a normally-expected rating.
- **macOS/Linux data paths** — fixed legacy directory references in the "Is my data safe?" support message template; the packaged Steam build uses `~/Library/Application Support/com.outrightmental.convsim` on macOS and `~/.local/share/convsim` on Linux/Steam Deck, not the old `~/.convsim` path.
- **Section anchor links** — corrected two broken GitHub anchor links in `LAUNCH_DAY_RUNBOOK.md` and `STEAM_REVIEW_SUBMISSION.md` that pointed to non-existent heading slugs.

## How it was tested

All documents were cross-checked against the existing `docs/steam-mvp-scope.md` gate criteria (G4-01–G4-05), `publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md` (SR-01–SR-09), `docs/release-checklist.md` (Parts A–J), and `docs/STEAM_BETA_VERIFICATION_REPORT.md` to ensure every cross-reference and gate number is consistent. Internal links between the new documents and all existing publishing and docs files were verified for accuracy. No code changes were made; these are operations and runbook documents.

Closes #241