### PR TITLE
Docs: fix stale useSteamDlcOwned hook reference in Steam integration docs

### DIFF
--- a/docs-site/src/content/docs/dev/steam-integration.md
+++ b/docs-site/src/content/docs/dev/steam-integration.md
@@ -299,10 +299,12 @@ gated purely by Steam ownership, checked at runtime:
   `steamworks::Apps::is_dlc_installed(AppId)`. It returns `false` when the `steam`
   feature is off, Steam is not running, or the player does not own the DLC.
 - The **`steam_is_dlc_installed`** Tauri command exposes it to the front end.
-- The **`useSteamDlc`** / **`useSteamDlcOwned`** hooks
-  (`apps/web/src/hooks/useSteamDlc.ts`) resolve to "not owned" in any non-Tauri /
-  non-Steam context, so the open-source and browser builds treat every premium pack
-  as available-to-buy without special-casing.
+- The **`useSteamDlc`** hook (`apps/web/src/hooks/useSteamDlc.ts`) exposes
+  `isDlcInstalled(dlcAppId)` and `isDlcInstalledForPack(packId)` (the latter resolves
+  the pack's DLC App ID from the build-time `DLC_REGISTRY`, populated from
+  `STEAM_DLC_APP_IDS`). Both resolve to "not owned" in any non-Tauri / non-Steam
+  context, so the open-source and browser builds treat every premium pack as
+  available-to-buy without special-casing.
 
 Privacy: the ownership check reads local Steam state only. No DLC-usage event,
 pack identifier, or conversation content is transmitted to Steam or any server —

--- a/docs/STEAM_INTEGRATION.md
+++ b/docs/STEAM_INTEGRATION.md
@@ -295,10 +295,12 @@ gated purely by Steam ownership, checked at runtime:
   `steamworks::Apps::is_dlc_installed(AppId)`. It returns `false` when the `steam`
   feature is off, Steam is not running, or the player does not own the DLC.
 - The **`steam_is_dlc_installed`** Tauri command exposes it to the front end.
-- The **`useSteamDlc`** / **`useSteamDlcOwned`** hooks
-  (`apps/web/src/hooks/useSteamDlc.ts`) resolve to "not owned" in any non-Tauri /
-  non-Steam context, so the open-source and browser builds treat every premium pack
-  as available-to-buy without special-casing.
+- The **`useSteamDlc`** hook (`apps/web/src/hooks/useSteamDlc.ts`) exposes
+  `isDlcInstalled(dlcAppId)` and `isDlcInstalledForPack(packId)` (the latter resolves
+  the pack's DLC App ID from the build-time `DLC_REGISTRY`, populated from
+  `STEAM_DLC_APP_IDS`). Both resolve to "not owned" in any non-Tauri / non-Steam
+  context, so the open-source and browser builds treat every premium pack as
+  available-to-buy without special-casing.
 
 Privacy: the ownership check reads local Steam state only. No DLC-usage event,
 pack identifier, or conversation content is transmitted to Steam or any server —
@@ -307,7 +309,8 @@ playing it requires no network.
 
 ```typescript
 // apps/web/src/hooks/useSteamDlc.ts
-const owned = useSteamDlcOwned(dlcAppId)   // false outside Steam / when unowned
+const { isDlcInstalledForPack } = useSteamDlc()
+const owned = await isDlcInstalledForPack(packId)   // false outside Steam / when unowned
 // owned packs load and show as playable; unowned show as "available to buy"
 ```
 


### PR DESCRIPTION
## Summary

Doc-only fix. `STEAM_INTEGRATION.md` and its docs-site mirror (`docs-site/src/content/docs/dev/steam-integration.md`) referenced a non-existent `useSteamDlcOwned` hook. The actual API is `useSteamDlc()`, which returns `{ isDlcInstalled, isDlcInstalledForPack }`:

- `isDlcInstalled(dlcAppId)` — checks ownership of a DLC by Steam App ID
- `isDlcInstalledForPack(packId)` — resolves the pack's DLC App ID from the build-time `DLC_REGISTRY` (populated from `STEAM_DLC_APP_IDS`), then checks ownership

Updated both documentation files and the code example to match the real API.

## Motivation

Loose end from the business-model pivot in #366. No code or behaviour change.