### PR TITLE
Fix recovery card to show the resolved platform-specific log path and add Open logs folder button

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -19,6 +19,10 @@ struct CoreStatusPayload {
     phase: String,
     message: String,
     error: Option<String>,
+    /// Absolute path to the app log directory on this platform.
+    /// Included so the recovery card can show (and open) the correct path
+    /// without hardcoding ~/.convsim or any other platform-specific default.
+    log_dir: Option<String>,
 }
 
 // ── Update check ─────────────────────────────────────────────────────────────
@@ -270,11 +274,13 @@ fn emit_core_status(
     phase: &str,
     message: &str,
     error: Option<&str>,
+    log_dir: Option<&str>,
 ) {
     let payload = CoreStatusPayload {
         phase: phase.to_string(),
         message: message.to_string(),
         error: error.map(|s| s.to_string()),
+        log_dir: log_dir.map(|s| s.to_string()),
     };
     if let Ok(mut guard) = store.lock() {
         *guard = Some(payload.clone());
@@ -383,10 +389,18 @@ fn launch_or_verify_core(
     std::thread::spawn(move || {
         const CORE_PORT: u16 = 7355;
 
+        // Compute the platform-specific log directory once so every status event
+        // carries the correct absolute path for the recovery card to display.
+        let log_dir: Option<String> = app.path()
+            .app_local_data_dir()
+            .ok()
+            .map(|p| p.join("logs").to_string_lossy().into_owned());
+        let log_dir_ref = log_dir.as_deref();
+
         // If core is already responding (e.g. started by dev-desktop.sh), signal
         // ready immediately.
         if is_port_open(CORE_PORT) {
-            emit_core_status(&app, &status_arc, "ready", "Core service is ready.", None);
+            emit_core_status(&app, &status_arc, "ready", "Core service is ready.", None, log_dir_ref);
             return;
         }
 
@@ -396,7 +410,7 @@ fn launch_or_verify_core(
             for _ in 0..20u32 {
                 std::thread::sleep(Duration::from_millis(500));
                 if is_port_open(CORE_PORT) {
-                    emit_core_status(&app, &status_arc, "ready", "Core service is ready.", None);
+                    emit_core_status(&app, &status_arc, "ready", "Core service is ready.", None, log_dir_ref);
                     return;
                 }
             }
@@ -409,13 +423,14 @@ fn launch_or_verify_core(
                     "In dev mode, start convsim-core before launching the desktop app:\n\
                      ./scripts/dev-desktop.sh",
                 ),
+                log_dir_ref,
             );
             return;
         }
 
         // ── Release mode: find, launch, and supervise convsim-core ───────────
 
-        emit_core_status(&app, &status_arc, "starting", "Locating core service…", None);
+        emit_core_status(&app, &status_arc, "starting", "Locating core service…", None, log_dir_ref);
 
         let resource_dir = app.path().resource_dir().ok();
 
@@ -428,12 +443,13 @@ fn launch_or_verify_core(
                     "error",
                     "Could not locate core service.",
                     Some(&e),
+                    log_dir_ref,
                 );
                 return;
             }
         };
 
-        emit_core_status(&app, &status_arc, "starting", "Starting core service…", None);
+        emit_core_status(&app, &status_arc, "starting", "Starting core service…", None, log_dir_ref);
 
         // convsim-core reads its bind address from CONVSIM_HOST / CONVSIM_PORT
         // (see services/convsim-core/convsim_core/config.py); it does not parse
@@ -485,10 +501,9 @@ fn launch_or_verify_core(
                     "The core service binary is not executable. \
                      This may indicate a corrupted installation — reinstall the app."
                 } else {
-                    "Failed to start the core service process. \
-                     Check the logs at ~/.convsim/logs for details."
+                    "Failed to start the core service process."
                 };
-                emit_core_status(&app, &status_arc, "error", hint, Some(&e.to_string()));
+                emit_core_status(&app, &status_arc, "error", hint, Some(&e.to_string()), log_dir_ref);
                 return;
             }
         };
@@ -506,6 +521,7 @@ fn launch_or_verify_core(
             "starting",
             "Waiting for core service to be ready…",
             None,
+            log_dir_ref,
         );
 
         for attempt in 0..30u32 {
@@ -525,7 +541,8 @@ fn launch_or_verify_core(
                             &status_arc,
                             "error",
                             &msg,
-                            Some("Check the logs at ~/.convsim/logs for details."),
+                            None,
+                            log_dir_ref,
                         );
                         return;
                     }
@@ -533,7 +550,7 @@ fn launch_or_verify_core(
             }
 
             if is_port_open(CORE_PORT) {
-                emit_core_status(&app, &status_arc, "ready", "Core service is ready.", None);
+                emit_core_status(&app, &status_arc, "ready", "Core service is ready.", None, log_dir_ref);
                 return;
             }
 
@@ -544,6 +561,7 @@ fn launch_or_verify_core(
                     "starting",
                     "Still starting core service — this may take a moment on first run…",
                     None,
+                    log_dir_ref,
                 );
             }
         }
@@ -556,8 +574,9 @@ fn launch_or_verify_core(
             "Core service did not become ready in time.",
             Some(
                 "The service started but did not respond within 15 seconds. \
-                 Check the logs at ~/.convsim/logs, then restart the app.",
+                 Open the logs folder for details, then restart the app.",
             ),
+            log_dir_ref,
         );
     });
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -391,10 +391,21 @@ fn launch_or_verify_core(
 
         // Compute the platform-specific log directory once so every status event
         // carries the correct absolute path for the recovery card to display.
+        //
+        // Create it eagerly: convsim-core normally creates logs/ when it runs
+        // configure_logging(), but if it never starts (binary missing, immediate
+        // exec failure) that never happens — leaving the recovery card's "Open
+        // logs folder" button pointing at a non-existent path and dead-ending the
+        // very stranded user the card exists to help. Making the directory here
+        // guarantees the path shown always exists and is openable.
         let log_dir: Option<String> = app.path()
             .app_local_data_dir()
             .ok()
-            .map(|p| p.join("logs").to_string_lossy().into_owned());
+            .map(|p| p.join("logs"))
+            .map(|p| {
+                let _ = std::fs::create_dir_all(&p);
+                p.to_string_lossy().into_owned()
+            });
         let log_dir_ref = log_dir.as_deref();
 
         // If core is already responding (e.g. started by dev-desktop.sh), signal

--- a/apps/web/src/__tests__/CoreStartup.test.tsx
+++ b/apps/web/src/__tests__/CoreStartup.test.tsx
@@ -289,6 +289,58 @@ describe('CoreStartupGuard — error state', () => {
 
     expect(screen.queryByText('App content loaded')).not.toBeInTheDocument()
   })
+
+  it('shows the resolved log directory from the event payload', async () => {
+    let handler: TauriListenHandler | undefined
+    stubTauri((_event, h) => {
+      handler = h
+      return Promise.resolve(() => {})
+    })
+
+    await act(async () => {
+      renderGuard()
+    })
+
+    await act(async () => {
+      handler?.({
+        payload: {
+          phase: 'error',
+          message: 'Failed.',
+          error: null,
+          log_dir: 'C:\\Users\\test\\AppData\\Local\\com.outrightmental.convsim\\logs',
+        },
+      })
+    })
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'C:\\Users\\test\\AppData\\Local\\com.outrightmental.convsim\\logs',
+    )
+  })
+
+  it('shows "Open logs folder" button when log_dir is present in error payload', async () => {
+    let handler: TauriListenHandler | undefined
+    stubTauri((_event, h) => {
+      handler = h
+      return Promise.resolve(() => {})
+    })
+
+    await act(async () => {
+      renderGuard()
+    })
+
+    await act(async () => {
+      handler?.({
+        payload: {
+          phase: 'error',
+          message: 'Failed.',
+          error: null,
+          log_dir: '/home/user/.local/share/convsim/logs',
+        },
+      })
+    })
+
+    expect(screen.getByRole('button', { name: /open logs folder/i })).toBeInTheDocument()
+  })
 })
 
 describe('CoreStartupGuard — health check fast-path', () => {

--- a/apps/web/src/__tests__/RuntimeRecoveryCard.test.tsx
+++ b/apps/web/src/__tests__/RuntimeRecoveryCard.test.tsx
@@ -63,16 +63,28 @@ describe('RuntimeRecoveryCard — basic rendering', () => {
     expect(screen.queryByText(/port/i)).not.toBeInTheDocument()
   })
 
-  it('shows the log path when provided', () => {
+  it('shows the log folder path when provided', () => {
     render(
       <RuntimeRecoveryCard
         title="Title"
         description="Desc"
-        logPath="~/.convsim/logs/app.log"
+        logPath="/home/user/.local/share/convsim/logs"
         troubleshootingHref={TROUBLESHOOTING_HREF}
       />,
     )
-    expect(screen.getByText('~/.convsim/logs/app.log')).toBeInTheDocument()
+    expect(screen.getByText('/home/user/.local/share/convsim/logs')).toBeInTheDocument()
+  })
+
+  it('shows "Logs folder:" label with the path', () => {
+    render(
+      <RuntimeRecoveryCard
+        title="Title"
+        description="Desc"
+        logPath="/home/user/.local/share/convsim/logs"
+        troubleshootingHref={TROUBLESHOOTING_HREF}
+      />,
+    )
+    expect(screen.getByRole('alert')).toHaveTextContent(/logs folder:/i)
   })
 })
 

--- a/apps/web/src/__tests__/VoiceSettingsPanel.test.tsx
+++ b/apps/web/src/__tests__/VoiceSettingsPanel.test.tsx
@@ -109,8 +109,7 @@ describe('voice readiness cards', () => {
 
   it('shows STT as ready when health reports stt_ready', async () => {
     render(<VoiceSettingsPanel />)
-    await waitFor(() => expect(screen.getByTestId('readiness-stt')).toBeInTheDocument())
-    expect(screen.getByTestId('readiness-stt')).toHaveTextContent('model loaded')
+    await waitFor(() => expect(screen.getByTestId('readiness-stt')).toHaveTextContent('model loaded'))
   })
 
   it('shows TTS as ready when health reports tts_ready', async () => {

--- a/apps/web/src/components/RuntimeRecoveryCard.tsx
+++ b/apps/web/src/components/RuntimeRecoveryCard.tsx
@@ -13,7 +13,7 @@ interface RuntimeRecoveryCardProps {
   title: string
   description: string
   errorDetail?: string | null
-  /** Path to the log file shown to advanced users. */
+  /** Path to the log directory shown to advanced users. */
   logPath?: string | null
   /** URL of the troubleshooting guide anchor for this failure class. */
   troubleshootingHref: string
@@ -137,7 +137,7 @@ export default function RuntimeRecoveryCard({
       {errorDetail && <p style={detailStyle}>{errorDetail}</p>}
       {logPath && (
         <p style={{ ...bodyStyle, marginBottom: '0' }}>
-          Logs:{' '}
+          Logs folder:{' '}
           <code style={{ fontSize: '0.8rem', color: '#71717a' }}>{logPath}</code>
         </p>
       )}

--- a/apps/web/src/screens/CoreStartup.tsx
+++ b/apps/web/src/screens/CoreStartup.tsx
@@ -8,6 +8,7 @@ interface CoreStatusPayload {
   phase: 'starting' | 'ready' | 'error'
   message: string
   error: string | null
+  log_dir?: string | null
 }
 
 interface TauriGlobal {
@@ -68,8 +69,7 @@ function classifyError(message: string, error: string | null): ErrorInfo {
   return {
     kind: 'crash',
     title: "The conversation engine didn't start",
-    description:
-      'Something went wrong when the app tried to start. Check the logs for details.',
+    description: 'Something went wrong when the app tried to start.',
     anchor: '#engine-startup-failure',
   }
 }
@@ -181,14 +181,25 @@ export default function CoreStartupGuard({ children }: { children: React.ReactNo
             title={errorInfo.title}
             description={errorInfo.description}
             errorDetail={status!.error}
-            logPath="~/.convsim/logs/app.log"
+            logPath={status!.log_dir ?? null}
             troubleshootingHref={`${TROUBLESHOOTING_BASE}${errorInfo.anchor}`}
             troubleshootingLabel="Troubleshooting guide"
             primaryAction={{
               label: 'Restart the app',
               onClick: () => window.location.reload(),
             }}
-            secondaryAction={{
+            secondaryAction={
+              status!.log_dir
+                ? {
+                    label: 'Open logs folder',
+                    onClick: () => {
+                      const logDir = status!.log_dir!
+                      void window.__TAURI__?.core?.invoke('plugin:shell|open', { path: logDir })
+                    },
+                  }
+                : undefined
+            }
+            tertiaryAction={{
               // The in-app support/crash-bundle screen is behind CoreStartupGuard
               // and needs the (currently down) core API, so it is unreachable
               // during a startup failure. Point players at the report-issue flow

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -23,7 +23,7 @@ The packaged app writes logs to the platform-specific application data directory
 |---|---|
 | Windows | `%LOCALAPPDATA%\com.outrightmental.convsim\logs\` |
 | macOS | `~/Library/Application Support/com.outrightmental.convsim/logs/` |
-| Linux / Steam Deck | `~/.local/share/convsim/logs/` (or `$XDG_DATA_HOME/convsim/logs/`) |
+| Linux / Steam Deck | `~/.local/share/com.outrightmental.convsim/logs/` (or `$XDG_DATA_HOME/com.outrightmental.convsim/logs/`) |
 
 The recovery card shows the exact path for your machine and includes an **Open logs folder** button. In developer mode (running without Tauri), logs go to `~/.convsim/logs/` unless `CONVSIM_DATA_ROOT` is set.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -25,7 +25,7 @@ The packaged app writes logs to the platform-specific application data directory
 | macOS | `~/Library/Application Support/com.outrightmental.convsim/logs/` |
 | Linux / Steam Deck | `~/.local/share/com.outrightmental.convsim/logs/` (or `$XDG_DATA_HOME/com.outrightmental.convsim/logs/`) |
 
-The recovery card shows the exact path for your machine and includes an **Open logs folder** button. In developer mode (running without Tauri), logs go to `~/.convsim/logs/` unless `CONVSIM_DATA_ROOT` is set.
+The recovery card shows the exact path for your machine and includes an **Open logs folder** button. In developer mode (running without Tauri), the `./scripts/dev.sh` and `./scripts/dev-desktop.sh` helpers set `CONVSIM_LOG_DIR=~/.convsim/logs`, so logs go there. Running `convsim-core` directly without `CONVSIM_LOG_DIR` writes to the platform-specific directory above (or `<CONVSIM_DATA_ROOT>/logs` when `CONVSIM_DATA_ROOT` is set).
 
 > **Legacy `~/.convsim` directory:** versions before v0.2.0 stored all app data under `~/.convsim/`. The packaged app no longer writes there. On first launch it runs a one-time migration that **copies** (never moves) `db/`, `packs/`, and other data into the platform-specific directory above — but only when that directory is still empty. If the new location already had data, migration is skipped and your `~/.convsim/` files are left untouched. Because the originals are only ever copied, `~/.convsim/` is safe to keep as a backup. Before deleting it, open the platform-specific directory above and confirm your `db/` and `packs/` folders are present there; a `.convsim_migrated_to_platform_dir` marker file inside `~/.convsim/` indicates a completed migration.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -27,7 +27,7 @@ The packaged app writes logs to the platform-specific application data directory
 
 The recovery card shows the exact path for your machine and includes an **Open logs folder** button. In developer mode (running without Tauri), logs go to `~/.convsim/logs/` unless `CONVSIM_DATA_ROOT` is set.
 
-> **Legacy `~/.convsim` directory:** versions before v0.2.0 stored all app data under `~/.convsim/`. That directory is no longer used by the packaged app. If you have a `~/.convsim/db/` or `~/.convsim/packs/` left over from an older install, they can be safely deleted — the app migrated that data to the platform-specific directory on first launch.
+> **Legacy `~/.convsim` directory:** versions before v0.2.0 stored all app data under `~/.convsim/`. The packaged app no longer writes there. On first launch it runs a one-time migration that **copies** (never moves) `db/`, `packs/`, and other data into the platform-specific directory above — but only when that directory is still empty. If the new location already had data, migration is skipped and your `~/.convsim/` files are left untouched. Because the originals are only ever copied, `~/.convsim/` is safe to keep as a backup. Before deleting it, open the platform-specific directory above and confirm your `db/` and `packs/` folders are present there; a `.convsim_migrated_to_platform_dir` marker file inside `~/.convsim/` indicates a completed migration.
 
 **Recovery steps:**
 
@@ -95,7 +95,7 @@ Possible causes:
 
 1. **Insufficient VRAM:** the model requires more GPU memory than is available. Try the starter model (Qwen3 4B, ~2.6 GB, 4 GB VRAM minimum). To force CPU-only mode and bypass the GPU entirely, open **Settings → Advanced**, set GPU layers (`n_gpu_layers`) to 0, and reload the model. Inference will be slower but the model will load.
 
-2. **Corrupted download:** delete the file from the `models/llm/` subfolder inside your log directory (see [Where are the logs?](#engine-startup-failure) above for the platform-specific path) and re-download through the model manager.
+2. **Corrupted download:** delete the file from the `models/llm/` subfolder of the application data directory (the parent of the `logs/` folder shown in [Where are the logs?](#engine-startup-failure) above — e.g. `%LOCALAPPDATA%\com.outrightmental.convsim\models\llm\` on Windows) and re-download through the model manager.
 
 3. **llama-server binary not found:** the llama.cpp binary must be present before the LLM runtime can start. Run `./runtimes/llama_cpp/download-runtime.sh` to fetch the binary for your platform. If that script is not yet available, check the [GitHub releases](https://github.com/outrightmental/ConversationSimulator/releases) page for pre-built binaries.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -13,13 +13,27 @@ The app could not start its background conversation engine (`convsim-core`). Com
 
 - **Port conflict:** another application is using port 7355. See [Port conflicts](#port-conflicts) below.
 - **Binary not found:** the `convsim-core` executable is missing. Reinstall the app or run `./scripts/setup.sh`.
-- **Crash on startup:** check the logs at `~/.convsim/logs/app.log` for the specific error.
+- **Crash on startup:** open the logs folder (the recovery card shows an **Open logs folder** button) and check `app.log` for the specific error.
+
+**Where are the logs?**
+
+The packaged app writes logs to the platform-specific application data directory:
+
+| Platform | Log directory |
+|---|---|
+| Windows | `%LOCALAPPDATA%\com.outrightmental.convsim\logs\` |
+| macOS | `~/Library/Application Support/com.outrightmental.convsim/logs/` |
+| Linux / Steam Deck | `~/.local/share/convsim/logs/` (or `$XDG_DATA_HOME/convsim/logs/`) |
+
+The recovery card shows the exact path for your machine and includes an **Open logs folder** button. In developer mode (running without Tauri), logs go to `~/.convsim/logs/` unless `CONVSIM_DATA_ROOT` is set.
+
+> **Legacy `~/.convsim` directory:** versions before v0.2.0 stored all app data under `~/.convsim/`. That directory is no longer used by the packaged app. If you have a `~/.convsim/db/` or `~/.convsim/packs/` left over from an older install, they can be safely deleted — the app migrated that data to the platform-specific directory on first launch.
 
 **Recovery steps:**
 
 1. Close other applications that might be using port 7355.
 2. Restart Conversation Simulator from Steam or your installation.
-3. If the problem persists, collect logs from `~/.convsim/logs/` and open a [GitHub issue](https://github.com/outrightmental/ConversationSimulator/issues).
+3. If the problem persists, open the logs folder using the **Open logs folder** button on the recovery card, collect `app.log`, and open a [GitHub issue](https://github.com/outrightmental/ConversationSimulator/issues).
 
 **"The conversation engine stopped"**
 
@@ -27,7 +41,7 @@ The engine started but stopped during a session. This can happen if the AI model
 
 1. Click **Restart conversation engine** in the status card on the home screen.
 2. If the problem repeats, try a lighter model from **Settings → Models**.
-3. Check `~/.convsim/logs/app.log` for crash details.
+3. Check `app.log` in the logs folder (see table above) for crash details.
 
 ---
 
@@ -81,7 +95,7 @@ Possible causes:
 
 1. **Insufficient VRAM:** the model requires more GPU memory than is available. Try the starter model (Qwen3 4B, ~2.6 GB, 4 GB VRAM minimum). To force CPU-only mode and bypass the GPU entirely, open **Settings → Advanced**, set GPU layers (`n_gpu_layers`) to 0, and reload the model. Inference will be slower but the model will load.
 
-2. **Corrupted download:** delete the file from `~/.convsim/models/llm/` and re-download through the model manager.
+2. **Corrupted download:** delete the file from the `models/llm/` subfolder inside your log directory (see [Where are the logs?](#engine-startup-failure) above for the platform-specific path) and re-download through the model manager.
 
 3. **llama-server binary not found:** the llama.cpp binary must be present before the LLM runtime can start. Run `./runtimes/llama_cpp/download-runtime.sh` to fetch the binary for your platform. If that script is not yet available, check the [GitHub releases](https://github.com/outrightmental/ConversationSimulator/releases) page for pre-built binaries.
 
@@ -95,7 +109,7 @@ The model is loaded but producing unexpected output. Try:
 
 1. Switching to a larger model from the registry.
 2. Reducing context length: open **Settings → Advanced**, lower the context length to 4 096, and restart the app.
-3. Checking `~/.convsim/logs/` for errors from convsim-core or the LLM runtime.
+3. Checking the logs folder (see [Where are the logs?](#engine-startup-failure) for the platform-specific path) for errors from convsim-core or the LLM runtime.
 
 ---
 
@@ -163,7 +177,7 @@ When STT is available, a microphone icon will appear in the conversation input. 
 
 1. Check that your browser has microphone permission for `127.0.0.1`.
 2. Confirm convsim-stt is running on port 7357 — look for it in the `./scripts/dev.sh` output.
-3. Check `~/.convsim/logs/` for errors from the STT service.
+3. Check the logs folder (see [Where are the logs?](#engine-startup-failure) for the platform-specific path) for errors from the STT service.
 
 **"Voice output unavailable" on the conversation screen**
 

--- a/services/convsim-core/convsim_core/logging_setup.py
+++ b/services/convsim-core/convsim_core/logging_setup.py
@@ -25,11 +25,20 @@ class _JsonFormatter(logging.Formatter):
 
 
 class _RuntimeFilter(logging.Filter):
-    """Accept only log records from the runtimes sub-package."""
+    """Accept only log records from the runtime sub-packages.
+
+    Matches both ``convsim_core.runtime.*`` (the actual package path) and the
+    historical ``convsim_core.runtimes.*`` alias so that neither naming variant
+    is silently dropped from runtime.log.
+    """
 
     def filter(self, record: logging.LogRecord) -> bool:
         name = record.name
-        return name == "convsim_core.runtimes" or name.startswith("convsim_core.runtimes.")
+        return (
+            name in ("convsim_core.runtime", "convsim_core.runtimes")
+            or name.startswith("convsim_core.runtime.")
+            or name.startswith("convsim_core.runtimes.")
+        )
 
 
 def configure_logging(log_dir: str, debug: bool = False) -> None:
@@ -76,10 +85,13 @@ def configure_logging(log_dir: str, debug: bool = False) -> None:
     rt_fh.setFormatter(json_fmt)
     rt_fh.addFilter(_RuntimeFilter())
 
-    # Attach to the runtimes logger so it propagates to app.log as well.
-    rt_logger = logging.getLogger("convsim_core.runtimes")
-    rt_logger.addHandler(rt_fh)
-    rt_logger.propagate = True
+    # Attach to both runtime logger trees so events propagate to app.log as well.
+    # convsim_core.runtime is the actual package path; convsim_core.runtimes is
+    # kept for compatibility with any code that used the old name.
+    for _rt_name in ("convsim_core.runtime", "convsim_core.runtimes"):
+        _rt_logger = logging.getLogger(_rt_name)
+        _rt_logger.addHandler(rt_fh)
+        _rt_logger.propagate = True
 
     ch = logging.StreamHandler(sys.stdout)
     ch.setFormatter(logging.Formatter("%(levelname)s %(name)s: %(message)s"))

--- a/services/convsim-core/tests/test_logging_setup.py
+++ b/services/convsim-core/tests/test_logging_setup.py
@@ -87,6 +87,19 @@ def test_runtime_filter_accepts_runtimes_root():
     assert f.filter(record) is True
 
 
+def test_runtime_filter_accepts_runtime_package():
+    """convsim_core.runtime.* (without s) must also route to runtime.log."""
+    f = _RuntimeFilter()
+    record = _make_record("convsim_core.runtime.supervisor", logging.WARNING, "msg")
+    assert f.filter(record) is True
+
+
+def test_runtime_filter_accepts_runtime_root():
+    f = _RuntimeFilter()
+    record = _make_record("convsim_core.runtime", logging.INFO, "msg")
+    assert f.filter(record) is True
+
+
 def test_runtime_filter_rejects_app_logger():
     f = _RuntimeFilter()
     record = _make_record("convsim_core.app", logging.WARNING, "msg")
@@ -105,6 +118,12 @@ def test_runtime_filter_rejects_partial_prefix():
     assert f.filter(record) is False
 
 
+def test_runtime_filter_rejects_partial_runtime_prefix():
+    f = _RuntimeFilter()
+    record = _make_record("convsim_core.runtime_extra", logging.INFO, "msg")
+    assert f.filter(record) is False
+
+
 # ---------------------------------------------------------------------------
 # configure_logging — called with an isolated fresh logger to avoid conflicts
 # with pytest's own root-logger capture handler.
@@ -120,14 +139,17 @@ def _call_configure_logging_isolated(log_dir: str, debug: bool = False) -> None:
     original handlers and any new ones after the call, leaving global state
     intact for the remainder of the test.
 
-    Also tracks new handlers added to the runtimes sub-logger (rt_fh) so the
+    Also tracks new handlers added to both runtime sub-loggers (rt_fh) so the
     autouse cleanup fixture can close and remove them; without this they would
     accumulate across tests and leak open file handles.
     """
     root = logging.getLogger()
-    rt = logging.getLogger("convsim_core.runtimes")
+    rt_loggers = [
+        logging.getLogger("convsim_core.runtime"),
+        logging.getLogger("convsim_core.runtimes"),
+    ]
     original_root = root.handlers[:]
-    original_rt = rt.handlers[:]
+    original_rt = {rt: rt.handlers[:] for rt in rt_loggers}
     root.handlers.clear()
     try:
         configure_logging(log_dir, debug=debug)
@@ -135,7 +157,12 @@ def _call_configure_logging_isolated(log_dir: str, debug: bool = False) -> None:
         # Keep the newly added file handlers so the test can assert on files,
         # but also restore any original handlers that were removed.
         new_root_handlers = [h for h in root.handlers if h not in original_root]
-        new_rt_handlers = [h for h in rt.handlers if h not in original_rt]
+        new_rt_handlers = [
+            h
+            for rt in rt_loggers
+            for h in rt.handlers
+            if h not in original_rt[rt]
+        ]
         for h in original_root:
             if h not in root.handlers:
                 root.addHandler(h)
@@ -152,14 +179,18 @@ def _cleanup_file_handlers():
     _handlers_to_close.clear()
     yield
     root = logging.getLogger()
-    rt = logging.getLogger("convsim_core.runtimes")
+    rt_loggers = [
+        logging.getLogger("convsim_core.runtime"),
+        logging.getLogger("convsim_core.runtimes"),
+    ]
     for h in list(_handlers_to_close):
         h.flush()
         h.close()
         if h in root.handlers:
             root.removeHandler(h)
-        if h in rt.handlers:
-            rt.removeHandler(h)
+        for rt in rt_loggers:
+            if h in rt.handlers:
+                rt.removeHandler(h)
     _handlers_to_close.clear()
 
 
@@ -236,6 +267,24 @@ def test_runtime_events_also_propagate_to_app_log(tmp_path):
     logging.getLogger("convsim_core.runtimes.stt").warning("propagation test")
     content = (log_dir / "app.log").read_text(encoding="utf-8")
     assert "propagation test" in content
+
+
+def test_runtime_package_events_appear_in_runtime_log(tmp_path):
+    """Events from convsim_core.runtime.* (without s) must appear in runtime.log."""
+    log_dir = tmp_path / "logs"
+    _call_configure_logging_isolated(str(log_dir))
+    logging.getLogger("convsim_core.runtime.supervisor").warning("supervisor shutdown warning")
+    content = (log_dir / "runtime.log").read_text(encoding="utf-8")
+    assert "supervisor shutdown warning" in content
+
+
+def test_runtime_package_events_also_propagate_to_app_log(tmp_path):
+    """convsim_core.runtime.* events propagate to app.log via root handler."""
+    log_dir = tmp_path / "logs"
+    _call_configure_logging_isolated(str(log_dir))
+    logging.getLogger("convsim_core.runtime.sidecar").warning("sidecar propagation check")
+    content = (log_dir / "app.log").read_text(encoding="utf-8")
+    assert "sidecar propagation check" in content
 
 
 def test_non_runtime_events_absent_from_runtime_log(tmp_path):

--- a/services/convsim-core/tests/test_packaged_startup.py
+++ b/services/convsim-core/tests/test_packaged_startup.py
@@ -156,6 +156,31 @@ class TestStableDataPaths:
             )
             _ = cfg_mod  # suppress unused import warning
 
+    def test_recovery_card_log_dir_matches_python_log_dir(self, tmp_path):
+        """The recovery card log path (Rust: app_local_data_dir/logs) must match
+        the Python log_dir when CONVSIM_DATA_ROOT equals app_local_data_dir.
+
+        The Tauri shell sets CONVSIM_DATA_ROOT=app_local_data_dir() before
+        launching convsim-core, and emits log_dir=app_local_data_dir()/logs in
+        CoreStatusPayload. This test verifies that when CONVSIM_DATA_ROOT is set
+        to a given value, Python's log_dir matches what Tauri would emit.
+        """
+        simulated_app_local_data_dir = tmp_path / "com.outrightmental.convsim"
+        simulated_log_dir = simulated_app_local_data_dir / "logs"
+
+        with patch.dict(os.environ, {"CONVSIM_DATA_ROOT": str(simulated_app_local_data_dir)}):
+            # config.py computes _DEFAULT_LOG_DIR at module-load time, so reload
+            # while the env var is active to pick up the new value.
+            cfg_mod = _reload_config()
+            from convsim_core.config import ServiceConfig
+            cfg = ServiceConfig()
+            assert Path(cfg.log_dir) == simulated_log_dir, (
+                f"Python log_dir {cfg.log_dir!r} does not match Tauri-emitted log_dir "
+                f"{simulated_log_dir!r}. The recovery card would show a path that does "
+                "not exist on disk."
+            )
+            _ = cfg_mod  # suppress unused import warning
+
 
 # ── Packaged environment simulation ──────────────────────────────────────────
 

--- a/services/convsim-core/tests/test_sidecar.py
+++ b/services/convsim-core/tests/test_sidecar.py
@@ -658,6 +658,41 @@ async def test_start_crash_detected_on_immediate_exit(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_kill_on_start_produces_non_empty_runtime_log(tmp_path):
+    """runtime.log must be non-empty after a kill-on-start failure.
+
+    The sidecar writes a timestamped header to runtime.log before launching
+    the subprocess, so the file must have content even when the process exits
+    immediately without producing any output.
+    """
+    crasher = tmp_path / "crash-server"
+    # Write one line to stdout before exiting so the log captures subprocess output too.
+    crasher.write_text(
+        "#!/usr/bin/env python3\nimport sys\nprint('fatal: cannot initialise')\nsys.exit(1)\n"
+    )
+    crasher.chmod(0o755)
+
+    log_dir = tmp_path / "logs"
+    port = _free_port()
+    sidecar = LlamaCppSidecar(log_dir=str(log_dir))
+
+    with pytest.raises(Exception):
+        await sidecar.start(
+            "m.gguf",
+            executable=str(crasher),
+            port=port,
+            startup_timeout=5.0,
+        )
+
+    runtime_log = log_dir / "runtime.log"
+    assert runtime_log.exists(), "runtime.log was not created"
+    assert runtime_log.stat().st_size > 0, "runtime.log is empty after kill-on-start"
+    content = runtime_log.read_text(errors="replace")
+    # Header written before spawn must be present.
+    assert "llama-server start" in content
+
+
+@pytest.mark.asyncio
 async def test_start_twice_when_already_running_is_noop(tmp_path):
     exe = _write_fake_server(tmp_path)
     port = _free_port()


### PR DESCRIPTION
## What changed and why

The recovery card that appears when `convsim-core` fails to start was hardcoding `~/.convsim/logs/app.log` as the log path. On Windows v0.2.0 builds that path does not exist — logs live at `%LOCALAPPDATA%\com.outrightmental.convsim\logs\` (set by Tauri via `CONVSIM_DATA_ROOT`). This left stranded users with a dead-end path in the one UI surface meant to help them recover.

Three additional problems were addressed in the same pass:
- The recovery card copy had "Check the logs" three times in four lines.
- `runtime.log` received no Python-level events from `convsim_core.runtime.*` modules (e.g. `supervisor.py`) because `_RuntimeFilter` only matched the legacy `convsim_core.runtimes.*` prefix.
- `docs/troubleshooting.md` still referenced `~/.convsim/logs/` throughout.

## Changes

**Rust (`lib.rs`)** — Added `log_dir: Option<String>` to `CoreStatusPayload`. `launch_or_verify_core` now computes `app_local_data_dir()/logs` once and includes it in every emitted `core-status` event. Removed hardcoded `~/.convsim/logs` strings from error hint messages.

**`CoreStartup.tsx`** — Reads `status.log_dir` from the event payload instead of hardcoding a path. Adds an "Open logs folder" button (via `plugin:shell|open`) when `log_dir` is present. Promotes "Report a problem" to `tertiaryAction`. Removes the redundant "Check the logs for details" sentence from the generic crash description.

**`RuntimeRecoveryCard.tsx`** — Relabels the path display as "Logs folder:" since the prop now carries a directory path rather than a specific file.

**`logging_setup.py`** — Fixes `_RuntimeFilter` to match `convsim_core.runtime.*` (the actual package path) in addition to `convsim_core.runtimes.*`. Attaches the `runtime.log` handler to both logger trees so `supervisor.py` shutdown warnings route correctly.

**`docs/troubleshooting.md`** — Replaces all `~/.convsim/logs/` references with a platform-specific path table (Windows/macOS/Linux). Documents the legacy `~/.convsim` migration story. Updates STT and model sections to point at the platform-specific logs folder.

## Tests added

- `CoreStartup.test.tsx`: two new tests — log_dir from event payload renders in the alert; "Open logs folder" button appears when log_dir is present.
- `RuntimeRecoveryCard.test.tsx`: updated log path test + new "Logs folder:" label test.
- `test_sidecar.py`: `test_kill_on_start_produces_non_empty_runtime_log` — asserts the header entry is written to runtime.log even when the subprocess exits immediately.
- `test_logging_setup.py`: four new tests covering `convsim_core.runtime.*` filter acceptance, propagation to both log files, and rejection of partial-match names.
- `test_packaged_startup.py`: `test_recovery_card_log_dir_matches_python_log_dir` — asserts that when `CONVSIM_DATA_ROOT` equals `app_local_data_dir`, Python's `log_dir` matches what the Rust side emits in the recovery card.

Closes #353