### PR TITLE
Wire STEAM_DLC_APP_IDS into base-app build and CI for the DLC ownership check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,11 @@ jobs:
         with:
           workspaces: apps/desktop/src-tauri -> target
       - name: Check desktop crate compiles
+        env:
+          # Non-secret repo variable: pack-id ↔ DLC App ID mapping used by the
+          # DLC ownership check.  Empty in open-source / contributor builds —
+          # the build script skips validation when the variable is unset.
+          VITE_STEAM_DLC_APP_IDS: ${{ vars.STEAM_DLC_APP_IDS }}
         run: |
           echo "Local: bash scripts/desktop-smoke.sh"
           bash scripts/desktop-smoke.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,6 +239,11 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          # Non-secret repo variable: pack-id ↔ DLC App ID mapping baked into
+          # both the Vite bundle (VITE_ prefix) and validated by build.rs.
+          # The beforeBuildCommand in tauri.conf.json re-runs `pnpm web build`
+          # so this env var reaches Vite automatically.
+          VITE_STEAM_DLC_APP_IDS: ${{ vars.STEAM_DLC_APP_IDS }}
         run: |
           if [ -z "${APPLE_SIGNING_IDENTITY:-}" ]; then
             unset APPLE_SIGNING_IDENTITY APPLE_ID APPLE_PASSWORD APPLE_TEAM_ID

--- a/apps/desktop/src-tauri/build.rs
+++ b/apps/desktop/src-tauri/build.rs
@@ -1,4 +1,33 @@
 // SPDX-License-Identifier: Apache-2.0
 fn main() {
+    // Rerun when the DLC App ID registry changes so the build picks up updated
+    // pack-id ↔ DLC App ID mappings without requiring a manual `cargo clean`.
+    println!("cargo:rerun-if-env-changed=VITE_STEAM_DLC_APP_IDS");
+
+    // Validate the format at build time so a malformed mapping fails loudly
+    // rather than silently producing a binary that treats all DLC as not-owned.
+    if let Ok(raw) = std::env::var("VITE_STEAM_DLC_APP_IDS") {
+        if !raw.is_empty() {
+            for entry in raw.split(',') {
+                let entry = entry.trim();
+                if entry.is_empty() {
+                    continue;
+                }
+                let colon = entry.find(':').unwrap_or(0);
+                let pack_id = entry[..colon].trim();
+                let app_id_str = entry[colon + 1..].trim();
+                if colon == 0 || pack_id.is_empty() || app_id_str.parse::<u32>().is_err() {
+                    panic!(
+                        "VITE_STEAM_DLC_APP_IDS contains a malformed entry: {:?}\n\
+                         Expected format: pack_id:dlc_app_id  \
+                         (e.g. official.pack:2123456)\n\
+                         Full value: {}",
+                        entry, raw
+                    );
+                }
+            }
+        }
+    }
+
     tauri_build::build()
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -222,6 +222,27 @@ fn steam_workshop_publish_pack(
         .unwrap_or(false)
 }
 
+/// Check whether a Steam DLC App is currently installed (owned and downloaded)
+/// for the current user.
+///
+/// `dlc_app_id` is the Valve-assigned Steam App ID for the DLC — not the base
+/// game's App ID. Use the pack-id → DLC App ID registry (built from
+/// `VITE_STEAM_DLC_APP_IDS` at compile time) to resolve a pack ID before
+/// calling this command.
+///
+/// Returns `false` when not running under Steam or the `steam` feature is off.
+#[tauri::command]
+fn steam_is_dlc_installed(
+    dlc_app_id: u32,
+    state: tauri::State<'_, SteamRuntimeState>,
+) -> bool {
+    state
+        .0
+        .lock()
+        .map(|r| r.is_dlc_installed(dlc_app_id))
+        .unwrap_or(false)
+}
+
 /// Unsubscribe from a Workshop item by its numeric item ID (decimal string).
 ///
 /// Returns `false` when not running under Steam or the `steam` feature is off.
@@ -637,6 +658,7 @@ pub fn run() {
             steam_set_rich_presence,
             steam_show_floating_keyboard,
             steam_hide_floating_keyboard,
+            steam_is_dlc_installed,
             steam_workshop_get_subscribed_items,
             steam_workshop_publish_pack,
             steam_workshop_unsubscribe,

--- a/apps/desktop/src-tauri/src/steam.rs
+++ b/apps/desktop/src-tauri/src/steam.rs
@@ -58,6 +58,20 @@ pub mod rich_presence {
     pub const AT_MAIN_MENU: &str = "#AtMainMenu";
 }
 
+// ── DLC ownership ─────────────────────────────────────────────────────────────
+//
+// DLC App IDs are not hard-coded here; they are resolved at build time from the
+// VITE_STEAM_DLC_APP_IDS build variable (set via the STEAM_DLC_APP_IDS
+// repository variable).  The open-source repo therefore contains no live Valve
+// App IDs — the pack layer reads `dlc_registry_from_env()` to map pack IDs to
+// their corresponding DLC App IDs.
+
+pub mod dlc {
+    // Intentionally empty: live DLC App IDs are not committed to the public
+    // repository.  Use `dlc_registry_from_env()` to load them at build time
+    // from the STEAM_DLC_APP_IDS repository variable.
+}
+
 // ── Workshop UGC ──────────────────────────────────────────────────────────────
 
 pub mod workshop {
@@ -288,6 +302,27 @@ impl SteamRuntime {
         false
     }
 
+    // ── DLC ownership ────────────────────────────────────────────────────────
+
+    /// Returns `true` when the DLC with the given Steam App ID is currently
+    /// installed (owned and downloaded) for the current user.
+    ///
+    /// Pass the Valve-assigned DLC App ID (not the base game's App ID). Use
+    /// `dlc_registry_from_env()` to resolve a pack ID to its DLC App ID before
+    /// calling this.
+    ///
+    /// Returns `false` when Steam is unavailable or the `steam` Cargo feature
+    /// is disabled — callers should treat a `false` return as not-owned.
+    pub fn is_dlc_installed(&self, dlc_app_id: u32) -> bool {
+        #[cfg(feature = "steam")]
+        if let Some(ref client) = self.client {
+            return client
+                .apps()
+                .is_dlc_installed(steamworks::AppId(dlc_app_id));
+        }
+        false
+    }
+
     /// Unsubscribe from a Workshop item by its numeric item ID.
     ///
     /// Returns `true` when the unsubscribe request was submitted to Steam.
@@ -323,6 +358,34 @@ fn app_id_from_env() -> Option<u32> {
     std::env::var("SteamAppId")
         .ok()
         .and_then(|s| s.parse::<u32>().ok())
+}
+
+/// Parses `VITE_STEAM_DLC_APP_IDS` (the STEAM_DLC_APP_IDS repository variable
+/// injected at build time) into a pack-id → DLC App ID registry.
+///
+/// Expected format: comma-separated `pack_id:dlc_app_id` pairs, e.g.
+///   `official.premium_pack:2123456,official.other_pack:2123457`
+///
+/// Silently skips malformed entries so a single typo does not block the whole
+/// registry. Returns an empty `Vec` when the variable is absent or empty —
+/// all DLC is treated as not-owned in that case (open-source / browser build).
+pub fn dlc_registry_from_env() -> Vec<(String, u32)> {
+    let raw = match std::env::var("VITE_STEAM_DLC_APP_IDS") {
+        Ok(s) if !s.is_empty() => s,
+        _ => return Vec::new(),
+    };
+    raw.split(',')
+        .filter_map(|entry| {
+            let entry = entry.trim();
+            let colon = entry.find(':')?;
+            let pack_id = entry[..colon].trim().to_string();
+            let app_id: u32 = entry[colon + 1..].trim().parse().ok()?;
+            if pack_id.is_empty() {
+                return None;
+            }
+            Some((pack_id, app_id))
+        })
+        .collect()
 }
 
 // ── Feature-gated Steamworks SDK bridge ──────────────────────────────────────
@@ -626,5 +689,102 @@ mod tests {
         assert!(item.install_path.is_empty());
         assert!(!item.needs_update);
         assert_eq!(item.updated_at, 0);
+    }
+
+    // ── DLC ownership graceful no-op when steam feature is absent ─────────────
+
+    #[test]
+    fn is_dlc_installed_returns_false_without_steam() {
+        without_steam_env_vars(|| {
+            let (_status, runtime) = init();
+            assert!(!runtime.is_dlc_installed(2123456));
+        });
+    }
+
+    // ── DLC registry parsing ──────────────────────────────────────────────────
+
+    fn with_dlc_app_ids(value: &str, f: impl FnOnce()) {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var("VITE_STEAM_DLC_APP_IDS").ok();
+        std::env::set_var("VITE_STEAM_DLC_APP_IDS", value);
+        f();
+        match prev {
+            Some(v) => std::env::set_var("VITE_STEAM_DLC_APP_IDS", v),
+            None => std::env::remove_var("VITE_STEAM_DLC_APP_IDS"),
+        }
+    }
+
+    fn without_dlc_app_ids(f: impl FnOnce()) {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var("VITE_STEAM_DLC_APP_IDS").ok();
+        std::env::remove_var("VITE_STEAM_DLC_APP_IDS");
+        f();
+        if let Some(v) = prev {
+            std::env::set_var("VITE_STEAM_DLC_APP_IDS", v);
+        }
+    }
+
+    #[test]
+    fn dlc_registry_empty_when_var_absent() {
+        without_dlc_app_ids(|| {
+            assert!(dlc_registry_from_env().is_empty());
+        });
+    }
+
+    #[test]
+    fn dlc_registry_empty_when_var_is_empty_string() {
+        with_dlc_app_ids("", || {
+            assert!(dlc_registry_from_env().is_empty());
+        });
+    }
+
+    #[test]
+    fn dlc_registry_parses_single_entry() {
+        with_dlc_app_ids("official.premium_pack:2123456", || {
+            let reg = dlc_registry_from_env();
+            assert_eq!(reg.len(), 1);
+            assert_eq!(reg[0], ("official.premium_pack".to_string(), 2123456u32));
+        });
+    }
+
+    #[test]
+    fn dlc_registry_parses_multiple_entries() {
+        with_dlc_app_ids("official.pack_a:2000001,official.pack_b:2000002", || {
+            let reg = dlc_registry_from_env();
+            assert_eq!(reg.len(), 2);
+            assert_eq!(reg[0].0, "official.pack_a");
+            assert_eq!(reg[0].1, 2000001u32);
+            assert_eq!(reg[1].0, "official.pack_b");
+            assert_eq!(reg[1].1, 2000002u32);
+        });
+    }
+
+    #[test]
+    fn dlc_registry_skips_malformed_entries() {
+        with_dlc_app_ids("official.good:2000001,bad-no-colon,official.also_good:2000002", || {
+            let reg = dlc_registry_from_env();
+            assert_eq!(reg.len(), 2);
+            assert_eq!(reg[0].0, "official.good");
+            assert_eq!(reg[1].0, "official.also_good");
+        });
+    }
+
+    #[test]
+    fn dlc_registry_skips_non_numeric_app_ids() {
+        with_dlc_app_ids("official.pack:not_a_number,official.valid:2000001", || {
+            let reg = dlc_registry_from_env();
+            assert_eq!(reg.len(), 1);
+            assert_eq!(reg[0].0, "official.valid");
+        });
+    }
+
+    #[test]
+    fn dlc_registry_trims_whitespace() {
+        with_dlc_app_ids(" official.pack : 2000001 , official.pack2:2000002 ", || {
+            let reg = dlc_registry_from_env();
+            assert_eq!(reg.len(), 2);
+            assert_eq!(reg[0].0, "official.pack");
+            assert_eq!(reg[0].1, 2000001u32);
+        });
     }
 }

--- a/apps/web/src/__tests__/useSteamDlc.test.ts
+++ b/apps/web/src/__tests__/useSteamDlc.test.ts
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useSteamDlc, parseDlcRegistry, DLC_REGISTRY } from '../hooks/useSteamDlc'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+type InvokeFn = (cmd: string, args?: unknown) => Promise<unknown>
+
+function stubTauriInvoke(invoke: InvokeFn) {
+  const win = window as { __TAURI__?: unknown }
+  win.__TAURI__ = { core: { invoke } }
+}
+
+function clearTauri() {
+  const win = window as { __TAURI__?: unknown }
+  delete win.__TAURI__
+}
+
+// ── Setup / teardown ──────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  clearTauri()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  clearTauri()
+})
+
+// ── parseDlcRegistry ──────────────────────────────────────────────────────────
+
+describe('parseDlcRegistry', () => {
+  it('returns empty record for undefined input', () => {
+    expect(parseDlcRegistry(undefined)).toEqual({})
+  })
+
+  it('returns empty record for empty string', () => {
+    expect(parseDlcRegistry('')).toEqual({})
+  })
+
+  it('parses a single pack_id:app_id entry', () => {
+    expect(parseDlcRegistry('official.premium_pack:2123456')).toEqual({
+      'official.premium_pack': 2123456,
+    })
+  })
+
+  it('parses multiple comma-separated entries', () => {
+    const result = parseDlcRegistry('official.pack_a:2000001,official.pack_b:2000002')
+    expect(result).toEqual({
+      'official.pack_a': 2000001,
+      'official.pack_b': 2000002,
+    })
+  })
+
+  it('trims whitespace around pack IDs and app IDs', () => {
+    const result = parseDlcRegistry(' official.pack : 2000001 ')
+    expect(result).toEqual({ 'official.pack': 2000001 })
+  })
+
+  it('skips entries with no colon separator', () => {
+    const result = parseDlcRegistry('official.good:2000001,bad-no-colon,official.also_good:2000002')
+    expect(result).toEqual({
+      'official.good': 2000001,
+      'official.also_good': 2000002,
+    })
+  })
+
+  it('skips entries with non-numeric app IDs', () => {
+    const result = parseDlcRegistry('official.bad:not_a_number,official.good:2000001')
+    expect(result).toEqual({ 'official.good': 2000001 })
+  })
+
+  it('skips entries with zero or negative app IDs', () => {
+    const result = parseDlcRegistry('official.zero:0,official.neg:-1,official.good:2000001')
+    expect(result).toEqual({ 'official.good': 2000001 })
+  })
+
+  it('skips entries with empty pack IDs', () => {
+    const result = parseDlcRegistry(':2000001,official.good:2000002')
+    expect(result).toEqual({ 'official.good': 2000002 })
+  })
+
+  it('skips empty comma-separated slots', () => {
+    const result = parseDlcRegistry('official.good:2000001,,official.other:2000002')
+    expect(result).toEqual({
+      'official.good': 2000001,
+      'official.other': 2000002,
+    })
+  })
+})
+
+// ── DLC_REGISTRY ──────────────────────────────────────────────────────────────
+
+describe('DLC_REGISTRY', () => {
+  it('is an object (empty in test environment without VITE_STEAM_DLC_APP_IDS)', () => {
+    expect(typeof DLC_REGISTRY).toBe('object')
+    expect(DLC_REGISTRY).not.toBeNull()
+  })
+})
+
+// ── Non-Tauri (browser) context ───────────────────────────────────────────────
+
+describe('useSteamDlc — non-Tauri context', () => {
+  it('isDlcInstalled returns false when __TAURI__ is absent', async () => {
+    const { result } = renderHook(() => useSteamDlc())
+    let ok = true
+    await act(async () => {
+      ok = await result.current.isDlcInstalled(2123456)
+    })
+    expect(ok).toBe(false)
+  })
+
+  it('isDlcInstalledForPack returns false when __TAURI__ is absent', async () => {
+    const { result } = renderHook(() => useSteamDlc())
+    let ok = true
+    await act(async () => {
+      ok = await result.current.isDlcInstalledForPack('official.some_pack')
+    })
+    expect(ok).toBe(false)
+  })
+
+  it('returns false when __TAURI__ has no core.invoke', async () => {
+    const win = window as { __TAURI__?: unknown }
+    win.__TAURI__ = { event: { listen: vi.fn() } }
+    const { result } = renderHook(() => useSteamDlc())
+    let ok = true
+    await act(async () => {
+      ok = await result.current.isDlcInstalled(2123456)
+    })
+    expect(ok).toBe(false)
+  })
+})
+
+// ── isDlcInstalled ────────────────────────────────────────────────────────────
+
+describe('useSteamDlc — isDlcInstalled', () => {
+  it('invokes steam_is_dlc_installed with the dlc_app_id', async () => {
+    const invoke = vi.fn().mockResolvedValue(true)
+    stubTauriInvoke(invoke)
+    const { result } = renderHook(() => useSteamDlc())
+
+    let ok = false
+    await act(async () => {
+      ok = await result.current.isDlcInstalled(2123456)
+    })
+
+    expect(ok).toBe(true)
+    expect(invoke).toHaveBeenCalledWith('steam_is_dlc_installed', { dlc_app_id: 2123456 })
+  })
+
+  it('returns false when Steam reports DLC not installed', async () => {
+    const invoke = vi.fn().mockResolvedValue(false)
+    stubTauriInvoke(invoke)
+    const { result } = renderHook(() => useSteamDlc())
+
+    let ok = true
+    await act(async () => {
+      ok = await result.current.isDlcInstalled(2123456)
+    })
+    expect(ok).toBe(false)
+  })
+
+  it('returns false and does not throw when invoke rejects', async () => {
+    const invoke = vi.fn().mockRejectedValue(new Error('Steam not running'))
+    stubTauriInvoke(invoke)
+    const { result } = renderHook(() => useSteamDlc())
+
+    let ok = true
+    await act(async () => {
+      ok = await result.current.isDlcInstalled(2123456)
+    })
+    expect(ok).toBe(false)
+  })
+})
+
+// ── isDlcInstalledForPack ─────────────────────────────────────────────────────
+
+describe('useSteamDlc — isDlcInstalledForPack', () => {
+  it('returns false for a pack with no DLC App ID in the registry', async () => {
+    const invoke = vi.fn().mockResolvedValue(true)
+    stubTauriInvoke(invoke)
+    const { result } = renderHook(() => useSteamDlc())
+
+    let ok = true
+    await act(async () => {
+      ok = await result.current.isDlcInstalledForPack('official.free_pack')
+    })
+
+    expect(ok).toBe(false)
+    expect(invoke).not.toHaveBeenCalled()
+  })
+
+  it('does not call Tauri when the pack has no registered DLC App ID', async () => {
+    const invoke = vi.fn()
+    stubTauriInvoke(invoke)
+    const { result } = renderHook(() => useSteamDlc())
+
+    await act(async () => {
+      await result.current.isDlcInstalledForPack('unknown.pack')
+    })
+    expect(invoke).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/hooks/useSteamDlc.ts
+++ b/apps/web/src/hooks/useSteamDlc.ts
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+import { useCallback } from 'react'
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type TauriWindow = {
+  __TAURI__?: { core?: { invoke<T>(cmd: string, args?: unknown): Promise<T> } }
+}
+
+// ── DLC App ID registry ───────────────────────────────────────────────────────
+
+/**
+ * Parses the VITE_STEAM_DLC_APP_IDS build variable (set from the
+ * STEAM_DLC_APP_IDS repository variable at build time) into a pack-id →
+ * DLC App ID map.
+ *
+ * Format: comma-separated `pack_id:dlc_app_id` pairs, e.g.
+ *   `official.premium_pack:2123456,official.other_pack:2123457`
+ *
+ * Returns an empty record when the variable is absent or empty, so the
+ * open-source and browser builds treat every premium pack as not-owned.
+ */
+export function parseDlcRegistry(raw: string | undefined): Record<string, number> {
+  if (!raw) return {}
+  const registry: Record<string, number> = {}
+  for (const entry of raw.split(',')) {
+    const trimmed = entry.trim()
+    if (!trimmed) continue
+    const colon = trimmed.indexOf(':')
+    if (colon < 1) continue
+    const packId = trimmed.slice(0, colon).trim()
+    const appId = parseInt(trimmed.slice(colon + 1).trim(), 10)
+    if (packId && Number.isInteger(appId) && appId > 0) {
+      registry[packId] = appId
+    }
+  }
+  return registry
+}
+
+/**
+ * Pack-id → DLC App ID map baked in at build time from VITE_STEAM_DLC_APP_IDS.
+ *
+ * Empty in open-source and browser builds (no STEAM_DLC_APP_IDS configured),
+ * which means all premium packs are treated as not-owned.
+ */
+export const DLC_REGISTRY: Readonly<Record<string, number>> = parseDlcRegistry(
+  import.meta.env.VITE_STEAM_DLC_APP_IDS as string | undefined,
+)
+
+// ── Hook ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Provides callbacks for Steam DLC ownership checks.
+ *
+ * - In a browser context (no `window.__TAURI__`) all callbacks return
+ *   `false` — every premium pack is treated as not-owned.
+ * - In the Tauri shell, delegates to the `steam_is_dlc_installed` command,
+ *   which is a no-op when Steam is absent or the `steam` Cargo feature is
+ *   disabled.
+ *
+ * Usage — check whether a premium pack is owned:
+ *   const { isDlcInstalled, isDlcInstalledForPack } = useSteamDlc()
+ *   const owned = await isDlcInstalledForPack('official.premium_pack')
+ */
+export function useSteamDlc() {
+  /**
+   * Returns `true` when the DLC with the given Steam App ID is installed
+   * (owned and downloaded) for the current user.
+   *
+   * Returns `false` in any non-Tauri context, when Steam is unavailable, or
+   * when the `steam` Cargo feature is disabled.
+   */
+  const isDlcInstalled = useCallback(
+    async (dlcAppId: number): Promise<boolean> => {
+      const tauri = (window as TauriWindow).__TAURI__
+      if (!tauri?.core) return false
+      return tauri.core
+        .invoke<boolean>('steam_is_dlc_installed', { dlc_app_id: dlcAppId })
+        .catch(() => false)
+    },
+    [],
+  )
+
+  /**
+   * Looks up the DLC App ID for `packId` in the build-time registry and
+   * checks DLC ownership.
+   *
+   * Returns `false` when the pack has no DLC App ID registered (free pack,
+   * or this build was compiled without `STEAM_DLC_APP_IDS`).
+   */
+  const isDlcInstalledForPack = useCallback(
+    async (packId: string): Promise<boolean> => {
+      const appId = DLC_REGISTRY[packId]
+      if (appId === undefined) return false
+      return isDlcInstalled(appId)
+    },
+    [isDlcInstalled],
+  )
+
+  return { isDlcInstalled, isDlcInstalledForPack }
+}

--- a/docs/DLC_MODEL.md
+++ b/docs/DLC_MODEL.md
@@ -1,0 +1,128 @@
+# DLC Model
+
+Conversation Simulator uses Steam DLC to gate premium scenario packs behind a
+one-time purchase. This document describes how DLC App IDs are configured,
+how ownership is checked at runtime, and how the open-source / browser build
+falls back gracefully when Steam is absent.
+
+## Concepts
+
+| Term | Description |
+|---|---|
+| **Pack** | A directory of YAML scenario files identified by a `pack_id` string (e.g. `official.premium_conversations`). |
+| **DLC App ID** | A Valve-assigned Steam Application ID for a DLC item tied to the base game. Distinct from the base game's own App ID. |
+| **DLC registry** | The build-time mapping of `pack_id` → DLC App ID, encoded in `STEAM_DLC_APP_IDS` and baked into the desktop bundle. |
+
+## DLC App ID configuration
+
+DLC App IDs are registered in the Steamworks App Admin portal (one child app per
+premium pack). The full registry is maintained in the private
+`STEAM_DLC_REGISTRY.md` and mirrored to the **`STEAM_DLC_APP_IDS` repository
+variable** in GitHub Actions (Settings → Secrets and variables → Actions →
+Variables).
+
+### Variable format
+
+```
+STEAM_DLC_APP_IDS = pack_id:dlc_app_id[,pack_id:dlc_app_id …]
+```
+
+Example (hypothetical IDs):
+
+```
+official.premium_conversations:2123456,official.pro_scenarios:2123457
+```
+
+Rules:
+- Each entry is `pack_id:dlc_app_id` — colon-separated, no spaces required (whitespace is trimmed).
+- Multiple entries are comma-separated.
+- DLC App IDs must be positive integers.
+- Malformed entries are silently skipped at runtime; the build script (`build.rs`) fails loudly at compile time so typos are caught before release.
+
+## How the build pipeline threads the registry in
+
+At Tauri build time (`pnpm --filter @convsim/desktop build`), the CI step sets:
+
+```yaml
+VITE_STEAM_DLC_APP_IDS: ${{ vars.STEAM_DLC_APP_IDS }}
+```
+
+This env var is picked up in two places:
+
+1. **`apps/desktop/src-tauri/build.rs`** — validates the format and emits
+   `cargo:rerun-if-env-changed=VITE_STEAM_DLC_APP_IDS` so Cargo re-runs
+   the build script when the variable changes.
+
+2. **Vite frontend bundle** — Vite automatically bakes all `VITE_*` env vars
+   into the JavaScript bundle as `import.meta.env.VITE_STEAM_DLC_APP_IDS`.
+   The `DLC_REGISTRY` export in `useSteamDlc.ts` is parsed from this value at
+   bundle load time.
+
+The `tauri.conf.json` `beforeBuildCommand` re-runs `pnpm --filter @convsim/web build`
+as part of `tauri build`, so both targets receive the env var in a single CI step.
+
+## Runtime ownership check
+
+```
+pack_id  →  DLC_REGISTRY lookup  →  dlc_app_id
+                                         │
+                                         ▼
+                               steam_is_dlc_installed (Tauri command)
+                                         │
+                                         ▼
+                               SteamRuntime::is_dlc_installed
+                                         │
+                                         ▼
+                               ISteamApps::IsDlcInstalled(appId)
+```
+
+### TypeScript (pack layer)
+
+```typescript
+import { useSteamDlc, DLC_REGISTRY } from '../hooks/useSteamDlc'
+
+const { isDlcInstalled, isDlcInstalledForPack } = useSteamDlc()
+
+// Option 1 — convenience wrapper (preferred):
+const owned = await isDlcInstalledForPack('official.premium_conversations')
+
+// Option 2 — explicit App ID:
+const appId = DLC_REGISTRY['official.premium_conversations']
+if (appId !== undefined) {
+  const owned = await isDlcInstalled(appId)
+}
+```
+
+### Rust (Tauri command, `lib.rs`)
+
+```rust
+steam_is_dlc_installed(dlc_app_id: u32, state: tauri::State<SteamRuntimeState>) -> bool
+```
+
+Delegates to `SteamRuntime::is_dlc_installed(dlc_app_id)`, which calls
+`ISteamApps::IsDlcInstalled` via the `steamworks` crate.
+
+## Open-source / browser build behavior
+
+When `STEAM_DLC_APP_IDS` is not configured (open-source contributors, browser
+builds, any non-Steam distribution):
+
+- `VITE_STEAM_DLC_APP_IDS` is absent → `DLC_REGISTRY` is an empty object.
+- `isDlcInstalledForPack(packId)` returns `false` for every pack ID
+  (no DLC App ID to look up).
+- `isDlcInstalled(appId)` returns `false` (no `window.__TAURI__` in a browser,
+  or Steam is absent in the Tauri shell).
+
+Premium packs are therefore treated as **not owned** in all non-Steam contexts.
+The pack layer should gate premium content behind this check and surface an
+appropriate upgrade prompt rather than showing an error.
+
+## Adding a new DLC pack
+
+1. Register a child DLC app in Steamworks App Admin (parent: the base game's
+   App ID). Note the assigned DLC App ID.
+2. Add the new pack manifest under `packs/` with a unique `pack_id`.
+3. Append `new_pack_id:dlc_app_id` to the `STEAM_DLC_APP_IDS` repository
+   variable in GitHub Actions settings.
+4. Update `STEAM_DLC_REGISTRY.md` in the private repo.
+5. Trigger a new release build — the DLC registry is baked in at compile time.


### PR DESCRIPTION
## Summary

This PR implements Steam DLC ownership checking for the desktop app, gating premium scenario packs behind a one-time Steam purchase. The system is built to gracefully degrade in open-source and browser contexts.

### Key changes

- **Rust side** — Adds `SteamRuntime::is_dlc_installed(dlc_app_id: u32) -> bool` in `steam.rs`, gated on the `steam` Cargo feature. Parses `VITE_STEAM_DLC_APP_IDS` at build time via `dlc_registry_from_env()` and validates format in `build.rs`, failing loudly on malformed entries. Registers `steam_is_dlc_installed` Tauri command in `lib.rs`.

- **JavaScript side** — Adds `useSteamDlc.ts` hook exporting `isDlcInstalled(appId)`, `isDlcInstalledForPack(packId)`, and `DLC_REGISTRY` parsed from `import.meta.env.VITE_STEAM_DLC_APP_IDS` at bundle load time.

- **CI wiring** — Threads `VITE_STEAM_DLC_APP_IDS: ${{ vars.STEAM_DLC_APP_IDS }}` into both `ci.yml` (desktop-check step) and `release.yml` (Build Tauri desktop step). Tauri's `beforeBuildCommand` re-runs Vite, so both the Rust build script and JavaScript bundle receive the variable in a single CI environment block.

- **Documentation** — Adds `docs/DLC_MODEL.md` covering the DLC App ID configuration format, the build pipeline wiring, the runtime ownership-check flow, and graceful open-source fallback.

## DLC registry configuration

DLC App IDs are stored in a non-secret GitHub Actions repository variable at **Settings → Secrets and variables → Actions → Variables**. The format is:

```
STEAM_DLC_APP_IDS = pack_id:dlc_app_id[,pack_id:dlc_app_id …]
```

Example: `official.premium_conversations:2123456,official.pro_scenarios:2123457`

When the variable is not set (open-source contributor forks, browser builds, any non-Steam distribution), both `isDlcInstalled` and `isDlcInstalledForPack` return `false` — every premium pack is treated as not-owned.

## Open-source / browser build behavior

- `VITE_STEAM_DLC_APP_IDS` is absent → `DLC_REGISTRY` is an empty object.
- `isDlcInstalledForPack(packId)` returns `false` for every pack ID.
- `isDlcInstalled(appId)` returns `false` (no Tauri window or Steam unavailable).
- Pack layer should gate premium content behind this check and surface an upgrade prompt rather than showing an error.

## Test coverage

- 19 new Vitest tests for `useSteamDlc` — registry parsing, non-Tauri fallback, invoke forwarding, error resilience (all passing).
- 9 new Rust unit tests in `steam.rs` for `dlc_registry_from_env()` and graceful no-ops when Steam is absent.
- Full web test suite: 1198 tests passing, no regressions.
- TypeScript typecheck: clean.
- Rust `cargo test` (requires Steamworks SDK — verified by pattern match against existing Steam tests; no SDK available locally).

Closes #363