### PR TITLE
[Steamworks] Steam Workshop distribution for free scenario packs

### DIFF
--- a/apps/api/src/db.test.ts
+++ b/apps/api/src/db.test.ts
@@ -133,7 +133,7 @@ describe('migration idempotency across restarts', () => {
         (db.prepare('SELECT name FROM schema_migrations').all() as { name: string }[]).map(
           (r) => r.name,
         ),
-      ).toEqual(['0001_initial_schema', '0002_session_ended_at']);
+      ).toEqual(['0001_initial_schema', '0002_session_ended_at', '0003_workshop_items']);
       db.prepare(
         'INSERT INTO sessions (session_id, scenario_id, state, created_at, setup_json) VALUES (?, ?, ?, ?, ?)',
       ).run('sess-persist-01', 'behavioral_interview', 'NotStarted', new Date().toISOString(), '{}');
@@ -145,7 +145,7 @@ describe('migration idempotency across restarts', () => {
       const applied = (
         db.prepare('SELECT name FROM schema_migrations').all() as { name: string }[]
       ).map((r) => r.name);
-      expect(applied).toEqual(['0001_initial_schema', '0002_session_ended_at']);
+      expect(applied).toEqual(['0001_initial_schema', '0002_session_ended_at', '0003_workshop_items']);
       const row = db
         .prepare('SELECT session_id FROM sessions WHERE session_id = ?')
         .get('sess-persist-01') as { session_id: string } | undefined;

--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -82,6 +82,28 @@ const MIGRATIONS: Migration[] = [
       }
     },
   },
+  {
+    name: '0003_workshop_items',
+    up: (db) => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS workshop_items (
+          item_id        TEXT PRIMARY KEY,
+          pack_id        TEXT NOT NULL,
+          author_name    TEXT NOT NULL DEFAULT '',
+          install_path   TEXT NOT NULL DEFAULT '',
+          workshop_updated_at INTEGER NOT NULL DEFAULT 0,
+          synced_at      INTEGER NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS workshop_quarantine (
+          item_id        TEXT PRIMARY KEY,
+          install_path   TEXT NOT NULL,
+          reason         TEXT NOT NULL,
+          quarantined_at INTEGER NOT NULL
+        );
+      `);
+    },
+  },
 ];
 
 function runMigrations(db: Database.Database): void {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -11,7 +11,7 @@ import { sessionRoutes } from './routes/sessions.js';
 import { sessionWsRoutes } from './routes/session-ws.js';
 import { privacyRoutes, setDataFolderPath, setExportsFolderPath, setLogsFolderPath, setModelsFolderPath, setPacksFolderPath } from './routes/privacy.js';
 import { workbenchRoutes, setWorkbenchRoots } from './routes/workbench.js';
-import { workshopRoutes, setWorkshopRoot } from './routes/workshop.js';
+import { workshopRoutes, setWorkshopRoot, setWorkshopPacksDbPath } from './routes/workshop.js';
 import { modelsRoutes } from './routes/models.js';
 import { runtimeSettingsRoutes } from './routes/runtime-settings.js';
 import { logbookRoutes } from './routes/logbook.js';
@@ -93,6 +93,7 @@ if (process.argv[1] === new URL(import.meta.url).pathname) {
   setWorkshopRoot(
     process.env['PACKS_WORKSHOP_ROOT'] ?? path.join(os.homedir(), '.convsim', 'packs', 'workshop'),
   );
+  setWorkshopPacksDbPath(packsDbPath);
   const app = await buildApp();
   await app.listen(listenConfig);
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -11,6 +11,7 @@ import { sessionRoutes } from './routes/sessions.js';
 import { sessionWsRoutes } from './routes/session-ws.js';
 import { privacyRoutes, setDataFolderPath, setExportsFolderPath, setLogsFolderPath, setModelsFolderPath, setPacksFolderPath } from './routes/privacy.js';
 import { workbenchRoutes, setWorkbenchRoots } from './routes/workbench.js';
+import { workshopRoutes, setWorkshopRoot } from './routes/workshop.js';
 import { modelsRoutes } from './routes/models.js';
 import { runtimeSettingsRoutes } from './routes/runtime-settings.js';
 import { logbookRoutes } from './routes/logbook.js';
@@ -43,6 +44,7 @@ export async function buildApp() {
   await app.register(privacyRoutes);
   await app.register(packRoutes);
   await app.register(workbenchRoutes);
+  await app.register(workshopRoutes);
   await app.register(modelsRoutes);
   await app.register(runtimeSettingsRoutes);
   await app.register(logbookRoutes);
@@ -87,6 +89,9 @@ if (process.argv[1] === new URL(import.meta.url).pathname) {
   setWorkbenchRoots(
     process.env['PACKS_OFFICIAL_ROOT'] ?? path.join(process.cwd(), 'packs', 'official'),
     process.env['PACKS_LOCAL_DEV_ROOT'] ?? path.join(os.homedir(), '.convsim', 'packs', 'local-dev'),
+  );
+  setWorkshopRoot(
+    process.env['PACKS_WORKSHOP_ROOT'] ?? path.join(os.homedir(), '.convsim', 'packs', 'workshop'),
   );
   const app = await buildApp();
   await app.listen(listenConfig);

--- a/apps/api/src/routes/workbench.ts
+++ b/apps/api/src/routes/workbench.ts
@@ -240,7 +240,7 @@ const ERROR_CATEGORY: Record<string, 'security' | 'schema' | 'structure' | 'synt
   UNSUPPORTED_VERSION: 'schema',
 };
 
-function convertPackLoaderError(e: PackLoaderError, packRoot: string): WorkbenchValidationIssue[] {
+export function convertPackLoaderError(e: PackLoaderError, packRoot: string): WorkbenchValidationIssue[] {
   const relFile = e.filePath
     ? path.relative(packRoot, e.filePath).replace(/\\/g, '/')
     : '';
@@ -287,7 +287,7 @@ function convertPackLoaderError(e: PackLoaderError, packRoot: string): Workbench
 
 // Scan the entire pack directory for forbidden file extensions, collecting all
 // violations instead of failing on the first one.
-function scanForbiddenFiles(packRoot: string): WorkbenchValidationIssue[] {
+export function scanForbiddenFiles(packRoot: string): WorkbenchValidationIssue[] {
   const issues: WorkbenchValidationIssue[] = [];
 
   function scan(dir: string): void {

--- a/apps/api/src/routes/workshop.test.ts
+++ b/apps/api/src/routes/workshop.test.ts
@@ -400,11 +400,21 @@ describe('DELETE /api/workshop/:pack_id', () => {
   });
 
   it('returns removed:false when active sessions reference the pack', async () => {
+    // Import a real pack so its scenarios are registered in the shared index —
+    // the pack→scenario mapping the endpoint uses to detect referencing sessions.
+    const packDir = setupValidPack(tmpBase, 'item-22222', 'workshop.active_pack');
+    await app.inject({
+      method: 'POST',
+      url: '/api/workshop/sync',
+      payload: {
+        items: [{ item_id: '22222', install_path: packDir, needs_update: false, updated_at: 1710000000 }],
+      },
+    });
+
+    // Insert an in-progress session that references the pack's scenario_id.
+    // Real sessions store a SessionCreateRequest (scenario_id only, no pack_id),
+    // so the endpoint must resolve the reference via scenario_id, not pack_id.
     const db = getDb();
-    db.prepare(
-      'INSERT INTO workshop_items (item_id, pack_id, author_name, install_path, workshop_updated_at, synced_at) VALUES (?,?,?,?,?,?)',
-    ).run('22222', 'workshop.active_pack', 'Creator', '/path', 1710000000, 1710000000);
-    // Insert a session that references the pack_id
     db.prepare(
       `INSERT INTO sessions (session_id, scenario_id, state, created_at, setup_json, state_vars_json)
        VALUES (?, ?, ?, ?, ?, ?)`,
@@ -413,7 +423,7 @@ describe('DELETE /api/workshop/:pack_id', () => {
       'ws_basic',
       'PlayerTurnListening',
       new Date().toISOString(),
-      JSON.stringify({ pack_id: 'workshop.active_pack', scenario_id: 'ws_basic' }),
+      JSON.stringify({ scenario_id: 'ws_basic' }),
       '{}',
     );
 
@@ -422,5 +432,43 @@ describe('DELETE /api/workshop/:pack_id', () => {
     const body = res.json() as { removed: boolean; has_active_sessions: boolean };
     expect(body.removed).toBe(false);
     expect(body.has_active_sessions).toBe(true);
+
+    // The pack must remain in the library index while the session is active.
+    const packsBody = (await app.inject({ method: 'GET', url: '/api/packs' })).json() as { packs: Array<{ pack_id: string }> };
+    expect(packsBody.packs.some((p) => p.pack_id === 'workshop.active_pack')).toBe(true);
+  });
+
+  it('removes the pack when only ended sessions reference it', async () => {
+    // An Ended session references the pack's scenario but must not block removal.
+    const packDir = setupValidPack(tmpBase, 'item-21212', 'workshop.ended_pack');
+    await app.inject({
+      method: 'POST',
+      url: '/api/workshop/sync',
+      payload: {
+        items: [{ item_id: '21212', install_path: packDir, needs_update: false, updated_at: 1710000000 }],
+      },
+    });
+
+    const db = getDb();
+    db.prepare(
+      `INSERT INTO sessions (session_id, scenario_id, state, created_at, setup_json, state_vars_json)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run(
+      'ended-session-1',
+      'ws_basic',
+      'Ended',
+      new Date().toISOString(),
+      JSON.stringify({ scenario_id: 'ws_basic' }),
+      '{}',
+    );
+
+    const res = await app.inject({ method: 'DELETE', url: '/api/workshop/workshop.ended_pack' });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { removed: boolean; has_active_sessions: boolean };
+    expect(body.removed).toBe(true);
+    expect(body.has_active_sessions).toBe(false);
+
+    const packsBody = (await app.inject({ method: 'GET', url: '/api/packs' })).json() as { packs: Array<{ pack_id: string }> };
+    expect(packsBody.packs.some((p) => p.pack_id === 'workshop.ended_pack')).toBe(false);
   });
 });

--- a/apps/api/src/routes/workshop.test.ts
+++ b/apps/api/src/routes/workshop.test.ts
@@ -1,0 +1,358 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { FastifyInstance } from 'fastify';
+import { buildApp } from '../index.js';
+import { setWorkshopRoot } from './workshop.js';
+import { resetDb, getDb } from '../db.js';
+
+let app: FastifyInstance;
+let workshopRoot: string;
+let tmpBase: string;
+
+// Writes a minimal valid pack directory to the given parent dir under `slug`.
+function setupValidPack(parentDir: string, slug: string, packId: string): string {
+  const packDir = join(parentDir, slug);
+  mkdirSync(join(packDir, 'scenarios'), { recursive: true });
+  mkdirSync(join(packDir, 'npcs'), { recursive: true });
+  mkdirSync(join(packDir, 'rubrics'), { recursive: true });
+  mkdirSync(join(packDir, 'safety'), { recursive: true });
+  writeFileSync(
+    join(packDir, 'manifest.yaml'),
+    `schema_version: "0.1"\npack_id: ${packId}\nname: Workshop Pack\nversion: 0.1.0\ndescription: A workshop pack\nauthor: WorkshopCreator\nlicense: MIT\ncontent_rating: PG\nsafety:\n  policy: safety/default.yaml\n`,
+  );
+  writeFileSync(
+    join(packDir, 'safety', 'default.yaml'),
+    `schema_version: "0.1"\npolicy_id: default\ncontent_rating_cap: PG\ncontent_categories: {}\nredirect_message: ""\n`,
+  );
+  writeFileSync(
+    join(packDir, 'npcs', 'npc.yaml'),
+    `schema_version: "0.1"\nnpc_id: ws_npc\ndisplay_name: Workshop NPC\narchetype: helper\nfictional: true\nage_band: adult\npublic_persona:\n  occupation: Tester\n  speaking_style: direct\n  demeanor: neutral\nprivate_persona: {}\n`,
+  );
+  writeFileSync(
+    join(packDir, 'rubrics', 'rubric.yaml'),
+    `schema_version: "0.1"\nrubric_id: ws_rubric\ntitle: Workshop Rubric\ndimensions:\n  - id: clarity\n    name: Clarity\n    description: How clear\n    scoring:\n      low: Unclear\n      medium: Somewhat clear\n      high: Very clear\n`,
+  );
+  writeFileSync(
+    join(packDir, 'scenarios', 'basic.yaml'),
+    `schema_version: "0.1"\nscenario_id: ws_basic\ntitle: Workshop Basic\nsummary: A workshop scenario.\nplayer_role:\n  label: Tester\n  brief: You are testing.\nnpc:\n  ref: ../npcs/npc.yaml\nrubric:\n  ref: ../rubrics/rubric.yaml\nduration:\n  max_turns: 10\nopening:\n  npc_says: Hello from Workshop!\ngoals: {}\n`,
+  );
+  return packDir;
+}
+
+beforeEach(async () => {
+  resetDb();
+  tmpBase = join(tmpdir(), `workshop-test-${Math.random().toString(36).slice(2)}`);
+  workshopRoot = join(tmpBase, 'workshop');
+  mkdirSync(workshopRoot, { recursive: true });
+  setWorkshopRoot(workshopRoot);
+  app = await buildApp();
+});
+
+afterEach(async () => {
+  await app.close();
+  try { rmSync(tmpBase, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/workshop/sync
+// ---------------------------------------------------------------------------
+
+describe('POST /api/workshop/sync', () => {
+  it('returns 400 when body has no items array', async () => {
+    const res = await app.inject({ method: 'POST', url: '/api/workshop/sync', payload: {} });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('skips items with missing item_id', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/workshop/sync',
+      payload: { items: [{ install_path: '/some/path', needs_update: false, updated_at: 0 }] },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { results: Array<{ status: string }> };
+    expect(body.results[0]?.status).toBe('skipped');
+  });
+
+  it('skips items with empty install_path (not yet downloaded)', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/workshop/sync',
+      payload: { items: [{ item_id: '123', install_path: '', needs_update: false, updated_at: 0 }] },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { results: Array<{ status: string }> };
+    expect(body.results[0]?.status).toBe('skipped');
+  });
+
+  it('skips items whose install_path does not exist', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/workshop/sync',
+      payload: {
+        items: [{
+          item_id: '456',
+          install_path: '/nonexistent/path/12345',
+          needs_update: false,
+          updated_at: 1710000000,
+        }],
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { results: Array<{ status: string }> };
+    expect(body.results[0]?.status).toBe('skipped');
+  });
+
+  it('imports a valid pack from a real directory', async () => {
+    const packDir = setupValidPack(tmpBase, 'item-99999', 'workshop.valid_pack');
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/workshop/sync',
+      payload: {
+        items: [{
+          item_id: '99999',
+          install_path: packDir,
+          needs_update: false,
+          updated_at: 1710000000,
+        }],
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as {
+      results: Array<{ item_id: string; pack_id: string | null; status: string }>;
+      imported: number;
+    };
+    expect(body.imported).toBe(1);
+    expect(body.results[0]?.status).toBe('imported');
+    expect(body.results[0]?.pack_id).toBe('workshop.valid_pack');
+  });
+
+  it('records the import in workshop_items table', async () => {
+    const packDir = setupValidPack(tmpBase, 'item-88888', 'workshop.db_pack');
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/workshop/sync',
+      payload: {
+        items: [{
+          item_id: '88888',
+          install_path: packDir,
+          needs_update: false,
+          updated_at: 1710000001,
+        }],
+      },
+    });
+
+    const db = getDb();
+    const row = db.prepare('SELECT * FROM workshop_items WHERE item_id = ?').get('88888') as {
+      pack_id: string;
+      author_name: string;
+      workshop_updated_at: number;
+    } | undefined;
+    expect(row).toBeDefined();
+    expect(row?.pack_id).toBe('workshop.db_pack');
+    expect(row?.author_name).toBe('WorkshopCreator');
+    expect(row?.workshop_updated_at).toBe(1710000001);
+  });
+
+  it('quarantines a pack with a forbidden executable file', async () => {
+    const badPackDir = join(tmpBase, 'item-77777');
+    mkdirSync(join(badPackDir, 'scenarios'), { recursive: true });
+    mkdirSync(join(badPackDir, 'npcs'), { recursive: true });
+    mkdirSync(join(badPackDir, 'rubrics'), { recursive: true });
+    mkdirSync(join(badPackDir, 'safety'), { recursive: true });
+    writeFileSync(join(badPackDir, 'evil.exe'), 'MZ\x00\x00');
+    writeFileSync(
+      join(badPackDir, 'manifest.yaml'),
+      `schema_version: "0.1"\npack_id: bad.pack\nname: Bad Pack\nversion: 0.1.0\ndescription: evil\nauthor: Attacker\nlicense: MIT\ncontent_rating: PG\nsafety:\n  policy: safety/default.yaml\n`,
+    );
+    writeFileSync(join(badPackDir, 'safety', 'default.yaml'), `schema_version: "0.1"\npolicy_id: default\ncontent_rating_cap: PG\ncontent_categories: {}\nredirect_message: ""\n`);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/workshop/sync',
+      payload: {
+        items: [{
+          item_id: '77777',
+          install_path: badPackDir,
+          needs_update: false,
+          updated_at: 1710000000,
+        }],
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as {
+      results: Array<{ status: string; reason?: string }>;
+      quarantined: number;
+    };
+    expect(body.quarantined).toBe(1);
+    expect(body.results[0]?.status).toBe('quarantined');
+    expect(body.results[0]?.reason).toContain('FORBIDDEN_FILE');
+
+    // Verify quarantine is recorded in DB
+    const db = getDb();
+    const row = db.prepare('SELECT * FROM workshop_quarantine WHERE item_id = ?').get('77777');
+    expect(row).toBeDefined();
+  });
+
+  it('marks unchanged when item_id + updated_at match existing record', async () => {
+    const packDir = setupValidPack(tmpBase, 'item-66666', 'workshop.unchanged_pack');
+
+    // Import once
+    await app.inject({
+      method: 'POST',
+      url: '/api/workshop/sync',
+      payload: {
+        items: [{
+          item_id: '66666',
+          install_path: packDir,
+          needs_update: false,
+          updated_at: 1710000000,
+        }],
+      },
+    });
+
+    // Sync again with same updated_at
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/workshop/sync',
+      payload: {
+        items: [{
+          item_id: '66666',
+          install_path: packDir,
+          needs_update: false,
+          updated_at: 1710000000,
+        }],
+      },
+    });
+
+    const body = res.json() as { results: Array<{ status: string }>; unchanged: number };
+    expect(body.unchanged).toBe(1);
+    expect(body.results[0]?.status).toBe('unchanged');
+  });
+
+  it('handles an empty items array without error', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/workshop/sync',
+      payload: { items: [] },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { results: unknown[]; imported: number };
+    expect(body.results).toHaveLength(0);
+    expect(body.imported).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/workshop/items
+// ---------------------------------------------------------------------------
+
+describe('GET /api/workshop/items', () => {
+  it('returns empty items array on a fresh DB', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/workshop/items' });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { items: unknown[] };
+    expect(Array.isArray(body.items)).toBe(true);
+    expect(body.items).toHaveLength(0);
+  });
+
+  it('returns synced Workshop items after a successful import', async () => {
+    const packDir = setupValidPack(tmpBase, 'item-55555', 'workshop.list_pack');
+    await app.inject({
+      method: 'POST',
+      url: '/api/workshop/sync',
+      payload: {
+        items: [{
+          item_id: '55555',
+          install_path: packDir,
+          needs_update: false,
+          updated_at: 1710000000,
+        }],
+      },
+    });
+
+    const res = await app.inject({ method: 'GET', url: '/api/workshop/items' });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as {
+      items: Array<{ item_id: string; pack_id: string; author_name: string }>;
+    };
+    expect(body.items).toHaveLength(1);
+    expect(body.items[0]?.item_id).toBe('55555');
+    expect(body.items[0]?.pack_id).toBe('workshop.list_pack');
+    expect(body.items[0]?.author_name).toBe('WorkshopCreator');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/workshop/quarantine
+// ---------------------------------------------------------------------------
+
+describe('GET /api/workshop/quarantine', () => {
+  it('returns empty items array when no packs are quarantined', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/workshop/quarantine' });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { items: unknown[] };
+    expect(body.items).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /api/workshop/:pack_id
+// ---------------------------------------------------------------------------
+
+describe('DELETE /api/workshop/:pack_id', () => {
+  it('returns 200 and removed:true when pack exists in workshop_items', async () => {
+    const db = getDb();
+    db.prepare(
+      'INSERT INTO workshop_items (item_id, pack_id, author_name, install_path, workshop_updated_at, synced_at) VALUES (?,?,?,?,?,?)',
+    ).run('11111', 'workshop.to_remove', 'Creator', '/some/path', 1710000000, 1710000000);
+
+    const res = await app.inject({ method: 'DELETE', url: '/api/workshop/workshop.to_remove' });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { removed: boolean };
+    expect(body.removed).toBe(true);
+
+    // Row should be gone from DB
+    const row = db.prepare('SELECT * FROM workshop_items WHERE pack_id = ?').get('workshop.to_remove');
+    expect(row).toBeUndefined();
+  });
+
+  it('returns removed:true when pack_id is not in workshop_items (idempotent)', async () => {
+    const res = await app.inject({ method: 'DELETE', url: '/api/workshop/does.not.exist' });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { removed: boolean };
+    expect(body.removed).toBe(true);
+  });
+
+  it('returns removed:false when active sessions reference the pack', async () => {
+    const db = getDb();
+    db.prepare(
+      'INSERT INTO workshop_items (item_id, pack_id, author_name, install_path, workshop_updated_at, synced_at) VALUES (?,?,?,?,?,?)',
+    ).run('22222', 'workshop.active_pack', 'Creator', '/path', 1710000000, 1710000000);
+    // Insert a session that references the pack_id
+    db.prepare(
+      `INSERT INTO sessions (session_id, scenario_id, state, created_at, setup_json, state_vars_json)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run(
+      'test-session-1',
+      'ws_basic',
+      'PlayerTurnListening',
+      new Date().toISOString(),
+      JSON.stringify({ pack_id: 'workshop.active_pack', scenario_id: 'ws_basic' }),
+      '{}',
+    );
+
+    const res = await app.inject({ method: 'DELETE', url: '/api/workshop/workshop.active_pack' });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { removed: boolean; has_active_sessions: boolean };
+    expect(body.removed).toBe(false);
+    expect(body.has_active_sessions).toBe(true);
+  });
+});

--- a/apps/api/src/routes/workshop.test.ts
+++ b/apps/api/src/routes/workshop.test.ts
@@ -5,11 +5,14 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import type { FastifyInstance } from 'fastify';
 import { buildApp } from '../index.js';
-import { setWorkshopRoot } from './workshop.js';
+import { setWorkshopRoot, setWorkshopPacksDbPath } from './workshop.js';
+import { setPacksDbPath, setPacksDataDir } from './packs.js';
+import { setScenariosDbPath } from './scenarios.js';
 import { resetDb, getDb } from '../db.js';
 
 let app: FastifyInstance;
 let workshopRoot: string;
+let packsDbPath: string;
 let tmpBase: string;
 
 // Writes a minimal valid pack directory to the given parent dir under `slug`.
@@ -48,11 +51,23 @@ beforeEach(async () => {
   workshopRoot = join(tmpBase, 'workshop');
   mkdirSync(workshopRoot, { recursive: true });
   setWorkshopRoot(workshopRoot);
+  // Wire the shared pack index so workshop imports register into installed_packs
+  // and become visible via /api/packs and /api/scenarios, exactly like manual import.
+  packsDbPath = join(tmpBase, 'packs.db');
+  mkdirSync(join(tmpBase, 'packs-data'), { recursive: true });
+  setWorkshopPacksDbPath(packsDbPath);
+  setPacksDbPath(packsDbPath);
+  setPacksDataDir(join(tmpBase, 'packs-data'));
+  setScenariosDbPath(packsDbPath);
   app = await buildApp();
 });
 
 afterEach(async () => {
   await app.close();
+  setWorkshopPacksDbPath(null);
+  setPacksDbPath(null);
+  setPacksDataDir(null);
+  setScenariosDbPath(null);
   try { rmSync(tmpBase, { recursive: true, force: true }); } catch { /* ignore */ }
 });
 
@@ -130,6 +145,33 @@ describe('POST /api/workshop/sync', () => {
     expect(body.imported).toBe(1);
     expect(body.results[0]?.status).toBe('imported');
     expect(body.results[0]?.pack_id).toBe('workshop.valid_pack');
+  });
+
+  it('registers the imported pack in the shared index so its scenarios appear in the library', async () => {
+    const packDir = setupValidPack(tmpBase, 'item-44444', 'workshop.indexed_pack');
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/workshop/sync',
+      payload: {
+        items: [{
+          item_id: '44444',
+          install_path: packDir,
+          needs_update: false,
+          updated_at: 1710000000,
+        }],
+      },
+    });
+
+    // The pack must show up in /api/packs (installed_packs index).
+    const packsRes = await app.inject({ method: 'GET', url: '/api/packs' });
+    const packsBody = packsRes.json() as { packs: Array<{ pack_id: string }> };
+    expect(packsBody.packs.some((p) => p.pack_id === 'workshop.indexed_pack')).toBe(true);
+
+    // And its scenario must be browsable/launchable via /api/scenarios.
+    const scenRes = await app.inject({ method: 'GET', url: '/api/scenarios' });
+    const scenBody = scenRes.json() as Array<{ scenario_id: string; pack_id: string }>;
+    expect(scenBody.some((s) => s.scenario_id === 'ws_basic' && s.pack_id === 'workshop.indexed_pack')).toBe(true);
   });
 
   it('records the import in workshop_items table', async () => {
@@ -322,6 +364,32 @@ describe('DELETE /api/workshop/:pack_id', () => {
     // Row should be gone from DB
     const row = db.prepare('SELECT * FROM workshop_items WHERE pack_id = ?').get('workshop.to_remove');
     expect(row).toBeUndefined();
+  });
+
+  it('removes the imported pack from the shared index on unsubscribe', async () => {
+    // Import a real pack so it lands in installed_packs, then unsubscribe it.
+    const packDir = setupValidPack(tmpBase, 'item-33333', 'workshop.cleanup_pack');
+    await app.inject({
+      method: 'POST',
+      url: '/api/workshop/sync',
+      payload: {
+        items: [{ item_id: '33333', install_path: packDir, needs_update: false, updated_at: 1710000000 }],
+      },
+    });
+
+    // Confirm it is present before removal.
+    let packsBody = (await app.inject({ method: 'GET', url: '/api/packs' })).json() as { packs: Array<{ pack_id: string }> };
+    expect(packsBody.packs.some((p) => p.pack_id === 'workshop.cleanup_pack')).toBe(true);
+
+    const res = await app.inject({ method: 'DELETE', url: '/api/workshop/workshop.cleanup_pack' });
+    expect(res.statusCode).toBe(200);
+    expect((res.json() as { removed: boolean }).removed).toBe(true);
+
+    // Pack and its scenarios must be gone from the library index.
+    packsBody = (await app.inject({ method: 'GET', url: '/api/packs' })).json() as { packs: Array<{ pack_id: string }> };
+    expect(packsBody.packs.some((p) => p.pack_id === 'workshop.cleanup_pack')).toBe(false);
+    const scenBody = (await app.inject({ method: 'GET', url: '/api/scenarios' })).json() as Array<{ pack_id: string }>;
+    expect(scenBody.some((s) => s.pack_id === 'workshop.cleanup_pack')).toBe(false);
   });
 
   it('returns removed:true when pack_id is not in workshop_items (idempotent)', async () => {

--- a/apps/api/src/routes/workshop.test.ts
+++ b/apps/api/src/routes/workshop.test.ts
@@ -243,6 +243,47 @@ describe('POST /api/workshop/sync', () => {
     expect(row).toBeDefined();
   });
 
+  it('removes a previously-imported pack from the index when a later update fails validation', async () => {
+    // Import a valid pack first so it lands in installed_packs + workshop_items.
+    const packDir = setupValidPack(tmpBase, 'item-70707', 'workshop.turns_bad');
+    await app.inject({
+      method: 'POST',
+      url: '/api/workshop/sync',
+      payload: {
+        items: [{ item_id: '70707', install_path: packDir, needs_update: false, updated_at: 1710000000 }],
+      },
+    });
+
+    // Confirm it is present and launchable.
+    let packsBody = (await app.inject({ method: 'GET', url: '/api/packs' })).json() as { packs: Array<{ pack_id: string }> };
+    expect(packsBody.packs.some((p) => p.pack_id === 'workshop.turns_bad')).toBe(true);
+
+    // Simulate a Steam update that introduces disguised executable content.
+    writeFileSync(join(packDir, 'evil.exe'), 'MZ\x00\x00');
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/workshop/sync',
+      payload: {
+        items: [{ item_id: '70707', install_path: packDir, needs_update: true, updated_at: 1710000500 }],
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { results: Array<{ status: string }>; quarantined: number };
+    expect(body.quarantined).toBe(1);
+    expect(body.results[0]?.status).toBe('quarantined');
+
+    // The stale index entry and workshop_items row must be gone so the library
+    // no longer lists the now-invalid pack as a valid Workshop pack.
+    packsBody = (await app.inject({ method: 'GET', url: '/api/packs' })).json() as { packs: Array<{ pack_id: string }> };
+    expect(packsBody.packs.some((p) => p.pack_id === 'workshop.turns_bad')).toBe(false);
+    const itemsBody = (await app.inject({ method: 'GET', url: '/api/workshop/items' })).json() as { items: Array<{ item_id: string }> };
+    expect(itemsBody.items.some((i) => i.item_id === '70707')).toBe(false);
+    // And the quarantine reason is surfaced.
+    const quarBody = (await app.inject({ method: 'GET', url: '/api/workshop/quarantine' })).json() as { items: Array<{ item_id: string }> };
+    expect(quarBody.items.some((i) => i.item_id === '70707')).toBe(true);
+  });
+
   it('marks unchanged when item_id + updated_at match existing record', async () => {
     const packDir = setupValidPack(tmpBase, 'item-66666', 'workshop.unchanged_pack');
 

--- a/apps/api/src/routes/workshop.ts
+++ b/apps/api/src/routes/workshop.ts
@@ -206,6 +206,24 @@ export async function workshopRoutes(app: FastifyInstance): Promise<void> {
               quarantined_at = excluded.quarantined_at
           `).run(item.item_id, installPath, reason, now);
 
+          // If this item was previously imported successfully and a later Steam
+          // update turned it invalid (e.g. an attacker added disguised executable
+          // content to an update), the stale index entry and workshop_items row
+          // must not survive — otherwise the library keeps listing the pack as a
+          // valid Workshop pack pointing at the now-invalid install path. Remove
+          // both so only the quarantine reason remains visible to the user.
+          if (existing) {
+            if (_packsDbPath) {
+              const index = PackIndex.open(_packsDbPath);
+              try {
+                index.removePack(existing.pack_id);
+              } finally {
+                index.close();
+              }
+            }
+            db.prepare('DELETE FROM workshop_items WHERE item_id = ?').run(item.item_id);
+          }
+
           results.push({ item_id: item.item_id, pack_id: null, status: 'quarantined', reason });
           continue;
         }

--- a/apps/api/src/routes/workshop.ts
+++ b/apps/api/src/routes/workshop.ts
@@ -1,0 +1,307 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Steam Workshop sync routes.
+//
+// These routes implement the server-side half of the Workshop subscribe/sync
+// flow. The Tauri desktop bridge supplies subscribed item paths via the
+// `steam_workshop_get_subscribed_items` command; this layer validates and
+// imports them through the same pipeline as manual zip import (pack-loader
+// schema validation + no-executable-content guard).
+//
+// Non-Steam builds never call these routes — the Workshop UI is hidden when
+// `SteamStatus.is_steam_enabled` is false.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import type { FastifyInstance } from 'fastify';
+import { loadPack, PackLoaderError } from '@convsim/pack-loader';
+import { getDb } from '../db.js';
+import {
+  scanForbiddenFiles,
+  convertPackLoaderError,
+  type WorkbenchValidationIssue,
+} from './workbench.js';
+
+let _workshopRoot = '';
+
+export function setWorkshopRoot(workshopRoot: string): void {
+  _workshopRoot = workshopRoot;
+}
+
+export function getWorkshopRoot(): string {
+  return _workshopRoot;
+}
+
+// ---------------------------------------------------------------------------
+// Request / response shapes
+// ---------------------------------------------------------------------------
+
+/** A single subscribed Workshop item as reported by the Tauri Steam bridge. */
+export interface WorkshopSyncItem {
+  item_id: string;
+  install_path: string;
+  needs_update: boolean;
+  updated_at: number;
+}
+
+export interface WorkshopSyncRequest {
+  items: WorkshopSyncItem[];
+}
+
+export interface WorkshopSyncResultEntry {
+  item_id: string;
+  pack_id: string | null;
+  status: 'imported' | 'updated' | 'unchanged' | 'quarantined' | 'skipped';
+  /** Present when status is 'quarantined'. */
+  reason?: string;
+  /** Non-fatal warnings from content analysis. */
+  warnings?: WorkbenchValidationIssue[];
+}
+
+export interface WorkshopSyncResponse {
+  results: WorkshopSyncResultEntry[];
+  imported: number;
+  updated: number;
+  unchanged: number;
+  quarantined: number;
+  skipped: number;
+}
+
+export interface WorkshopItemRecord {
+  item_id: string;
+  pack_id: string;
+  author_name: string;
+  install_path: string;
+  workshop_updated_at: number;
+  synced_at: number;
+}
+
+// ---------------------------------------------------------------------------
+// Route registration
+// ---------------------------------------------------------------------------
+
+export async function workshopRoutes(app: FastifyInstance): Promise<void> {
+  // POST /api/workshop/sync
+  //
+  // Accepts the list of subscribed Workshop items from the Tauri bridge and
+  // imports any that are new or updated through the exact same pipeline as
+  // manual pack import: forbidden-content scan + pack-loader schema validation.
+  //
+  // Invalid packs are quarantined (recorded in workshop_quarantine) rather than
+  // imported; they never crash the library. The caller is responsible for
+  // showing quarantine reasons to the user.
+  //
+  // Items with an empty `install_path` are still downloading and are skipped.
+  app.post<{ Body: WorkshopSyncRequest }>(
+    '/api/workshop/sync',
+    async (req, reply): Promise<WorkshopSyncResponse> => {
+      const { items } = req.body;
+      if (!Array.isArray(items)) {
+        reply.status(400);
+        throw new Error('Body must include an "items" array');
+      }
+
+      const db = getDb();
+      const now = Math.floor(Date.now() / 1000);
+      const results: WorkshopSyncResultEntry[] = [];
+
+      for (const item of items) {
+        if (!item.item_id || typeof item.item_id !== 'string') {
+          results.push({ item_id: String(item.item_id ?? ''), pack_id: null, status: 'skipped', reason: 'Missing item_id' });
+          continue;
+        }
+
+        // Skip items that Steam hasn't downloaded yet.
+        if (!item.install_path || typeof item.install_path !== 'string') {
+          results.push({ item_id: item.item_id, pack_id: null, status: 'skipped', reason: 'Not yet downloaded' });
+          continue;
+        }
+
+        const installPath = item.install_path;
+
+        // Verify the install path exists and is a directory.
+        let stat: fs.Stats;
+        try {
+          stat = fs.statSync(installPath);
+        } catch {
+          results.push({ item_id: item.item_id, pack_id: null, status: 'skipped', reason: `Install path not accessible: ${installPath}` });
+          continue;
+        }
+        if (!stat.isDirectory()) {
+          results.push({ item_id: item.item_id, pack_id: null, status: 'skipped', reason: `Install path is not a directory: ${installPath}` });
+          continue;
+        }
+
+        // Check if we already have this item at the same version.
+        const existing = db
+          .prepare('SELECT pack_id, workshop_updated_at FROM workshop_items WHERE item_id = ?')
+          .get(item.item_id) as { pack_id: string; workshop_updated_at: number } | undefined;
+
+        if (existing && existing.workshop_updated_at === item.updated_at && !item.needs_update) {
+          results.push({ item_id: item.item_id, pack_id: existing.pack_id, status: 'unchanged' });
+          continue;
+        }
+
+        // Two-phase validation (same pipeline as manual import and workbench validate).
+        const securityIssues: WorkbenchValidationIssue[] = scanForbiddenFiles(installPath);
+        const reportedSecurityFiles = new Set(securityIssues.filter((i) => i.category === 'security').map((i) => i.file));
+        const validationIssues: WorkbenchValidationIssue[] = [...securityIssues];
+
+        let pack_id: string | null = null;
+        let author_name = '';
+        let packLoadWarnings: WorkbenchValidationIssue[] = [];
+
+        try {
+          const loaded = loadPack(installPath, 'workshop');
+          pack_id = loaded.manifest.pack_id;
+          author_name = loaded.manifest.author;
+          // Convert pack-loader ValidationWarning to the workbench issue shape.
+          packLoadWarnings = loaded.warnings.map((w) => ({
+            severity: 'warning' as const,
+            rule_id: w.code,
+            file: w.field,
+            pointer: '',
+            message: w.message,
+            suggested_fix: '',
+          }));
+        } catch (e) {
+          if (e instanceof PackLoaderError) {
+            for (const issue of convertPackLoaderError(e, installPath)) {
+              if (issue.category === 'security' && reportedSecurityFiles.has(issue.file)) continue;
+              validationIssues.push(issue);
+            }
+          } else {
+            throw e;
+          }
+        }
+
+        const errors = validationIssues.filter((i) => i.severity === 'error');
+
+        if (errors.length > 0 || pack_id === null) {
+          // Quarantine the invalid pack — record the reason but never import it.
+          const reason = errors.length > 0
+            ? errors.map((e) => `${e.rule_id}: ${e.message}`).join('; ')
+            : 'Pack manifest could not be loaded';
+          db.prepare(`
+            INSERT INTO workshop_quarantine (item_id, install_path, reason, quarantined_at)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(item_id) DO UPDATE SET
+              install_path = excluded.install_path,
+              reason = excluded.reason,
+              quarantined_at = excluded.quarantined_at
+          `).run(item.item_id, installPath, reason, now);
+
+          results.push({ item_id: item.item_id, pack_id: null, status: 'quarantined', reason });
+          continue;
+        }
+
+        // Remove from quarantine if it was previously listed there (pack was fixed upstream).
+        db.prepare('DELETE FROM workshop_quarantine WHERE item_id = ?').run(item.item_id);
+
+        // Record the Workshop item metadata.
+        db.prepare(`
+          INSERT INTO workshop_items (item_id, pack_id, author_name, install_path, workshop_updated_at, synced_at)
+          VALUES (?, ?, ?, ?, ?, ?)
+          ON CONFLICT(item_id) DO UPDATE SET
+            pack_id = excluded.pack_id,
+            author_name = excluded.author_name,
+            install_path = excluded.install_path,
+            workshop_updated_at = excluded.workshop_updated_at,
+            synced_at = excluded.synced_at
+        `).run(item.item_id, pack_id, author_name, installPath, item.updated_at, now);
+
+        const status = existing ? 'updated' : 'imported';
+        results.push({
+          item_id: item.item_id,
+          pack_id,
+          status,
+          warnings: packLoadWarnings.length > 0 ? packLoadWarnings : undefined,
+        });
+      }
+
+      const counts = {
+        imported: results.filter((r) => r.status === 'imported').length,
+        updated: results.filter((r) => r.status === 'updated').length,
+        unchanged: results.filter((r) => r.status === 'unchanged').length,
+        quarantined: results.filter((r) => r.status === 'quarantined').length,
+        skipped: results.filter((r) => r.status === 'skipped').length,
+      };
+
+      return { results, ...counts };
+    },
+  );
+
+  // GET /api/workshop/items
+  //
+  // Returns all successfully synced Workshop items with their metadata.
+  // The library uses this to badge Workshop packs with author + update state.
+  app.get('/api/workshop/items', async (): Promise<{ items: WorkshopItemRecord[] }> => {
+    const db = getDb();
+    const rows = db.prepare('SELECT * FROM workshop_items ORDER BY synced_at DESC').all() as WorkshopItemRecord[];
+    return { items: rows };
+  });
+
+  // GET /api/workshop/quarantine
+  //
+  // Returns all quarantined Workshop items so the UI can show creators why
+  // their subscribed packs were rejected.
+  app.get('/api/workshop/quarantine', async (): Promise<{
+    items: Array<{ item_id: string; install_path: string; reason: string; quarantined_at: number }>;
+  }> => {
+    const db = getDb();
+    const rows = db
+      .prepare('SELECT * FROM workshop_quarantine ORDER BY quarantined_at DESC')
+      .all() as Array<{ item_id: string; install_path: string; reason: string; quarantined_at: number }>;
+    return { items: rows };
+  });
+
+  // DELETE /api/workshop/:pack_id
+  //
+  // Remove a Workshop pack from the local index after the player unsubscribes.
+  // Respects sessions that still reference the pack: when active or in-progress
+  // sessions exist, the pack record is kept but marked for cleanup on next sync.
+  //
+  // The Workshop files themselves are removed by Steam — this only cleans up
+  // the in-app metadata and pack index entries.
+  app.delete<{ Params: { pack_id: string } }>(
+    '/api/workshop/:pack_id',
+    async (req, reply): Promise<{
+      removed: boolean;
+      has_active_sessions: boolean;
+      message: string;
+    }> => {
+      const { pack_id } = req.params;
+      if (!pack_id) {
+        reply.status(400);
+        throw new Error('pack_id is required');
+      }
+
+      const db = getDb();
+
+      // Check for sessions that reference this pack's scenarios.
+      const activeCount = (db.prepare(`
+        SELECT COUNT(*) as cnt FROM sessions
+        WHERE setup_json LIKE ?
+          AND state NOT IN ('Ended', 'Abandoned')
+      `).get(`%"pack_id":"${pack_id}"%`) as { cnt: number }).cnt;
+
+      if (activeCount > 0) {
+        return {
+          removed: false,
+          has_active_sessions: true,
+          message: `Pack "${pack_id}" has ${activeCount} active session(s). Unsubscribe will take effect after those sessions end.`,
+        };
+      }
+
+      // Remove from workshop_items and quarantine tables.
+      db.prepare('DELETE FROM workshop_items WHERE pack_id = ?').run(pack_id);
+      db.prepare('DELETE FROM workshop_quarantine WHERE item_id IN (SELECT item_id FROM workshop_items WHERE pack_id = ?)').run(pack_id);
+
+      return {
+        removed: true,
+        has_active_sessions: false,
+        message: `Workshop pack "${pack_id}" removed from local index.`,
+      };
+    },
+  );
+}

--- a/apps/api/src/routes/workshop.ts
+++ b/apps/api/src/routes/workshop.ts
@@ -306,7 +306,10 @@ export async function workshopRoutes(app: FastifyInstance): Promise<void> {
   //
   // Remove a Workshop pack from the local index after the player unsubscribes.
   // Respects sessions that still reference the pack: when active or in-progress
-  // sessions exist, the pack record is kept but marked for cleanup on next sync.
+  // sessions exist, nothing is removed and the endpoint returns removed:false
+  // with has_active_sessions:true. The caller must not unsubscribe from Steam in
+  // that case (doing so would delete files out from under a running session) and
+  // should retry the unsubscribe once the referencing sessions have ended.
   //
   // The Workshop files themselves are removed by Steam — this only cleans up
   // the in-app metadata and pack index entries.

--- a/apps/api/src/routes/workshop.ts
+++ b/apps/api/src/routes/workshop.ts
@@ -14,7 +14,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import type { FastifyInstance } from 'fastify';
-import { loadPack, PackLoaderError } from '@convsim/pack-loader';
+import { loadPack, PackIndex, PackLoaderError, type LoadedPack } from '@convsim/pack-loader';
 import { getDb } from '../db.js';
 import {
   scanForbiddenFiles,
@@ -30,6 +30,19 @@ export function setWorkshopRoot(workshopRoot: string): void {
 
 export function getWorkshopRoot(): string {
   return _workshopRoot;
+}
+
+// Path to the shared pack index (installed_packs / indexed_scenarios). Workshop
+// packs are registered here through the same PackIndex used by manual import so
+// their scenarios become visible in the library and launchable at runtime.
+let _packsDbPath: string | null = null;
+
+export function setWorkshopPacksDbPath(dbPath: string | null): void {
+  _packsDbPath = dbPath;
+}
+
+export function getWorkshopPacksDbPath(): string | null {
+  return _packsDbPath;
 }
 
 // ---------------------------------------------------------------------------
@@ -150,9 +163,11 @@ export async function workshopRoutes(app: FastifyInstance): Promise<void> {
         let pack_id: string | null = null;
         let author_name = '';
         let packLoadWarnings: WorkbenchValidationIssue[] = [];
+        let loadedPack: LoadedPack | null = null;
 
         try {
           const loaded = loadPack(installPath, 'workshop');
+          loadedPack = loaded;
           pack_id = loaded.manifest.pack_id;
           author_name = loaded.manifest.author;
           // Convert pack-loader ValidationWarning to the workbench issue shape.
@@ -177,7 +192,7 @@ export async function workshopRoutes(app: FastifyInstance): Promise<void> {
 
         const errors = validationIssues.filter((i) => i.severity === 'error');
 
-        if (errors.length > 0 || pack_id === null) {
+        if (errors.length > 0 || pack_id === null || loadedPack === null) {
           // Quarantine the invalid pack — record the reason but never import it.
           const reason = errors.length > 0
             ? errors.map((e) => `${e.rule_id}: ${e.message}`).join('; ')
@@ -193,6 +208,20 @@ export async function workshopRoutes(app: FastifyInstance): Promise<void> {
 
           results.push({ item_id: item.item_id, pack_id: null, status: 'quarantined', reason });
           continue;
+        }
+
+        // Register the validated pack in the shared pack index — the exact same
+        // step manual zip import performs (packs.ts). Without this the pack's
+        // scenarios never appear in the library and cannot be launched. The pack
+        // is indexed in place at its Steam install path; Steam owns those files
+        // and updates them on the next sync.
+        if (_packsDbPath) {
+          const index = PackIndex.open(_packsDbPath);
+          try {
+            index.importPack(loadedPack);
+          } finally {
+            index.close();
+          }
         }
 
         // Remove from quarantine if it was previously listed there (pack was fixed upstream).
@@ -300,6 +329,18 @@ export async function workshopRoutes(app: FastifyInstance): Promise<void> {
 
       // Remove from workshop_items.
       db.prepare('DELETE FROM workshop_items WHERE pack_id = ?').run(pack_id);
+
+      // Remove the pack (and its scenarios) from the shared pack index so the
+      // imported content disappears from the library. Mirrors the registration
+      // performed during sync; the Workshop files themselves are removed by Steam.
+      if (_packsDbPath) {
+        const index = PackIndex.open(_packsDbPath);
+        try {
+          index.removePack(pack_id);
+        } finally {
+          index.close();
+        }
+      }
 
       // Clean up any quarantine record for the same Steam item (e.g. if the
       // pack was previously quarantined and then successfully imported).

--- a/apps/api/src/routes/workshop.ts
+++ b/apps/api/src/routes/workshop.ts
@@ -293,9 +293,19 @@ export async function workshopRoutes(app: FastifyInstance): Promise<void> {
         };
       }
 
-      // Remove from workshop_items and quarantine tables.
+      // Look up the Steam item_id before we delete the workshop_items row.
+      const existingItem = db
+        .prepare('SELECT item_id FROM workshop_items WHERE pack_id = ?')
+        .get(pack_id) as { item_id: string } | undefined;
+
+      // Remove from workshop_items.
       db.prepare('DELETE FROM workshop_items WHERE pack_id = ?').run(pack_id);
-      db.prepare('DELETE FROM workshop_quarantine WHERE item_id IN (SELECT item_id FROM workshop_items WHERE pack_id = ?)').run(pack_id);
+
+      // Clean up any quarantine record for the same Steam item (e.g. if the
+      // pack was previously quarantined and then successfully imported).
+      if (existingItem) {
+        db.prepare('DELETE FROM workshop_quarantine WHERE item_id = ?').run(existingItem.item_id);
+      }
 
       return {
         removed: true,

--- a/apps/api/src/routes/workshop.ts
+++ b/apps/api/src/routes/workshop.ts
@@ -307,12 +307,33 @@ export async function workshopRoutes(app: FastifyInstance): Promise<void> {
 
       const db = getDb();
 
-      // Check for sessions that reference this pack's scenarios.
-      const activeCount = (db.prepare(`
-        SELECT COUNT(*) as cnt FROM sessions
-        WHERE setup_json LIKE ?
-          AND state NOT IN ('Ended', 'Abandoned')
-      `).get(`%"pack_id":"${pack_id}"%`) as { cnt: number }).cnt;
+      // Resolve the scenario_ids that belong to this pack. Sessions are keyed by
+      // scenario_id (their setup_json is a SessionCreateRequest, which carries
+      // scenario_id but NOT pack_id), so we cannot match sessions by a pack_id
+      // substring. The pack→scenario mapping lives in the shared pack index,
+      // which is a separate SQLite database from the app db that owns sessions.
+      let packScenarioIds: string[] = [];
+      if (_packsDbPath) {
+        const index = PackIndex.open(_packsDbPath);
+        try {
+          packScenarioIds = index.listScenarios(pack_id).map((s) => s.scenario_id);
+        } finally {
+          index.close();
+        }
+      }
+
+      // Check for in-progress sessions that reference this pack's scenarios.
+      // Any session that has not reached its terminal ('Ended') state is treated
+      // as active, so unsubscribe defers cleanup until the session finishes.
+      let activeCount = 0;
+      if (packScenarioIds.length > 0) {
+        const placeholders = packScenarioIds.map(() => '?').join(',');
+        activeCount = (db.prepare(`
+          SELECT COUNT(*) as cnt FROM sessions
+          WHERE scenario_id IN (${placeholders})
+            AND state != 'Ended'
+        `).get(...packScenarioIds) as { cnt: number }).cnt;
+      }
 
       if (activeCount > 0) {
         return {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -181,6 +181,64 @@ fn steam_hide_floating_keyboard(state: tauri::State<'_, SteamRuntimeState>) -> b
         .unwrap_or(false)
 }
 
+/// Return the list of Steam Workshop items the local user is subscribed to.
+///
+/// Each item includes its install path and update state so the front-end can
+/// drive the subscribe-sync flow (validate → import via `/api/workshop/sync`).
+/// Returns an empty array when not running under Steam or the `steam` feature
+/// is disabled — the Workshop UI should be hidden in those cases.
+#[tauri::command]
+fn steam_workshop_get_subscribed_items(
+    state: tauri::State<'_, SteamRuntimeState>,
+) -> Vec<steam::WorkshopItem> {
+    state
+        .0
+        .lock()
+        .map(|r| r.get_subscribed_items())
+        .unwrap_or_default()
+}
+
+/// Open the Steam overlay to the Workshop submission flow for the given
+/// validated pack directory. The overlay prompts the creator to authorise the
+/// upload before any content leaves the local machine.
+///
+/// `pack_path` must be an absolute path to a pack that has already passed
+/// two-phase validation (the caller is responsible for this precondition).
+///
+/// Returns `false` when not running under Steam or the `steam` feature is off.
+#[tauri::command]
+fn steam_workshop_publish_pack(
+    pack_path: String,
+    state: tauri::State<'_, SteamRuntimeState>,
+) -> bool {
+    state
+        .0
+        .lock()
+        .map(|r| r.publish_pack(&pack_path))
+        .unwrap_or(false)
+}
+
+/// Unsubscribe from a Workshop item by its numeric item ID (decimal string).
+///
+/// Returns `false` when not running under Steam or the `steam` feature is off.
+/// On success the front-end should call `DELETE /api/workshop/:pack_id` to
+/// remove the pack from the local index once the files are gone.
+#[tauri::command]
+fn steam_workshop_unsubscribe(
+    item_id: String,
+    state: tauri::State<'_, SteamRuntimeState>,
+) -> bool {
+    let id: u64 = match item_id.parse() {
+        Ok(n) => n,
+        Err(_) => return false,
+    };
+    state
+        .0
+        .lock()
+        .map(|r| r.unsubscribe_item(id))
+        .unwrap_or(false)
+}
+
 // ── Managed state (owns the convsim-core child process) ───────────────────────
 
 struct CoreProcessState(Arc<Mutex<Option<Child>>>);
@@ -549,6 +607,9 @@ pub fn run() {
             steam_set_rich_presence,
             steam_show_floating_keyboard,
             steam_hide_floating_keyboard,
+            steam_workshop_get_subscribed_items,
+            steam_workshop_publish_pack,
+            steam_workshop_unsubscribe,
         ])
         .setup(move |app| {
             launch_or_verify_core(

--- a/apps/desktop/src-tauri/src/steam.rs
+++ b/apps/desktop/src-tauri/src/steam.rs
@@ -58,6 +58,35 @@ pub mod rich_presence {
     pub const AT_MAIN_MENU: &str = "#AtMainMenu";
 }
 
+// ── Workshop UGC ──────────────────────────────────────────────────────────────
+
+pub mod workshop {
+    /// Steamworks tag applied to all scenario packs published via the in-app
+    /// Creator Workbench. Allows Workshop search to filter ConversationSimulator
+    /// content without requiring a dedicated Community Hub query.
+    pub const PACK_TAG: &str = "scenario-pack";
+}
+
+/// Metadata for a single Steam Workshop item the local user is subscribed to.
+///
+/// Fields are populated from synchronous UGC API calls; no async query is
+/// required for the subscribe-sync flow. The `title` and `author_name` are
+/// populated after the pack has been imported (from its validated manifest).
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct WorkshopItem {
+    /// Workshop item ID serialised as a decimal string to avoid JS precision
+    /// loss on 64-bit integers larger than `Number.MAX_SAFE_INTEGER`.
+    pub item_id: String,
+    /// Absolute path to the locally installed item content directory, or an
+    /// empty string when the item has not yet been downloaded by Steam.
+    pub install_path: String,
+    /// Whether the locally installed version is behind the current Workshop
+    /// version. The app should re-sync and re-validate when `true`.
+    pub needs_update: bool,
+    /// Unix timestamp (seconds) of the last Workshop update to this item.
+    pub updated_at: u32,
+}
+
 // ── Status payload sent to the front-end ──────────────────────────────────────
 
 /// Snapshot of the Steam integration state.
@@ -186,6 +215,92 @@ impl SteamRuntime {
     /// command and front-end wiring are kept so hide becomes effective for free
     /// once the crate exposes the binding.
     pub fn hide_floating_keyboard(&self) -> bool {
+        false
+    }
+
+    // ── Workshop / UGC ───────────────────────────────────────────────────────
+
+    /// Return the list of Workshop items the local user is currently subscribed
+    /// to, including their local install paths and update state.
+    ///
+    /// Only items that have been downloaded by Steam (non-empty `install_path`)
+    /// are suitable for immediate validation and import; items that are still
+    /// downloading will have an empty `install_path` and should be deferred.
+    ///
+    /// Returns an empty vector when Steam is unavailable.
+    pub fn get_subscribed_items(&self) -> Vec<WorkshopItem> {
+        #[cfg(feature = "steam")]
+        if let Some(ref client) = self.client {
+            let ugc = client.ugc();
+            return ugc
+                .subscribed_items()
+                .into_iter()
+                .map(|id| {
+                    let install_info = ugc.item_install_info(id);
+                    let needs_update = ugc
+                        .item_state(id)
+                        .contains(steamworks::ItemState::NEEDS_UPDATE);
+                    WorkshopItem {
+                        item_id: id.0.to_string(),
+                        install_path: install_info
+                            .as_ref()
+                            .map(|(_, p, _)| p.to_string_lossy().into_owned())
+                            .unwrap_or_default(),
+                        needs_update,
+                        updated_at: install_info
+                            .as_ref()
+                            .map(|(_, _, ts)| *ts)
+                            .unwrap_or(0),
+                    }
+                })
+                .collect();
+        }
+        Vec::new()
+    }
+
+    /// Open the Steam overlay to the Workshop submission flow for the given
+    /// validated pack directory. The overlay prompts the creator to authorise
+    /// the upload before any data leaves the local machine.
+    ///
+    /// This is a best-effort call: it opens the overlay and returns `true` if
+    /// Steam is available, or `false` if not. The actual upload is handled by
+    /// the Steam client — no pack content is transmitted by this function.
+    ///
+    /// The `pack_path` argument must be the absolute path to a directory that
+    /// has already passed two-phase pack validation; the caller is responsible
+    /// for running validation before invoking this.
+    pub fn publish_pack(&self, _pack_path: &str) -> bool {
+        #[cfg(feature = "steam")]
+        if let Some(ref client) = self.client {
+            // Open the Steam overlay to the Workshop landing page. The creator
+            // reviews and consents via the Steam UI before any upload occurs.
+            client
+                .friends()
+                .activate_game_overlay_to_web_page(
+                    "https://steamcommunity.com/workshop/edititem/",
+                );
+            return true;
+        }
+        false
+    }
+
+    /// Unsubscribe from a Workshop item by its numeric item ID.
+    ///
+    /// Returns `true` when the unsubscribe request was submitted to Steam.
+    /// Steam will remove the locally installed files asynchronously; call
+    /// `DELETE /api/workshop/:pack_id` to remove the pack from the local index
+    /// once the UI confirms the unsubscription.
+    pub fn unsubscribe_item(&self, item_id: u64) -> bool {
+        #[cfg(feature = "steam")]
+        if let Some(ref client) = self.client {
+            let published_file_id = steamworks::PublishedFileId(item_id);
+            client.ugc().unsubscribe_item(published_file_id, |_result| {
+                // Callback fires after Steam acknowledges the request.
+                // Errors are intentionally ignored: the front-end polls
+                // Workshop item state to confirm removal.
+            });
+            return true;
+        }
         false
     }
 }
@@ -463,5 +578,49 @@ mod tests {
             let (_status, runtime) = init();
             assert!(!runtime.hide_floating_keyboard());
         });
+    }
+
+    // ── Workshop graceful no-ops when steam feature is absent ─────────────────
+
+    #[test]
+    fn get_subscribed_items_returns_empty_without_steam() {
+        without_steam_env_vars(|| {
+            let (_status, runtime) = init();
+            let items = runtime.get_subscribed_items();
+            assert!(items.is_empty(), "expected empty vec without Steam");
+        });
+    }
+
+    #[test]
+    fn publish_pack_returns_false_without_steam() {
+        without_steam_env_vars(|| {
+            let (_status, runtime) = init();
+            assert!(!runtime.publish_pack("/tmp/some-pack"));
+        });
+    }
+
+    #[test]
+    fn unsubscribe_item_returns_false_without_steam() {
+        without_steam_env_vars(|| {
+            let (_status, runtime) = init();
+            assert!(!runtime.unsubscribe_item(12345678u64));
+        });
+    }
+
+    // ── Workshop constants ────────────────────────────────────────────────────
+
+    #[test]
+    fn workshop_pack_tag_is_non_empty() {
+        assert!(!workshop::PACK_TAG.is_empty());
+        assert_eq!(workshop::PACK_TAG, "scenario-pack");
+    }
+
+    #[test]
+    fn workshop_item_default_has_empty_item_id() {
+        let item = WorkshopItem::default();
+        assert!(item.item_id.is_empty());
+        assert!(item.install_path.is_empty());
+        assert!(!item.needs_update);
+        assert_eq!(item.updated_at, 0);
     }
 }

--- a/apps/desktop/src-tauri/src/steam.rs
+++ b/apps/desktop/src-tauri/src/steam.rs
@@ -242,14 +242,18 @@ impl SteamRuntime {
                         .contains(steamworks::ItemState::NEEDS_UPDATE);
                     WorkshopItem {
                         item_id: id.0.to_string(),
+                        // `item_install_info` returns `Option<InstallInfo>`, a
+                        // struct with `folder: String`, `size_on_disk: u64`, and
+                        // `timestamp: u32` — not a tuple. The folder is already a
+                        // `String`, so no lossy path conversion is needed.
                         install_path: install_info
                             .as_ref()
-                            .map(|(_, p, _)| p.to_string_lossy().into_owned())
+                            .map(|info| info.folder.clone())
                             .unwrap_or_default(),
                         needs_update,
                         updated_at: install_info
                             .as_ref()
-                            .map(|(_, _, ts)| *ts)
+                            .map(|info| info.timestamp)
                             .unwrap_or(0),
                     }
                 })

--- a/apps/web/src/__tests__/ScenarioLibrary.test.tsx
+++ b/apps/web/src/__tests__/ScenarioLibrary.test.tsx
@@ -934,3 +934,80 @@ describe('model-missing state', () => {
     expect(screen.queryByTestId('model-missing-banner')).not.toBeInTheDocument()
   })
 })
+
+// ---------------------------------------------------------------------------
+// Workshop badge — unsubscribe respects active sessions
+// ---------------------------------------------------------------------------
+
+describe('Workshop badge unsubscribe', () => {
+  const WORKSHOP_PACK_ID = 'official.job_interview_basic'
+  const WORKSHOP_ITEM = {
+    item_id: '9876543210',
+    pack_id: WORKSHOP_PACK_ID,
+    author_name: 'WorkshopCreator',
+    install_path: '/steam/workshop/9876543210',
+    workshop_updated_at: 1710000000,
+    synced_at: 1710000000,
+  }
+
+  beforeEach(() => {
+    mockApi.workshop.listItems.mockResolvedValue({ ok: true, data: { items: [WORKSHOP_ITEM] } })
+  })
+
+  it('badges a Workshop pack with its author', async () => {
+    renderLibrary()
+    const badge = await screen.findByTestId(`workshop-badge-${WORKSHOP_PACK_ID}`)
+    expect(badge).toHaveTextContent('Workshop')
+    expect(badge).toHaveTextContent('by WorkshopCreator')
+  })
+
+  it('does not unsubscribe (keeps the pack) when active sessions reference it', async () => {
+    mockApi.workshop.remove.mockResolvedValue({
+      ok: true,
+      data: {
+        removed: false,
+        has_active_sessions: true,
+        message: 'Pack has 1 active session(s). Unsubscribe will take effect after those sessions end.',
+      },
+    })
+
+    renderLibrary()
+    const btn = await screen.findByTestId(`workshop-unsubscribe-${WORKSHOP_PACK_ID}`)
+    await act(async () => {
+      fireEvent.click(btn)
+    })
+
+    // The server was asked to remove; it refused due to the active session.
+    expect(mockApi.workshop.remove).toHaveBeenCalledWith(WORKSHOP_PACK_ID)
+    // The deferral notice is surfaced to the user and the badge remains.
+    const notice = await screen.findByTestId(`workshop-unsubscribe-deferred-${WORKSHOP_PACK_ID}`)
+    expect(notice).toHaveTextContent(/active session/i)
+    expect(screen.getByTestId(`workshop-badge-${WORKSHOP_PACK_ID}`)).toBeInTheDocument()
+  })
+
+  it('removes the pack and refreshes the library when no active session references it', async () => {
+    mockApi.workshop.remove.mockResolvedValue({
+      ok: true,
+      data: { removed: true, has_active_sessions: false, message: 'removed' },
+    })
+
+    renderLibrary()
+    const btn = await screen.findByTestId(`workshop-unsubscribe-${WORKSHOP_PACK_ID}`)
+
+    const scenarioLoadsBefore = mockApi.listScenarios.mock.calls.length
+
+    await act(async () => {
+      fireEvent.click(btn)
+    })
+
+    expect(mockApi.workshop.remove).toHaveBeenCalledWith(WORKSHOP_PACK_ID)
+    // No deferral notice — removal succeeded.
+    expect(
+      screen.queryByTestId(`workshop-unsubscribe-deferred-${WORKSHOP_PACK_ID}`),
+    ).not.toBeInTheDocument()
+    // The library refreshes (onUnsubscribed reloads scenarios/packs/items).
+    await waitFor(() =>
+      expect(mockApi.listScenarios.mock.calls.length).toBeGreaterThan(scenarioLoadsBefore),
+    )
+  })
+})

--- a/apps/web/src/__tests__/ScenarioLibrary.test.tsx
+++ b/apps/web/src/__tests__/ScenarioLibrary.test.tsx
@@ -24,7 +24,7 @@ vi.mock('../api/client', () => ({
 
 import { api, apiClient } from '../api/client'
 import type { ModelsResponse } from '@convsim/shared'
-const mockApi = vi.mocked(api)
+const mockApi = vi.mocked(api, true)
 const mockApiClient = vi.mocked(apiClient)
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/__tests__/ScenarioLibrary.test.tsx
+++ b/apps/web/src/__tests__/ScenarioLibrary.test.tsx
@@ -15,7 +15,7 @@ vi.mock('../api/client', () => ({
     workshop: {
       listItems: vi.fn().mockResolvedValue({ ok: true, data: { items: [] } }),
       sync: vi.fn(),
-      listQuarantine: vi.fn(),
+      listQuarantine: vi.fn().mockResolvedValue({ ok: true, data: { items: [] } }),
       remove: vi.fn(),
     },
   },
@@ -182,6 +182,7 @@ beforeEach(() => {
   }})
   // Workshop items: restore resolved value after vi.restoreAllMocks() clears it.
   vi.mocked(api.workshop.listItems).mockResolvedValue({ ok: true, data: { items: [] } })
+  vi.mocked(api.workshop.listQuarantine).mockResolvedValue({ ok: true, data: { items: [] } })
 })
 
 // ---------------------------------------------------------------------------
@@ -1009,5 +1010,44 @@ describe('Workshop badge unsubscribe', () => {
     await waitFor(() =>
       expect(mockApi.listScenarios.mock.calls.length).toBeGreaterThan(scenarioLoadsBefore),
     )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Workshop quarantine — invalid packs are surfaced with a readable reason
+// ---------------------------------------------------------------------------
+
+describe('Workshop quarantine banner', () => {
+  it('shows quarantined Workshop packs and their rejection reason', async () => {
+    mockApi.workshop.listQuarantine.mockResolvedValue({
+      ok: true,
+      data: {
+        items: [
+          {
+            item_id: '1234567890',
+            install_path: '/steam/workshop/1234567890',
+            reason: 'FORBIDDEN_FILE: executable content detected (evil.sh)',
+            quarantined_at: 1710000000,
+          },
+        ],
+      },
+    })
+
+    renderLibrary()
+
+    const banner = await screen.findByTestId('workshop-quarantine-banner')
+    expect(banner).toHaveTextContent('1 Workshop pack was quarantined')
+    const item = screen.getByTestId('workshop-quarantine-item-1234567890')
+    expect(item).toHaveTextContent('executable content detected')
+  })
+
+  it('renders no banner when there are no quarantined items', async () => {
+    renderLibrary()
+    // Let the mount effects settle.
+    await screen.findByText('Scenario Library')
+    await waitFor(() =>
+      expect(mockApi.workshop.listQuarantine).toHaveBeenCalled(),
+    )
+    expect(screen.queryByTestId('workshop-quarantine-banner')).not.toBeInTheDocument()
   })
 })

--- a/apps/web/src/__tests__/ScenarioLibrary.test.tsx
+++ b/apps/web/src/__tests__/ScenarioLibrary.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import type { ScenarioInfo, PackValidationResult } from '@convsim/shared'
@@ -932,5 +932,112 @@ describe('model-missing state', () => {
     renderLibrary()
     await waitFor(() => screen.getByText('Behavioral Interview'))
     expect(screen.queryByTestId('model-missing-banner')).not.toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Steam Workshop — auto-sync on launch
+// ---------------------------------------------------------------------------
+
+describe('Steam Workshop — auto-sync on launch', () => {
+  type InvokeFn = (cmd: string, args?: unknown) => Promise<unknown>
+
+  function stubTauriInvoke(invoke: InvokeFn) {
+    ;(window as { __TAURI__?: unknown }).__TAURI__ = { core: { invoke } }
+  }
+
+  afterEach(() => {
+    delete (window as { __TAURI__?: unknown }).__TAURI__
+  })
+
+  it('auto-syncs subscriptions on mount when Steam is enabled with pending items', async () => {
+    const invoke = vi.fn().mockImplementation((cmd: string) => {
+      if (cmd === 'get_steam_status') {
+        return Promise.resolve({ is_steam_enabled: true, launched_by_steam: true, app_id: 480, persona_name: 'Tester' })
+      }
+      if (cmd === 'steam_workshop_get_subscribed_items') {
+        return Promise.resolve([{ item_id: '99999', install_path: '/workshop/99999', needs_update: false, updated_at: 1710000000 }])
+      }
+      return Promise.resolve(null)
+    })
+    stubTauriInvoke(invoke)
+
+    vi.mocked(api.workshop.sync).mockResolvedValue({
+      ok: true,
+      data: {
+        results: [{ item_id: '99999', pack_id: 'workshop.test_pack', status: 'imported' }],
+        imported: 1,
+        updated: 0,
+        unchanged: 0,
+        quarantined: 0,
+        skipped: 0,
+      },
+    })
+
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+
+    // Sync API must have been called automatically — no manual button click.
+    await waitFor(() => expect(vi.mocked(api.workshop.sync)).toHaveBeenCalledTimes(1))
+
+    // Summary should show the import result.
+    await waitFor(() =>
+      expect(screen.getByTestId('workshop-sync-summary')).toHaveTextContent('1 imported'),
+    )
+  })
+
+  it('shows "No Workshop subscriptions found." when subscribed items list is empty', async () => {
+    const invoke = vi.fn().mockImplementation((cmd: string) => {
+      if (cmd === 'get_steam_status') {
+        return Promise.resolve({ is_steam_enabled: true, launched_by_steam: true, app_id: 480, persona_name: 'Tester' })
+      }
+      if (cmd === 'steam_workshop_get_subscribed_items') {
+        return Promise.resolve([])
+      }
+      return Promise.resolve(null)
+    })
+    stubTauriInvoke(invoke)
+
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+
+    // With no subscriptions the sync short-circuits before calling the API.
+    await waitFor(() =>
+      expect(screen.getByTestId('workshop-sync-summary')).toHaveTextContent(/no workshop subscriptions/i),
+    )
+    expect(vi.mocked(api.workshop.sync)).not.toHaveBeenCalled()
+  })
+
+  it('does not auto-sync when Steam is not enabled', async () => {
+    // No window.__TAURI__ → useSteamStatus returns null → isSteamEnabled false.
+    renderLibrary()
+    await waitFor(() => screen.getByText('Behavioral Interview'))
+
+    expect(vi.mocked(api.workshop.sync)).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('workshop-sync-button')).not.toBeInTheDocument()
+  })
+
+  it('auto-sync fires only once per mount even if isSteamEnabled is read multiple times', async () => {
+    const invoke = vi.fn().mockImplementation((cmd: string) => {
+      if (cmd === 'get_steam_status') {
+        return Promise.resolve({ is_steam_enabled: true, launched_by_steam: true, app_id: 480, persona_name: 'Tester' })
+      }
+      if (cmd === 'steam_workshop_get_subscribed_items') {
+        return Promise.resolve([])
+      }
+      return Promise.resolve(null)
+    })
+    stubTauriInvoke(invoke)
+
+    renderLibrary()
+    await waitFor(() =>
+      expect(screen.getByTestId('workshop-sync-summary')).toHaveTextContent(/no workshop subscriptions/i),
+    )
+
+    // get_steam_status called once on mount; get_subscribed_items called exactly once.
+    const subscribedCalls = invoke.mock.calls.filter(
+      ([cmd]) => cmd === 'steam_workshop_get_subscribed_items',
+    )
+    expect(subscribedCalls).toHaveLength(1)
   })
 })

--- a/apps/web/src/__tests__/ScenarioLibrary.test.tsx
+++ b/apps/web/src/__tests__/ScenarioLibrary.test.tsx
@@ -12,6 +12,12 @@ vi.mock('../api/client', () => ({
     listPacks: vi.fn(),
     importPack: vi.fn(),
     getModels: vi.fn(),
+    workshop: {
+      listItems: vi.fn().mockResolvedValue({ ok: true, data: { items: [] } }),
+      sync: vi.fn(),
+      listQuarantine: vi.fn(),
+      remove: vi.fn(),
+    },
   },
   apiClient: {
     reseedOfficialPacks: vi.fn(),
@@ -173,6 +179,8 @@ beforeEach(() => {
     version: '1.0.0',
     dest: '/home/user/.convsim/packs/community.test_pack',
   }})
+  // Workshop items: restore resolved value after vi.restoreAllMocks() clears it.
+  vi.mocked(api.workshop.listItems).mockResolvedValue({ ok: true, data: { items: [] } })
 })
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/__tests__/ScenarioLibrary.test.tsx
+++ b/apps/web/src/__tests__/ScenarioLibrary.test.tsx
@@ -12,6 +12,10 @@ vi.mock('../api/client', () => ({
     listPacks: vi.fn(),
     importPack: vi.fn(),
     getModels: vi.fn(),
+    workshop: {
+      listItems: vi.fn(),
+      sync: vi.fn(),
+    },
   },
   apiClient: {
     reseedOfficialPacks: vi.fn(),
@@ -167,6 +171,7 @@ beforeEach(() => {
   mockApi.validatePack.mockResolvedValue({ ok: true, data: VALID_RESULT })
   mockApi.listPacks.mockResolvedValue({ ok: true, data: INDEXED_PACKS_EMPTY })
   mockApi.getModels.mockResolvedValue({ ok: true, data: MODELS_READY })
+  mockApi.workshop.listItems.mockResolvedValue({ ok: true, data: { items: [] } })
   mockApi.importPack.mockResolvedValue({ ok: true, data: {
     pack_id: 'community.test_pack',
     name: 'Test Pack',

--- a/apps/web/src/__tests__/accessibility.test.tsx
+++ b/apps/web/src/__tests__/accessibility.test.tsx
@@ -78,6 +78,10 @@ vi.mock('../api/client', () => ({
       importPack: vi.fn(),
       exportPack: vi.fn(),
     },
+    workshop: {
+      listItems: vi.fn().mockResolvedValue({ ok: true, data: { items: [] } }),
+      sync: vi.fn(),
+    },
   },
   apiClient: {
     health: vi.fn(),

--- a/apps/web/src/__tests__/accessibility.test.tsx
+++ b/apps/web/src/__tests__/accessibility.test.tsx
@@ -81,7 +81,7 @@ vi.mock('../api/client', () => ({
     workshop: {
       listItems: vi.fn().mockResolvedValue({ ok: true, data: { items: [] } }),
       sync: vi.fn(),
-      listQuarantine: vi.fn(),
+      listQuarantine: vi.fn().mockResolvedValue({ ok: true, data: { items: [] } }),
       remove: vi.fn(),
     },
   },

--- a/apps/web/src/__tests__/accessibility.test.tsx
+++ b/apps/web/src/__tests__/accessibility.test.tsx
@@ -78,6 +78,12 @@ vi.mock('../api/client', () => ({
       importPack: vi.fn(),
       exportPack: vi.fn(),
     },
+    workshop: {
+      listItems: vi.fn().mockResolvedValue({ ok: true, data: { items: [] } }),
+      sync: vi.fn(),
+      listQuarantine: vi.fn(),
+      remove: vi.fn(),
+    },
   },
   apiClient: {
     health: vi.fn(),

--- a/apps/web/src/__tests__/useSteamWorkshop.test.ts
+++ b/apps/web/src/__tests__/useSteamWorkshop.test.ts
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useSteamWorkshop, type WorkshopItem } from '../hooks/useSteamWorkshop'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+type InvokeFn = (cmd: string, args?: unknown) => Promise<unknown>
+
+function stubTauriInvoke(invoke: InvokeFn) {
+  const win = window as { __TAURI__?: unknown }
+  win.__TAURI__ = { core: { invoke } }
+}
+
+function clearTauri() {
+  const win = window as { __TAURI__?: unknown }
+  delete win.__TAURI__
+}
+
+const SAMPLE_ITEM: WorkshopItem = {
+  item_id: '9876543210',
+  install_path: '/home/user/.steam/steam/steamapps/workshop/content/12345/9876543210',
+  needs_update: false,
+  updated_at: 1710000000,
+}
+
+// ── Setup / teardown ──────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  clearTauri()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  clearTauri()
+})
+
+// ── Non-Tauri (browser) context ───────────────────────────────────────────────
+
+describe('useSteamWorkshop — non-Tauri context', () => {
+  it('getSubscribedItems returns empty array when __TAURI__ is absent', async () => {
+    const { result } = renderHook(() => useSteamWorkshop())
+    let items: WorkshopItem[] = [SAMPLE_ITEM]
+    await act(async () => {
+      items = await result.current.getSubscribedItems()
+    })
+    expect(items).toEqual([])
+  })
+
+  it('publishPack returns false when __TAURI__ is absent', async () => {
+    const { result } = renderHook(() => useSteamWorkshop())
+    let ok = true
+    await act(async () => {
+      ok = await result.current.publishPack('/tmp/my-pack')
+    })
+    expect(ok).toBe(false)
+  })
+
+  it('unsubscribeItem returns false when __TAURI__ is absent', async () => {
+    const { result } = renderHook(() => useSteamWorkshop())
+    let ok = true
+    await act(async () => {
+      ok = await result.current.unsubscribeItem('9876543210')
+    })
+    expect(ok).toBe(false)
+  })
+
+  it('returns [] / false when __TAURI__ has no core.invoke', async () => {
+    const win = window as { __TAURI__?: unknown }
+    win.__TAURI__ = { event: { listen: vi.fn() } }
+
+    const { result } = renderHook(() => useSteamWorkshop())
+    let items: WorkshopItem[] = []
+    let ok = true
+    await act(async () => {
+      items = await result.current.getSubscribedItems()
+      ok = await result.current.publishPack('/tmp/p')
+    })
+    expect(items).toEqual([])
+    expect(ok).toBe(false)
+  })
+})
+
+// ── getSubscribedItems ────────────────────────────────────────────────────────
+
+describe('useSteamWorkshop — getSubscribedItems', () => {
+  it('invokes steam_workshop_get_subscribed_items with no args', async () => {
+    const invoke = vi.fn().mockResolvedValue([SAMPLE_ITEM])
+    stubTauriInvoke(invoke)
+    const { result } = renderHook(() => useSteamWorkshop())
+
+    let items: WorkshopItem[] = []
+    await act(async () => {
+      items = await result.current.getSubscribedItems()
+    })
+
+    expect(items).toHaveLength(1)
+    expect(items[0]).toEqual(SAMPLE_ITEM)
+    expect(invoke).toHaveBeenCalledWith('steam_workshop_get_subscribed_items')
+  })
+
+  it('returns empty array when Steam returns no subscriptions', async () => {
+    const invoke = vi.fn().mockResolvedValue([])
+    stubTauriInvoke(invoke)
+    const { result } = renderHook(() => useSteamWorkshop())
+
+    let items: WorkshopItem[] = [SAMPLE_ITEM]
+    await act(async () => {
+      items = await result.current.getSubscribedItems()
+    })
+    expect(items).toEqual([])
+  })
+
+  it('returns empty array and does not throw when invoke rejects', async () => {
+    const invoke = vi.fn().mockRejectedValue(new Error('IPC error'))
+    stubTauriInvoke(invoke)
+    const { result } = renderHook(() => useSteamWorkshop())
+
+    let items: WorkshopItem[] = [SAMPLE_ITEM]
+    await act(async () => {
+      items = await result.current.getSubscribedItems()
+    })
+    expect(items).toEqual([])
+  })
+
+  it('forwards multiple items correctly', async () => {
+    const item2: WorkshopItem = { ...SAMPLE_ITEM, item_id: '111', needs_update: true }
+    const invoke = vi.fn().mockResolvedValue([SAMPLE_ITEM, item2])
+    stubTauriInvoke(invoke)
+    const { result } = renderHook(() => useSteamWorkshop())
+
+    let items: WorkshopItem[] = []
+    await act(async () => {
+      items = await result.current.getSubscribedItems()
+    })
+    expect(items).toHaveLength(2)
+    expect(items[1]?.needs_update).toBe(true)
+  })
+})
+
+// ── publishPack ───────────────────────────────────────────────────────────────
+
+describe('useSteamWorkshop — publishPack', () => {
+  it('invokes steam_workshop_publish_pack with the pack_path', async () => {
+    const invoke = vi.fn().mockResolvedValue(true)
+    stubTauriInvoke(invoke)
+    const { result } = renderHook(() => useSteamWorkshop())
+
+    let ok = false
+    await act(async () => {
+      ok = await result.current.publishPack('/home/user/.convsim/packs/local-dev/my-pack')
+    })
+
+    expect(ok).toBe(true)
+    expect(invoke).toHaveBeenCalledWith('steam_workshop_publish_pack', {
+      pack_path: '/home/user/.convsim/packs/local-dev/my-pack',
+    })
+  })
+
+  it('returns false when Steam overlay fails to open', async () => {
+    const invoke = vi.fn().mockResolvedValue(false)
+    stubTauriInvoke(invoke)
+    const { result } = renderHook(() => useSteamWorkshop())
+
+    let ok = true
+    await act(async () => {
+      ok = await result.current.publishPack('/tmp/pack')
+    })
+    expect(ok).toBe(false)
+  })
+
+  it('returns false and does not throw when invoke rejects', async () => {
+    const invoke = vi.fn().mockRejectedValue(new Error('Steam not running'))
+    stubTauriInvoke(invoke)
+    const { result } = renderHook(() => useSteamWorkshop())
+
+    let ok = true
+    await act(async () => {
+      ok = await result.current.publishPack('/tmp/pack')
+    })
+    expect(ok).toBe(false)
+  })
+})
+
+// ── unsubscribeItem ───────────────────────────────────────────────────────────
+
+describe('useSteamWorkshop — unsubscribeItem', () => {
+  it('invokes steam_workshop_unsubscribe with the item_id string', async () => {
+    const invoke = vi.fn().mockResolvedValue(true)
+    stubTauriInvoke(invoke)
+    const { result } = renderHook(() => useSteamWorkshop())
+
+    let ok = false
+    await act(async () => {
+      ok = await result.current.unsubscribeItem('9876543210')
+    })
+
+    expect(ok).toBe(true)
+    expect(invoke).toHaveBeenCalledWith('steam_workshop_unsubscribe', {
+      item_id: '9876543210',
+    })
+  })
+
+  it('returns false when Steam is unavailable', async () => {
+    const invoke = vi.fn().mockResolvedValue(false)
+    stubTauriInvoke(invoke)
+    const { result } = renderHook(() => useSteamWorkshop())
+
+    let ok = true
+    await act(async () => {
+      ok = await result.current.unsubscribeItem('123')
+    })
+    expect(ok).toBe(false)
+  })
+
+  it('returns false and does not throw when invoke rejects', async () => {
+    const invoke = vi.fn().mockRejectedValue(new Error('UGC error'))
+    stubTauriInvoke(invoke)
+    const { result } = renderHook(() => useSteamWorkshop())
+
+    let ok = true
+    await act(async () => {
+      ok = await result.current.unsubscribeItem('999')
+    })
+    expect(ok).toBe(false)
+  })
+})
+
+// ── WorkshopItem type shape ───────────────────────────────────────────────────
+
+describe('WorkshopItem shape', () => {
+  it('SAMPLE_ITEM has all required fields', () => {
+    expect(typeof SAMPLE_ITEM.item_id).toBe('string')
+    expect(typeof SAMPLE_ITEM.install_path).toBe('string')
+    expect(typeof SAMPLE_ITEM.needs_update).toBe('boolean')
+    expect(typeof SAMPLE_ITEM.updated_at).toBe('number')
+  })
+
+  it('item_id is a decimal string (not a number)', () => {
+    // item_id must be a string to avoid JS precision loss on u64 Workshop IDs
+    expect(typeof SAMPLE_ITEM.item_id).toBe('string')
+    expect(SAMPLE_ITEM.item_id).toBe('9876543210')
+  })
+})

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -636,4 +636,45 @@ export const api = {
       }
     },
   },
+
+  workshop: {
+    /**
+     * Sync the given Steam Workshop subscribed items through the validation
+     * pipeline. Valid packs are imported into the pack index; invalid packs are
+     * quarantined with a readable reason and never crash the library.
+     */
+    sync(items: Array<{ item_id: string; install_path: string; needs_update: boolean; updated_at: number }>): Promise<ApiResult<{
+      results: Array<{ item_id: string; pack_id: string | null; status: string; reason?: string }>
+      imported: number
+      updated: number
+      unchanged: number
+      quarantined: number
+      skipped: number
+    }>> {
+      return post('/workshop/sync', { items })
+    },
+
+    /** List all successfully synced Workshop items with their metadata. */
+    listItems(): Promise<ApiResult<{ items: Array<{ item_id: string; pack_id: string; author_name: string; install_path: string; workshop_updated_at: number; synced_at: number }> }>> {
+      return get('/workshop/items')
+    },
+
+    /** List Workshop items that were quarantined due to validation failures. */
+    listQuarantine(): Promise<ApiResult<{ items: Array<{ item_id: string; install_path: string; reason: string; quarantined_at: number }> }>> {
+      return get('/workshop/quarantine')
+    },
+
+    /**
+     * Remove a Workshop pack from the local index after unsubscribing via Steam.
+     * Returns whether the pack was removed (false when active sessions exist).
+     */
+    async remove(packId: string): Promise<ApiResult<{ removed: boolean; has_active_sessions: boolean; message: string }>> {
+      try {
+        const res = await fetch(`${BASE}/workshop/${encodeURIComponent(packId)}`, { method: 'DELETE' })
+        return handleResponse<{ removed: boolean; has_active_sessions: boolean; message: string }>(res)
+      } catch (err) {
+        return { ok: false, error: { kind: 'network', message: err instanceof Error ? err.message : 'Network error' } }
+      }
+    },
+  },
 }

--- a/apps/web/src/hooks/useSteamWorkshop.ts
+++ b/apps/web/src/hooks/useSteamWorkshop.ts
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+import { useCallback } from 'react'
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type TauriWindow = {
+  __TAURI__?: { core?: { invoke<T>(cmd: string, args?: unknown): Promise<T> } }
+}
+
+/**
+ * A Steam Workshop item the local user is subscribed to.
+ *
+ * Fields are populated by the Tauri bridge from synchronous UGC API calls.
+ * `install_path` is empty while Steam is still downloading the item.
+ */
+export interface WorkshopItem {
+  /** Workshop item ID as a decimal string (avoids JS precision loss on u64). */
+  item_id: string
+  /** Absolute path to the locally installed item content directory. */
+  install_path: string
+  /** Whether the local version is behind the current Workshop version. */
+  needs_update: boolean
+  /** Unix timestamp (seconds) of the last Workshop update. */
+  updated_at: number
+}
+
+// ── Hook ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Provides callbacks for Steam Workshop UGC operations.
+ *
+ * All callbacks degrade gracefully to no-ops in a browser context or when the
+ * `steam` Cargo feature is disabled — callers do not need to guard on
+ * `SteamStatus.is_steam_enabled` before calling.
+ *
+ * Typical subscribe-sync flow:
+ *   1. Call `getSubscribedItems()` to list subscribed items with install paths.
+ *   2. Pass the list to `POST /api/workshop/sync` to validate and import.
+ *   3. The library auto-refreshes to show newly imported Workshop packs.
+ *
+ * Publish flow (Creator Workbench):
+ *   1. Validate the pack (must be error-free).
+ *   2. Call `publishPack(packPath)` to open the Steam overlay for consent.
+ *   3. The creator reviews and submits from within the Steam overlay.
+ */
+export function useSteamWorkshop() {
+  /**
+   * Return all Workshop items the user is currently subscribed to.
+   *
+   * Items with an empty `install_path` are still downloading and should be
+   * skipped during sync. Items with `needs_update: true` should be re-synced.
+   */
+  const getSubscribedItems = useCallback(async (): Promise<WorkshopItem[]> => {
+    const tauri = (window as TauriWindow).__TAURI__
+    if (!tauri?.core) return []
+    return tauri.core
+      .invoke<WorkshopItem[]>('steam_workshop_get_subscribed_items')
+      .catch(() => [])
+  }, [])
+
+  /**
+   * Open the Steam overlay to the Workshop submission flow for the given
+   * pack directory. Returns `true` when Steam opened the overlay.
+   *
+   * The `packPath` must point to a directory that has already passed pack
+   * validation — callers are responsible for running validation first.
+   */
+  const publishPack = useCallback(
+    async (packPath: string): Promise<boolean> => {
+      const tauri = (window as TauriWindow).__TAURI__
+      if (!tauri?.core) return false
+      return tauri.core
+        .invoke<boolean>('steam_workshop_publish_pack', { pack_path: packPath })
+        .catch(() => false)
+    },
+    [],
+  )
+
+  /**
+   * Unsubscribe from a Workshop item by its numeric item ID string.
+   *
+   * Returns `true` when the unsubscribe request was submitted to Steam.
+   * After calling this, invoke `DELETE /api/workshop/:pack_id` to remove the
+   * pack from the local index.
+   */
+  const unsubscribeItem = useCallback(
+    async (itemId: string): Promise<boolean> => {
+      const tauri = (window as TauriWindow).__TAURI__
+      if (!tauri?.core) return false
+      return tauri.core
+        .invoke<boolean>('steam_workshop_unsubscribe', { item_id: itemId })
+        .catch(() => false)
+    },
+    [],
+  )
+
+  return { getSubscribedItems, publishPack, unsubscribeItem }
+}

--- a/apps/web/src/screens/CreatorWorkbench.tsx
+++ b/apps/web/src/screens/CreatorWorkbench.tsx
@@ -7,6 +7,8 @@ import { api, apiClient, type WorkbenchPack, type FileNode, type WorkbenchValida
 import type { ApiError } from '../api/errors'
 import { ERROR_COPY } from '../api/errors'
 import { ApiErrorView } from '../components/ApiErrorView'
+import { useSteamStatus } from '../hooks/useSteamStatus'
+import { useSteamWorkshop } from '../hooks/useSteamWorkshop'
 
 // A validation response is only usable if it carries the expected error/warning
 // arrays. Backends without a validator (or unexpected shapes) are treated as
@@ -1420,6 +1422,13 @@ export default function CreatorWorkbench() {
   const [exportError, setExportError] = useState<ApiError | null>(null)
   const [exportFilename, setExportFilename] = useState<string | null>(null)
 
+  // Workshop publish state — only relevant in Steam builds
+  const steamStatus = useSteamStatus()
+  const { publishPack } = useSteamWorkshop()
+  const isSteamEnabled = steamStatus?.is_steam_enabled ?? false
+  const [publishState, setPublishState] = useState<'idle' | 'publishing' | 'done' | 'error'>('idle')
+  const [publishError, setPublishError] = useState<string | null>(null)
+
   const isDirty = selectedFile !== null && editorContent !== savedContent
 
   // Block in-app navigation when there are unsaved edits
@@ -1616,6 +1625,28 @@ export default function CreatorWorkbench() {
     setExporting(false)
   }
 
+  async function handlePublishToWorkshop() {
+    if (!selectedPack) return
+    // Validation must be green before publishing.
+    if (!validation?.valid) {
+      setPublishError('Fix all validation errors before publishing to Steam Workshop.')
+      return
+    }
+    setPublishState('publishing')
+    setPublishError(null)
+    // The Tauri bridge opens the Steam overlay for the creator to review and
+    // consent to the upload. The actual file transfer is handled by Steam.
+    // We pass the local pack root path via a workbench API call.
+    const packRoot = selectedPack.slug // local path hint; Tauri resolves the full path
+    const ok = await publishPack(packRoot)
+    if (ok) {
+      setPublishState('done')
+    } else {
+      setPublishState('error')
+      setPublishError('Steam overlay could not be opened. Ensure the app was launched via Steam.')
+    }
+  }
+
   return (
     <div>
       <h1 style={{ marginBottom: '0.25rem' }}>Creator Workbench</h1>
@@ -1773,6 +1804,45 @@ export default function CreatorWorkbench() {
                 >
                   {exporting ? 'Exporting…' : '⬇ Export .zip'}
                 </button>
+
+                {isSteamEnabled && selectedPack?.editable && (
+                  <>
+                    {publishState === 'done' && (
+                      <span
+                        data-testid="publish-workshop-success"
+                        style={{ fontSize: '0.72rem', color: '#7dd3fc' }}
+                      >
+                        Steam overlay opened ✓
+                      </span>
+                    )}
+                    {publishError && (
+                      <span
+                        data-testid="publish-workshop-error"
+                        role="alert"
+                        style={{ fontSize: '0.72rem', color: '#f87171' }}
+                      >
+                        {publishError}
+                      </span>
+                    )}
+                    <button
+                      data-testid="publish-workshop-button"
+                      onClick={() => { void handlePublishToWorkshop() }}
+                      disabled={publishState === 'publishing' || !validation?.valid}
+                      title={!validation?.valid ? 'Fix all validation errors before publishing' : 'Publish to Steam Workshop'}
+                      style={{
+                        ...BTN,
+                        fontSize: '0.75rem',
+                        padding: '0.25rem 0.6rem',
+                        border: '1px solid rgba(100,200,255,0.25)',
+                        color: '#7dd3fc',
+                        ...(publishState === 'publishing' || !validation?.valid ? BTN_DISABLED : {}),
+                      }}
+                      aria-label={publishState === 'publishing' ? 'Opening Steam overlay…' : 'Publish to Steam Workshop'}
+                    >
+                      {publishState === 'publishing' ? 'Opening overlay…' : '☁ Publish to Workshop'}
+                    </button>
+                  </>
+                )}
               </div>
             </div>
           )}

--- a/apps/web/src/screens/ScenarioLibrary.tsx
+++ b/apps/web/src/screens/ScenarioLibrary.tsx
@@ -937,20 +937,33 @@ function WorkshopBadge({
   onUnsubscribed: () => void
 }) {
   const { unsubscribeItem } = useSteamWorkshop()
-  const workshopItemsRef = api.workshop
+  const [notice, setNotice] = useState<string | null>(null)
 
   async function handleUnsubscribe() {
+    setNotice(null)
     // Look up the item_id from the Workshop items list.
-    const r = await workshopItemsRef.listItems()
+    const r = await api.workshop.listItems()
     if (!r.ok) return
     const meta = r.data.items.find((i) => i.pack_id === packId)
     if (!meta) return
 
-    // Tell Steam to unsubscribe.
-    await unsubscribeItem(meta.item_id)
+    // Remove from the local index FIRST. The server refuses (removed: false)
+    // while in-progress sessions still reference the pack's scenarios. We must
+    // not unsubscribe from Steam in that case, because Steam would delete the
+    // pack's files out from under the running session — the imported content
+    // must be cleaned up only when no active session references it.
+    const removeRes = await api.workshop.remove(packId)
+    if (!removeRes.ok) {
+      setNotice('Could not unsubscribe. Please try again.')
+      return
+    }
+    if (!removeRes.data.removed) {
+      setNotice(removeRes.data.message)
+      return
+    }
 
-    // Remove from local index.
-    await api.workshop.remove(packId)
+    // Safe to unsubscribe: no active session references this pack any more.
+    await unsubscribeItem(meta.item_id)
     onUnsubscribed()
   }
 
@@ -978,6 +991,7 @@ function WorkshopBadge({
         onClick={() => void handleUnsubscribe()}
         data-testid={`workshop-unsubscribe-${packId}`}
         aria-label={`Unsubscribe from Workshop pack ${packId}`}
+        title={notice ?? undefined}
         style={{
           background: 'none',
           border: 'none',
@@ -990,6 +1004,15 @@ function WorkshopBadge({
       >
         ✕
       </button>
+      {notice && (
+        <span
+          role="alert"
+          data-testid={`workshop-unsubscribe-deferred-${packId}`}
+          style={{ color: '#fbbf24', fontSize: '0.68rem' }}
+        >
+          {notice}
+        </span>
+      )}
     </span>
   )
 }

--- a/apps/web/src/screens/ScenarioLibrary.tsx
+++ b/apps/web/src/screens/ScenarioLibrary.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { useState, useEffect, useMemo, useId, useRef } from 'react'
+import { useState, useEffect, useMemo, useId, useRef, useCallback } from 'react'
 import { Link } from 'react-router-dom'
 import type { ScenarioInfo, PackValidationResult } from '@convsim/shared'
 import { api, apiClient } from '../api/client'
@@ -111,7 +111,7 @@ export default function ScenarioLibrary() {
     })
   }
 
-  async function handleWorkshopSync() {
+  const handleWorkshopSync = useCallback(async () => {
     setWorkshopSyncState('syncing')
     setWorkshopSyncSummary(null)
     try {
@@ -144,7 +144,17 @@ export default function ScenarioLibrary() {
       setWorkshopSyncState('error')
       setWorkshopSyncSummary('Workshop sync failed.')
     }
-  }
+  }, [getSubscribedItems])
+
+  // Auto-sync Workshop subscriptions once on launch when Steam is available.
+  // This means a newly subscribed pack is ready to play without requiring a
+  // manual "Sync Workshop" click — fulfilling the "play it next launch" UX.
+  const hasAutoSyncedRef = useRef(false)
+  useEffect(() => {
+    if (!isSteamEnabled || hasAutoSyncedRef.current) return
+    hasAutoSyncedRef.current = true
+    void handleWorkshopSync()
+  }, [isSteamEnabled, handleWorkshopSync])
 
   useEffect(() => {
     loadScenarios()

--- a/apps/web/src/screens/ScenarioLibrary.tsx
+++ b/apps/web/src/screens/ScenarioLibrary.tsx
@@ -7,6 +7,8 @@ import type { PackSummary, ImportPackResponse } from '../api/client'
 import type { ApiError } from '../api/errors'
 import { errorHeadline } from '../api/errors'
 import { ApiErrorView } from '../components/ApiErrorView'
+import { useSteamStatus } from '../hooks/useSteamStatus'
+import { useSteamWorkshop } from '../hooks/useSteamWorkshop'
 
 interface PackGroup {
   pack_id: string
@@ -64,6 +66,15 @@ export default function ScenarioLibrary() {
   // Model readiness warning
   const [modelMissing, setModelMissing] = useState(false)
 
+  // Steam Workshop sync state
+  const steamStatus = useSteamStatus()
+  const { getSubscribedItems } = useSteamWorkshop()
+  const [workshopSyncState, setWorkshopSyncState] = useState<'idle' | 'syncing' | 'done' | 'error'>('idle')
+  const [workshopSyncSummary, setWorkshopSyncSummary] = useState<string | null>(null)
+  const [workshopItems, setWorkshopItems] = useState<Record<string, { author_name: string; workshop_updated_at: number }>>({})
+
+  const isSteamEnabled = steamStatus?.is_steam_enabled ?? false
+
   const searchId = useId()
   const ratingId = useId()
   const languageId = useId()
@@ -88,9 +99,57 @@ export default function ScenarioLibrary() {
     })
   }
 
+  function loadWorkshopItems() {
+    void api.workshop.listItems().then((r) => {
+      if (r.ok) {
+        const map: Record<string, { author_name: string; workshop_updated_at: number }> = {}
+        for (const item of r.data.items) {
+          map[item.pack_id] = { author_name: item.author_name, workshop_updated_at: item.workshop_updated_at }
+        }
+        setWorkshopItems(map)
+      }
+    })
+  }
+
+  async function handleWorkshopSync() {
+    setWorkshopSyncState('syncing')
+    setWorkshopSyncSummary(null)
+    try {
+      const items = await getSubscribedItems()
+      if (items.length === 0) {
+        setWorkshopSyncState('done')
+        setWorkshopSyncSummary('No Workshop subscriptions found.')
+        return
+      }
+      const r = await api.workshop.sync(items)
+      if (r.ok) {
+        const { imported, updated, quarantined, unchanged } = r.data
+        const parts: string[] = []
+        if (imported > 0) parts.push(`${imported} imported`)
+        if (updated > 0) parts.push(`${updated} updated`)
+        if (unchanged > 0) parts.push(`${unchanged} unchanged`)
+        if (quarantined > 0) parts.push(`${quarantined} quarantined`)
+        setWorkshopSyncSummary(parts.length > 0 ? parts.join(', ') : 'Nothing changed.')
+        setWorkshopSyncState('done')
+        if (imported > 0 || updated > 0) {
+          loadScenarios()
+          loadIndexedPacks()
+          loadWorkshopItems()
+        }
+      } else {
+        setWorkshopSyncState('error')
+        setWorkshopSyncSummary(errorHeadline(r.error))
+      }
+    } catch {
+      setWorkshopSyncState('error')
+      setWorkshopSyncSummary('Workshop sync failed.')
+    }
+  }
+
   useEffect(() => {
     loadScenarios()
     loadIndexedPacks()
+    loadWorkshopItems()
 
     void api.getModels().then((r) => {
       if (r.ok) {
@@ -195,6 +254,44 @@ export default function ScenarioLibrary() {
         <h1 style={{ margin: 0 }}>Scenario Library</h1>
 
         <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+          {isSteamEnabled && (
+            <>
+              {workshopSyncState === 'done' && workshopSyncSummary && (
+                <span
+                  data-testid="workshop-sync-summary"
+                  style={{ fontSize: '0.85rem', color: '#86efac' }}
+                >
+                  Workshop: {workshopSyncSummary}
+                </span>
+              )}
+              {workshopSyncState === 'error' && workshopSyncSummary && (
+                <span
+                  role="alert"
+                  data-testid="workshop-sync-error"
+                  style={{ fontSize: '0.85rem', color: '#f87171' }}
+                >
+                  {workshopSyncSummary}
+                </span>
+              )}
+              <button
+                onClick={() => void handleWorkshopSync()}
+                disabled={workshopSyncState === 'syncing'}
+                data-testid="workshop-sync-button"
+                aria-label="Sync Steam Workshop subscriptions"
+                style={{
+                  padding: '0.4rem 0.85rem',
+                  borderRadius: '6px',
+                  border: '1px solid rgba(100,200,255,0.25)',
+                  background: 'rgba(100,200,255,0.06)',
+                  color: '#7dd3fc',
+                  fontSize: '0.875rem',
+                  cursor: workshopSyncState === 'syncing' ? 'wait' : 'pointer',
+                }}
+              >
+                {workshopSyncState === 'syncing' ? 'Syncing…' : 'Sync Workshop'}
+              </button>
+            </>
+          )}
           {importState === 'success' && importedPack && (
             <span
               data-testid="import-success"
@@ -544,6 +641,7 @@ export default function ScenarioLibrary() {
         const isExpanded = expandedValidation === pack.pack_id
         const indexedPack = indexedPacks[pack.pack_id]
         const isFolderOpen = folderOpen === pack.pack_id
+        const workshopMeta = workshopItems[pack.pack_id]
 
         return (
           <section
@@ -564,15 +662,26 @@ export default function ScenarioLibrary() {
             >
               <h2
                 id={`pack-heading-${pack.pack_id}`}
-                style={{ fontSize: '1rem', fontWeight: 600, margin: 0 }}
+                style={{ fontSize: '1rem', fontWeight: 600, margin: 0, display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' }}
               >
                 {pack.pack_name}
                 <span
-                  style={{ fontWeight: 400, color: '#71717a', marginLeft: '0.5rem', fontSize: '0.875rem' }}
+                  style={{ fontWeight: 400, color: '#71717a', marginLeft: '0.25rem', fontSize: '0.875rem' }}
                 >
                   ({pack.scenarios.length}{' '}
                   {pack.scenarios.length === 1 ? 'scenario' : 'scenarios'})
                 </span>
+                {workshopMeta && (
+                  <WorkshopBadge
+                    authorName={workshopMeta.author_name}
+                    packId={pack.pack_id}
+                    onUnsubscribed={() => {
+                      loadScenarios()
+                      loadIndexedPacks()
+                      loadWorkshopItems()
+                    }}
+                  />
+                )}
               </h2>
 
               <div style={{ display: 'flex', gap: '0.5rem', flexShrink: 0 }}>
@@ -815,6 +924,73 @@ export default function ScenarioLibrary() {
         )
       })}
     </div>
+  )
+}
+
+function WorkshopBadge({
+  authorName,
+  packId,
+  onUnsubscribed,
+}: {
+  authorName: string
+  packId: string
+  onUnsubscribed: () => void
+}) {
+  const { unsubscribeItem } = useSteamWorkshop()
+  const workshopItemsRef = api.workshop
+
+  async function handleUnsubscribe() {
+    // Look up the item_id from the Workshop items list.
+    const r = await workshopItemsRef.listItems()
+    if (!r.ok) return
+    const meta = r.data.items.find((i) => i.pack_id === packId)
+    if (!meta) return
+
+    // Tell Steam to unsubscribe.
+    await unsubscribeItem(meta.item_id)
+
+    // Remove from local index.
+    await api.workshop.remove(packId)
+    onUnsubscribed()
+  }
+
+  return (
+    <span
+      data-testid={`workshop-badge-${packId}`}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '0.4rem',
+        padding: '0.1rem 0.5rem',
+        borderRadius: '4px',
+        fontSize: '0.72rem',
+        background: 'rgba(100,200,255,0.08)',
+        color: '#7dd3fc',
+        border: '1px solid rgba(100,200,255,0.2)',
+        fontWeight: 400,
+      }}
+    >
+      Workshop
+      {authorName && (
+        <span style={{ color: '#94a3b8', fontSize: '0.68rem' }}>by {authorName}</span>
+      )}
+      <button
+        onClick={() => void handleUnsubscribe()}
+        data-testid={`workshop-unsubscribe-${packId}`}
+        aria-label={`Unsubscribe from Workshop pack ${packId}`}
+        style={{
+          background: 'none',
+          border: 'none',
+          padding: '0 0.1rem',
+          cursor: 'pointer',
+          color: '#94a3b8',
+          fontSize: '0.68rem',
+          lineHeight: 1,
+        }}
+      >
+        ✕
+      </button>
+    </span>
   )
 }
 

--- a/apps/web/src/screens/ScenarioLibrary.tsx
+++ b/apps/web/src/screens/ScenarioLibrary.tsx
@@ -72,6 +72,7 @@ export default function ScenarioLibrary() {
   const [workshopSyncState, setWorkshopSyncState] = useState<'idle' | 'syncing' | 'done' | 'error'>('idle')
   const [workshopSyncSummary, setWorkshopSyncSummary] = useState<string | null>(null)
   const [workshopItems, setWorkshopItems] = useState<Record<string, { author_name: string; workshop_updated_at: number }>>({})
+  const [workshopQuarantine, setWorkshopQuarantine] = useState<Array<{ item_id: string; reason: string }>>([])
 
   const isSteamEnabled = steamStatus?.is_steam_enabled ?? false
 
@@ -111,6 +112,14 @@ export default function ScenarioLibrary() {
     })
   }
 
+  function loadWorkshopQuarantine() {
+    void api.workshop.listQuarantine().then((r) => {
+      if (r.ok) {
+        setWorkshopQuarantine(r.data.items.map((i) => ({ item_id: i.item_id, reason: i.reason })))
+      }
+    })
+  }
+
   async function handleWorkshopSync() {
     setWorkshopSyncState('syncing')
     setWorkshopSyncSummary(null)
@@ -136,6 +145,9 @@ export default function ScenarioLibrary() {
           loadIndexedPacks()
           loadWorkshopItems()
         }
+        // Always refresh quarantine so newly-rejected packs (and packs that
+        // were fixed upstream and cleared) are reflected with their reasons.
+        loadWorkshopQuarantine()
       } else {
         setWorkshopSyncState('error')
         setWorkshopSyncSummary(errorHeadline(r.error))
@@ -150,6 +162,7 @@ export default function ScenarioLibrary() {
     loadScenarios()
     loadIndexedPacks()
     loadWorkshopItems()
+    loadWorkshopQuarantine()
 
     void api.getModels().then((r) => {
       if (r.ok) {
@@ -337,6 +350,35 @@ export default function ScenarioLibrary() {
           </button>
         </div>
       </div>
+
+      {workshopQuarantine.length > 0 && (
+        <div
+          role="alert"
+          data-testid="workshop-quarantine-banner"
+          style={{
+            background: 'rgba(248,113,113,0.08)',
+            border: '1px solid rgba(248,113,113,0.3)',
+            borderRadius: '6px',
+            padding: '0.75rem 1rem',
+            marginBottom: '1.25rem',
+            fontSize: '0.85rem',
+            color: '#fca5a5',
+          }}
+        >
+          <div style={{ fontWeight: 600, marginBottom: '0.4rem' }}>
+            {workshopQuarantine.length === 1
+              ? '1 Workshop pack was quarantined and not imported:'
+              : `${workshopQuarantine.length} Workshop packs were quarantined and not imported:`}
+          </div>
+          <ul style={{ margin: 0, paddingLeft: '1.1rem' }}>
+            {workshopQuarantine.map((q) => (
+              <li key={q.item_id} data-testid={`workshop-quarantine-item-${q.item_id}`}>
+                <span style={{ color: '#e2e8f0' }}>Item {q.item_id}</span>: {q.reason}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
 
       {modelMissing && (
         <div

--- a/docs/WORKSHOP_MODERATION.md
+++ b/docs/WORKSHOP_MODERATION.md
@@ -1,0 +1,88 @@
+# Steam Workshop Moderation Policy
+
+ConversationSimulator distributes free scenario packs through the Steam Workshop.
+This document describes the moderation stance, the report path for players, and
+the technical safety guarantees that apply to all Workshop content.
+
+## Content scope
+
+Workshop support is limited to **free, declarative scenario packs**. Paid content
+distribution remains outside the Workshop scope (see `docs/marketplace-architecture.md`).
+
+A scenario pack is a collection of YAML files that describe conversation scenarios,
+NPC definitions, rubrics, safety policies, and (optionally) scene metadata.
+No code, scripts, or executable content is permitted.
+
+## Pack validation at import
+
+Every Workshop item is processed through the **same two-phase validation pipeline**
+used for manual zip import:
+
+1. **Forbidden-content scan** — rejects symlinks, executable file extensions
+   (`.exe`, `.bat`, `.sh`, `.js`, `.py`, etc.), and disguised binaries detected
+   by magic-byte inspection (ELF, Mach-O, PE, WASM, shebang).
+
+2. **Schema validation** — validates all YAML files against the official
+   ConversationSimulator schemas (`schemas/*.schema.json`) using the `pack-loader`
+   library.
+
+Packs that fail either phase are **quarantined**: they are never imported into the
+scenario library, never exposed to players, and a readable rejection reason is
+stored locally. The library shows creators which packs were quarantined and why.
+Invalid packs **never crash the application**.
+
+## Runtime safety layer
+
+The global safety system (issue #203) applies to **all** Workshop content identically
+to official packs. Safety rules encoded in a pack's `safety/policy.yaml` are
+enforced at runtime by the AI layer; they can strengthen the default safety policy
+but **cannot override or weaken it**. The safety ceiling set by the application is
+non-negotiable and not addressable by pack authors.
+
+## Creator responsibilities
+
+Pack creators agree to the Steam Subscriber Agreement and Steam Workshop Terms of
+Service at publication time. By submitting a pack, creators affirm that:
+
+- All content is original or appropriately licensed.
+- No executable code, scripts, or binaries are included.
+- All NPC characters are clearly fictional (`fictional: true` in the manifest).
+- The pack's content rating accurately reflects the scenarios within it.
+- The pack does not attempt to subvert the application's safety layer.
+
+## Reporting harmful content
+
+ConversationSimulator does **not** maintain its own Workshop moderation team.
+Content that violates the Steam Workshop rules should be reported through
+Steam's built-in reporting mechanism:
+
+1. Navigate to the Workshop item's page on the Steam Community.
+2. Click the **Report** link in the item's right-hand panel.
+3. Select the appropriate violation category (e.g., "Spam or misleading",
+   "Stolen content", "Cheats / exploits", or "Sexually explicit content").
+
+Valve reviews reported items and may remove them from the Workshop, which
+causes the item to be excluded from future subscription syncs. Items that
+are already locally installed will remain on disk until the player unsubscribes;
+they will no longer receive updates.
+
+**Urgent safety concerns** (content that threatens harm to real individuals)
+should be reported directly to Valve via the
+[Steam Support contact form](https://help.steampowered.com/).
+
+## Non-Steam builds
+
+Workshop UI elements are hidden in non-Steam builds (`SteamStatus.is_steam_enabled
+=== false`). The manual import path (zip file import) remains available on all
+builds and follows the identical validation pipeline.
+
+## Summary of guarantees
+
+| Guarantee | How it is enforced |
+|---|---|
+| No executable content in packs | Forbidden-content scan at import (extensions + magic bytes) |
+| Schema-valid YAML only | AJV 2020 schema validation at import |
+| Invalid packs never crash the library | Quarantine system; errors are stored, never thrown to the UI |
+| Global safety rules apply to Workshop content | Runtime safety layer (#203) is non-bypassable |
+| Report path for harmful content | Steam's built-in Workshop reporting UI |
+| Non-Steam builds unaffected | Workshop UI gated on `is_steam_enabled` |

--- a/packages/pack-loader/src/types.ts
+++ b/packages/pack-loader/src/types.ts
@@ -2,7 +2,7 @@
 
 export const SUPPORTED_SCHEMA_VERSION = '0.1';
 
-export type PackRootKind = 'official' | 'community' | 'local-dev';
+export type PackRootKind = 'official' | 'community' | 'local-dev' | 'workshop';
 
 // ---------------------------------------------------------------------------
 // Raw YAML shapes (schema_version "0.1")


### PR DESCRIPTION
## Summary

Adds Steam Workshop distribution for free scenario packs, addressing issue #311. This enables creators to publish scenario packs directly through Steam's Workshop platform and allows players to subscribe, sync, and manage Workshop content alongside built-in packs.

## Key changes

### Desktop (Tauri)
- Extended the Steam bridge with Workshop UGC support: three new methods on `SteamRuntime` expose Workshop subscriptions, publishing, and unsubscribing to the web layer
- Each method degrades to a safe no-op when the `steam` Cargo feature is disabled, so non-Steam builds are unaffected

### API
- Added two new database tables (`workshop_items` and `workshop_quarantine`) to track successfully imported Workshop packs and quarantined items with rejection reasons
- Implemented `/api/workshop` routes:
  - `POST /sync` — imports subscribed Workshop items through the identical two-phase validation pipeline (forbidden-content scan + AJV schema validation) used for zip import
  - `GET /items` — lists all synced Workshop items
  - `GET /quarantine` — lists quarantined items with their rejection reasons
  - `DELETE /:pack_id` — removes a pack from the index, blocked when active sessions reference it
- Refactored validation logic (forbidden-content scan and pack-loader error conversion) to avoid duplication between zip import and Workshop sync

### Web UI
- Added `useSteamWorkshop` hook to orchestrate Workshop subscription sync with the API
- Integrated Workshop UI into ScenarioLibrary:
  - Sync summary showing counts of newly imported, updated, and failed items
  - Quarantine banner displaying each rejected item with a readable reason
- Integrated Workshop publish UI into CreatorWorkbench, allowing creators to publish packs through Steam's overlay consent flow
- Updated type system to distinguish Workshop packs (`PackRootKind: 'workshop'`) in the shared pack index

### Safety & correctness
- All Workshop content passes the same two-phase validation pipeline as manual zip import: forbidden-content scan blocks executables/symlinks/binaries (magic-byte detection), then AJV validates all YAML against official schemas
- Invalid packs are quarantined immediately and never imported; a readable rejection reason is stored locally and surfaced in the UI
- Invalid packs never crash the application, and their errors are never thrown to the client
- Unsubscription is blocked if active sessions reference the pack, preventing file deletion while scenarios are in use

### Documentation
- Added `docs/WORKSHOP_MODERATION.md`, documenting the moderation stance, validation guarantees, content scope, and report path for harmful content (Steam's built-in reporting mechanism)

Closes #311