### PR TITLE
Fix convsim-core.exe dead on arrival in PyInstaller bundle by passing app object to uvicorn.run

### DIFF
--- a/.github/workflows/binary-health-check.yml
+++ b/.github/workflows/binary-health-check.yml
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+# Regression guard for issue #352: verify that the PyInstaller-built
+# convsim-core binary starts successfully and answers /api/health within 10 s.
+#
+# In a frozen PyInstaller bundle the entry script executes as __main__, so the
+# module convsim_core.main is not present in the frozen importer's namespace.
+# Passing an import string to uvicorn.run() causes uvicorn to call
+# importlib.import_module("convsim_core.main"), which raises ModuleNotFoundError
+# and kills the binary before it binds a port.  This workflow catches that class
+# of regression automatically on all three shipping platforms.
+#
+# The binary is built from source on each runner so the test exercises exactly
+# the same PyInstaller code path used by the release workflow.
+
+name: Binary health check
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'services/convsim-core/**'
+      - '.github/workflows/binary-health-check.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'services/convsim-core/**'
+      - '.github/workflows/binary-health-check.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  binary-health-check:
+    name: Binary health check / ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux-x86_64
+            runner: ubuntu-latest
+          - name: macOS-aarch64
+            runner: macos-latest
+          - name: Windows-x86_64
+            runner: windows-2022
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: |
+            services/convsim-core/pyproject.toml
+            packages/prompt-composer/pyproject.toml
+
+      - name: Install prompt-composer
+        run: pip install -e "packages/prompt-composer"
+
+      - name: Install convsim-core with build extras
+        run: pip install -e "services/convsim-core[build]"
+
+      - name: Build convsim-core binary with PyInstaller
+        shell: bash
+        working-directory: services/convsim-core
+        run: python -m PyInstaller convsim-core.spec --noconfirm
+
+      # ── Linux / macOS ──────────────────────────────────────────────────────────
+      - name: Start binary and verify /api/health (Linux / macOS)
+        if: runner.os != 'Windows'
+        shell: bash
+        working-directory: services/convsim-core
+        run: |
+          set -euo pipefail
+          BINARY=dist/convsim-core
+
+          echo "=== Starting $BINARY ==="
+          "$BINARY" &
+          BINARY_PID=$!
+          echo "Binary PID: $BINARY_PID"
+
+          echo "=== Polling /api/health (10 s deadline) ==="
+          python3 - <<'PYEOF'
+          import sys, time, urllib.request, urllib.error
+
+          deadline = time.time() + 10
+          last_err = None
+          while time.time() < deadline:
+              try:
+                  with urllib.request.urlopen("http://127.0.0.1:7355/api/health", timeout=2) as r:
+                      if r.status == 200:
+                          print(f"OK: /api/health responded with HTTP {r.status}")
+                          sys.exit(0)
+              except Exception as exc:
+                  last_err = exc
+              time.sleep(0.5)
+
+          print(f"FAIL: /api/health did not respond within 10 s. Last error: {last_err}", file=sys.stderr)
+          sys.exit(1)
+          PYEOF
+
+          echo "=== Stopping binary ==="
+          kill "$BINARY_PID" 2>/dev/null || true
+
+      # ── Windows ───────────────────────────────────────────────────────────────
+      - name: Start binary and verify /api/health (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        working-directory: services/convsim-core
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $binary = "dist\convsim-core.exe"
+
+          Write-Host "=== Starting $binary ==="
+          $proc = Start-Process -FilePath $binary -PassThru -WindowStyle Hidden
+          Write-Host "Binary PID: $($proc.Id)"
+
+          Write-Host "=== Polling /api/health (10 s deadline) ==="
+          $deadline = (Get-Date).AddSeconds(10)
+          $ok = $false
+          while ((Get-Date) -lt $deadline) {
+              try {
+                  $resp = Invoke-WebRequest -Uri "http://127.0.0.1:7355/api/health" `
+                      -UseBasicParsing -TimeoutSec 2 -ErrorAction Stop
+                  if ($resp.StatusCode -eq 200) {
+                      Write-Host "OK: /api/health responded with HTTP $($resp.StatusCode)"
+                      $ok = $true
+                      break
+                  }
+              } catch {
+                  # not ready yet
+              }
+              Start-Sleep -Milliseconds 500
+          }
+
+          Write-Host "=== Stopping binary ==="
+          try { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue } catch {}
+
+          if (-not $ok) {
+              Write-Error "FAIL: /api/health did not respond within 10 s"
+              exit 1
+          }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,41 @@
 <!-- SPDX-License-Identifier: CC-BY-4.0 -->
+# Conversation Simulator v0.2.1 — Release Notes
+
+> **Patch release** — hotfix for the v0.2.0 Windows DOA (dead on arrival) bug.
+> All Windows users on v0.2.0 must update; macOS and Linux are unaffected but
+> are included in this release for consistency.
+
+---
+
+## What's fixed in v0.2.1
+
+### [Bug] Windows: `convsim-core.exe` exited immediately on any invocation (#352)
+
+Fresh v0.2.0 installs on Windows were broken: the sidecar process died the
+instant it was launched (exit code 1, recovery card shown every time). The
+root cause was an import-string passed to `uvicorn.run()` inside the
+PyInstaller bundle.
+
+**Root cause:** `main()` called `uvicorn.run("convsim_core.main:app", ...)`.
+In a frozen PyInstaller executable the entry script runs as `__main__`, so
+`convsim_core.main` is not present in the frozen importer's namespace. When
+uvicorn tried to resolve the string via `importlib.import_module`, it raised
+`ModuleNotFoundError` before the server ever bound a port. This was
+undetectable in a standard developer-venv run, where the package is always
+importable.
+
+**Fix:** `main()` now passes the ASGI app object directly:
+`uvicorn.run(app, ...)`. Since `reload=False` is the default, the import-string
+indirection bought nothing; the object form is equivalent in behaviour and works
+correctly inside a frozen executable.
+
+**Regression guard added:** A new CI workflow (`binary-health-check.yml`) builds
+the PyInstaller binary from source on Linux, macOS, and Windows and verifies
+that the binary starts and answers `GET /api/health` within 10 s. This catches
+any future recurrence of this class of frozen-importer regression.
+
+---
+
 # Conversation Simulator v0.1.0-alpha.1 — Release Notes
 
 > **Alpha release** — This build is an early preview. Expect rough edges and

--- a/services/convsim-core/convsim_core/main.py
+++ b/services/convsim-core/convsim_core/main.py
@@ -19,11 +19,10 @@ app = create_app(_config)
 
 def main() -> None:
     uvicorn.run(
-        "convsim_core.main:app",
+        app,
         host=_config.host,
         port=_config.port,
         log_config=None,
-        reload=False,
     )
 
 

--- a/services/convsim-core/tests/test_main.py
+++ b/services/convsim-core/tests/test_main.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Verify that main() passes the ASGI app object to uvicorn, not an import string.
+
+In a PyInstaller bundle the entry script runs as __main__, so the module
+convsim_core.main is NOT present in the frozen importer's namespace. Passing
+an import string to uvicorn.run() causes uvicorn to call
+importlib.import_module("convsim_core.main"), which raises ModuleNotFoundError
+and kills the binary on any invocation (issue #352).
+
+Passing the object directly avoids the frozen-importer lookup entirely and is
+safe because reload=False is the default, so the indirection buys nothing.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch, MagicMock
+
+import uvicorn
+from fastapi import FastAPI
+
+import convsim_core.main as main_mod
+
+
+def test_main_passes_app_object_not_string():
+    """main() must hand uvicorn.run() the ASGI app object, not an import string."""
+    captured: list = []
+
+    def fake_run(app_or_str, **kwargs):
+        captured.append(app_or_str)
+
+    with patch.object(uvicorn, "run", fake_run):
+        main_mod.main()
+
+    assert captured, "uvicorn.run was never called"
+    first_arg = captured[0]
+    assert not isinstance(first_arg, str), (
+        f"main() passed an import string {first_arg!r} to uvicorn.run(); "
+        "in a PyInstaller bundle this causes a ModuleNotFoundError. "
+        "Pass the app object directly instead."
+    )
+    assert isinstance(first_arg, FastAPI), (
+        f"Expected a FastAPI app instance, got {type(first_arg)}"
+    )
+
+
+def test_main_passes_correct_host_and_port():
+    """main() forwards host and port from ServiceConfig to uvicorn.run()."""
+    captured_kwargs: list[dict] = []
+
+    def fake_run(app_or_str, **kwargs):
+        captured_kwargs.append(kwargs)
+
+    with patch.object(uvicorn, "run", fake_run):
+        main_mod.main()
+
+    assert captured_kwargs
+    kw = captured_kwargs[0]
+    assert kw["host"] == main_mod._config.host
+    assert kw["port"] == main_mod._config.port
+    assert kw["log_config"] is None


### PR DESCRIPTION
## Summary

**Issue:** `convsim-core.exe` exited with code 1 on every invocation in v0.2.0 Windows releases (#352).

**Root cause:** `main()` in `services/convsim-core/convsim_core/main.py` was calling `uvicorn.run("convsim_core.main:app", ...)`. In a PyInstaller frozen executable, the entry script runs as `__main__`, so the module `convsim_core.main` is absent from the frozen importer's namespace. When uvicorn tried to resolve the import string via `importlib.import_module()`, it raised `ModuleNotFoundError` before the server bound a port, killing the binary on every launch. This bug went undetected in development because the package is always importable in a standard venv.

**Fix:** Changed `uvicorn.run("convsim_core.main:app", ...)` to `uvicorn.run(app, ...)` — pass the ASGI app object directly. Since `reload=False` is the default, the import-string indirection was redundant; the object form is functionally identical and works in both venv and frozen-exe environments.

**Regression guard:** Added `.github/workflows/binary-health-check.yml`, which builds the PyInstaller binary from source on Linux, macOS, and Windows, then launches it and verifies that `GET /api/health` responds HTTP 200 within 10 s. This catches frozen-importer regressions before they reach a tagged release.

**Testing:** Added `services/convsim-core/tests/test_main.py` with two tests:
- `test_main_passes_app_object_not_string()` — asserts that `uvicorn.run()` receives the `FastAPI` app instance, not a string.
- `test_main_passes_correct_host_and_port()` — verifies that host, port, and log config are forwarded correctly.

All tests pass locally. The new CI workflow exercises the built binary on all three platforms.

## Backward compatibility

- `python -m convsim_core.main` — unaffected.
- `uvicorn convsim_core.main:app` — unaffected (module-level `app` export is unchanged).
- Installed `convsim-core` console script — unaffected.

Closes #352