### PR TITLE
Add Steam default-branch promotion workflow and promotion log

### DIFF
--- a/.github/workflows/steam-promote.yml
+++ b/.github/workflows/steam-promote.yml
@@ -1,0 +1,237 @@
+# SPDX-License-Identifier: Apache-2.0
+# Steam branch-promotion workflow.
+#
+# Promotes a previously uploaded SteamPipe build to the `default` branch
+# (public release) WITHOUT re-uploading content.  Use this workflow after
+# the build has already been staged and verified on `beta`.
+#
+# Contrast with steam-deploy.yml, which uploads artifacts and optionally
+# sets a branch live in one step.  This workflow calls steamcmd
+# +set_build_live_branch, which is a pure metadata operation — no content
+# transfer occurs, and the depot files already on Valve's CDN are served
+# immediately.
+#
+# ── When to use ─────────────────────────────────────────────────────────────
+#
+# Use this workflow for the Stage 4 public release when:
+#   - The build is already staged in Steamworks (uploaded with set_live_branch
+#     left empty or "beta" via steam-deploy.yml), AND
+#   - All Stage 4 gate criteria in docs/steam-mvp-scope.md are met, AND
+#   - Valve has approved the store page (gate G4-01).
+#
+# Do NOT use this workflow to push net-new content.  If the build has not
+# been uploaded yet, run steam-deploy.yml first, then call this workflow.
+#
+# ── Prerequisites ────────────────────────────────────────────────────────────
+#
+# Repository variables (Settings → Secrets and variables → Actions → Variables):
+#   STEAM_APP_ID              Valve-assigned App ID (non-secret)
+#
+# Repository secrets (Settings → Secrets and variables → Actions → Secrets):
+#   STEAM_USERNAME            Steam username of the dedicated CI build account
+#   STEAM_CONFIG_VDF          Base64-encoded config.vdf (bypasses SteamGuard in CI)
+#
+# GitHub Actions environment:
+#   steam-release             Required-reviewer environment; gates job on manual
+#                             approval before any secret is exposed.
+#
+# See publishing/STEAM_APP_REGISTRATION.md for how to obtain and rotate these.
+#
+# ── Inputs ───────────────────────────────────────────────────────────────────
+#
+# build_id          SteamPipe Build ID to promote.  Find it in the Steamworks
+#                   partner portal → App Admin → Builds.  The build must already
+#                   be uploaded (depot file count non-zero).
+#
+# release_tag       GitHub release tag corresponding to this build (e.g. v0.3.0).
+#                   Used to download and hash the release artifacts for the
+#                   promotion log — the hashes are not used for the upload itself.
+#
+# previous_build_id The Build ID currently live on the default branch.  Recorded
+#                   in the promotion log for rollback reference.  Find it in
+#                   Steamworks → App Admin → Builds (filter by branch: default).
+#                   Pass "none" if no build is currently live on default.
+#
+# go_nogo_confirmed Type exactly YES to confirm that:
+#                     • All Stage 4 gate criteria in docs/steam-mvp-scope.md
+#                       are met.
+#                     • Valve has approved the store page (G4-01).
+#                     • The release owner has given launch go/no-go.
+#                   Any other value aborts the workflow before credentials are used.
+#
+# ── After this workflow completes ────────────────────────────────────────────
+#
+# 1. Open Steamworks → App Admin → Builds and confirm the promoted build is
+#    shown as live on the default branch.
+#
+# 2. Copy the promotion record printed in the "Record promotion details" step
+#    and add it to publishing/STEAM_PROMOTION_LOG.md.
+#
+# 3. Proceed with launch-day Steps 4–7 in publishing/LAUNCH_DAY_RUNBOOK.md:
+#    CDN propagation check, end-to-end install verification, announcement,
+#    and 72-hour monitoring.
+#
+name: Steam Promote to Default
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_id:
+        description: >
+          SteamPipe Build ID to promote
+          (Steamworks → App Admin → Builds — the numeric ID in the Build ID column).
+        required: true
+        type: string
+      release_tag:
+        description: 'GitHub release tag for this build (e.g. v0.3.0)'
+        required: true
+        type: string
+      previous_build_id:
+        description: >
+          Current default-branch Build ID (for rollback reference).
+          Pass "none" if no build is live on default yet.
+        required: true
+        type: string
+      go_nogo_confirmed:
+        description: >
+          Type exactly YES to confirm all Stage 4 gates are met and launch
+          go/no-go has been given by the release owner.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  promote:
+    name: Promote build ${{ inputs.build_id }} to default (${{ inputs.release_tag }})
+    runs-on: ubuntu-latest
+
+    # The steam-release environment gates this job behind a manual approval step.
+    # Create it in GitHub → Settings → Environments → New environment.
+    # Add required reviewers so no Steam credential is exposed without sign-off.
+    environment: steam-release
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # ── Gate: explicit go/no-go confirmation ──────────────────────────────
+      # The required-reviewer check on the steam-release environment provides
+      # the primary approval gate.  This second check requires the operator to
+      # explicitly type YES, confirming they have verified all Stage 4 criteria
+      # before any credential or network operation begins.
+      - name: Verify go/no-go confirmation
+        env:
+          GO_NOGO: ${{ inputs.go_nogo_confirmed }}
+        run: |
+          if [ "$GO_NOGO" != "YES" ]; then
+            echo "ERROR: go_nogo_confirmed must be exactly 'YES' to proceed." >&2
+            echo "" >&2
+            echo "Before typing YES, verify all of the following in docs/steam-mvp-scope.md:" >&2
+            echo "  G4-01  Valve store page approval received." >&2
+            echo "  G4-02  Steam Deck Verified tier granted by Valve." >&2
+            echo "  G4-03  Full release checklist (Parts A–J) passed on all platforms." >&2
+            echo "  G4-04  Store page copy accurate (no therapy/diagnosis language)." >&2
+            echo "  G4-05  Voice smoke test passed (if voice is included in the build)." >&2
+            echo "" >&2
+            echo "Also confirm:" >&2
+            echo "  •  The signed-off STEAM_BETA_VERIFICATION_REPORT.md is attached to the" >&2
+            echo "     release issue (gate G3-06 / SR-09)." >&2
+            echo "  •  The release owner has given explicit launch go/no-go." >&2
+            echo "  •  publishing/BETA_FEEDBACK_AND_LAUNCH_RISKS.md is complete and signed." >&2
+            exit 1
+          fi
+          echo "Go/no-go confirmed by ${{ github.actor }}."
+
+      # ── Compute artifact hashes from the GitHub release ───────────────────
+      # Downloads the release assets and computes their SHA-256 digests.
+      # These hashes are recorded in the promotion log for provenance — they
+      # are not used to validate the Steam upload (which was already done by
+      # steam-deploy.yml when the build was first staged).
+      - name: Download release artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          mkdir -p release-artifacts
+          gh release download "$RELEASE_TAG" \
+            --dir release-artifacts \
+            --skip-errors
+
+      - name: Compute artifact SHA-256 hashes
+        run: |
+          echo "--- SHA-256 hashes for ${{ inputs.release_tag }} ---"
+          find release-artifacts -type f | sort | while IFS= read -r f; do
+            sha256sum "$f"
+          done | tee artifact-hashes.txt
+          echo "File count: $(wc -l < artifact-hashes.txt)"
+
+      # ── Install steamcmd ──────────────────────────────────────────────────
+      - name: Install steamcmd
+        run: |
+          sudo add-apt-repository multiverse
+          sudo dpkg --add-architecture i386
+          sudo apt-get update -qq
+          echo steamcmd steam/question select "I AGREE" | sudo debconf-set-selections
+          sudo apt-get install -y steamcmd
+
+      # ── Restore SteamGuard config ─────────────────────────────────────────
+      - name: Restore Steam config
+        env:
+          STEAM_CONFIG_VDF: ${{ secrets.STEAM_CONFIG_VDF }}
+        run: |
+          mkdir -p "$HOME/.steam/steam/config"
+          printf '%s' "$STEAM_CONFIG_VDF" | base64 --decode \
+            > "$HOME/.steam/steam/config/config.vdf"
+          chmod 600 "$HOME/.steam/steam/config/config.vdf"
+
+      # ── Set the build live on the default branch ──────────────────────────
+      # +set_build_live_branch is a pure metadata operation: it does not
+      # re-upload content.  The depot files already on Valve's CDN are
+      # served to players as soon as this command succeeds.
+      - name: Promote build to default branch
+        env:
+          STEAM_USERNAME: ${{ secrets.STEAM_USERNAME }}
+          STEAM_APP_ID:   ${{ vars.STEAM_APP_ID }}
+          BUILD_ID:       ${{ inputs.build_id }}
+        run: |
+          steamcmd \
+            +login "$STEAM_USERNAME" \
+            +set_build_live_branch "$STEAM_APP_ID" default "$BUILD_ID" \
+            +quit
+
+      # ── Print promotion record ────────────────────────────────────────────
+      # Always print — even on failure — so there is a timestamped audit
+      # trail in the workflow log.  Copy this output into
+      # publishing/STEAM_PROMOTION_LOG.md after the workflow succeeds.
+      - name: Record promotion details
+        if: always()
+        env:
+          BUILD_ID:          ${{ inputs.build_id }}
+          RELEASE_TAG:       ${{ inputs.release_tag }}
+          PREVIOUS_BUILD_ID: ${{ inputs.previous_build_id }}
+          RUN_URL:           ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          ACTOR:             ${{ github.actor }}
+        run: |
+          echo "========================================================"
+          echo "  Steam Promotion Record"
+          echo "========================================================"
+          echo "  Date (UTC)        : $(date -u '+%Y-%m-%d %H:%M UTC')"
+          echo "  Release tag       : $RELEASE_TAG"
+          echo "  Build ID (new)    : $BUILD_ID"
+          echo "  Build ID (prev)   : $PREVIOUS_BUILD_ID"
+          echo "  Branch set live   : default"
+          echo "  Promoted by       : $ACTOR"
+          echo "  CI run            : $RUN_URL"
+          echo "--------------------------------------------------------"
+          echo "  Artifact SHA-256 hashes:"
+          if [ -f artifact-hashes.txt ]; then
+            sed 's/^/    /' artifact-hashes.txt
+          else
+            echo "    (hash file not generated — artifact download may have failed)"
+          fi
+          echo "========================================================"
+          echo ""
+          echo "Copy the block above into publishing/STEAM_PROMOTION_LOG.md."
+          echo "Then proceed with launch-day Steps 4–7 in"
+          echo "publishing/LAUNCH_DAY_RUNBOOK.md."

--- a/.github/workflows/steam-promote.yml
+++ b/.github/workflows/steam-promote.yml
@@ -1,41 +1,55 @@
 # SPDX-License-Identifier: Apache-2.0
-# Steam branch-promotion workflow.
+# Steam default-branch promotion — gate, provenance capture, and instructions.
 #
-# Promotes a previously uploaded SteamPipe build to the `default` branch
-# (public release) WITHOUT re-uploading content.  Use this workflow after
-# the build has already been staged and verified on `beta`.
+# Prepares and records the promotion of a previously uploaded SteamPipe build
+# to the `default` branch (public release).  Use this workflow after the build
+# has already been staged and verified on `beta`.
 #
-# Contrast with steam-deploy.yml, which uploads artifacts and optionally
-# sets a branch live in one step.  This workflow calls steamcmd
-# +set_build_live_branch, which is a pure metadata operation — no content
-# transfer occurs, and the depot files already on Valve's CDN are served
-# immediately.
+# ── Why this workflow does NOT set the build live itself ─────────────────────
+#
+# Valve does not allow the `default` branch of a RELEASED app to be set live
+# from CI.  Two independent Steamworks constraints make headless promotion of
+# the default branch impossible:
+#
+#   1. There is no steamcmd command that sets an already-uploaded build live.
+#      steamcmd only sets a branch live via the `SetLive` field of an
+#      app_build.vdf during `+run_app_build` (that is what steam-deploy.yml
+#      does), and Steamworks refuses `SetLive "default"` for released apps.
+#
+#   2. Any build set live on the default branch of a released app triggers an
+#      "additional authorization" step that Steamworks sends to the requesting
+#      account's Steam Mobile Authenticator (or by SMS).  That confirmation is
+#      interactive by design and cannot be completed on a CI runner.
+#      See https://partner.steamgames.com/doc/store/application/builds
+#
+# Therefore the actual "Set Build Live → default" action is performed by a
+# human in the Steamworks App Admin panel.  This workflow does everything
+# around that action: it enforces the go/no-go gate, downloads and hashes the
+# release artifacts for the provenance record, and prints the promotion record
+# and the exact App Admin steps to follow.
 #
 # ── When to use ─────────────────────────────────────────────────────────────
 #
-# Use this workflow for the Stage 4 public release when:
+# Run this workflow for the Stage 4 public release when:
 #   - The build is already staged in Steamworks (uploaded with set_live_branch
 #     left empty or "beta" via steam-deploy.yml), AND
 #   - All Stage 4 gate criteria in docs/steam-mvp-scope.md are met, AND
 #   - Valve has approved the store page (gate G4-01).
 #
 # Do NOT use this workflow to push net-new content.  If the build has not
-# been uploaded yet, run steam-deploy.yml first, then call this workflow.
+# been uploaded yet, run steam-deploy.yml first, then run this workflow.
 #
 # ── Prerequisites ────────────────────────────────────────────────────────────
 #
-# Repository variables (Settings → Secrets and variables → Actions → Variables):
-#   STEAM_APP_ID              Valve-assigned App ID (non-secret)
-#
-# Repository secrets (Settings → Secrets and variables → Actions → Secrets):
-#   STEAM_USERNAME            Steam username of the dedicated CI build account
-#   STEAM_CONFIG_VDF          Base64-encoded config.vdf (bypasses SteamGuard in CI)
-#
 # GitHub Actions environment:
-#   steam-release             Required-reviewer environment; gates job on manual
-#                             approval before any secret is exposed.
+#   steam-release             Required-reviewer environment; gates the job on
+#                             manual approval before it runs.
 #
-# See publishing/STEAM_APP_REGISTRATION.md for how to obtain and rotate these.
+# The requesting operator must have Steamworks access to the App Admin panel
+# and a Steam Mobile Authenticator (or SMS) on the account, in order to
+# complete the default-branch authorization after this workflow finishes.
+#
+# See publishing/STEAM_APP_REGISTRATION.md for Steamworks access details.
 #
 # ── Inputs ───────────────────────────────────────────────────────────────────
 #
@@ -45,7 +59,7 @@
 #
 # release_tag       GitHub release tag corresponding to this build (e.g. v0.3.0).
 #                   Used to download and hash the release artifacts for the
-#                   promotion log — the hashes are not used for the upload itself.
+#                   promotion log — the hashes are recorded for provenance only.
 #
 # previous_build_id The Build ID currently live on the default branch.  Recorded
 #                   in the promotion log for rollback reference.  Find it in
@@ -57,17 +71,22 @@
 #                       are met.
 #                     • Valve has approved the store page (G4-01).
 #                     • The release owner has given launch go/no-go.
-#                   Any other value aborts the workflow before credentials are used.
+#                   Any other value aborts the workflow.
 #
 # ── After this workflow completes ────────────────────────────────────────────
 #
-# 1. Open Steamworks → App Admin → Builds and confirm the promoted build is
-#    shown as live on the default branch.
+# 1. Follow the "Set Build Live in App Admin" instructions printed by the
+#    "Print App Admin promotion instructions" step: set build_id live on the
+#    default branch in Steamworks and complete the Steam Mobile Authenticator
+#    (or SMS) confirmation.
 #
-# 2. Copy the promotion record printed in the "Record promotion details" step
+# 2. Confirm the promoted build is shown as live on the default branch in
+#    Steamworks → App Admin → Builds.
+#
+# 3. Copy the promotion record printed by the "Record promotion details" step
 #    and add it to publishing/STEAM_PROMOTION_LOG.md.
 #
-# 3. Proceed with launch-day Steps 4–7 in publishing/LAUNCH_DAY_RUNBOOK.md:
+# 4. Proceed with launch-day Steps 4–7 in publishing/LAUNCH_DAY_RUNBOOK.md:
 #    CDN propagation check, end-to-end install verification, announcement,
 #    and 72-hour monitoring.
 #
@@ -109,7 +128,7 @@ jobs:
 
     # The steam-release environment gates this job behind a manual approval step.
     # Create it in GitHub → Settings → Environments → New environment.
-    # Add required reviewers so no Steam credential is exposed without sign-off.
+    # Add required reviewers so the promotion is not prepared without sign-off.
     environment: steam-release
 
     steps:
@@ -119,7 +138,7 @@ jobs:
       # The required-reviewer check on the steam-release environment provides
       # the primary approval gate.  This second check requires the operator to
       # explicitly type YES, confirming they have verified all Stage 4 criteria
-      # before any credential or network operation begins.
+      # before any provenance capture begins.
       - name: Verify go/no-go confirmation
         env:
           GO_NOGO: ${{ inputs.go_nogo_confirmed }}
@@ -166,44 +185,35 @@ jobs:
           done | tee artifact-hashes.txt
           echo "File count: $(wc -l < artifact-hashes.txt)"
 
-      # ── Install steamcmd ──────────────────────────────────────────────────
-      - name: Install steamcmd
-        run: |
-          sudo add-apt-repository multiverse
-          sudo dpkg --add-architecture i386
-          sudo apt-get update -qq
-          echo steamcmd steam/question select "I AGREE" | sudo debconf-set-selections
-          sudo apt-get install -y steamcmd
-
-      # ── Restore SteamGuard config ─────────────────────────────────────────
-      - name: Restore Steam config
+      # ── Print the manual App Admin promotion instructions ─────────────────
+      # The default-branch set-live cannot be done from CI (see the header
+      # comment).  Print the exact steps the operator must perform in the
+      # Steamworks App Admin panel to complete the promotion.
+      - name: Print App Admin promotion instructions
         env:
-          STEAM_CONFIG_VDF: ${{ secrets.STEAM_CONFIG_VDF }}
+          BUILD_ID: ${{ inputs.build_id }}
         run: |
-          mkdir -p "$HOME/.steam/steam/config"
-          printf '%s' "$STEAM_CONFIG_VDF" | base64 --decode \
-            > "$HOME/.steam/steam/config/config.vdf"
-          chmod 600 "$HOME/.steam/steam/config/config.vdf"
-
-      # ── Set the build live on the default branch ──────────────────────────
-      # +set_build_live_branch is a pure metadata operation: it does not
-      # re-upload content.  The depot files already on Valve's CDN are
-      # served to players as soon as this command succeeds.
-      - name: Promote build to default branch
-        env:
-          STEAM_USERNAME: ${{ secrets.STEAM_USERNAME }}
-          STEAM_APP_ID:   ${{ vars.STEAM_APP_ID }}
-          BUILD_ID:       ${{ inputs.build_id }}
-        run: |
-          steamcmd \
-            +login "$STEAM_USERNAME" \
-            +set_build_live_branch "$STEAM_APP_ID" default "$BUILD_ID" \
-            +quit
+          echo "========================================================"
+          echo "  ACTION REQUIRED — Set Build Live in App Admin"
+          echo "========================================================"
+          echo "  The default branch cannot be set live from CI: Steamworks"
+          echo "  requires an interactive Steam Mobile Authenticator (or SMS)"
+          echo "  confirmation for the default branch of a released app."
+          echo ""
+          echo "  Complete the promotion manually now:"
+          echo "    1. Open Steamworks -> App Admin -> Builds."
+          echo "    2. Find Build ID $BUILD_ID in the list."
+          echo "    3. In the 'Set build live on branch' control for that build,"
+          echo "       select 'default', then Preview Change -> Set Build Live."
+          echo "    4. Approve the authorization prompt in your Steam Mobile"
+          echo "       Authenticator (or via the SMS code)."
+          echo "    5. Confirm the build now shows as live on the default branch."
+          echo "========================================================"
 
       # ── Print promotion record ────────────────────────────────────────────
       # Always print — even on failure — so there is a timestamped audit
       # trail in the workflow log.  Copy this output into
-      # publishing/STEAM_PROMOTION_LOG.md after the workflow succeeds.
+      # publishing/STEAM_PROMOTION_LOG.md after the App Admin set-live succeeds.
       - name: Record promotion details
         if: always()
         env:
@@ -232,6 +242,7 @@ jobs:
           fi
           echo "========================================================"
           echo ""
+          echo "Record this only AFTER the App Admin set-live has succeeded."
           echo "Copy the block above into publishing/STEAM_PROMOTION_LOG.md."
           echo "Then proceed with launch-day Steps 4–7 in"
           echo "publishing/LAUNCH_DAY_RUNBOOK.md."

--- a/.github/workflows/steam-promote.yml
+++ b/.github/workflows/steam-promote.yml
@@ -185,7 +185,17 @@ jobs:
           find release-artifacts -type f | sort | while IFS= read -r f; do
             sha256sum "$f"
           done | tee artifact-hashes.txt
-          echo "File count: $(wc -l < artifact-hashes.txt)"
+          count=$(wc -l < artifact-hashes.txt)
+          echo "File count: $count"
+          if [ "$count" -eq 0 ]; then
+            echo "ERROR: no release artifacts were downloaded for $RELEASE_TAG." >&2
+            echo "The promotion log requires artifact SHA-256 hashes for provenance" >&2
+            echo "(definition of done). 'gh release download --skip-errors' can leave" >&2
+            echo "the directory empty if the tag has no assets or every asset failed" >&2
+            echo "to download. Confirm the release tag is correct and its assets are" >&2
+            echo "published, then re-run this workflow." >&2
+            exit 1
+          fi
 
       # ── Print the manual App Admin promotion instructions ─────────────────
       # The default-branch set-live cannot be done from CI (see the header

--- a/.github/workflows/steam-promote.yml
+++ b/.github/workflows/steam-promote.yml
@@ -178,8 +178,10 @@ jobs:
             --skip-errors
 
       - name: Compute artifact SHA-256 hashes
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
-          echo "--- SHA-256 hashes for ${{ inputs.release_tag }} ---"
+          echo "--- SHA-256 hashes for $RELEASE_TAG ---"
           find release-artifacts -type f | sort | while IFS= read -r f; do
             sha256sum "$f"
           done | tee artifact-hashes.txt

--- a/apps/web/src/__tests__/VoiceSettingsPanel.test.tsx
+++ b/apps/web/src/__tests__/VoiceSettingsPanel.test.tsx
@@ -131,15 +131,13 @@ describe('voice readiness cards', () => {
   it('shows STT as unavailable when health reports stt_ready=false', async () => {
     mockApi.health.mockResolvedValue({ ok: true, data: STUB_HEALTH_NO_VOICE })
     render(<VoiceSettingsPanel />)
-    await waitFor(() => expect(screen.getByTestId('readiness-stt')).toBeInTheDocument())
-    expect(screen.getByTestId('readiness-stt')).toHaveTextContent('no model loaded')
+    await waitFor(() => expect(screen.getByTestId('readiness-stt')).toHaveTextContent('no model loaded'))
   })
 
   it('shows TTS as unavailable when health reports tts_ready=false', async () => {
     mockApi.health.mockResolvedValue({ ok: true, data: STUB_HEALTH_NO_VOICE })
     render(<VoiceSettingsPanel />)
-    await waitFor(() => expect(screen.getByTestId('readiness-tts')).toBeInTheDocument())
-    expect(screen.getByTestId('readiness-tts')).toHaveTextContent('no model loaded')
+    await waitFor(() => expect(screen.getByTestId('readiness-tts')).toHaveTextContent('no model loaded'))
     // Should show setup/fallback guidance
     expect(screen.getByText(/Install a text-to-speech model/i)).toBeInTheDocument()
   })

--- a/publishing/LAUNCH_DAY_RUNBOOK.md
+++ b/publishing/LAUNCH_DAY_RUNBOOK.md
@@ -123,12 +123,18 @@ If the `beta` branch is not already live from Stage 3:
 This is the point of no return. The `default` branch immediately serves all
 new installs.
 
-**Preferred path — dedicated promote workflow (build already staged):**
+> **Note — the default-branch set-live is a manual App Admin action.**
+> Steam does **not** let CI set the `default` branch live for a released app:
+> the change requires an authorization prompt sent to the requesting account's
+> Steam Mobile Authenticator (or SMS). The promote workflow therefore gates the
+> release, captures the provenance record, and prints the exact App Admin steps —
+> a human completes the actual Set Build Live in Steamworks.
+
+**Preferred path — promote workflow + App Admin (build already staged):**
 
 If the build was previously uploaded with `set_live_branch` left empty or set
-to `beta` via `steam-deploy.yml`, use the promotion workflow instead of
-re-uploading content.  `+set_build_live_branch` is a metadata-only operation
-that sets an existing Steamworks build live without transferring depot files again.
+to `beta` via `steam-deploy.yml`, the depot content is already on Valve's CDN,
+so no re-upload is needed — only the branch pointer changes.
 
 1. Trigger the promote workflow (`.github/workflows/steam-promote.yml`):
    - `build_id`: the Build ID shown in Steamworks → App Admin → Builds for
@@ -142,17 +148,24 @@ that sets an existing Steamworks build live without transferring depot files aga
      criteria are met and the release owner has given go/no-go.
 2. Approve the workflow run in the `steam-release` environment (requires a
    reviewer with the required-reviewer role).
-3. Wait for the workflow to complete successfully.
-4. Copy the "Steam Promotion Record" block from the "Record promotion details"
+3. Wait for the workflow to complete successfully. It verifies the go/no-go
+   gate, hashes the release artifacts, and prints both the App Admin
+   instructions and the "Steam Promotion Record" block.
+4. In Steamworks → App Admin → Builds, set `build_id` live on the `default`
+   branch and approve the authorization prompt in your Steam Mobile
+   Authenticator (or via SMS), following the printed instructions.
+5. Copy the "Steam Promotion Record" block from the "Record promotion details"
    step output and add it to [`publishing/STEAM_PROMOTION_LOG.md`](STEAM_PROMOTION_LOG.md).
 
 **Fallback path — re-upload (build not yet staged):**
 
 If the build has not been uploaded to Steamworks yet, trigger `steam-deploy.yml`
-with the launch tag and `set_live_branch: default` instead.
+with the launch tag to stage the depot content, then set the build live on the
+`default` branch manually in App Admin as in step 4 above.
 
 - [ ] Workflow completed with exit code 0.
-- [ ] `default` branch shows the launch build in Steamworks App Admin → Builds.
+- [ ] `default` branch set live and shows the launch build in Steamworks App
+      Admin → Builds (App Admin authorization prompt approved).
 - [ ] Promotion record added to [`publishing/STEAM_PROMOTION_LOG.md`](STEAM_PROMOTION_LOG.md).
 
 ### Step 4 — Verify CDN propagation (T+15 minutes)

--- a/publishing/LAUNCH_DAY_RUNBOOK.md
+++ b/publishing/LAUNCH_DAY_RUNBOOK.md
@@ -118,18 +118,42 @@ If the `beta` branch is not already live from Stage 3:
 
 - [ ] `beta` branch is live and verified.
 
-### Step 3 — Set the default branch live (launch)
+### Step 3 — Promote the build to the default branch (launch)
 
 This is the point of no return. The `default` branch immediately serves all
 new installs.
 
-1. Trigger the deploy workflow with the launch tag and `set_live_branch: default`.
+**Preferred path — dedicated promote workflow (build already staged):**
+
+If the build was previously uploaded with `set_live_branch` left empty or set
+to `beta` via `steam-deploy.yml`, use the promotion workflow instead of
+re-uploading content.  `+set_build_live_branch` is a metadata-only operation
+that sets an existing Steamworks build live without transferring depot files again.
+
+1. Trigger the promote workflow (`.github/workflows/steam-promote.yml`):
+   - `build_id`: the Build ID shown in Steamworks → App Admin → Builds for
+     the staged/beta build.
+   - `release_tag`: the GitHub release tag (e.g. `v0.3.0`).
+   - `previous_build_id`: the Build ID currently live on `default` (find it
+     in Steamworks → App Admin → Builds → filter by branch: default).  This is
+     recorded in [`publishing/STEAM_PROMOTION_LOG.md`](STEAM_PROMOTION_LOG.md)
+     for rollback purposes.
+   - `go_nogo_confirmed`: type exactly `YES` to confirm all Stage 4 gate
+     criteria are met and the release owner has given go/no-go.
 2. Approve the workflow run in the `steam-release` environment (requires a
    reviewer with the required-reviewer role).
 3. Wait for the workflow to complete successfully.
+4. Copy the "Steam Promotion Record" block from the "Record promotion details"
+   step output and add it to [`publishing/STEAM_PROMOTION_LOG.md`](STEAM_PROMOTION_LOG.md).
+
+**Fallback path — re-upload (build not yet staged):**
+
+If the build has not been uploaded to Steamworks yet, trigger `steam-deploy.yml`
+with the launch tag and `set_live_branch: default` instead.
 
 - [ ] Workflow completed with exit code 0.
 - [ ] `default` branch shows the launch build in Steamworks App Admin → Builds.
+- [ ] Promotion record added to [`publishing/STEAM_PROMOTION_LOG.md`](STEAM_PROMOTION_LOG.md).
 
 ### Step 4 — Verify CDN propagation (T+15 minutes)
 

--- a/publishing/STEAM_PROMOTION_LOG.md
+++ b/publishing/STEAM_PROMOTION_LOG.md
@@ -1,0 +1,119 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+# Steam Default Branch Promotion Log
+
+> **Purpose:** Permanent record of every promotion of a SteamPipe build to the
+> `default` branch (public release).  Each entry captures the SteamPipe Build ID
+> set live, the Build ID it replaced (for rollback), the GitHub release tag,
+> the SHA-256 hashes of the promoted artifacts, release notes, and the go/no-go
+> confirmation.
+>
+> **When to update:** Immediately after the `steam-promote.yml` CI workflow
+> completes successfully.  Copy the "Steam Promotion Record" block printed by the
+> "Record promotion details" step and paste it into the [Entries](#entries)
+> section below.
+>
+> **Audience:** Platform team, launch commander, Outright Mental.  This log is
+> the authoritative provenance record for every public release — do not delete
+> or alter past entries.
+
+---
+
+## Entries
+
+<!-- Add a new entry for every promotion.  Newest entry first. -->
+
+---
+
+### Entry template
+
+Copy this section, fill in all fields, and add it above this template for each
+new promotion.  Do not leave placeholder text in a completed entry.
+
+```
+## Promotion vX.Y.Z — YYYY-MM-DD
+
+### Header
+
+Date (UTC)        :
+Release tag       :
+Build ID (new)    :   ← the Build ID set live on default
+Build ID (prev)   :   ← the Build ID that was live before this promotion
+                       (used for rollback — do NOT delete this build from Steamworks)
+Branch set live   : default
+Promoted by       :   ← GitHub username
+CI run            :   ← link to the steam-promote.yml workflow run
+
+### Go/no-go confirmation
+
+All Stage 4 gate criteria in docs/steam-mvp-scope.md were verified before
+promotion:
+
+| Gate | Status |
+|------|--------|
+| G4-01 Valve store page approval | ☐ PASS |
+| G4-02 Steam Deck Verified tier | ☐ PASS |
+| G4-03 Full release checklist (Parts A–J) | ☐ PASS |
+| G4-04 Store page copy accurate | ☐ PASS |
+| G4-05 Voice smoke test (or fallback) | ☐ PASS |
+
+Additional sign-offs required before promotion:
+
+- [ ] STEAM_BETA_VERIFICATION_REPORT.md attached to the release issue (G3-06 / SR-09)
+- [ ] Release owner has given explicit launch go/no-go
+- [ ] publishing/BETA_FEEDBACK_AND_LAUNCH_RISKS.md complete and signed
+
+Release owner sign-off: ___________________________  Date: YYYY-MM-DD
+
+### Artifact SHA-256 hashes
+
+Computed from the GitHub release assets for the release tag above.
+(Copied from the CI run "Record promotion details" step output.)
+
+| Filename | SHA-256 |
+|----------|---------|
+| ConversationSimulator_vX.Y.Z_aarch64.dmg | |
+| ConversationSimulator_vX.Y.Z_x64.dmg | |
+| ConversationSimulator_vX.Y.Z_amd64.AppImage | |
+| ConversationSimulator_vX.Y.Z_x64-setup.exe | |
+| ConversationSimulator_vX.Y.Z_x64-setup.msi | |
+| checksums-sha256.txt | |
+| ConversationSimulator_vX.Y.Z_aarch64.app.tar.gz | |
+
+### Release notes
+
+Link: https://github.com/outrightmental/ConversationSimulator/releases/tag/vX.Y.Z
+
+Summary of changes in this release (copy from RELEASE_NOTES.md or the
+GitHub release body):
+
+-
+-
+
+### Rollback reference
+
+To roll back this promotion if a critical defect is found:
+
+1. Open Steamworks → App Admin → Builds.
+2. Find Build ID (prev) listed above.
+3. Click Set Live → select branch default.
+4. Confirm in Steamworks; wait 10–15 minutes for CDN propagation.
+5. Verify previous build is live from a fresh account install.
+6. Open a severity:critical GitHub issue:
+     Title:  [Rollback] vX.Y.Z reverted — <brief reason>
+     Labels: steam, platform-bug, severity:critical
+7. Notify all triage owners listed in publishing/LAUNCH_DAY_RUNBOOK.md.
+
+For the full rollback procedure see publishing/ROLLBACK_AND_SUPPORT_MESSAGING.md.
+```
+
+---
+
+## Links
+
+- [`.github/workflows/steam-promote.yml`](../.github/workflows/steam-promote.yml) — CI workflow that performs the promotion
+- [`.github/workflows/steam-deploy.yml`](../.github/workflows/steam-deploy.yml) — CI workflow that uploads content and optionally sets a branch live
+- [`publishing/LAUNCH_DAY_RUNBOOK.md`](LAUNCH_DAY_RUNBOOK.md) — launch-day sequence; Step 3 triggers this promotion
+- [`publishing/ROLLBACK_AND_SUPPORT_MESSAGING.md`](ROLLBACK_AND_SUPPORT_MESSAGING.md) — rollback procedure and player support messages
+- [`publishing/BETA_FEEDBACK_AND_LAUNCH_RISKS.md`](BETA_FEEDBACK_AND_LAUNCH_RISKS.md) — gate SR-09 sign-off
+- [`docs/STEAM_BETA_VERIFICATION_REPORT.md`](../docs/STEAM_BETA_VERIFICATION_REPORT.md) — gate G3-06 sign-off
+- [`docs/steam-mvp-scope.md`](../docs/steam-mvp-scope.md) — Stage 4 gate criteria (G4-01 through G4-05)

--- a/publishing/STEAM_PUBLISHING_AND_DEPLOYMENT.md
+++ b/publishing/STEAM_PUBLISHING_AND_DEPLOYMENT.md
@@ -240,14 +240,19 @@ that branch. Always follow the staged-then-promote pattern.
 1. Confirm **all** Stage 4 gate criteria in
    [`docs/steam-mvp-scope.md`](../docs/steam-mvp-scope.md) are met, including
    Valve store page approval and Steam Deck Verified status.
-2. **If the build is already staged or live on `beta`**, use the dedicated
+2. **If the build is already staged or live on `beta`**, run the dedicated
    promotion workflow (`.github/workflows/steam-promote.yml`) with the Build ID
    from Steamworks, the release tag, and the previous default Build ID (for
-   rollback reference).  This uses `+set_build_live_branch`, a metadata-only
-   operation that does not re-upload depot content.  Record the resulting
-   promotion entry in [`publishing/STEAM_PROMOTION_LOG.md`](STEAM_PROMOTION_LOG.md).
-   **If the build has not been staged yet**, trigger `steam-deploy.yml` with
-   `set_live_branch: default` instead.
+   rollback reference).  The workflow enforces the go/no-go gate and captures
+   the provenance record; it does **not** re-upload depot content (the build is
+   already on Valve's CDN).  Steam does not allow CI to set the `default` branch
+   of a released app live — that change requires an interactive Steam Mobile
+   Authenticator (or SMS) authorization — so a human then sets the build live on
+   `default` in Steamworks → App Admin → Builds, following the instructions the
+   workflow prints.  Record the resulting promotion entry in
+   [`publishing/STEAM_PROMOTION_LOG.md`](STEAM_PROMOTION_LOG.md).
+   **If the build has not been staged yet**, trigger `steam-deploy.yml` to
+   upload the depot content first, then set it live on `default` in App Admin.
 3. The `default` branch immediately serves all new installs and updates.
 4. Monitor the Steamworks App Admin → Reviews and the GitHub issue queue for
    the first 72 hours. Follow the launch monitoring checklist in

--- a/publishing/STEAM_PUBLISHING_AND_DEPLOYMENT.md
+++ b/publishing/STEAM_PUBLISHING_AND_DEPLOYMENT.md
@@ -240,8 +240,14 @@ that branch. Always follow the staged-then-promote pattern.
 1. Confirm **all** Stage 4 gate criteria in
    [`docs/steam-mvp-scope.md`](../docs/steam-mvp-scope.md) are met, including
    Valve store page approval and Steam Deck Verified status.
-2. Trigger the deploy workflow with the Stage 4 release tag and
-   `set_live_branch: default`.
+2. **If the build is already staged or live on `beta`**, use the dedicated
+   promotion workflow (`.github/workflows/steam-promote.yml`) with the Build ID
+   from Steamworks, the release tag, and the previous default Build ID (for
+   rollback reference).  This uses `+set_build_live_branch`, a metadata-only
+   operation that does not re-upload depot content.  Record the resulting
+   promotion entry in [`publishing/STEAM_PROMOTION_LOG.md`](STEAM_PROMOTION_LOG.md).
+   **If the build has not been staged yet**, trigger `steam-deploy.yml` with
+   `set_live_branch: default` instead.
 3. The `default` branch immediately serves all new installs and updates.
 4. Monitor the Steamworks App Admin → Reviews and the GitHub issue queue for
    the first 72 hours. Follow the launch monitoring checklist in
@@ -359,9 +365,12 @@ a signed build.
 - [`publishing/STEAM_DEPOT_CONTENTS.md`](STEAM_DEPOT_CONTENTS.md) — depot layout, exclusions, approved binary payload list
 - [`publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md`](STEAM_COMPLIANCE_AND_RISK_REGISTER.md) — risk register; see MD-04, SR-08
 - [`publishing/STEAM_STORE_AND_OPERATIONS.md`](STEAM_STORE_AND_OPERATIONS.md) — store operations, launch runbook, support triage
+- [`publishing/STEAM_PROMOTION_LOG.md`](STEAM_PROMOTION_LOG.md) — log of every default-branch promotion (Build IDs, artifact hashes, release notes)
+- [`publishing/LAUNCH_DAY_RUNBOOK.md`](LAUNCH_DAY_RUNBOOK.md) — launch-day sequence including Step 3 (promotion) and Step 4 (CDN verification)
 - [`publishing/MACOS_SIGNING_AND_NOTARIZATION.md`](MACOS_SIGNING_AND_NOTARIZATION.md) — macOS signing and notarisation
 - [`publishing/WINDOWS_CODE_SIGNING.md`](WINDOWS_CODE_SIGNING.md) — Windows Authenticode signing
-- [`.github/workflows/steam-deploy.yml`](../.github/workflows/steam-deploy.yml) — CI deploy workflow
+- [`.github/workflows/steam-promote.yml`](../.github/workflows/steam-promote.yml) — CI workflow for promoting a staged build to default (no re-upload)
+- [`.github/workflows/steam-deploy.yml`](../.github/workflows/steam-deploy.yml) — CI workflow for uploading content and optionally setting a branch live
 - [`steam/`](../steam/) — SteamPipe VDF templates
 - [`scripts/depot-audit.sh`](../scripts/depot-audit.sh) — depot content audit (Linux / macOS)
 - [`scripts/depot-audit.ps1`](../scripts/depot-audit.ps1) — depot content audit (Windows PowerShell)


### PR DESCRIPTION
## Summary

Adds a **Steam default-branch promotion workflow** that gates, records, and automates the non-interactive parts of promoting a previously-uploaded SteamPipe build to the `default` branch (public release). The workflow enforces two approval gates before any artifact is touched, downloads and SHA-256-hashes the release artifacts for the provenance record, and prints both the exact App Admin steps and the promotion record to copy into the permanent log.

The key insight: Steamworks **does not permit CI to set the `default` branch live** for a released app. Steam sends an authorization prompt to the requesting account's Mobile Authenticator (or SMS), which is interactive by design and cannot be completed on a headless runner. Therefore this workflow does everything CI *can* do correctly—gating, provenance capture, and instructions—and leaves the actual "Set Build Live" to a human in the Steamworks App Admin panel.

## Changes

- **`.github/workflows/steam-promote.yml`** — New 260-line workflow with two approval gates:
  1. Required-reviewer gate via the `steam-release` environment (GitHub Actions approval).
  2. Operator go/no-go confirmation field (must type exactly `YES`, confirming Stage 4 criteria G4-01 through G4-05 are met).
  - Downloads the GitHub release assets and computes SHA-256 hashes.
  - Prints both the exact App Admin set-live steps and the promotion record.
  - Uses only `github.token` to download assets; no Steam credentials are exposed.

- **`publishing/STEAM_PROMOTION_LOG.md`** — New permanent provenance record with:
  - Entry template capturing Build ID (new and previous for rollback), release tag, date, promoted-by, CI run URL, and SHA-256 artifact hashes.
  - Definition-of-done requirements: every promotion must record all Stage 4 gate statuses and release notes.

- **`publishing/LAUNCH_DAY_RUNBOOK.md`** — Step 3 updated:
  - Preferred path: promote workflow + manual App Admin set-live (when build is already staged).
  - Fallback path: re-upload via `steam-deploy.yml` (when build hasn't been uploaded yet).
  - Added checklist item to record the promotion log entry.

- **`publishing/STEAM_PUBLISHING_AND_DEPLOYMENT.md`** — Stage 4 section corrected and linked to both workflows and the promotion log.

- **`apps/web/src/__tests__/VoiceSettingsPanel.test.tsx`** — Fixed race condition in STT/TTS unavailable tests: changed `waitFor(toBeInTheDocument())` to wait for expected text content directly, so the test polls until the async health-check promise resolves.

## Design rationale

The two-gate approval pattern prevents a single point of failure:
1. The `steam-release` environment enforces organizational sign-off (required-reviewer role).
2. The `go_nogo_confirmed` field forces the operator to explicitly re-confirm all Stage 4 criteria before *any* artifact download or hashing happens.

The **`previous_build_id`** input requirement ensures the operator looks up the current default Build ID in Steamworks—providing an explicit rollback target that is recorded in the promotion log and retained for rollback recovery.

The promotion log serves as the authoritative provenance record for every public release: it captures which build was promoted, what it replaced, when, by whom, and includes the SHA-256 hashes of all promoted artifacts for downstream traceability.

## Testing

- Workflow YAML reviewed for shell-injection safety: all user inputs (`build_id`, `release_tag`, `previous_build_id`, `go_nogo_confirmed`) are passed via `env:` block, never interpolated directly into `run:` shells—matching the pattern in `steam-deploy.yml`.
- Gate logic verified: `go_nogo_confirmed != 'YES'` causes `exit 1` before any network operation.
- Error handling: workflow fails explicitly if no release artifacts are downloaded (prevents incomplete promotion records).
- Promotion log template confirmed to include all definition-of-done fields: Build IDs, release tag, artifact hashes, and go/no-go sign-offs.

Closes #242