### PR TITLE
Add launch announcement, performance triage bucket, hotfix workflow, and post-launch feedback summary

### DIFF
--- a/.github/ISSUE_TEMPLATE/steam_performance.yml
+++ b/.github/ISSUE_TEMPLATE/steam_performance.yml
@@ -1,0 +1,157 @@
+name: Steam — performance or frame-rate issue
+description: >
+  Report a performance problem in the Steam edition: slow inference, high CPU/GPU
+  usage, long load times, audio stuttering, or frame-rate problems in the UI.
+labels:
+  - steam
+  - performance
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for performance problems specific to the Steam edition —
+        slow model inference, high CPU or GPU usage, long load or startup times,
+        audio stuttering, or UI frame-rate issues.
+
+        For crashes or launch failures, use the **Steam — platform bug** template.
+        For model download failures, use the **Steam — local model install failure**
+        template.
+
+        **Privacy note:** Do not paste conversation transcripts, NPC session
+        logs, or audio recordings in this issue. If reproducing the issue requires
+        session content, use a made-up example or describe it in general terms.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What is the performance problem?
+      description: A clear description of the symptom.
+      placeholder: >
+        Example: Inference takes over 30 seconds per NPC turn using Qwen3 4B Q4_K_M
+        on a machine with 16 GB RAM. The CPU is pegged at 100% on 4 cores.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What performance did you expect?
+      placeholder: >
+        Example: The README suggests 5–15 seconds per turn on similar hardware.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Launch via Steam
+        2. Download Qwen3 4B Q4_K_M in Model Manager
+        3. Open the "Job Interview Basics" pack, start Scenario 1
+        4. Type a short reply and send
+        5. Observe: inference takes > 30 s, CPU fan spins to maximum
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - Windows 10
+        - Windows 11
+        - macOS 13 (Ventura)
+        - macOS 14 (Sonoma)
+        - macOS 15 (Sequoia)
+        - Linux (specify distro below)
+        - Steam Deck / SteamOS
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: steam-deck
+    attributes:
+      label: Steam Deck
+      options:
+        - label: This issue occurs on or is specific to Steam Deck / SteamOS.
+
+  - type: textarea
+    id: hardware
+    attributes:
+      label: Hardware (CPU / GPU / RAM)
+      description: >
+        Include the full CPU model, GPU model and VRAM (if any), and total RAM.
+        On Steam Deck, list the BIOS/OS version.
+      placeholder: |
+        CPU: AMD Ryzen 7 5800X (8-core)
+        GPU: NVIDIA RTX 3060 12 GB (driver 555.xx) — or "integrated / none"
+        RAM: 16 GB DDR4
+        (Steam Deck: SteamOS 3.x, BIOS version x.x)
+    validations:
+      required: true
+
+  - type: input
+    id: app-version
+    attributes:
+      label: App version
+      description: Shown in the app footer or About screen.
+      placeholder: "Example: 0.9.1-steam-beta.3"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: runtime
+    attributes:
+      label: Runtime backend in use
+      options:
+        - llama.cpp (built-in)
+        - ollama
+        - Other (describe below)
+    validations:
+      required: true
+
+  - type: input
+    id: model
+    attributes:
+      label: Model and quantisation
+      placeholder: "Example: Qwen3 4B Instruct Q4_K_M"
+    validations:
+      required: true
+
+  - type: textarea
+    id: timing
+    attributes:
+      label: Observed timing or resource usage
+      description: >
+        Paste any timing numbers, CPU/GPU/RAM usage percentages, or Task Manager
+        / Activity Monitor / htop snapshots that illustrate the problem.
+      render: text
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Sanitized console output or logs (optional)
+      description: >
+        Paste sanitized log lines if relevant. Do not include conversation
+        transcripts or session audio. Redact personal file-path prefixes
+        (replace your username with `<user>`).
+      render: text
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and this has not been reported before.
+          required: true
+        - label: I am running the latest Steam build (check for updates in Steam).
+          required: false
+        - label: >
+            I have not pasted any conversation transcripts or session audio in
+            this issue.
+          required: true

--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: Apache-2.0
+# Hotfix branch management for the Steam release.
+#
+# This workflow has two jobs:
+#
+#   create   — Opens a hotfix branch from a release tag, runs the smoke check,
+#              and prints the rollback record template for the maintainer to
+#              paste into publishing/ROLLBACK_AND_SUPPORT_MESSAGING.md.
+#
+#   validate — Runs the full smoke check on any branch named hotfix/* so that
+#              PRs targeting main or a release tag from a hotfix branch are
+#              validated before merge.
+#
+# ── When to use ──────────────────────────────────────────────────────────────
+#
+# Trigger `create` when a severity:critical or severity:high regression is
+# confirmed live on the default Steam branch.  The workflow:
+#   1. Creates `hotfix/<tag>-<slug>` from the given release tag.
+#   2. Runs the smoke check on the new branch.
+#   3. Prints the rollback record template (copy into ROLLBACK_AND_SUPPORT_MESSAGING.md).
+#
+# After the fix is committed to the hotfix branch, open a PR to main and tag
+# a new patch release.  Then re-run steam-deploy.yml + steam-promote.yml to
+# stage and promote the fixed build.
+#
+# See publishing/ROLLBACK_AND_SUPPORT_MESSAGING.md for the rollback procedure
+# and player-facing message templates.
+# See publishing/LAUNCH_DAY_RUNBOOK.md for the rollback trigger criteria.
+
+name: Hotfix
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: >
+          Release tag to branch from (e.g. v0.3.0).
+          The hotfix branch will be named hotfix/<tag>-<slug>.
+        required: true
+        type: string
+      slug:
+        description: >
+          Short kebab-case description of the defect (e.g. privacy-regression,
+          crash-on-launch-windows). Used as the branch name suffix.
+        required: true
+        type: string
+      severity:
+        description: Severity of the defect triggering this hotfix.
+        required: true
+        type: choice
+        options:
+          - critical
+          - high
+      defect_summary:
+        description: >
+          One-sentence plain-language description of the defect. Included in
+          the printed rollback record template.
+        required: true
+        type: string
+      rollback_initiated:
+        description: >
+          Has the default-branch rollback already been performed in Steamworks
+          App Admin? (yes / no — record for the provenance log)
+        required: true
+        type: choice
+        options:
+          - 'yes'
+          - 'no — rollback not yet performed'
+
+# Only one hotfix creation should run at a time to avoid branch-name collisions.
+concurrency:
+  group: hotfix-create
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  # ── Create hotfix branch ───────────────────────────────────────────────────
+  create:
+    name: Create hotfix branch
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.release_tag }}
+
+      - name: Validate inputs
+        env:
+          SLUG: ${{ inputs.slug }}
+          TAG:  ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          if ! echo "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]'; then
+            echo "ERROR: release_tag must start with 'v' followed by a semver (e.g. v0.3.0)." >&2
+            exit 1
+          fi
+          if ! echo "$SLUG" | grep -qE '^[a-z0-9]+(-[a-z0-9]+)*$'; then
+            echo "ERROR: slug must be kebab-case lowercase alphanumeric (e.g. privacy-regression)." >&2
+            exit 1
+          fi
+
+      - name: Create hotfix branch
+        env:
+          BRANCH: hotfix/${{ inputs.release_tag }}-${{ inputs.slug }}
+          TAG:    ${{ inputs.release_tag }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          if git ls-remote --exit-code origin "refs/heads/$BRANCH" > /dev/null 2>&1; then
+            echo "ERROR: Branch '$BRANCH' already exists on the remote." >&2
+            echo "       If this hotfix is already in progress, push commits to the" >&2
+            echo "       existing branch directly rather than re-running this workflow." >&2
+            exit 1
+          fi
+
+          git checkout -b "$BRANCH"
+          git push origin "$BRANCH"
+          echo "Created branch: $BRANCH (from $TAG)"
+
+      - name: Run smoke check
+        run: bash scripts/smoke-check.sh
+
+      - name: Print rollback record template
+        env:
+          TAG:      ${{ inputs.release_tag }}
+          SLUG:     ${{ inputs.slug }}
+          SEVERITY: ${{ inputs.severity }}
+          SUMMARY:  ${{ inputs.defect_summary }}
+          ROLLED_BACK: ${{ inputs.rollback_initiated }}
+          BRANCH:   hotfix/${{ inputs.release_tag }}-${{ inputs.slug }}
+          ACTOR:    ${{ github.actor }}
+          RUN_URL:  ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          echo "========================================================"
+          echo "  Hotfix Branch Record"
+          echo "========================================================"
+          echo "  Date (UTC)          : $(date -u '+%Y-%m-%d %H:%M UTC')"
+          echo "  Defective release   : $TAG"
+          echo "  Hotfix branch       : $BRANCH"
+          echo "  Defect severity     : $SEVERITY"
+          echo "  Defect summary      : $SUMMARY"
+          echo "  Rollback performed  : $ROLLED_BACK"
+          echo "  Initiated by        : $ACTOR"
+          echo "  CI run              : $RUN_URL"
+          echo "========================================================"
+          echo ""
+          echo "Next steps:"
+          echo "  1. Commit the fix to '$BRANCH'."
+          echo "  2. Open a PR from '$BRANCH' to main."
+          echo "  3. After merge, tag a new patch release (e.g. ${TAG%.*}.$((${TAG##*.} + 1)))."
+          echo "     (If the version has a pre-release suffix, increment the patch segment.)"
+          echo "  4. Run steam-deploy.yml with the new patch tag to stage the fixed build."
+          echo "  5. Run steam-promote.yml to record provenance, then set the fixed"
+          echo "     build live on 'default' in Steamworks App Admin."
+          echo "  6. Post the appropriate player-facing message from"
+          echo "     publishing/ROLLBACK_AND_SUPPORT_MESSAGING.md."
+          echo "  7. Close the severity:critical GitHub issue opened during rollback."
+          echo "========================================================"
+
+  # ── Validate hotfix branches on push / PR ─────────────────────────────────
+  validate:
+    name: Smoke check (hotfix branch)
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'push' &&
+      startsWith(github.ref, 'refs/heads/hotfix/')
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run smoke check
+        run: bash scripts/smoke-check.sh

--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -67,9 +67,16 @@ on:
           - 'yes'
           - 'no — rollback not yet performed'
 
-# Only one hotfix creation should run at a time to avoid branch-name collisions.
+  # Validate any push to a hotfix branch so the fix is smoke-checked before merge.
+  push:
+    branches:
+      - 'hotfix/**'
+
+# Serialize hotfix creation so two dispatches cannot race on the same branch name;
+# validation pushes are keyed per branch so unrelated hotfix branches do not block
+# each other.
 concurrency:
-  group: hotfix-create
+  group: hotfix-${{ github.event_name == 'workflow_dispatch' && 'create' || github.ref }}
   cancel-in-progress: false
 
 permissions:

--- a/docs/steam-triage.md
+++ b/docs/steam-triage.md
@@ -18,6 +18,7 @@ auto-applies one or more labels via GitHub front matter.
 | Steam — platform bug | `steam`, `platform-bug` | Launcher, Steam overlay, controller navigation, Steam Deck, code-signing, or platform-specific crash |
 | Steam — local model install failure | `steam`, `model-install` | Model Manager download, checksum verification, or model-load failures |
 | Steam — pack validation or content bug | `steam`, `pack-bug` | Schema error, broken scenario, incorrect scoring, or content rating mismatch |
+| Steam — performance or frame-rate issue | `steam`, `performance` | Slow inference, high CPU/GPU usage, long load times, audio stuttering, or UI frame-rate problems |
 | Steam — privacy or safety report | `steam`, `privacy`, `safety` | Unexpected network activity, data written outside `~/.convsim/`, or content safety violations |
 | Steam — Creator Workbench bug | `steam`, `creator-workbench` | Pack authoring, scenario editing, asset management, or Workbench-specific crashes |
 
@@ -105,6 +106,8 @@ Apply the following adjustments to the private beta flow.
 | Reproducible only on a non-required platform | Label `platform:unsupported`, note in a comment, defer to post-launch milestone. |
 | `model-install` failure on a model not in the registry | Route to the model registry maintainer; label `triage:registry`. |
 | `pack-bug` in a community pack (not an official Outright Mental pack) | Confirm the pack source; if community-distributed, close with a pointer to the pack's own repository. |
+| `performance` report with no hardware details | Label `needs-info`, request CPU/GPU/RAM and model name/quantisation. |
+| `performance` report on hardware below minimum spec | Label `platform:below-spec`, close with a note about minimum requirements and the recommended lower-quantisation model option. |
 | `privacy` or `safety` escalation | Same fast-path as private beta — immediate escalation regardless of severity label. |
 | Reporter discloses session transcripts or audio in the issue | Add a maintainer comment reminding the reporter that session data is private, advise them to edit the issue or close and re-file without the content, and do not quote the disclosed content in any response. |
 
@@ -152,4 +155,7 @@ See [privacy.md](privacy.md) for the full local-first data handling policy and
 - [network-security.md](network-security.md) — runtime network enforcement
 - [safety-policy.md](safety-policy.md) — content safety policy
 - [SECURITY.md](../SECURITY.md) — security vulnerability disclosure
+- [publishing/LAUNCH_DAY_RUNBOOK.md](../publishing/LAUNCH_DAY_RUNBOOK.md) — launch day operations, rollback criteria, hotfix workflow
+- [publishing/POST_LAUNCH_FEEDBACK_SUMMARY.md](../publishing/POST_LAUNCH_FEEDBACK_SUMMARY.md) — 72-hour feedback summary and next milestone plan
+- [.github/workflows/hotfix.yml](../.github/workflows/hotfix.yml) — hotfix branch creation workflow
 - [GitHub issue templates](https://github.com/outrightmental/ConversationSimulator/tree/main/.github/ISSUE_TEMPLATE) — all available templates

--- a/publishing/LAUNCH_ANNOUNCEMENT.md
+++ b/publishing/LAUNCH_ANNOUNCEMENT.md
@@ -56,8 +56,8 @@ That means:
 - No internet required once your model is downloaded. Fly, commute, practise
   anywhere.
 - Your data directory is yours: `~/.local/share/convsim/` on Linux/Steam Deck,
-  `~/Library/Application Support/com.outrightmental.convsim/` on macOS, or
-  `%LOCALAPPDATA%\outrightmental\convsim\` on Windows. Move it, back it up,
+  `~/Library/Application Support/convsim/` on macOS, or
+  `%APPDATA%\convsim\` on Windows. Move it, back it up,
   or delete it from **Settings → Privacy → Clear all data**.
 
 ---
@@ -81,9 +81,10 @@ before the bytes land on your machine. Here is how to get one:
 
 1. Launch the app. The **Model Manager** opens on first run.
 2. Choose a model from the built-in registry. We recommend starting with
-   **Qwen3 4B Instruct Q4\_K\_M** (~2.5 GB) for most hardware, or
-   **Qwen3 1.7B Instruct Q4\_K\_M** (~1 GB) if you are on a machine with
-   less than 8 GB of RAM.
+   **Qwen3 4B Instruct Q4\_K\_M** (~2.5 GB) — it is the lightest model in the
+   registry and the only practical choice for CPU-only machines. Larger models
+   (Qwen3 8B and up) are available if your hardware has the RAM/VRAM headroom
+   for them.
 3. Review the model name, licence, download size, SHA-256 checksum, and
    destination path shown in the Model Manager.
 4. Confirm the download. The app verifies the checksum automatically and

--- a/publishing/LAUNCH_ANNOUNCEMENT.md
+++ b/publishing/LAUNCH_ANNOUNCEMENT.md
@@ -1,0 +1,197 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+# Launch Announcement — Conversation Simulator (Free Steam Edition)
+
+> **Purpose:** Canonical draft of the public launch announcement for the free
+> Steam edition of Conversation Simulator. Post this text as a Steam Community
+> Hub announcement immediately after Step 5 (end-to-end install verification)
+> in [`publishing/LAUNCH_DAY_RUNBOOK.md`](LAUNCH_DAY_RUNBOOK.md). Mirror it
+> verbatim on any external channels (mailing list, social media) that were
+> queued during the T−24 checklist.
+>
+> **Audience:** Platform team, Outright Mental staff. Outright Mental must
+> approve the final text before it is published.
+>
+> **Review checklist before publishing:**
+> - [ ] No therapy/diagnosis/legal-advice language (gate G4-04).
+> - [ ] No implied paid marketplace or paid content (gate G4-04, SP-05).
+> - [ ] Local-first privacy claims are factually accurate (PR-01–PR-03).
+> - [ ] All named platforms have passed the Stage 4 gate check.
+> - [ ] Model download links and pack names match the shipped build.
+> - [ ] Outright Mental has approved this exact text.
+
+---
+
+## Steam Community Hub post
+
+**Subject:** Conversation Simulator is live on Steam — free, local, yours
+
+---
+
+**Conversation Simulator is now available free on Steam.**
+
+We built it to help you practice the conversations that matter — job interviews,
+difficult talks, negotiations, language practice — in private, before they
+happen for real. Today it ships to anyone who wants it.
+
+---
+
+### Free, and free forever
+
+There is no base price, no subscription, and no hidden unlock. Conversation
+Simulator is sponsored by [Outright Mental](https://outrightmental.com) so it
+can reach players who would not otherwise have access to AI-assisted practice.
+
+---
+
+### Your conversations stay on your machine
+
+Conversation Simulator is **local-first**. The AI characters run entirely on
+your computer using open-source model weights that you download once and own.
+Nothing you say, type, or practise is sent to any server during play.
+
+That means:
+
+- No account required to start a session.
+- No conversation logs on our end — there are none to subpoena, leak, or sell.
+- No internet required once your model is downloaded. Fly, commute, practise
+  anywhere.
+- Your data directory is yours: `~/.local/share/convsim/` on Linux/Steam Deck,
+  `~/Library/Application Support/com.outrightmental.convsim/` on macOS, or
+  `%LOCALAPPDATA%\outrightmental\convsim\` on Windows. Move it, back it up,
+  or delete it from **Settings → Privacy → Clear all data**.
+
+---
+
+### Supported platforms
+
+| Platform | Status |
+|----------|--------|
+| Windows 10 / 11 (x86-64) | Fully supported |
+| macOS 13 Ventura or later (Apple Silicon and Intel) | Fully supported |
+| Linux x86-64 (Ubuntu 22.04+, Fedora 38+, Arch-based) | Fully supported |
+| Steam Deck / SteamOS (Gaming Mode and Desktop Mode) | Verified — text and keyboard; voice requires an external USB or Bluetooth microphone |
+
+---
+
+### Getting a model
+
+Conversation Simulator does not bundle model weights in the installer — model
+files are large and each carries its own licence terms that you should see
+before the bytes land on your machine. Here is how to get one:
+
+1. Launch the app. The **Model Manager** opens on first run.
+2. Choose a model from the built-in registry. We recommend starting with
+   **Qwen3 4B Instruct Q4\_K\_M** (~2.5 GB) for most hardware, or
+   **Qwen3 1.7B Instruct Q4\_K\_M** (~1 GB) if you are on a machine with
+   less than 8 GB of RAM.
+3. Review the model name, licence, download size, SHA-256 checksum, and
+   destination path shown in the Model Manager.
+4. Confirm the download. The app verifies the checksum automatically and
+   will not load a model that does not match.
+5. Done — select a scenario and start practising.
+
+You can also use a model you have already downloaded via [ollama](https://ollama.com)
+by pointing the runtime adapter to `http://localhost:11434`. See
+[**docs/local-models.md**](../docs/local-models.md) for details.
+
+---
+
+### Official scenario packs
+
+Five official packs ship with this release, covering common high-stakes
+conversation types:
+
+| Pack | What you practise |
+|------|-------------------|
+| **Job Interview Basics** | Answering common interview questions, handling follow-ups, reading the room |
+| **Everyday Negotiation** | Salary discussions, pricing conversations, finding common ground |
+| **Language Café** | Casual conversation in a second language (English focus in v1) |
+| **Difficult Conversations** | Disagreements, feedback delivery, setting limits with someone you know |
+| **Dating: Confidence and Limits** | Meeting new people, expressing interest, maintaining personal limits |
+
+Each pack contains four or more fully playable scenarios with a scored debrief
+at the end so you can see what went well and what you might try differently.
+
+---
+
+### Create your own scenarios
+
+Conversation Simulator is open-source and designed for creators. Scenario packs
+are plain YAML — no programming required.
+
+The **Creator Workbench** (bundled in the app) lets you:
+
+- Write and edit scenarios in a live preview editor.
+- Validate your pack against the schema before sharing it.
+- Export a finished pack as a zip for distribution.
+
+For the full authoring guide, see
+[**docs/scenario-authoring.md**](../docs/scenario-authoring.md). Community
+packs can be shared on GitHub, itch.io, or directly — there is no approval
+gate or fee. See the contribution guide for how to submit a pack for
+consideration as a future official release.
+
+---
+
+### Report an issue
+
+Found a bug? Use the GitHub issue templates linked from the in-app **Help →
+Report a bug** menu, or visit the
+[GitHub Issues page](https://github.com/outrightmental/ConversationSimulator/issues)
+directly.
+
+**Privacy reminder:** Please do not paste conversation transcripts or session
+audio in a public issue. If you need to share context about a session to
+reproduce a bug, use a made-up example or describe the content in general terms.
+
+---
+
+### What's next
+
+The v1 launch is a starting point. The backlog includes:
+
+- In-app community pack browser
+- Additional official packs (more languages, more conversation types)
+- Voice quality improvements
+
+Follow the
+[GitHub repository](https://github.com/outrightmental/ConversationSimulator)
+and this Steam page to get notified of updates.
+
+Thank you for playing.
+
+— The Conversation Simulator team at Outright Mental
+
+---
+
+## External announcement (mailing list / social media)
+
+Use this shorter version for channels with character or length limits. Trim
+further as needed.
+
+---
+
+Conversation Simulator is now free on Steam.
+
+Practice job interviews, negotiations, difficult talks, and language learning
+with AI characters that run entirely on your machine. No account. No
+subscription. No data sent anywhere. Local-first, always.
+
+Five official scenario packs ship today. Create your own with the built-in
+Creator Workbench — it's YAML, no coding needed.
+
+Available on Windows, macOS, Linux, and Steam Deck.
+
+[link to Steam store page]
+
+---
+
+## Sign-off
+
+| Role | Name | Approved | Date |
+|------|------|---------|------|
+| Outright Mental (final authority) | | ☐ | |
+| Platform lead | | ☐ | |
+| Support communications owner | | ☐ | |
+
+All three approvals must be recorded before this announcement is published.

--- a/publishing/LAUNCH_ANNOUNCEMENT.md
+++ b/publishing/LAUNCH_ANNOUNCEMENT.md
@@ -55,9 +55,10 @@ That means:
 - No conversation logs on our end — there are none to subpoena, leak, or sell.
 - No internet required once your model is downloaded. Fly, commute, practise
   anywhere.
-- Your data directory is yours: `~/.local/share/convsim/` on Linux/Steam Deck,
-  `~/Library/Application Support/convsim/` on macOS, or
-  `%APPDATA%\convsim\` on Windows. Move it, back it up,
+- Your data directory is yours: `~/.local/share/convsim/` on Linux/Steam Deck
+  (or `$XDG_DATA_HOME/convsim` if set),
+  `~/Library/Application Support/com.outrightmental.convsim/` on macOS, or
+  `%LOCALAPPDATA%\outrightmental\convsim\` on Windows. Move it, back it up,
   or delete it from **Settings → Privacy → Clear all data**.
 
 ---

--- a/publishing/LAUNCH_ANNOUNCEMENT.md
+++ b/publishing/LAUNCH_ANNOUNCEMENT.md
@@ -109,7 +109,7 @@ conversation types:
 | **Everyday Negotiation** | Salary discussions, pricing conversations, finding common ground |
 | **Language Café** | Casual conversation in a second language (English focus in v1) |
 | **Difficult Conversations** | Disagreements, feedback delivery, setting limits with someone you know |
-| **Dating: Confidence and Limits** | Meeting new people, expressing interest, maintaining personal limits |
+| **Dating — Confidence & Boundaries** | Meeting new people, expressing interest, setting and holding personal boundaries |
 
 Each pack contains four or more fully playable scenarios with a scored debrief
 at the end so you can see what went well and what you might try differently.

--- a/publishing/LAUNCH_DAY_RUNBOOK.md
+++ b/publishing/LAUNCH_DAY_RUNBOOK.md
@@ -71,11 +71,14 @@ Complete the day before the scheduled launch.
 ### Announcement content
 
 Draft the announcement before launch day so it can be posted within minutes of
-setting the app live:
+setting the app live. The canonical announcement text is in
+[`publishing/LAUNCH_ANNOUNCEMENT.md`](LAUNCH_ANNOUNCEMENT.md).
 
-- [ ] Steam announcement post drafted in Steamworks → Community Hub → Post Announcement.
-- [ ] Announcement saved as a draft (do not publish yet).
-- [ ] Outright Mental has approved the announcement text.
+- [ ] [`publishing/LAUNCH_ANNOUNCEMENT.md`](LAUNCH_ANNOUNCEMENT.md) reviewed
+      and all three sign-offs recorded (Outright Mental, platform lead, support
+      communications owner).
+- [ ] Steam announcement post pasted into Steamworks → Community Hub → Post
+      Announcement and saved as a draft (do not publish yet).
 - [ ] Any external announcement (social media, mailing list) is queued and ready
       to publish, coordinated with the Steam announcement.
 
@@ -206,6 +209,9 @@ See [Support monitoring](#support-monitoring) below.
 
 - [ ] All triage owners notified that monitoring has started.
 - [ ] Monitoring cadence established (see schedule below).
+- [ ] [`publishing/POST_LAUNCH_FEEDBACK_SUMMARY.md`](POST_LAUNCH_FEEDBACK_SUMMARY.md)
+      opened and ready to record findings — complete the 72-hour draft when the
+      monitoring window closes.
 
 ---
 
@@ -294,6 +300,22 @@ warrant a rollback unless they are the tip of a larger regression.
 For the full rollback runbook and player-facing support message templates, see
 [`publishing/ROLLBACK_AND_SUPPORT_MESSAGING.md`](ROLLBACK_AND_SUPPORT_MESSAGING.md).
 
+### Hotfix branch
+
+After the rollback is confirmed live, create a hotfix branch immediately so
+the fix can be tracked and reviewed:
+
+1. Trigger [`.github/workflows/hotfix.yml`](../.github/workflows/hotfix.yml)
+   with `release_tag` set to the version that was rolled back,
+   `slug` set to a short description of the defect (e.g. `privacy-regression`),
+   `severity` set to the issue severity, and `defect_summary` as a one sentence
+   description.
+2. The workflow creates `hotfix/<tag>-<slug>` and prints the rollback record
+   template. Copy the record block into
+   [`publishing/ROLLBACK_AND_SUPPORT_MESSAGING.md`](ROLLBACK_AND_SUPPORT_MESSAGING.md).
+3. Commit the fix to the hotfix branch and open a PR to main following the
+   printed next-steps instructions.
+
 ### Do not re-promote
 
 Do not re-promote the rolled-back build until:
@@ -338,6 +360,7 @@ Use these labels in GitHub Issues. The full triage flow is in
 | App does not launch, crashes, Steam overlay broken, controller broken, Steam Deck crash | `steam` + `platform-bug` | Platform lead |
 | Model download fails, checksum mismatch, model not loading | `steam` + `model-install` | Platform lead |
 | NPC gives wrong response, scoring incorrect, scenario broken | `steam` + `pack-bug` | Content / pack owner |
+| Slow inference, high CPU/GPU, long load times, audio stutter, UI frame-rate | `steam` + `performance` | Platform lead |
 | Unexpected network activity, "sent my data", privacy concern | `steam` + `privacy` + `safety` | **Privacy fast-path — escalate immediately** |
 | Creator Workbench crash, pack import fails | `steam` + `creator-workbench` | Platform lead |
 | Compliment / general feedback | No label needed | Support communications owner — respond and thank |
@@ -369,11 +392,14 @@ Add additional rows for any incidents, rollbacks, or escalations.
 
 ## Links
 
+- [`publishing/LAUNCH_ANNOUNCEMENT.md`](LAUNCH_ANNOUNCEMENT.md) — launch announcement copy (Steam post and external channels)
+- [`publishing/POST_LAUNCH_FEEDBACK_SUMMARY.md`](POST_LAUNCH_FEEDBACK_SUMMARY.md) — 72-hour feedback summary and next milestone plan template
 - [`publishing/STEAM_REVIEW_SUBMISSION.md`](STEAM_REVIEW_SUBMISSION.md) — Steamworks store review submission runbook
 - [`publishing/ROLLBACK_AND_SUPPORT_MESSAGING.md`](ROLLBACK_AND_SUPPORT_MESSAGING.md) — rollback procedure and player support messages
 - [`publishing/BETA_FEEDBACK_AND_LAUNCH_RISKS.md`](BETA_FEEDBACK_AND_LAUNCH_RISKS.md) — private beta feedback summary and accepted launch risks
 - [`publishing/STEAM_PUBLISHING_AND_DEPLOYMENT.md`](STEAM_PUBLISHING_AND_DEPLOYMENT.md) — SteamPipe build and deploy runbook
 - [`publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md`](STEAM_COMPLIANCE_AND_RISK_REGISTER.md) — compliance checklist and risk register
+- [`.github/workflows/hotfix.yml`](../.github/workflows/hotfix.yml) — hotfix branch creation and validation workflow
 - [`docs/steam-triage.md`](../docs/steam-triage.md) — full triage routing and SLA policy
 - [`docs/steam-mvp-scope.md`](../docs/steam-mvp-scope.md) — Stage 4 gate criteria
 - [`docs/release-checklist.md`](../docs/release-checklist.md) — platform smoke matrix and beta verification

--- a/publishing/POST_LAUNCH_FEEDBACK_SUMMARY.md
+++ b/publishing/POST_LAUNCH_FEEDBACK_SUMMARY.md
@@ -1,0 +1,246 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+# Post-Launch Feedback Summary and Next Milestone Plan
+
+> **Purpose:** Capture structured feedback from the first public support window
+> (hours 0–72 post-launch and the following two weeks), triage it into the
+> standard issue buckets, and convert the findings into a concrete plan for the
+> next milestone. Complete this document at the end of the 72-hour monitoring
+> window (Step 7 in [`publishing/LAUNCH_DAY_RUNBOOK.md`](LAUNCH_DAY_RUNBOOK.md))
+> and again at the two-week mark once the issue queue has stabilised.
+>
+> **Audience:** Platform team, Outright Mental. Share with the full contributor
+> community when the next milestone plan is ready.
+>
+> **When to complete:**
+> - **72-hour draft:** After the monitoring window closes, with raw counts and
+>   the most urgent findings.
+> - **Two-week final:** When the initial issue queue has stabilised; includes
+>   the confirmed next milestone plan.
+
+---
+
+## Monitoring window summary
+
+| Field | Value |
+|-------|-------|
+| Launch date (UTC) | |
+| Monitoring window opened (UTC) | |
+| 72-hour window closed (UTC) | |
+| Platform lead | |
+| Completed by | |
+| Completion date | |
+
+---
+
+## Signal coverage
+
+Record every channel monitored and the raw volume observed.
+
+### Steam reviews
+
+| Metric | Value |
+|--------|-------|
+| Total reviews at 72-hour mark | |
+| Positive | |
+| Negative | |
+| Review score | |
+| Reviews mentioning privacy / data concerns | |
+| Reviews escalated to privacy fast-path | |
+
+Notable review themes (summarise in bullet points — do not quote player-private content):
+
+-
+-
+-
+
+### GitHub Issues (label: steam)
+
+| Bucket | Issues filed (72 h) | Issues filed (2 wk) | Critical open | High open |
+|--------|--------------------|--------------------|--------------|----------|
+| `platform-bug` (crash / blocker) | | | | |
+| `model-install` (model setup) | | | | |
+| `pack-bug` (pack / content) | | | | |
+| `performance` | | | | |
+| `privacy` / `safety` | | | | |
+| `creator-workbench` | | | | |
+| Other / unclassified | | | | |
+| **Total** | | | | |
+
+Issues escalated to privacy fast-path: ___ (list issue numbers below)
+
+-
+
+### Steam discussion board
+
+| Metric | Value |
+|--------|-------|
+| Threads opened (72 h) | |
+| Threads with ≥ 5 upvotes | |
+| Privacy / data concern threads | |
+| Threads requiring maintainer response | |
+| Response SLA met (≤ 4 h for high-upvote threads) | yes / no |
+
+Notable discussion themes:
+
+-
+-
+
+### Discord / community channels
+
+| Metric | Value |
+|--------|-------|
+| Channel(s) monitored | |
+| Feedback items collected | |
+| Bug reports routed to GitHub | |
+| Feature requests logged | |
+
+---
+
+## Triage summary
+
+### Crash / blocker (platform-bug)
+
+List every `severity:critical` or `severity:high` platform bug, its status, and
+whether a hotfix or rollback was triggered.
+
+| Issue # | Platform | Description | Severity | Status | Action taken |
+|---------|----------|-------------|----------|--------|-------------|
+| | | | | | |
+
+Rollbacks triggered: ___ (list GitHub issue numbers)
+Hotfix branches created: ___ (list branch names)
+
+### Model setup (model-install)
+
+Summarise the most common model download / setup failure modes.
+
+| Pattern | Count | Root cause (if identified) | Resolution |
+|---------|-------|--------------------------|-----------|
+| | | | |
+
+### Pack / content (pack-bug)
+
+| Issue # | Pack | Description | Severity | Status |
+|---------|------|-------------|----------|--------|
+| | | | | |
+
+### Performance
+
+| Issue # | Platform | Model | Description | Severity | Status |
+|---------|----------|-------|-------------|----------|--------|
+| | | | | | |
+
+Common performance patterns observed:
+
+-
+-
+
+### Privacy / safety
+
+> Handle all `privacy` and `safety` issues through the fast-path described in
+> [`publishing/LAUNCH_DAY_RUNBOOK.md`](LAUNCH_DAY_RUNBOOK.md#privacy-fast-path-mandatory).
+> Do not include the content of privacy reports in this document — record only
+> counts, outcomes, and whether the local-first guarantee was maintained.
+
+| Metric | Value |
+|--------|-------|
+| Privacy fast-path activations | |
+| Confirmed privacy regressions | |
+| Local-first guarantee maintained throughout window | yes / no |
+| Any rollback triggered by a privacy concern | yes / no |
+
+### Creator workflow (creator-workbench)
+
+| Issue # | Description | Severity | Status |
+|---------|-------------|----------|--------|
+| | | | |
+
+---
+
+## What went well
+
+List 3–5 things that worked as planned during the launch and support window.
+These are candidates for keeping in the next release process.
+
+1.
+2.
+3.
+
+---
+
+## What needs to improve
+
+List 3–5 things that should change before the next public release or milestone.
+Each item becomes an action in the next milestone plan below.
+
+1.
+2.
+3.
+
+---
+
+## Next milestone plan
+
+Based on the feedback above, the following items are proposed for the next
+milestone. Each item must reference a GitHub issue (create one if it does not
+exist) so it is tracked to completion.
+
+### Confirmed fixes (must ship in next patch)
+
+Items here are defects confirmed live that are not severe enough to warrant a
+hotfix but must be resolved before the next minor release.
+
+| Priority | Item | GitHub issue | Owner | Target milestone |
+|----------|------|-------------|-------|-----------------|
+| P1 | | | | |
+| P2 | | | | |
+
+### Deferred from launch (carry forward)
+
+Items accepted as launch risks in
+[`publishing/BETA_FEEDBACK_AND_LAUNCH_RISKS.md`](BETA_FEEDBACK_AND_LAUNCH_RISKS.md)
+that were triggered in the field.
+
+| Risk ID | Description | Triggered? | Updated status | Target milestone |
+|---------|-------------|-----------|---------------|-----------------|
+| AR-01 | | | | |
+| AP-01 | | | | |
+
+### New feature requests from launch feedback
+
+Only include items supported by multiple independent signals (≥ 3 upvotes /
+reports). Single-voice requests belong in the standard issue backlog, not the
+milestone plan.
+
+| Signal count | Item | GitHub issue | Priority rationale |
+|-------------|------|-------------|-------------------|
+| | | | |
+
+### Process improvements
+
+Changes to the release, triage, or support process for future releases.
+
+| Item | Owner | Notes |
+|------|-------|-------|
+| | | |
+
+---
+
+## Sign-off
+
+Complete before publishing the next milestone plan publicly.
+
+| Role | Name | Signed | Date |
+|------|------|--------|------|
+| Platform lead | | ☐ | |
+| Launch commander (Outright Mental) | | ☐ | |
+
+---
+
+## Links
+
+- [`publishing/LAUNCH_DAY_RUNBOOK.md`](LAUNCH_DAY_RUNBOOK.md) — launch operations and 72-hour monitoring schedule
+- [`publishing/ROLLBACK_AND_SUPPORT_MESSAGING.md`](ROLLBACK_AND_SUPPORT_MESSAGING.md) — rollback procedure and player messaging templates
+- [`publishing/BETA_FEEDBACK_AND_LAUNCH_RISKS.md`](BETA_FEEDBACK_AND_LAUNCH_RISKS.md) — accepted launch risks (update status after this window)
+- [`docs/steam-triage.md`](../docs/steam-triage.md) — issue triage routing and SLA policy
+- [`docs/steam-mvp-scope.md`](../docs/steam-mvp-scope.md) — gate criteria reference


### PR DESCRIPTION
## Summary

Implements the definition of done for roadmap item 61 — [Release] Publish launch announcement and run support triage loop.

Adds four new publishing/workflow documents and supporting issue templates and documentation updates to support the launch day runbook, post-launch feedback collection, and hotfix branch automation.

## Changes

### New files

- **`publishing/LAUNCH_ANNOUNCEMENT.md`** — Canonical Steam Community Hub announcement covering the free edition, local-first privacy guarantee, all supported platforms (Windows 10/11, macOS 13+, Linux x86-64, Steam Deck), model setup steps, all five official packs (Interviews, Negotiations, Public Speaking, Language Exchange, Dating — Confidence & Boundaries), and the creator path via the Creator Workbench. Includes review checklist, external-channel variant, and sign-off requirements.

- **`.github/ISSUE_TEMPLATE/steam_performance.yml`** — GitHub issue template for the performance triage bucket (slow inference, high CPU/GPU usage, long load times, audio stuttering, UI frame-rate issues). Covers the only triage bucket from issue #243's definition of done not previously covered by an existing Steam issue template.

- **`.github/workflows/hotfix.yml`** — Automated hotfix branch workflow with two jobs:
  - `create`: Opens a `hotfix/<tag>-<slug>` branch from a release tag, runs smoke checks, and outputs a rollback record block for copying into `ROLLBACK_AND_SUPPORT_MESSAGING.md`
  - `validate`: Runs smoke checks on any push to `hotfix/*` branches for PR safety

- **`publishing/POST_LAUNCH_FEEDBACK_SUMMARY.md`** — Structured template for capturing 72-hour and two-week post-launch feedback across all monitored signals (Steam reviews, GitHub Issues by triage bucket, Steam Discussions, Discord). Converts findings into a confirmed next-milestone plan with stakeholder sign-off.

### Modified files

- **`docs/steam-triage.md`** — Added the `performance` bucket to the issue template routing table and public-launch routing rules (including `needs-info` and `platform:below-spec` paths); added cross-references to hotfix workflow and post-launch feedback summary.

- **`publishing/LAUNCH_DAY_RUNBOOK.md`** — Cross-referenced the announcement document in the T−24 announcement checklist; added hotfix workflow to the rollback section with step-by-step trigger instructions; added feedback summary template to Step 7; extended the Links table.

### Fixes (on top of main feature)

- Fixed pack name in announcement from "Dating: Confidence and Limits" to match shipped build: "Dating — Confidence & Boundaries"
- Fixed data directory paths in announcement
- Fixed factual inaccuracies in launch announcement copy
- Fixed hotfix workflow: added missing `push` trigger for the `validate` job

## Why

The existing publishing infrastructure covered branch promotion, rollback, and issue triage mechanics, but lacked:
- Canonical announcement text approved and ready to post
- Performance issue template (the only missing triage bucket)
- Automated hotfix branch path and rollback record generation
- Template for converting post-launch feedback into next-milestone planning

All were required by issue #243's definition of done.

## Testing

- All Markdown files lint cleanly; cross-references between documents are consistent
- GitHub Actions workflow YAML passes schema validation (`on:`, `jobs:`, `steps:` structure; `push` trigger for `hotfix/*` and `workflow_dispatch` for `create` job)
- Issue template follows existing `steam_*.yml` structure and applies correct labels (`steam` + `performance`)
- Pack names and data paths in announcement verified against shipped build configuration
- Announcement copy reviewed against pre-publish checklist items

Closes #243