### PR TITLE
Links to Outright Mental should be to outrightmental.com

### DIFF
--- a/website/layouts/partials/footer.html
+++ b/website/layouts/partials/footer.html
@@ -39,7 +39,7 @@
     </div>
     <p class="footer-legal">
       Free and open source. Code Apache-2.0 · packs &amp; docs CC BY 4.0 ·
-      an <a href="https://github.com/outrightmental">Outright Mental</a> project.
+      an <a href="https://outrightmental.com" target="_blank" rel="noopener noreferrer">Outright Mental</a> project.
     </p>
   </div>
 </footer>


### PR DESCRIPTION
## Summary

Update the footer "Outright Mental" link to point to the official website (outrightmental.com) instead of the GitHub organization page. The link now opens in a new tab with appropriate security attributes.

## Changes

- Changed footer link destination from `https://github.com/outrightmental` to `https://outrightmental.com`
- Added `target="_blank"` to open link in new tab
- Added `rel="noopener noreferrer"` for security best practices

Closes #359