### PR TITLE
Business model pivot: FOSS on GitHub, $9.99 on Steam, premium DLC

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,8 +285,11 @@ deliberately out of scope, and links to the acceptance criteria and docs.
 
 ### Steam release
 
-The project is being prepared for a free, Outright Mental-sponsored Steam release.
-The Steam edition makes the same local-first guarantee as the open-source build.
+The project is being prepared for a $9.99 one-time Steam release.
+The Steam edition is the same open-source build packaged for non-technical
+players — signed, notarised, auto-updating, and Steam Deck–verified.
+It makes the same local-first guarantee as the open-source build.
+Building from source on GitHub is and will remain free.
 
 | Document | Purpose |
 |----------|---------|

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -222,6 +222,24 @@ fn steam_workshop_publish_pack(
         .unwrap_or(false)
 }
 
+/// Check whether the local Steam user owns and has installed the DLC identified
+/// by `dlc_app_id`.
+///
+/// Uses `ISteamApps::BIsDlcInstalled` — synchronous, no network call.
+/// Returns `false` when not running under Steam, the user does not own the DLC,
+/// or the DLC content is not yet downloaded. See `docs/DLC_MODEL.md`.
+#[tauri::command]
+fn steam_is_dlc_installed(
+    dlc_app_id: u32,
+    state: tauri::State<'_, SteamRuntimeState>,
+) -> bool {
+    state
+        .0
+        .lock()
+        .map(|r| r.is_dlc_installed(dlc_app_id))
+        .unwrap_or(false)
+}
+
 /// Unsubscribe from a Workshop item by its numeric item ID (decimal string).
 ///
 /// Returns `false` when not running under Steam or the `steam` feature is off.
@@ -640,6 +658,7 @@ pub fn run() {
             steam_workshop_get_subscribed_items,
             steam_workshop_publish_pack,
             steam_workshop_unsubscribe,
+            steam_is_dlc_installed,
         ])
         .setup(move |app| {
             launch_or_verify_core(

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -222,15 +222,18 @@ fn steam_workshop_publish_pack(
         .unwrap_or(false)
 }
 
-/// Check whether a Steam DLC App is currently installed (owned and downloaded)
-/// for the current user.
+/// Check whether the local Steam user owns and has installed the DLC identified
+/// by `dlc_app_id`.
 ///
 /// `dlc_app_id` is the Valve-assigned Steam App ID for the DLC — not the base
 /// game's App ID. Use the pack-id → DLC App ID registry (built from
 /// `VITE_STEAM_DLC_APP_IDS` at compile time) to resolve a pack ID before
 /// calling this command.
 ///
-/// Returns `false` when not running under Steam or the `steam` feature is off.
+/// Uses `ISteamApps::BIsDlcInstalled` — synchronous, no network call.
+/// Returns `false` when not running under Steam, the user does not own the DLC,
+/// the DLC content is not yet downloaded, or the `steam` feature is off.
+/// See `docs/DLC_MODEL.md`.
 #[tauri::command]
 fn steam_is_dlc_installed(
     dlc_app_id: u32,
@@ -662,6 +665,7 @@ pub fn run() {
             steam_workshop_get_subscribed_items,
             steam_workshop_publish_pack,
             steam_workshop_unsubscribe,
+            steam_is_dlc_installed,
         ])
         .setup(move |app| {
             launch_or_verify_core(

--- a/apps/desktop/src-tauri/src/steam.rs
+++ b/apps/desktop/src-tauri/src/steam.rs
@@ -218,6 +218,32 @@ impl SteamRuntime {
         false
     }
 
+    // ── DLC ownership ────────────────────────────────────────────────────────
+
+    /// Return `true` when the local Steam user owns and has installed the DLC
+    /// identified by `dlc_app_id`.
+    ///
+    /// Uses `ISteamApps::BIsDlcInstalled` — a synchronous API that reads
+    /// locally cached license data and does not make a network call.
+    ///
+    /// Returns `false` when:
+    /// - the `steam` Cargo feature is disabled,
+    /// - the Steamworks SDK is not initialized (Steam not running),
+    /// - the user does not own the DLC, or
+    /// - the DLC content is not yet installed locally.
+    ///
+    /// Callers should treat `false` as "not accessible" and show the
+    /// pack-library "Available on Steam" state. See `docs/DLC_MODEL.md`.
+    pub fn is_dlc_installed(&self, dlc_app_id: u32) -> bool {
+        #[cfg(feature = "steam")]
+        if let Some(ref client) = self.client {
+            return client
+                .apps()
+                .is_dlc_installed(steamworks::AppId(dlc_app_id));
+        }
+        false
+    }
+
     // ── Workshop / UGC ───────────────────────────────────────────────────────
 
     /// Return the list of Workshop items the local user is currently subscribed
@@ -608,6 +634,26 @@ mod tests {
         without_steam_env_vars(|| {
             let (_status, runtime) = init();
             assert!(!runtime.unsubscribe_item(12345678u64));
+        });
+    }
+
+    // ── DLC ownership ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn is_dlc_installed_returns_false_without_steam() {
+        without_steam_env_vars(|| {
+            let (_status, runtime) = init();
+            // Without the `steam` feature (or without Steam running) the DLC
+            // check must always return false — treat as "not accessible".
+            assert!(!runtime.is_dlc_installed(1234567));
+        });
+    }
+
+    #[test]
+    fn is_dlc_installed_returns_false_for_zero_app_id() {
+        without_steam_env_vars(|| {
+            let (_status, runtime) = init();
+            assert!(!runtime.is_dlc_installed(0));
         });
     }
 

--- a/apps/desktop/src-tauri/src/steam.rs
+++ b/apps/desktop/src-tauri/src/steam.rs
@@ -232,6 +232,32 @@ impl SteamRuntime {
         false
     }
 
+    // ── DLC ownership ────────────────────────────────────────────────────────
+
+    /// Return `true` when the local Steam user owns and has installed the DLC
+    /// identified by `dlc_app_id`.
+    ///
+    /// Uses `ISteamApps::BIsDlcInstalled` — a synchronous API that reads
+    /// locally cached license data and does not make a network call.
+    ///
+    /// Returns `false` when:
+    /// - the `steam` Cargo feature is disabled,
+    /// - the Steamworks SDK is not initialized (Steam not running),
+    /// - the user does not own the DLC, or
+    /// - the DLC content is not yet installed locally.
+    ///
+    /// Callers should treat `false` as "not accessible" and show the
+    /// pack-library "Available on Steam" state. See `docs/DLC_MODEL.md`.
+    pub fn is_dlc_installed(&self, dlc_app_id: u32) -> bool {
+        #[cfg(feature = "steam")]
+        if let Some(ref client) = self.client {
+            return client
+                .apps()
+                .is_dlc_installed(steamworks::AppId(dlc_app_id));
+        }
+        false
+    }
+
     // ── Workshop / UGC ───────────────────────────────────────────────────────
 
     /// Return the list of Workshop items the local user is currently subscribed
@@ -671,6 +697,26 @@ mod tests {
         without_steam_env_vars(|| {
             let (_status, runtime) = init();
             assert!(!runtime.unsubscribe_item(12345678u64));
+        });
+    }
+
+    // ── DLC ownership ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn is_dlc_installed_returns_false_without_steam() {
+        without_steam_env_vars(|| {
+            let (_status, runtime) = init();
+            // Without the `steam` feature (or without Steam running) the DLC
+            // check must always return false — treat as "not accessible".
+            assert!(!runtime.is_dlc_installed(1234567));
+        });
+    }
+
+    #[test]
+    fn is_dlc_installed_returns_false_for_zero_app_id() {
+        without_steam_env_vars(|| {
+            let (_status, runtime) = init();
+            assert!(!runtime.is_dlc_installed(0));
         });
     }
 

--- a/apps/web/src/__tests__/useSteamDlc.test.ts
+++ b/apps/web/src/__tests__/useSteamDlc.test.ts
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useSteamDlc } from '../hooks/useSteamDlc'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+type InvokeFn = (cmd: string, args?: unknown) => Promise<unknown>
+
+function stubTauriInvoke(invoke: InvokeFn) {
+  const win = window as { __TAURI__?: unknown }
+  win.__TAURI__ = { core: { invoke } }
+}
+
+function clearTauri() {
+  const win = window as { __TAURI__?: unknown }
+  delete win.__TAURI__
+}
+
+// ── Setup / teardown ──────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  clearTauri()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  clearTauri()
+})
+
+// ── Non-Tauri (browser) context ───────────────────────────────────────────────
+
+describe('useSteamDlc — non-Tauri context', () => {
+  it('isDlcInstalled returns false when __TAURI__ is absent', async () => {
+    const { result } = renderHook(() => useSteamDlc())
+    let owned = true
+    await act(async () => {
+      owned = await result.current.isDlcInstalled(1234567)
+    })
+    expect(owned).toBe(false)
+  })
+
+  it('returns false when __TAURI__ has no core.invoke', async () => {
+    const win = window as { __TAURI__?: unknown }
+    win.__TAURI__ = { event: { listen: vi.fn() } }
+
+    const { result } = renderHook(() => useSteamDlc())
+    let owned = true
+    await act(async () => {
+      owned = await result.current.isDlcInstalled(1234567)
+    })
+    expect(owned).toBe(false)
+  })
+})
+
+// ── isDlcInstalled ────────────────────────────────────────────────────────────
+
+describe('useSteamDlc — isDlcInstalled', () => {
+  it('invokes steam_is_dlc_installed with the dlc_app_id', async () => {
+    const invoke = vi.fn().mockResolvedValue(true)
+    stubTauriInvoke(invoke)
+    const { result } = renderHook(() => useSteamDlc())
+
+    let owned = false
+    await act(async () => {
+      owned = await result.current.isDlcInstalled(1234567)
+    })
+
+    expect(owned).toBe(true)
+    expect(invoke).toHaveBeenCalledWith('steam_is_dlc_installed', {
+      dlc_app_id: 1234567,
+    })
+  })
+
+  it('returns false when the user does not own the DLC', async () => {
+    const invoke = vi.fn().mockResolvedValue(false)
+    stubTauriInvoke(invoke)
+    const { result } = renderHook(() => useSteamDlc())
+
+    let owned = true
+    await act(async () => {
+      owned = await result.current.isDlcInstalled(1234567)
+    })
+    expect(owned).toBe(false)
+  })
+
+  it('returns false and does not throw when invoke rejects', async () => {
+    const invoke = vi.fn().mockRejectedValue(new Error('Steam not running'))
+    stubTauriInvoke(invoke)
+    const { result } = renderHook(() => useSteamDlc())
+
+    let owned = true
+    await act(async () => {
+      owned = await result.current.isDlcInstalled(1234567)
+    })
+    expect(owned).toBe(false)
+  })
+
+  it('returns false for a DLC App ID of 0', async () => {
+    const invoke = vi.fn().mockResolvedValue(false)
+    stubTauriInvoke(invoke)
+    const { result } = renderHook(() => useSteamDlc())
+
+    let owned = true
+    await act(async () => {
+      owned = await result.current.isDlcInstalled(0)
+    })
+    expect(owned).toBe(false)
+    expect(invoke).toHaveBeenCalledWith('steam_is_dlc_installed', {
+      dlc_app_id: 0,
+    })
+  })
+
+  it('handles multiple DLC App IDs independently', async () => {
+    const invoke = vi.fn().mockImplementation((_cmd, args) => {
+      const { dlc_app_id } = args as { dlc_app_id: number }
+      return Promise.resolve(dlc_app_id === 1111111)
+    })
+    stubTauriInvoke(invoke)
+    const { result } = renderHook(() => useSteamDlc())
+
+    let owned1 = false
+    let owned2 = true
+    await act(async () => {
+      owned1 = await result.current.isDlcInstalled(1111111)
+      owned2 = await result.current.isDlcInstalled(2222222)
+    })
+    expect(owned1).toBe(true)
+    expect(owned2).toBe(false)
+  })
+})

--- a/apps/web/src/__tests__/useSteamDlc.test.ts
+++ b/apps/web/src/__tests__/useSteamDlc.test.ts
@@ -104,31 +104,32 @@ describe('DLC_REGISTRY', () => {
 describe('useSteamDlc — non-Tauri context', () => {
   it('isDlcInstalled returns false when __TAURI__ is absent', async () => {
     const { result } = renderHook(() => useSteamDlc())
-    let ok = true
+    let owned = true
     await act(async () => {
-      ok = await result.current.isDlcInstalled(2123456)
+      owned = await result.current.isDlcInstalled(1234567)
     })
-    expect(ok).toBe(false)
+    expect(owned).toBe(false)
   })
 
   it('isDlcInstalledForPack returns false when __TAURI__ is absent', async () => {
     const { result } = renderHook(() => useSteamDlc())
-    let ok = true
+    let owned = true
     await act(async () => {
-      ok = await result.current.isDlcInstalledForPack('official.some_pack')
+      owned = await result.current.isDlcInstalledForPack('official.some_pack')
     })
-    expect(ok).toBe(false)
+    expect(owned).toBe(false)
   })
 
   it('returns false when __TAURI__ has no core.invoke', async () => {
     const win = window as { __TAURI__?: unknown }
     win.__TAURI__ = { event: { listen: vi.fn() } }
+
     const { result } = renderHook(() => useSteamDlc())
-    let ok = true
+    let owned = true
     await act(async () => {
-      ok = await result.current.isDlcInstalled(2123456)
+      owned = await result.current.isDlcInstalled(1234567)
     })
-    expect(ok).toBe(false)
+    expect(owned).toBe(false)
   })
 })
 
@@ -140,25 +141,27 @@ describe('useSteamDlc — isDlcInstalled', () => {
     stubTauriInvoke(invoke)
     const { result } = renderHook(() => useSteamDlc())
 
-    let ok = false
+    let owned = false
     await act(async () => {
-      ok = await result.current.isDlcInstalled(2123456)
+      owned = await result.current.isDlcInstalled(1234567)
     })
 
-    expect(ok).toBe(true)
-    expect(invoke).toHaveBeenCalledWith('steam_is_dlc_installed', { dlc_app_id: 2123456 })
+    expect(owned).toBe(true)
+    expect(invoke).toHaveBeenCalledWith('steam_is_dlc_installed', {
+      dlc_app_id: 1234567,
+    })
   })
 
-  it('returns false when Steam reports DLC not installed', async () => {
+  it('returns false when the user does not own the DLC', async () => {
     const invoke = vi.fn().mockResolvedValue(false)
     stubTauriInvoke(invoke)
     const { result } = renderHook(() => useSteamDlc())
 
-    let ok = true
+    let owned = true
     await act(async () => {
-      ok = await result.current.isDlcInstalled(2123456)
+      owned = await result.current.isDlcInstalled(1234567)
     })
-    expect(ok).toBe(false)
+    expect(owned).toBe(false)
   })
 
   it('returns false and does not throw when invoke rejects', async () => {
@@ -166,11 +169,44 @@ describe('useSteamDlc — isDlcInstalled', () => {
     stubTauriInvoke(invoke)
     const { result } = renderHook(() => useSteamDlc())
 
-    let ok = true
+    let owned = true
     await act(async () => {
-      ok = await result.current.isDlcInstalled(2123456)
+      owned = await result.current.isDlcInstalled(1234567)
     })
-    expect(ok).toBe(false)
+    expect(owned).toBe(false)
+  })
+
+  it('returns false for a DLC App ID of 0', async () => {
+    const invoke = vi.fn().mockResolvedValue(false)
+    stubTauriInvoke(invoke)
+    const { result } = renderHook(() => useSteamDlc())
+
+    let owned = true
+    await act(async () => {
+      owned = await result.current.isDlcInstalled(0)
+    })
+    expect(owned).toBe(false)
+    expect(invoke).toHaveBeenCalledWith('steam_is_dlc_installed', {
+      dlc_app_id: 0,
+    })
+  })
+
+  it('handles multiple DLC App IDs independently', async () => {
+    const invoke = vi.fn().mockImplementation((_cmd, args) => {
+      const { dlc_app_id } = args as { dlc_app_id: number }
+      return Promise.resolve(dlc_app_id === 1111111)
+    })
+    stubTauriInvoke(invoke)
+    const { result } = renderHook(() => useSteamDlc())
+
+    let owned1 = false
+    let owned2 = true
+    await act(async () => {
+      owned1 = await result.current.isDlcInstalled(1111111)
+      owned2 = await result.current.isDlcInstalled(2222222)
+    })
+    expect(owned1).toBe(true)
+    expect(owned2).toBe(false)
   })
 })
 
@@ -182,12 +218,12 @@ describe('useSteamDlc — isDlcInstalledForPack', () => {
     stubTauriInvoke(invoke)
     const { result } = renderHook(() => useSteamDlc())
 
-    let ok = true
+    let owned = true
     await act(async () => {
-      ok = await result.current.isDlcInstalledForPack('official.free_pack')
+      owned = await result.current.isDlcInstalledForPack('official.free_pack')
     })
 
-    expect(ok).toBe(false)
+    expect(owned).toBe(false)
     expect(invoke).not.toHaveBeenCalled()
   })
 

--- a/apps/web/src/hooks/useSteamDlc.ts
+++ b/apps/web/src/hooks/useSteamDlc.ts
@@ -50,25 +50,30 @@ export const DLC_REGISTRY: Readonly<Record<string, number>> = parseDlcRegistry(
 // ── Hook ──────────────────────────────────────────────────────────────────────
 
 /**
- * Provides callbacks for Steam DLC ownership checks.
+ * Ownership gate for premium Steam DLC packs.
  *
- * - In a browser context (no `window.__TAURI__`) all callbacks return
- *   `false` — every premium pack is treated as not-owned.
- * - In the Tauri shell, delegates to the `steam_is_dlc_installed` command,
- *   which is a no-op when Steam is absent or the `steam` Cargo feature is
- *   disabled.
+ * Calls the `steam_is_dlc_installed` Tauri command, which uses the Steamworks
+ * SDK to confirm that the local Steam user owns and has installed the DLC with
+ * the given App ID. Degrades gracefully to `false` in a browser context or
+ * when the `steam` Cargo feature is disabled — callers do not need to guard on
+ * `SteamStatus.is_steam_enabled` before calling.
+ *
+ * A pack whose `manifest.yaml` carries a non-zero `dlc_app_id` should be
+ * passed through this check before allowing a scenario launch. Packs without
+ * `dlc_app_id` are always playable and do not need this check.
  *
  * Usage — check whether a premium pack is owned:
  *   const { isDlcInstalled, isDlcInstalledForPack } = useSteamDlc()
  *   const owned = await isDlcInstalledForPack('official.premium_pack')
+ *
+ * See docs/DLC_MODEL.md for the full ownership-gate contract.
  */
 export function useSteamDlc() {
   /**
-   * Returns `true` when the DLC with the given Steam App ID is installed
-   * (owned and downloaded) for the current user.
-   *
-   * Returns `false` in any non-Tauri context, when Steam is unavailable, or
-   * when the `steam` Cargo feature is disabled.
+   * Returns `true` when the local Steam user owns and has installed the DLC
+   * identified by `dlcAppId`. Returns `false` when Steam is unavailable,
+   * the user does not own the DLC, the DLC is not yet installed, or this is
+   * a non-Tauri context.
    */
   const isDlcInstalled = useCallback(
     async (dlcAppId: number): Promise<boolean> => {

--- a/apps/web/src/hooks/useSteamDlc.ts
+++ b/apps/web/src/hooks/useSteamDlc.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+import { useCallback } from 'react'
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type TauriWindow = {
+  __TAURI__?: { core?: { invoke<T>(cmd: string, args?: unknown): Promise<T> } }
+}
+
+// ── Hook ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Ownership gate for premium Steam DLC packs.
+ *
+ * Calls the `steam_is_dlc_installed` Tauri command, which uses the Steamworks
+ * SDK to confirm that the local Steam user owns and has installed the DLC with
+ * the given App ID.
+ *
+ * Degrades gracefully to `false` in a browser context or when the `steam`
+ * Cargo feature is disabled — callers do not need to guard on
+ * `SteamStatus.is_steam_enabled` before calling.
+ *
+ * Usage:
+ *   const { isDlcInstalled } = useSteamDlc()
+ *   const owned = await isDlcInstalled(1234567)
+ *
+ * A pack whose `manifest.yaml` carries a non-zero `dlc_app_id` should be
+ * passed through this check before allowing a scenario launch. Packs without
+ * `dlc_app_id` are always playable and do not need this check.
+ *
+ * See docs/DLC_MODEL.md for the full ownership-gate contract.
+ */
+export function useSteamDlc() {
+  /**
+   * Return `true` when the local Steam user owns and has installed the DLC
+   * identified by `dlcAppId`. Returns `false` when Steam is unavailable,
+   * the user does not own the DLC, or the DLC is not yet installed.
+   */
+  const isDlcInstalled = useCallback(
+    async (dlcAppId: number): Promise<boolean> => {
+      const tauri = (window as TauriWindow).__TAURI__
+      if (!tauri?.core) return false
+      return tauri.core
+        .invoke<boolean>('steam_is_dlc_installed', { dlc_app_id: dlcAppId })
+        .catch(() => false)
+    },
+    [],
+  )
+
+  return { isDlcInstalled }
+}

--- a/docs/DLC_MODEL.md
+++ b/docs/DLC_MODEL.md
@@ -1,9 +1,44 @@
-# DLC Model
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+# DLC Model Contract
 
-Conversation Simulator uses Steam DLC to gate premium scenario packs behind a
-one-time purchase. This document describes how DLC App IDs are configured,
-how ownership is checked at runtime, and how the open-source / browser build
-falls back gracefully when Steam is absent.
+> **Purpose:** Define what can and cannot be DLC, the depot layout for DLC
+> packs, the build-time registry configuration, and the runtime ownership-gate
+> API. This document is the authoritative reference for any issue or PR that
+> touches premium scenario-pack DLC.
+>
+> **Audience:** Platform team, publishing team, and DLC pack authors working in
+> the private [`ConversationSimulator-DLC`](https://github.com/outrightmental/ConversationSimulator-DLC)
+> repo.
+
+---
+
+## The invariant
+
+> **Nothing that ships free in the base app may ever be relocked as paid DLC.**
+
+DLC is always additive. The four official packs included in the base app are
+Apache-2.0 / CC BY 4.0 and remain so permanently. Community packs are free.
+Premium DLC packs are new content, sourced from the private DLC repo, sold
+only on Steam.
+
+---
+
+## What can be DLC
+
+- First-party scenario packs authored in the private
+  [`ConversationSimulator-DLC`](https://github.com/outrightmental/ConversationSimulator-DLC)
+  repo.
+- Each DLC pack is a standard scenario pack (same schema as
+  [`schemas/pack.schema.json`](../schemas/pack.schema.json)) with a proprietary
+  `LicenseRef-*` identifier (see #365) reflecting its non-open license.
+
+## What can never be DLC
+
+- Any pack or scenario already released in the base app or on GitHub.
+- Engine features, bug fixes, or UI improvements — these ship in the base app.
+- Community packs — they are always free.
+
+---
 
 ## Concepts
 
@@ -13,15 +48,21 @@ falls back gracefully when Steam is absent.
 | **DLC App ID** | A Valve-assigned Steam Application ID for a DLC item tied to the base game. Distinct from the base game's own App ID. |
 | **DLC registry** | The build-time mapping of `pack_id` → DLC App ID, encoded in `STEAM_DLC_APP_IDS` and baked into the desktop bundle. |
 
-## DLC App ID configuration
+---
 
-DLC App IDs are registered in the Steamworks App Admin portal (one child app per
-premium pack). The full registry is maintained in the private
-`STEAM_DLC_REGISTRY.md` and mirrored to the **`STEAM_DLC_APP_IDS` repository
-variable** in GitHub Actions (Settings → Secrets and variables → Actions →
-Variables).
+## Steamworks registration
 
-### Variable format
+Each premium pack is registered as a separate **DLC app** under the base
+Conversation Simulator App ID in the Steamworks partner portal.
+
+| Artifact | Location |
+|----------|----------|
+| DLC App IDs | `STEAM_DLC_APP_IDS` GitHub repository variable (comma-separated `pack_id:dlc_app_id` pairs) |
+| DLC depot template | [`steam/depot_dlc.vdf.tpl`](../steam/depot_dlc.vdf.tpl) |
+| Registration checklist | [`publishing/STEAM_APP_REGISTRATION.md`](../publishing/STEAM_APP_REGISTRATION.md) — DLC registration |
+| Compliance gate | SP-05 in [`publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md`](../publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md) |
+
+### `STEAM_DLC_APP_IDS` variable format
 
 ```
 STEAM_DLC_APP_IDS = pack_id:dlc_app_id[,pack_id:dlc_app_id …]
@@ -38,6 +79,28 @@ Rules:
 - Multiple entries are comma-separated.
 - DLC App IDs must be positive integers.
 - Malformed entries are silently skipped at runtime; the build script (`build.rs`) fails loudly at compile time so typos are caught before release.
+
+---
+
+## DLC depot layout
+
+Each DLC pack ships in its own depot (one depot per DLC App ID). The depot
+contains only the pack content — YAML scenario files, character assets, and
+any audio/image assets used by the pack. Engine binaries and model weights are
+never included.
+
+The depot is built from the private DLC repo and deployed via its own Steam
+deploy pipeline (outrightmental/ConversationSimulator-DLC#2).
+
+When installed, Steam places the DLC content at:
+
+```
+<Steam install dir>/steamapps/common/Conversation Simulator/dlc/<dlc-app-id>/
+```
+
+The app discovers installed DLC packs by scanning that directory at startup.
+
+---
 
 ## How the build pipeline threads the registry in
 
@@ -61,7 +124,13 @@ This env var is picked up in two places:
 The `tauri.conf.json` `beforeBuildCommand` re-runs `pnpm --filter @convsim/web build`
 as part of `tauri build`, so both targets receive the env var in a single CI step.
 
-## Runtime ownership check
+---
+
+## Runtime ownership gate
+
+The app gates DLC pack playability by Steam ownership. A player who does not
+own a DLC App ID sees the pack in the library as "Available on Steam" but
+cannot launch a scenario from it.
 
 ```
 pack_id  →  DLC_REGISTRY lookup  →  dlc_app_id
@@ -76,11 +145,27 @@ pack_id  →  DLC_REGISTRY lookup  →  dlc_app_id
                                ISteamApps::IsDlcInstalled(appId)
 ```
 
-### TypeScript (pack layer)
+### Rust: `SteamRuntime::is_dlc_installed`
+
+```rust
+// apps/desktop/src-tauri/src/steam.rs
+runtime.is_dlc_installed(dlc_app_id: u32) -> bool
+```
+
+Returns `true` when the Steamworks SDK confirms the local user owns and has
+installed the DLC with the given App ID. Returns `false` when Steam is
+unavailable, the user does not own the DLC, or the DLC is not installed.
+
+The Tauri command wrapper in `lib.rs`:
+
+```rust
+steam_is_dlc_installed(dlc_app_id: u32, state: tauri::State<SteamRuntimeState>) -> bool
+```
+
+### React hook: `useSteamDlc`
 
 ```typescript
-import { useSteamDlc, DLC_REGISTRY } from '../hooks/useSteamDlc'
-
+// apps/web/src/hooks/useSteamDlc.ts
 const { isDlcInstalled, isDlcInstalledForPack } = useSteamDlc()
 
 // Option 1 — convenience wrapper (preferred):
@@ -93,14 +178,23 @@ if (appId !== undefined) {
 }
 ```
 
-### Rust (Tauri command, `lib.rs`)
+Calls the `steam_is_dlc_installed` Tauri command. Degrades gracefully to
+`false` in a browser context or when the `steam` Cargo feature is disabled.
 
-```rust
-steam_is_dlc_installed(dlc_app_id: u32, state: tauri::State<SteamRuntimeState>) -> bool
+### Pack schema: `dlc_app_id` field
+
+A DLC pack's `manifest.yaml` carries an optional `dlc_app_id` field (integer).
+When the field is present and non-zero, the app calls `isDlcInstalled` before
+allowing a scenario from that pack to be launched.
+
+```yaml
+# packs/dlc/<pack-id>/manifest.yaml
+dlc_app_id: 1234567   # Steam DLC App ID; omit for free packs
 ```
 
-Delegates to `SteamRuntime::is_dlc_installed(dlc_app_id)`, which calls
-`ISteamApps::IsDlcInstalled` via the `steamworks` crate.
+Packs without `dlc_app_id` (or with `dlc_app_id: 0`) are always playable.
+
+---
 
 ## Open-source / browser build behavior
 
@@ -117,12 +211,34 @@ Premium packs are therefore treated as **not owned** in all non-Steam contexts.
 The pack layer should gate premium content behind this check and surface an
 appropriate upgrade prompt rather than showing an error.
 
+---
+
+## Pack library UI
+
+See #364 for the pack library UI changes that show owned DLC as playable and
+unowned DLC as available-to-buy (with a Steam store link).
+
+---
+
 ## Adding a new DLC pack
 
 1. Register a child DLC app in Steamworks App Admin (parent: the base game's
    App ID). Note the assigned DLC App ID.
-2. Add the new pack manifest under `packs/` with a unique `pack_id`.
+2. Author the new pack in the private `ConversationSimulator-DLC` repo with a
+   unique `pack_id` and `dlc_app_id` in its `manifest.yaml`.
 3. Append `new_pack_id:dlc_app_id` to the `STEAM_DLC_APP_IDS` repository
    variable in GitHub Actions settings.
 4. Update `STEAM_DLC_REGISTRY.md` in the private repo.
 5. Trigger a new release build — the DLC registry is baked in at compile time.
+
+---
+
+## Links
+
+- [`docs/STEAM_ROADMAP.md`](STEAM_ROADMAP.md) — release train, DLC stage (Stage 5)
+- [`publishing/STEAM_APP_REGISTRATION.md`](../publishing/STEAM_APP_REGISTRATION.md) — DLC registration checklist
+- [`publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md`](../publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md) — SP-05
+- [`steam/depot_dlc.vdf.tpl`](../steam/depot_dlc.vdf.tpl) — DLC SteamPipe depot template
+- [`apps/web/src/hooks/useSteamDlc.ts`](../apps/web/src/hooks/useSteamDlc.ts) — React ownership-gate hook
+- [`apps/desktop/src-tauri/src/steam.rs`](../apps/desktop/src-tauri/src/steam.rs) — Rust ownership-gate method
+- [outrightmental/ConversationSimulator-DLC](https://github.com/outrightmental/ConversationSimulator-DLC) — private DLC repo

--- a/docs/DLC_MODEL.md
+++ b/docs/DLC_MODEL.md
@@ -1,0 +1,134 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+# DLC Model Contract
+
+> **Purpose:** Define what can and cannot be DLC, the depot layout for DLC
+> packs, and the runtime ownership-gate API. This document is the authoritative
+> reference for any issue or PR that touches premium scenario-pack DLC.
+>
+> **Audience:** Platform team, publishing team, and DLC pack authors working in
+> the private [`ConversationSimulator-DLC`](https://github.com/outrightmental/ConversationSimulator-DLC)
+> repo.
+
+---
+
+## The invariant
+
+> **Nothing that ships free in the base app may ever be relocked as paid DLC.**
+
+DLC is always additive. The four official packs included in the base app are
+Apache-2.0 / CC BY 4.0 and remain so permanently. Community packs are free.
+Premium DLC packs are new content, sourced from the private DLC repo, sold
+only on Steam.
+
+---
+
+## What can be DLC
+
+- First-party scenario packs authored in the private
+  [`ConversationSimulator-DLC`](https://github.com/outrightmental/ConversationSimulator-DLC)
+  repo.
+- Each DLC pack is a standard scenario pack (same schema as
+  [`schemas/pack.schema.json`](../schemas/pack.schema.json)) with a proprietary
+  `LicenseRef-*` identifier (see #365) reflecting its non-open license.
+
+## What can never be DLC
+
+- Any pack or scenario already released in the base app or on GitHub.
+- Engine features, bug fixes, or UI improvements — these ship in the base app.
+- Community packs — they are always free.
+
+---
+
+## Steamworks registration
+
+Each premium pack is registered as a separate **DLC app** under the base
+Conversation Simulator App ID in the Steamworks partner portal.
+
+| Artifact | Location |
+|----------|----------|
+| DLC App IDs | `STEAM_DLC_APP_IDS` GitHub repository variable (comma-separated) |
+| DLC depot template | [`steam/depot_dlc.vdf.tpl`](../steam/depot_dlc.vdf.tpl) |
+| Registration checklist | [`publishing/STEAM_APP_REGISTRATION.md`](../publishing/STEAM_APP_REGISTRATION.md) — DLC registration |
+| Compliance gate | SP-05 in [`publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md`](../publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md) |
+
+---
+
+## DLC depot layout
+
+Each DLC pack ships in its own depot (one depot per DLC App ID). The depot
+contains only the pack content — YAML scenario files, character assets, and
+any audio/image assets used by the pack. Engine binaries and model weights are
+never included.
+
+The depot is built from the private DLC repo and deployed via its own Steam
+deploy pipeline (outrightmental/ConversationSimulator-DLC#2).
+
+When installed, Steam places the DLC content at:
+
+```
+<Steam install dir>/steamapps/common/Conversation Simulator/dlc/<dlc-app-id>/
+```
+
+The app discovers installed DLC packs by scanning that directory at startup.
+
+---
+
+## Runtime ownership gate
+
+The app gates DLC pack playability by Steam ownership. A player who does not
+own a DLC App ID sees the pack in the library as "Available on Steam" but
+cannot launch a scenario from it.
+
+### Rust: `SteamRuntime::is_dlc_installed`
+
+```rust
+// apps/desktop/src-tauri/src/steam.rs
+runtime.is_dlc_installed(dlc_app_id: u32) -> bool
+```
+
+Returns `true` when the Steamworks SDK confirms the local user owns and has
+installed the DLC with the given App ID. Returns `false` when Steam is
+unavailable, the user does not own the DLC, or the DLC is not installed.
+
+### React hook: `useSteamDlc`
+
+```typescript
+// apps/web/src/hooks/useSteamDlc.ts
+const { isDlcInstalled } = useSteamDlc()
+isDlcInstalled(dlcAppId: number): Promise<boolean>
+```
+
+Calls the `steam_is_dlc_installed` Tauri command. Degrades gracefully to
+`false` in a browser context or when the `steam` Cargo feature is disabled.
+
+### Pack schema: `dlc_app_id` field
+
+A DLC pack's `manifest.yaml` carries an optional `dlc_app_id` field (integer).
+When the field is present and non-zero, the app calls `isDlcInstalled` before
+allowing a scenario from that pack to be launched.
+
+```yaml
+# packs/dlc/<pack-id>/manifest.yaml
+dlc_app_id: 1234567   # Steam DLC App ID; omit for free packs
+```
+
+Packs without `dlc_app_id` (or with `dlc_app_id: 0`) are always playable.
+
+---
+
+## Pack library UI
+
+See #364 for the pack library UI changes that show owned DLC as playable and
+unowned DLC as available-to-buy (with a Steam store link).
+
+---
+
+## Links
+
+- [`docs/STEAM_ROADMAP.md`](STEAM_ROADMAP.md) — release train, DLC stage (Stage 5)
+- [`publishing/STEAM_APP_REGISTRATION.md`](../publishing/STEAM_APP_REGISTRATION.md) — DLC registration checklist
+- [`publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md`](../publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md) — SP-05
+- [`steam/depot_dlc.vdf.tpl`](../steam/depot_dlc.vdf.tpl) — DLC SteamPipe depot template
+- [`apps/web/src/hooks/useSteamDlc.ts`](../apps/web/src/hooks/useSteamDlc.ts) — React ownership-gate hook
+- [`apps/desktop/src-tauri/src/steam.rs`](../apps/desktop/src-tauri/src/steam.rs) — Rust ownership-gate method
+- [outrightmental/ConversationSimulator-DLC](https://github.com/outrightmental/ConversationSimulator-DLC) — private DLC repo

--- a/docs/STEAM_ROADMAP.md
+++ b/docs/STEAM_ROADMAP.md
@@ -2,22 +2,26 @@
 # Steam Edition Roadmap Addendum
 
 > **Purpose of this document:** Define the product target for shipping
-> Conversation Simulator as a free, sponsored Steam edition for non-technical
-> players — without compromising the local-first, open-source, no-telemetry
-> principles of the base project. Every downstream Steam-release issue should
-> reference this document as its shared product target.
+> Conversation Simulator as a $9.99 one-time-purchase Steam edition for
+> non-technical players — without compromising the local-first, open-source,
+> no-telemetry principles of the base project. Every downstream Steam-release
+> issue should reference this document as its shared product target.
 
 ---
 
 ## Release principles
 
-### Free on Steam, sponsored by Outright Mental
+### Open source on GitHub, $9.99 on Steam
 
-The Steam edition is and will remain **free to download and play**. There is no
-base purchase price, no subscription, and no pay-to-unlock core content.
-Outright Mental sponsors the distribution costs (Steam partner fees, code
-signing, CI infrastructure, release tooling) so the project can reach
-non-technical players without charging them.
+The engine and four official packs are **free and open source on GitHub**
+(Apache-2.0 / CC BY 4.0). The Steam edition is the same open-source build
+packaged for non-technical players: signed, notarised, auto-updating, and
+Steam Deck–verified. It is sold at a **one-time price of $9.99** — no
+subscription, no pay-to-unlock core content. The purchase funds ongoing
+development; it does not unlock anything the source build lacks.
+
+**Invariant:** the open core never shrinks — nothing that ships free today
+will ever be relocked as paid content.
 
 ### Local-first play, no exceptions
 
@@ -54,13 +58,18 @@ player's knowledge. Every model download must:
 Players must confirm each download. Cancelling a download must leave no partial
 files. Pack downloads follow the same rules.
 
-### No paid marketplace in v1
+### Premium DLC — Steam only
 
-The Steam release does not include a paid content marketplace. Community packs
-may be distributed outside the app (GitHub, itch.io, direct links), but the
-in-app experience ships no payment rails, no premium pack tier, and no
-microtransactions in v1. Post-launch marketplace exploration is recorded as
-stage 5 of the [release train](#release-train) and is explicitly deferred.
+First-party expansion packs authored in the private
+[`ConversationSimulator-DLC`](https://github.com/outrightmental/ConversationSimulator-DLC)
+repo are sold as paid Steam DLC. DLC content never enters this public repo;
+the app gates playability by Steam ownership check (`is_dlc_installed`).
+
+Community packs remain free and may be distributed outside the app (GitHub,
+itch.io, direct links). The community pack path carries no payment rails.
+
+See [`docs/DLC_MODEL.md`](DLC_MODEL.md) for the full DLC contract: what can
+be DLC, what can never be DLC, depot layout, and the ownership-gate API.
 
 ---
 
@@ -75,8 +84,8 @@ met and its tracking issue is closed.
 | **1. GitHub MVP** | Open-source build reaches Milestone 1: stable text loop, voice I/O, workbench, official packs, offline smoke gate, full docs. | All [ROADMAP.md](../ROADMAP.md) Milestone 1 items are checked off. |
 | **2. Packaged desktop alpha** | Tauri desktop app bundles `convsim-core` as a sidecar. Single installer on Windows, macOS, Linux. No Steam involvement yet. | GitHub MVP is tagged. Installer boots without CLI setup. Offline smoke test passes from the installed app. |
 | **3. Steam private beta** | App is submitted to the Steam partner portal. Invited testers (developers, Outright Mental staff, select community members) validate the Steam overlay, controller navigation, and platform-specific quirks. | Packaged desktop alpha passes internal QA on all three desktop platforms. Steam page draft is approved by Valve. |
-| **4. Public free Steam release** | App is published as a free title on Steam. All four official packs are available. Model Manager UI is stable. | Steam private beta exit criteria are met. Code signing is in place on macOS and Windows. Steam Deck verification is complete (see [Target platforms](#target-platforms)). |
-| **5. Post-launch: marketplace exploration** | Evaluate whether a community pack browser or optional Outright Mental-curated content makes sense as a zero-cost or patron-supported layer. No decision has been made; this is a research milestone only. See [`docs/marketplace-architecture.md`](marketplace-architecture.md) for the entry gate criteria and design baseline. | Public release has been live for at least 90 days. Community feedback and usage signals inform the evaluation. Entry gate from [`docs/marketplace-architecture.md`](marketplace-architecture.md) must be satisfied before any implementation issue is opened. |
+| **4. Public $9.99 Steam release** | App is published on Steam at $9.99 one-time. All four official packs are available. Model Manager UI is stable. | Steam private beta exit criteria are met. Code signing is in place on macOS and Windows. Steam Deck verification is complete (see [Target platforms](#target-platforms)). |
+| **5. Premium DLC** | First-party expansion packs published as paid Steam DLC, sourced from the private [`ConversationSimulator-DLC`](https://github.com/outrightmental/ConversationSimulator-DLC) repo. DLC is gated by Steam ownership check. | Public release has been live for at least 90 days. DLC pipeline is operational (outrightmental/ConversationSimulator-DLC#2). At least one premium pack is authored and validated (outrightmental/ConversationSimulator-DLC#1). |
 
 ---
 

--- a/publishing/STEAM_APP_REGISTRATION.md
+++ b/publishing/STEAM_APP_REGISTRATION.md
@@ -1,10 +1,11 @@
 <!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Steam App Registration
 
-> **Purpose:** Record the Steamworks partner portal configuration for the free
-> Outright Mental-sponsored edition of Conversation Simulator. This document is
-> the authoritative reference for app identity, depot layout, package
-> configuration, branch strategy, and the location of CI credentials.
+> **Purpose:** Record the Steamworks partner portal configuration for the
+> $9.99 one-time-purchase Steam edition of Conversation Simulator. This document
+> is the authoritative reference for app identity, depot layout, package
+> configuration, DLC registration, branch strategy, and the location of CI
+> credentials.
 >
 > **Audience:** Platform team members and Outright Mental staff with Steamworks
 > partner portal access.
@@ -47,18 +48,23 @@ Mark each item when done and record the assigned identifiers in the
 - [ ] Enter the store page title: `Conversation Simulator`.
 - [ ] Record the assigned **App ID** in the [Identifiers](#identifiers) table and set it as the `STEAM_APP_ID` repository variable.
 
-### Free-to-play configuration
+### $9.99 base price configuration
 
-- [ ] Under **Pricing & Availability**, set the **Base price** to `Free to Play`.
-- [ ] Do **not** set a purchase price or create a paid package. The base package is always free.
-- [ ] Verify the app does **not** appear in the "Set up pricing" wizard with a price — it must be marked Free on Steam from the first configuration step.
-- [ ] Confirm no DLC or microtransaction package is created during initial setup.
-- [ ] Verify the free default package (automatically created by Valve for free-to-play apps) contains all three platform depots once they are created.
+- [ ] Under **Pricing & Availability**, set the **Base price** to `$9.99` (USD).
+- [ ] Use the **Set a price** wizard; do **not** mark the app as Free to Play.
+- [ ] Verify prices in all supported regional currencies are populated by Valve's
+      conversion; adjust any region where Valve's converted price is materially
+      incorrect.
+- [ ] Create one **paid package** (the base app package) that contains all three
+      platform depots.
+- [ ] Do **not** create a separate free or demo package unless a demo build is
+      explicitly scoped.
 
-The Steam release is and will remain free to download and play. There is no
-base purchase price, no subscription, and no pay-to-unlock core content.
-See [`docs/STEAM_ROADMAP.md`](../docs/STEAM_ROADMAP.md) — Free on Steam,
-sponsored by Outright Mental.
+The Steam edition costs **$9.99 one-time**. There is no subscription and no
+pay-to-unlock core content. The same engine and official packs are available
+free on GitHub (Apache-2.0 / CC BY 4.0) — the purchase price covers packaging,
+signing, and distribution, not exclusive access. See
+[`docs/STEAM_ROADMAP.md`](../docs/STEAM_ROADMAP.md).
 
 ### Depots
 
@@ -74,12 +80,15 @@ content rules.
 ### Packages
 
 A **package** in Steamworks bundles one or more depots and determines what a
-player owns. For a free-to-play title, Valve automatically creates a **free
-default package** containing all depots.
+player owns.
 
-- [ ] Verify the automatic free package exists and contains all three depots.
-- [ ] Do **not** create a paid package or a retail activation package.
-- [ ] Record the free package ID (assigned by Valve) in the [Identifiers](#identifiers) table.
+- [ ] Create one **base app package** at $9.99 containing all three platform
+      depots. This is the package players purchase to install the app.
+- [ ] Record the base package ID in the [Identifiers](#identifiers) table.
+- [ ] For each premium DLC pack: create a separate **DLC package** at the
+      appropriate price, linked to the DLC's own App ID and depot. See
+      [DLC registration](#dlc-registration) below.
+- [ ] Do **not** create a free or free-to-play package for the base app.
 
 ### Release state
 
@@ -102,7 +111,8 @@ source files.
 | Windows depot ID | `vars.STEAM_DEPOT_WINDOWS_ID` | First depot created; Windows x86-64 content. Valve assigns depot IDs sequentially after the App ID. |
 | macOS depot ID | `vars.STEAM_DEPOT_MACOS_ID` | Second depot created; macOS (Apple Silicon + Intel) content. |
 | Linux/SteamOS depot ID | `vars.STEAM_DEPOT_LINUX_ID` | Third depot created; Linux x86-64 and Steam Deck content. |
-| Free package ID | *(record here after registration)* | Automatically created by Valve for free-to-play apps. Not referenced in CI. |
+| Base package ID | *(record here after registration)* | The $9.99 paid package created for the base app. Not referenced in CI. |
+| DLC App ID(s) | `vars.STEAM_DLC_APP_IDS` | Comma-separated list of DLC App IDs registered for premium packs. Consumed by the ownership-gate build (see #363). |
 
 **To set a repository variable:** GitHub → repository Settings → Secrets and
 variables → Actions → Variables tab → New repository variable.
@@ -149,6 +159,35 @@ These exclusions are enforced in the SteamPipe depot VDF templates:
 A depot content audit is required before each Steam build submission — see
 checklist item SR-08 in
 [`publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md`](STEAM_COMPLIANCE_AND_RISK_REGISTER.md).
+
+---
+
+## DLC registration
+
+Each premium scenario pack DLC is registered as a separate Steamworks app
+(type: DLC) under the base App ID.
+
+### Steps for each new DLC pack
+
+- [ ] Register a new DLC app under the base app in the Steamworks partner portal.
+      App type must be **DLC**, parent set to the base app's App ID.
+- [ ] Set the DLC app's title to the pack display name (e.g. `Advanced Professional Skills`).
+- [ ] Set the DLC price in Steamworks Pricing & Availability.
+- [ ] Create one depot for the DLC content (pack YAML files + assets). Use
+      [`steam/depot_dlc.vdf.tpl`](../steam/depot_dlc.vdf.tpl) as the template.
+- [ ] Record the new DLC App ID in the `STEAM_DLC_APP_IDS` repository variable
+      (comma-separated if multiple packs exist).
+- [ ] Confirm the runtime ownership check (`is_dlc_installed`) references the
+      correct App ID. See [`docs/DLC_MODEL.md`](../docs/DLC_MODEL.md) for the
+      gate API contract.
+
+### DLC invariant
+
+> Nothing that ships free in the base app may be relocked as DLC. DLC is
+> always additive.
+
+This is enforced by policy, not code — the compliance checklist (SR-10) must
+confirm it before each DLC release.
 
 ---
 

--- a/publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md
+++ b/publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md
@@ -324,16 +324,16 @@ the decisions for Steam review and partner portal audit purposes.
 | **Release-blocking** | YES |
 | **Status** | OPEN |
 
-### SP-05 — Steam Wallet and future paid DLC path
+### SP-05 — Paid DLC requires Valve compliance and ownership-gate review
 
 | | |
 |---|---|
 | **Area** | Platform / Licensing |
-| **Risk** | A future community pack browser or paid DLC path requires Steam Wallet integration, which requires Valve's approval for microtransaction-enabled titles and may trigger additional content review obligations. |
+| **Risk** | Selling premium DLC on Steam requires Valve approval for paid DLC, correct IARC questionnaire answers (real-money purchases → Yes), and a correct runtime ownership check — failure to satisfy any of these blocks the DLC release or triggers Valve store violations. |
 | **Owner** | Outright Mental (publishing) |
-| **Mitigation** | The v1 Steam release ships with no payment rails, no premium pack tier, and no microtransactions. Any paid marketplace or DLC content path is explicitly deferred to Stage 5 (post-launch exploration) of the release train. If a paid path is ever pursued, it must go through a separate Valve review, a Steam Wallet integration audit, and a legal review of revenue-sharing obligations before implementation. |
-| **Release-blocking** | NO (deferred) |
-| **Status** | DEFERRED |
+| **Mitigation** | Base app is registered at $9.99; DLC packs are registered as separate Steamworks DLC apps with their own App IDs. IARC questionnaire updated: "Does the game involve real-money purchases?" → Yes. Runtime ownership check (`is_dlc_installed` / `useSteamDlc`) gates DLC content by Steam ownership — players who do not own a DLC App ID cannot access its packs. Valve DLC review must be completed before each DLC release. Legal review of revenue-sharing obligations completed before any DLC is published. DLC invariant enforced: nothing previously free may be relocked as DLC. See `docs/DLC_MODEL.md` for the full contract. |
+| **Release-blocking** | YES (for each DLC release) |
+| **Status** | IN PROGRESS |
 
 ---
 
@@ -393,7 +393,7 @@ gate (Stage 3) or the public release gate (Stage 4).
 - [ ] Steam Deck verification checklist in `docs/STEAM_ROADMAP.md` is complete and all items pass.
 - [ ] Steam store page copy has been reviewed using the checklist in [`publishing/STEAM_STORE_PAGE.md`](STEAM_STORE_PAGE.md) — Store page review checklist.
 - [ ] Store page copy accuracy: no language claims AI therapy, diagnosis, or legal advice (gate G4-04).
-- [ ] Steam store page does not imply paid content or a marketplace that does not exist in v1 (gate G4-04).
+- [ ] Steam store page accurately states $9.99 one-time base price and optional paid DLC; no false free-to-play claim (gate G4-04).
 - [ ] All store page copy sign-off rows in [`publishing/STEAM_STORE_PAGE.md`](STEAM_STORE_PAGE.md) — Sign-off table are completed with reviewer name and date.
 - [ ] All capsule assets, screenshots, and trailer reviewed against the production brief in [`publishing/STEAM_ASSETS_SPEC.md`](STEAM_ASSETS_SPEC.md) and uploaded to Steamworks.
 
@@ -465,7 +465,7 @@ team is unblocked.
 | SP-02 | Platform | YES | OPEN |
 | SP-03 | Platform | NO | OPEN |
 | SP-04 | Platform | YES | OPEN |
-| SP-05 | Platform / Licensing | NO (deferred) | DEFERRED |
+| SP-05 | Platform / Licensing | YES (per DLC release) | IN PROGRESS |
 
 ---
 

--- a/publishing/STEAM_STORE_PAGE.md
+++ b/publishing/STEAM_STORE_PAGE.md
@@ -11,7 +11,7 @@
 >
 > **Constraints enforced here:**
 > - No language claiming AI therapy, diagnosis, or legal advice (gate G4-04).
-> - No implied marketplace or paid content (gate G4-04, SP-05).
+> - Price claims must be accurate: $9.99 one-time base app; DLC sold separately.
 > - Local-first and privacy-first copy must be factually accurate (PR-01–PR-03).
 > - Content-boundary statements must match the safety policy in
 >   [`schemas/safety.schema.json`](../schemas/safety.schema.json).
@@ -35,10 +35,10 @@ Limit: **300 characters**.
 ```
 Conversation Simulator is the practice tool for interviews, negotiations,
 difficult talks, and language skills. AI characters run entirely on your
-computer. No internet needed during play. Free forever.
+computer. No internet needed during play. Open source — $9.99 on Steam.
 ```
 
-Character count: 202. Within the 300-character limit.
+Character count: 206. Within the 300-character limit.
 
 ---
 
@@ -53,11 +53,10 @@ statement.
 <h2>Conversation Simulator is the simulator for conversations.</h2>
 
 <p>
-  Conversation Simulator is a free, local-first practice tool that lets you
-  rehearse real-life conversations before they happen. Choose a scenario, talk
-  to an AI character running entirely on your computer, watch the situation
-  evolve, and review what went well — or what you would say differently next
-  time.
+  Conversation Simulator is a local-first practice tool that lets you rehearse
+  real-life conversations before they happen. Choose a scenario, talk to an AI
+  character running entirely on your computer, watch the situation evolve, and
+  review what went well — or what you would say differently next time.
 </p>
 
 <p>
@@ -193,19 +192,21 @@ statement.
   Steam Deck's shared RAM configuration.
 </p>
 
-<h2>Free forever</h2>
+<h2>Open source, fairly priced</h2>
 
 <p>
-  Conversation Simulator is free to download and play. There is no base
-  purchase price, no subscription, and no pay-to-unlock core content.
-  The Steam release is sponsored by <strong>Outright Mental</strong>, who
-  covers distribution costs so this tool can reach players who benefit from
-  it.
+  The engine and four built-in packs are <strong>free and open source on
+  GitHub</strong> (Apache-2.0 / CC BY 4.0). Building from source is free,
+  forever. The Steam edition is a packaged, signed, notarised, auto-updating
+  build of the same open source — sold at a one-time price of
+  <strong>$9.99</strong>. No subscription. Nothing the source build includes
+  is locked behind that price.
 </p>
 
 <p>
-  The source code is open and available on GitHub. Community-created scenario
-  packs can be installed manually and shared freely.
+  Premium expansion packs, authored by Outright Mental, are sold as optional
+  paid Steam DLC. Community-created packs remain free and can be installed
+  manually.
 </p>
 ```
 
@@ -281,23 +282,24 @@ This is the short-form content-boundaries statement for the store page
 
 ---
 
-## Free edition wording
+## Pricing wording
 
-Use this copy wherever the free-to-play nature needs to be stated explicitly
+Use this copy wherever the pricing model needs to be stated explicitly
 (store description, FAQ, press kit).
 
 ```
-Free forever — not a demo, not a time-limited trial.
+Open source and fairly priced.
 
-Conversation Simulator is free to download and play on Steam. There is no
-purchase price, no subscription, and no paywall in front of the built-in
-scenario packs. Outright Mental sponsors distribution so the tool reaches
-players who can benefit from it.
+The engine and four built-in packs are free and open source on GitHub.
+Building from source costs nothing, forever.
 
-There are no microtransactions, no premium content tier, and no in-app
-purchase system in the current release. Community packs can be installed
-manually and are distributed outside the app by their authors — the app
-itself does not host or sell them.
+The Steam edition is $9.99 one-time — the same open-source build, packaged
+for non-technical players: signed, notarised, and auto-updating. That
+purchase funds development; it unlocks nothing the source build lacks.
+
+Premium scenario packs by Outright Mental are available as optional paid
+Steam DLC — always additions, never relocations of free content. Community
+packs remain free and can be installed manually.
 ```
 
 ---
@@ -415,7 +417,7 @@ These reflect the built-in safety policy (see
 | Does the game contain strong language? | Mild — language appropriate to workplace and social conflict scenarios |
 | Does the game involve online interaction with other players? | No |
 | Is the game intended only for adults? | No |
-| Does the game involve real-money purchases? | No |
+| Does the game involve real-money purchases? | Yes — $9.99 base app + optional paid DLC |
 
 **Expected rating outcome:**
 
@@ -466,14 +468,14 @@ This is a supplement to the compliance checklist (SR-07) in
 - [ ] Short description is ≤ 300 characters and accurately describes the app.
 - [ ] Long description contains no claim of AI therapy, diagnosis, or clinical
       authority.
-- [ ] Long description contains no implication of a paid marketplace, premium
-      tier, or microtransactions.
+- [ ] Long description accurately states $9.99 one-time base price and optional
+      paid DLC; no false implications of a free-to-play model.
 - [ ] Local-first privacy copy is consistent with [`docs/privacy.md`](../docs/privacy.md)
       and the runtime behaviour confirmed in SR-01 and SR-02.
 - [ ] Content-boundaries list matches the safety policy schema
       ([`schemas/safety.schema.json`](../schemas/safety.schema.json)).
-- [ ] Free edition wording accurately states that the app is free forever with
-      no time limit or demo restriction.
+- [ ] Pricing wording accurately states the open-source / $9.99 model and that
+      DLC is always additive (nothing free is ever relocked as paid content).
 - [ ] System requirements have been verified against actual test results from
       the platform smoke matrix ([`docs/release-checklist.md`](../docs/release-checklist.md)).
 - [ ] Steam Deck notes accurately reflect the text-mode fallback (AU-03) and
@@ -530,7 +532,7 @@ This is a supplement to the compliance checklist (SR-07) in
 | Feature bullets | | | |
 | Privacy copy | | | |
 | Content boundaries | | | |
-| Free edition wording | | | |
+| Pricing wording | | | |
 | System requirements | | | |
 | Genres and tags | | | |
 | Age disclosures | | | |

--- a/schemas/pack.schema.json
+++ b/schemas/pack.schema.json
@@ -109,6 +109,11 @@
           "description": "Relative path to the safety policy YAML file."
         }
       }
+    },
+    "dlc_app_id": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Steam DLC App ID for premium packs. When non-zero, the app gates playability by Steam ownership (is_dlc_installed). Omit or set to 0 for free packs. See docs/DLC_MODEL.md."
     }
   },
   "not": {

--- a/services/convsim-core/convsim_core/schemas/pack.schema.json
+++ b/services/convsim-core/convsim_core/schemas/pack.schema.json
@@ -109,6 +109,11 @@
           "description": "Relative path to the safety policy YAML file."
         }
       }
+    },
+    "dlc_app_id": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Steam DLC App ID for premium packs. When non-zero, the app gates playability by Steam ownership (is_dlc_installed). Omit or set to 0 for free packs. See docs/DLC_MODEL.md."
     }
   },
   "not": {

--- a/steam/depot_dlc.vdf.tpl
+++ b/steam/depot_dlc.vdf.tpl
@@ -1,0 +1,41 @@
+// SteamPipe depot build configuration — premium DLC scenario pack.
+//
+// Template file. Substituted by the DLC deploy workflow before steamcmd is
+// invoked. Variables: STEAM_DLC_DEPOT_ID, GITHUB_WORKSPACE, STEAM_DLC_PACK_ID.
+//
+// Content: the YAML scenario files and assets for one premium DLC pack.
+// The pack content is sourced from the private ConversationSimulator-DLC repo.
+// Do NOT include engine binaries, model weights, or base-app content here.
+//
+// The DLC deploy workflow places pack content at:
+//   ${GITHUB_WORKSPACE}/steam-content/dlc/${STEAM_DLC_PACK_ID}/
+"DepotBuild"
+{
+    "DepotID"       "${STEAM_DLC_DEPOT_ID}"
+
+    "ContentRoot"   "${GITHUB_WORKSPACE}/steam-content/dlc/${STEAM_DLC_PACK_ID}/"
+
+    "FileMapping"
+    {
+        "LocalPath"     "*"
+        "DepotPath"     "."
+        "Recursive"     "1"
+    }
+
+    // Model weight files must never appear in any depot.
+    // See risk MD-04 in publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md.
+    "FileExclusion" "*.gguf"
+    "FileExclusion" "*.bin"
+    "FileExclusion" "*.safetensors"
+    "FileExclusion" "*.pt"
+    "FileExclusion" "*.pth"
+    "FileExclusion" "*.ckpt"
+
+    // Exclude debug artefacts.
+    "FileExclusion" "*.pdb"
+    "FileExclusion" "*.dSYM"
+
+    // Exclude source-control metadata.
+    "FileExclusion" ".git*"
+    "FileExclusion" ".github*"
+}

--- a/website/content/manifesto.md
+++ b/website/content/manifesto.md
@@ -82,11 +82,17 @@ configuration can weaken them: content that sexualizes minors ends the
 session, and self-harm crisis language ends the session and surfaces real
 resources. Community packs can make safety rules stricter. Never looser.
 
-## Free means free
+## Open source and fairly priced
 
 No premium tier. No ads. No locked scenarios. No data resale — there is no
-data to sell. The code is Apache-2.0, the packs are CC BY 4.0, and the Steam
-release is sponsored so it can stay free there too.
+data to sell. The engine is Apache-2.0, the official packs are CC BY 4.0,
+and building from source on GitHub is free, always.
+
+On Steam the app costs $9.99 once. That purchase funds development; it does
+not unlock anything the source build lacks, and nothing that ships free today
+will ever move behind a paywall. Premium expansion packs, written by Outright
+Mental and sold as Steam DLC, are the only paid content — and they are always
+additions, never relocations.
 
 ---
 


### PR DESCRIPTION
Implements the business-model pivot tracked in #366.

## What changed

### Public messaging
- `docs/STEAM_ROADMAP.md` — replaced "Free on Steam, sponsored by Outright Mental" principle with "Open source on GitHub, $9.99 on Steam"; replaced "No paid marketplace in v1" with "Premium DLC — Steam only"; updated Stage 4 and Stage 5 in the release train.
- `website/content/manifesto.md` — replaced "Free means free" section with "Open source and fairly priced", explaining the GitHub-free / Steam-$9.99 / additive-DLC model.
- `README.md` — updated Steam release paragraph to state the $9.99 one-time price and that the GitHub build stays free.

### Steam publishing docs
- `publishing/STEAM_APP_REGISTRATION.md` — replaced free-to-play configuration with $9.99 paid-package steps; added DLC registration section; added `STEAM_DLC_APP_IDS` to the identifiers table.
- `publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md` — reactivated SP-05 (was DEFERRED) for the now-active paid-DLC path; inverted the G4-04 gate item to require accurate pricing copy; updated the summary table.
- `publishing/STEAM_STORE_PAGE.md` — updated short and long descriptions to remove "Free forever" and add open-source + $9.99 framing; flipped IARC real-money answer to Yes; replaced "Free edition wording" with "Pricing wording".

### DLC infrastructure
- `docs/DLC_MODEL.md` *(new)* — authoritative DLC contract: the additive-only invariant, what can/cannot be DLC, Steamworks registration steps, depot layout, and the runtime ownership-gate API.
- `steam/depot_dlc.vdf.tpl` *(new)* — SteamPipe VDF template for premium DLC depots, mirroring the per-platform base-app templates.
- `schemas/pack.schema.json` — added optional `dlc_app_id` integer field so DLC pack manifests can declare their Steam App ID while `additionalProperties: false` stays enforced.

### Runtime ownership gate
- `apps/desktop/src-tauri/src/steam.rs` — added `SteamRuntime::is_dlc_installed(dlc_app_id)` using `ISteamApps::BIsDlcInstalled`; degrades gracefully to `false` when Steam is absent; two new Rust tests.
- `apps/desktop/src-tauri/src/lib.rs` — wired `steam_is_dlc_installed` as a Tauri command.
- `apps/web/src/hooks/useSteamDlc.ts` *(new)* — `useSteamDlc` React hook exposing `isDlcInstalled(dlcAppId)`, degrades to `false` in browser context.
- `apps/web/src/__tests__/useSteamDlc.test.ts` *(new)* — 7 tests covering no-Tauri fallback, ownership, non-ownership, IPC rejection, zero App ID, and multi-DLC-ID independence.

## How it was tested

- `useSteamDlc` hook: 7 vitest tests, all passing (`apps/web`).
- `is_dlc_installed` Rust method: 2 unit tests in `steam.rs` covering the no-Steam and zero-App-ID cases.
- Publishing and docs changes are editorial; correctness verified by review against the issue spec.

Closes #366