### PR TITLE
Provision llama-server on every platform with Windows-native one-click install

### DIFF
--- a/.github/workflows/binary-health-check.yml
+++ b/.github/workflows/binary-health-check.yml
@@ -19,11 +19,13 @@ on:
     branches: [main]
     paths:
       - 'services/convsim-core/**'
+      - 'runtimes/llama_cpp/**'
       - '.github/workflows/binary-health-check.yml'
   pull_request:
     branches: [main]
     paths:
       - 'services/convsim-core/**'
+      - 'runtimes/llama_cpp/**'
       - '.github/workflows/binary-health-check.yml'
 
 permissions:
@@ -142,3 +144,31 @@ jobs:
               Write-Error "FAIL: /api/health did not respond within 10 s"
               exit 1
           }
+
+      # ── Engine platform detection smoke test (all platforms) ─────────────────
+      # Verifies that detect_platform_string() now returns a valid string on
+      # every shipping platform, and that the download-runtime endpoint reports
+      # a non-null platform (i.e. Windows is no longer PLATFORM_NOT_SUPPORTED).
+      - name: Verify engine platform detection
+        shell: bash
+        working-directory: services/convsim-core
+        run: |
+          python3 - <<'PYEOF'
+          import sys
+          from convsim_core.runtime.llama_cpp_download import detect_platform_string
+
+          try:
+              tag = detect_platform_string()
+          except RuntimeError as exc:
+              print(f"FAIL: detect_platform_string() raised on {sys.platform}: {exc}", file=sys.stderr)
+              sys.exit(1)
+
+          print(f"OK: detect_platform_string() = {tag!r} on {sys.platform}")
+
+          # Sanity: Windows must return a win-* string, not raise.
+          if sys.platform == "win32" and not tag.startswith("win-"):
+              print(f"FAIL: expected win-* tag on win32, got {tag!r}", file=sys.stderr)
+              sys.exit(1)
+
+          sys.exit(0)
+          PYEOF

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,26 +203,29 @@ jobs:
       # block): GitHub release installers leave it unset so they stay lean and
       # download the engine on first run instead.
       #
-      # The binary is placed at src-tauri/resources/bin/llama-server[.exe] and
-      # picked up by Tauri's bundle.resources: ["resources/**/*"] glob.
-      # find_executable() discovers it via CONVSIM_BUNDLED_RUNTIME_DIR (set by
-      # the Tauri shell at runtime, pointing at the depot's runtimes/ directory).
+      # The binary is placed at src-tauri/resources/runtimes/llama-server[.exe]
+      # and picked up by Tauri's bundle.resources: ["resources/**/*"] glob.
+      # At runtime the Tauri shell sets CONVSIM_BUNDLED_RUNTIME_DIR to the
+      # resources/runtimes directory (see src-tauri/src/lib.rs), and Python's
+      # find_executable() resolves <CONVSIM_BUNDLED_RUNTIME_DIR>/llama-server[.exe]
+      # from there. Do NOT place it under resources/bin/ — that is where
+      # convsim-core lives and is never scanned for sidecar binaries.
       - name: Bundle llama-server (Linux / macOS — Steam only)
         if: env.BUNDLE_LLAMA_SERVER == 'true' && runner.os != 'Windows'
         shell: bash
         env:
-          LLAMA_CPP_DEST: apps/desktop/src-tauri/resources/bin
+          LLAMA_CPP_DEST: apps/desktop/src-tauri/resources/runtimes
         run: |
           set -euo pipefail
           bash runtimes/llama_cpp/download-runtime.sh
-          ls -lh apps/desktop/src-tauri/resources/bin/llama-server
+          ls -lh apps/desktop/src-tauri/resources/runtimes/llama-server
 
       - name: Bundle llama-server (Windows — Steam only)
         if: env.BUNDLE_LLAMA_SERVER == 'true' && runner.os == 'Windows'
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          $dest = "apps\desktop\src-tauri\resources\bin"
+          $dest = "apps\desktop\src-tauri\resources\runtimes"
           .\runtimes\llama_cpp\download-runtime.ps1 -Dest $dest
           Get-Item "$dest\llama-server.exe" | Select-Object Name, Length
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,6 +190,34 @@ jobs:
             exit 1
           fi
 
+      # ── Bundle llama-server binary (Steam builds) ─────────────────────────────
+      # Downloads and bundles the llama-server binary alongside convsim-core so
+      # Steam players get zero-setup inference with no first-run download.
+      # GitHub release installers omit this step to keep download sizes lean.
+      #
+      # The binary is placed at src-tauri/resources/bin/llama-server[.exe] and
+      # picked up by Tauri's bundle.resources: ["resources/**/*"] glob.
+      # find_executable() discovers it via CONVSIM_BUNDLED_RUNTIME_DIR (set by
+      # the Tauri shell at runtime, pointing at the depot's runtimes/ directory).
+      - name: Bundle llama-server (Linux / macOS — Steam only)
+        if: runner.os != 'Windows'
+        shell: bash
+        env:
+          LLAMA_CPP_DEST: apps/desktop/src-tauri/resources/bin
+        run: |
+          set -euo pipefail
+          bash runtimes/llama_cpp/download-runtime.sh
+          ls -lh apps/desktop/src-tauri/resources/bin/llama-server
+
+      - name: Bundle llama-server (Windows — Steam only)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $dest = "apps\desktop\src-tauri\resources\bin"
+          .\runtimes\llama_cpp\download-runtime.ps1 -Dest $dest
+          Get-Item "$dest\llama-server.exe" | Select-Object Name, Length
+
       # ── Sync app version to the release tag ──────────────────────────────────
       # The built binary reports the `version` field from tauri.conf.json, and
       # the in-app updater compares that against the `version` in latest.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,12 @@ jobs:
       HAS_NOTARIZATION: ${{ secrets.APPLE_ID != '' }}
       HAS_WINDOWS_CERT: ${{ secrets.WINDOWS_SIGN_CERT_PFX != '' }}
       HAS_UPDATER_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY != '' }}
+      # Steam depot builds bundle llama-server so players get zero-setup
+      # inference; GitHub release installers stay lean and download it on first
+      # run (see docs/model-download-policy.md §8). This one workflow feeds both
+      # channels, so bundling is an explicit opt-in: set the BUNDLE_LLAMA_SERVER
+      # repository variable to 'true' only for Steam-depot builds.
+      BUNDLE_LLAMA_SERVER: ${{ vars.BUNDLE_LLAMA_SERVER == 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -190,17 +196,19 @@ jobs:
             exit 1
           fi
 
-      # ── Bundle llama-server binary (Steam builds) ─────────────────────────────
+      # ── Bundle llama-server binary (Steam builds only) ────────────────────────
       # Downloads and bundles the llama-server binary alongside convsim-core so
       # Steam players get zero-setup inference with no first-run download.
-      # GitHub release installers omit this step to keep download sizes lean.
+      # Gated on the BUNDLE_LLAMA_SERVER repository variable (see the job `env`
+      # block): GitHub release installers leave it unset so they stay lean and
+      # download the engine on first run instead.
       #
       # The binary is placed at src-tauri/resources/bin/llama-server[.exe] and
       # picked up by Tauri's bundle.resources: ["resources/**/*"] glob.
       # find_executable() discovers it via CONVSIM_BUNDLED_RUNTIME_DIR (set by
       # the Tauri shell at runtime, pointing at the depot's runtimes/ directory).
       - name: Bundle llama-server (Linux / macOS — Steam only)
-        if: runner.os != 'Windows'
+        if: env.BUNDLE_LLAMA_SERVER == 'true' && runner.os != 'Windows'
         shell: bash
         env:
           LLAMA_CPP_DEST: apps/desktop/src-tauri/resources/bin
@@ -210,7 +218,7 @@ jobs:
           ls -lh apps/desktop/src-tauri/resources/bin/llama-server
 
       - name: Bundle llama-server (Windows — Steam only)
-        if: runner.os == 'Windows'
+        if: env.BUNDLE_LLAMA_SERVER == 'true' && runner.os == 'Windows'
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'

--- a/docs/model-download-policy.md
+++ b/docs/model-download-policy.md
@@ -265,8 +265,6 @@ verified SHA-256 checksum; no entry ships a `PENDING` value.
 
 ---
 
----
-
 ## 8. Engine binary download policy
 
 The inference engine (`llama-server`) follows the same `NetworkMode.EXPLICIT_DOWNLOAD`

--- a/docs/model-download-policy.md
+++ b/docs/model-download-policy.md
@@ -294,11 +294,17 @@ file is removed immediately and no partial binary is ever registered.
 | Variant | When to use |
 |---------|-------------|
 | `cpu` (default) | Universally safe; works on every machine |
-| `cuda` | NVIDIA GPU acceleration; offered as opt-in when `nvidia-smi` is detected |
-| `vulkan` | GPU acceleration via Vulkan; offered as opt-in when `vulkaninfo` is detected |
+| `vulkan` | GPU acceleration via Vulkan; auto-offered as opt-in when a GPU is detected (`nvidia-smi` or `vulkaninfo`). Works on NVIDIA, AMD, and Intel |
 
 GPU variants are **never required** for first-run. The product offers them as
 optional upgrades; the CPU variant is always the default.
+
+The auto-detection (`GET /api/sidecar/gpu-variant`) only ever recommends `cpu`
+or `vulkan`. Vulkan is chosen for NVIDIA GPUs too because the NVIDIA driver
+ships the Vulkan runtime, and — unlike CUDA — Vulkan is a single, self-contained
+release asset. llama.cpp publishes CUDA builds per toolkit version
+(`win-cuda-12.4-x64`, `win-cuda-13.3-x64`, …) plus a separate `cudart-*` runtime
+archive, which the single-asset engine downloader cannot provision.
 
 ### Offline behaviour
 

--- a/docs/model-download-policy.md
+++ b/docs/model-download-policy.md
@@ -265,6 +265,58 @@ verified SHA-256 checksum; no entry ships a `PENDING` value.
 
 ---
 
+---
+
+## 8. Engine binary download policy
+
+The inference engine (`llama-server`) follows the same `NetworkMode.EXPLICIT_DOWNLOAD`
+gate as model weights — nothing is downloaded silently at startup.
+
+### Trigger
+
+Engine download is user-initiated via `POST /api/sidecar/download-runtime` in
+the app's Settings screen. The preflight check (`GET /api/preflight`) surfaces
+an `install-engine` fix action when `llama-server` is absent; pressing
+**Install engine** in the UI is the only thing that starts a transfer.
+
+### Source
+
+Binaries are downloaded from the official llama.cpp GitHub release page
+(`https://github.com/ggml-org/llama.cpp/releases`). The exact release tag
+and asset URL are shown to the player before the transfer begins.
+
+### Integrity
+
+SHA-256 verification against `sha256sum.txt` published alongside each release.
+A mismatch transitions the download to `checksum_mismatch` state; the `.part`
+file is removed immediately and no partial binary is ever registered.
+
+### Variants
+
+| Variant | When to use |
+|---------|-------------|
+| `cpu` (default) | Universally safe; works on every machine |
+| `cuda` | NVIDIA GPU acceleration; offered as opt-in when `nvidia-smi` is detected |
+| `vulkan` | GPU acceleration via Vulkan; offered as opt-in when `vulkaninfo` is detected |
+
+GPU variants are **never required** for first-run. The product offers them as
+optional upgrades; the CPU variant is always the default.
+
+### Offline behaviour
+
+When the network is unavailable, the download endpoint returns a clear error:
+"you're offline — engine download needs a connection (~5 MB)." No timeout is
+shown; the connection check is immediate.
+
+### Steam builds
+
+Steam depot builds bundle `llama-server` directly in
+`apps/desktop/src-tauri/resources/bin/` — no download is needed at first
+launch. The bundled binary is resolved by `CONVSIM_BUNDLED_RUNTIME_DIR` before
+any user-installed or PATH binary.
+
+---
+
 ## Links
 
 - [`model-registry/registry.yaml`](../model-registry/registry.yaml) — model metadata
@@ -274,3 +326,4 @@ verified SHA-256 checksum; no entry ships a `PENDING` value.
 - [`publishing/STEAM_DEPOT_CONTENTS.md`](../publishing/STEAM_DEPOT_CONTENTS.md) — what ships in the depot
 - [`docs/local-models.md`](local-models.md) — player-facing model installation guide
 - [`docs/STEAM_ROADMAP.md`](STEAM_ROADMAP.md) — model download transparency specification
+- [`docs/sidecar-bundling.md`](sidecar-bundling.md) — sidecar bundling and executable resolution

--- a/docs/model-download-policy.md
+++ b/docs/model-download-policy.md
@@ -315,7 +315,8 @@ shown; the connection check is immediate.
 ### Steam builds
 
 Steam depot builds bundle `llama-server` directly in
-`apps/desktop/src-tauri/resources/bin/` — no download is needed at first
+`apps/desktop/src-tauri/resources/runtimes/` — the directory the Tauri shell
+exposes as `CONVSIM_BUNDLED_RUNTIME_DIR` — so no download is needed at first
 launch. The bundled binary is resolved by `CONVSIM_BUNDLED_RUNTIME_DIR` before
 any user-installed or PATH binary.
 

--- a/docs/sidecar-bundling.md
+++ b/docs/sidecar-bundling.md
@@ -42,7 +42,7 @@ In a developer build the application is started directly from the repository
 (`uvicorn convsim_core.app:app` or `python -m convsim_core`). Sidecar
 binaries are expected to be on the developer's `PATH`.
 
-**Install sidecars for development:**
+**Install sidecars for development (Linux / macOS):**
 
 ```sh
 # llama.cpp (llama-server)
@@ -58,10 +58,36 @@ binaries are expected to be on the developer's `PATH`.
 # → binary at ~/.convsim/bin/sherpa-onnx-offline-tts; add to PATH
 ```
 
+**Install sidecars for development (Windows):**
+
+```powershell
+# llama.cpp (llama-server) — CPU variant (default, works on every machine)
+.\runtimes\llama_cpp\download-runtime.ps1
+# → binary at $HOME\.convsim\bin\llama-server.exe
+
+# GPU-accelerated variants (optional, never required for first-run):
+.\runtimes\llama_cpp\download-runtime.ps1 -Variant cuda   # NVIDIA
+.\runtimes\llama_cpp\download-runtime.ps1 -Variant vulkan # AMD / Intel / NVIDIA via Vulkan
+
+# Add to PATH (current session):
+$env:PATH = "$HOME\.convsim\bin;$env:PATH"
+```
+
+The `find_executable()` function also probes `~/.convsim/bin/llama-server.exe`
+directly (step 3 in the resolution order), so the binary is found immediately
+after an in-app install via `POST /api/sidecar/download-runtime` without
+needing a PATH change or app restart.
+
 You can also set the explicit override variable to point to any binary:
 
 ```sh
+# Linux / macOS
 export CONVSIM_LLAMA_CPP_EXECUTABLE=/path/to/llama-server
+```
+
+```powershell
+# Windows
+$env:CONVSIM_LLAMA_CPP_EXECUTABLE = "C:\path\to\llama-server.exe"
 ```
 
 ---

--- a/docs/sidecar-bundling.md
+++ b/docs/sidecar-bundling.md
@@ -65,9 +65,8 @@ binaries are expected to be on the developer's `PATH`.
 .\runtimes\llama_cpp\download-runtime.ps1
 # → binary at $HOME\.convsim\bin\llama-server.exe
 
-# GPU-accelerated variants (optional, never required for first-run):
-.\runtimes\llama_cpp\download-runtime.ps1 -Variant cuda   # NVIDIA
-.\runtimes\llama_cpp\download-runtime.ps1 -Variant vulkan # AMD / Intel / NVIDIA via Vulkan
+# GPU-accelerated variant (optional, never required for first-run):
+.\runtimes\llama_cpp\download-runtime.ps1 -Variant vulkan # NVIDIA / AMD / Intel via Vulkan
 
 # Add to PATH (current session):
 $env:PATH = "$HOME\.convsim\bin;$env:PATH"

--- a/runtimes/llama_cpp/download-runtime.ps1
+++ b/runtimes/llama_cpp/download-runtime.ps1
@@ -26,7 +26,7 @@
 [CmdletBinding()]
 param(
     [string]$Version = "",
-    [string]$Dest    = (Join-Path $HOME ".convsim" "bin"),
+    [string]$Dest    = (Join-Path (Join-Path $HOME ".convsim") "bin"),
     [ValidateSet("cpu", "cuda", "vulkan")]
     [string]$Variant = "cpu"
 )

--- a/runtimes/llama_cpp/download-runtime.ps1
+++ b/runtimes/llama_cpp/download-runtime.ps1
@@ -162,11 +162,21 @@ if (-not $extractedBin) {
 }
 
 # ── Install (atomic replace) ──────────────────────────────────────────────────
+# llama-server.exe is dynamically linked against sibling DLLs (ggml*.dll,
+# llama.dll, …) shipped in the same archive directory; copy them alongside the
+# exe or it cannot start ("ggml.dll was not found"). Install the DLLs first so
+# the executable never resolves before its dependencies are in place.
 
 $destBin  = Join-Path $Dest "llama-server.exe"
 $partPath = Join-Path $Dest "llama-server.exe.part"
+$srcDir   = $extractedBin.Directory.FullName
 
 try {
+    Get-ChildItem -Path $srcDir -File |
+        Where-Object { $_.Name -ne "llama-server.exe" } |
+        ForEach-Object {
+            Copy-Item -Path $_.FullName -Destination (Join-Path $Dest $_.Name) -Force
+        }
     Copy-Item -Path $extractedBin.FullName -Destination $partPath -Force
     # Move-Item with -Force is the closest atomic replace available on Windows.
     # If llama-server.exe is currently running this will fail with a sharing

--- a/runtimes/llama_cpp/download-runtime.ps1
+++ b/runtimes/llama_cpp/download-runtime.ps1
@@ -2,24 +2,28 @@
 # download-runtime.ps1 — Download a pre-built llama-server binary for Windows.
 #
 # Usage:
-#   .\runtimes\llama_cpp\download-runtime.ps1 [[-Version] <tag>] [[-Dest] <dir>] [-Variant <cpu|cuda|vulkan>]
+#   .\runtimes\llama_cpp\download-runtime.ps1 [[-Version] <tag>] [[-Dest] <dir>] [-Variant <cpu|vulkan>]
 #
 # Options:
 #   -Version <tag>      llama.cpp release tag to download (default: latest)
 #   -Dest    <dir>      directory to place the binary (default: $HOME\.convsim\bin)
-#   -Variant <name>     build variant: cpu (default), cuda, vulkan
+#   -Variant <name>     build variant: cpu (default), vulkan
 #
 # After the download, add the destination to PATH or pass its full path to
 # POST /api/sidecar/start as the "executable" field.
 #
 # Supported platforms:
-#   Windows x86_64 — win-x64  (cpu / cuda / vulkan variants)
+#   Windows x86_64 — win-x64  (cpu / vulkan variants)
 #   Windows arm64  — win-arm64 (cpu variant)
 #
 # Variant selection:
 #   cpu    — universally safe, works on every Windows machine (default)
-#   cuda   — NVIDIA GPU acceleration; requires CUDA runtime
 #   vulkan — GPU acceleration via Vulkan; works on NVIDIA, AMD, Intel
+#
+# CUDA builds are intentionally not offered: llama.cpp publishes them per CUDA
+# toolkit version (win-cuda-12.4-x64, win-cuda-13.3-x64, …) plus a separate
+# cudart runtime archive, so there is no single "cuda" asset to fetch. Vulkan
+# accelerates on NVIDIA too (the driver ships the Vulkan runtime).
 #
 # For Linux / macOS use runtimes/llama_cpp/download-runtime.sh instead.
 
@@ -27,7 +31,7 @@
 param(
     [string]$Version = "",
     [string]$Dest    = (Join-Path (Join-Path $HOME ".convsim") "bin"),
-    [ValidateSet("cpu", "cuda", "vulkan")]
+    [ValidateSet("cpu", "vulkan")]
     [string]$Variant = "cpu"
 )
 

--- a/runtimes/llama_cpp/download-runtime.ps1
+++ b/runtimes/llama_cpp/download-runtime.ps1
@@ -1,0 +1,190 @@
+# SPDX-License-Identifier: Apache-2.0
+# download-runtime.ps1 — Download a pre-built llama-server binary for Windows.
+#
+# Usage:
+#   .\runtimes\llama_cpp\download-runtime.ps1 [[-Version] <tag>] [[-Dest] <dir>] [-Variant <cpu|cuda|vulkan>]
+#
+# Options:
+#   -Version <tag>      llama.cpp release tag to download (default: latest)
+#   -Dest    <dir>      directory to place the binary (default: $HOME\.convsim\bin)
+#   -Variant <name>     build variant: cpu (default), cuda, vulkan
+#
+# After the download, add the destination to PATH or pass its full path to
+# POST /api/sidecar/start as the "executable" field.
+#
+# Supported platforms:
+#   Windows x86_64 — win-x64  (cpu / cuda / vulkan variants)
+#   Windows arm64  — win-arm64 (cpu variant)
+#
+# Variant selection:
+#   cpu    — universally safe, works on every Windows machine (default)
+#   cuda   — NVIDIA GPU acceleration; requires CUDA runtime
+#   vulkan — GPU acceleration via Vulkan; works on NVIDIA, AMD, Intel
+#
+# For Linux / macOS use runtimes/llama_cpp/download-runtime.sh instead.
+
+[CmdletBinding()]
+param(
+    [string]$Version = "",
+    [string]$Dest    = (Join-Path $HOME ".convsim" "bin"),
+    [ValidateSet("cpu", "cuda", "vulkan")]
+    [string]$Variant = "cpu"
+)
+
+$ErrorActionPreference = "Stop"
+
+$REPO  = "ggml-org/llama.cpp"
+
+# ── Platform detection ────────────────────────────────────────────────────────
+
+$arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+switch ($arch) {
+    "X64"   { $PLATFORM = "win-x64" }
+    "Arm64" { $PLATFORM = "win-arm64" }
+    default {
+        Write-Error "Unsupported Windows architecture: $arch"
+        Write-Error "Build from source: https://github.com/ggml-org/llama.cpp#build"
+        exit 1
+    }
+}
+
+# ── Resolve latest tag if not specified ───────────────────────────────────────
+
+if (-not $Version) {
+    Write-Host "Fetching latest llama.cpp release tag..."
+    try {
+        $apiUrl = "https://api.github.com/repos/$REPO/releases/latest"
+        $resp   = Invoke-RestMethod -Uri $apiUrl -UseBasicParsing -ErrorAction Stop
+        $Version = $resp.tag_name
+        if (-not $Version) { throw "tag_name is empty" }
+    } catch {
+        Write-Error "Failed to fetch latest release from GitHub: $_"
+        Write-Error "Check your internet connection. Engine download requires a network connection (~5 MB)."
+        exit 1
+    }
+    Write-Host "Latest release: $Version"
+}
+
+# ── Build asset name ──────────────────────────────────────────────────────────
+# Windows naming convention: llama-{tag}-bin-win-{variant}-{arch}.zip
+# e.g. llama-b5140-bin-win-cpu-x64.zip
+
+$archSuffix = $PLATFORM -replace "^win-", ""   # "x64" or "arm64"
+$ASSET_NAME = "llama-$Version-bin-win-$Variant-$archSuffix.zip"
+$DOWNLOAD_URL = "https://github.com/$REPO/releases/download/$Version/$ASSET_NAME"
+$SHA256_URL   = "https://github.com/$REPO/releases/download/$Version/sha256sum.txt"
+
+Write-Host ""
+Write-Host "Platform : $PLATFORM"
+Write-Host "Version  : $Version"
+Write-Host "Variant  : $Variant"
+Write-Host "Asset    : $ASSET_NAME"
+Write-Host "Dest     : $Dest"
+Write-Host ""
+
+# ── Download ──────────────────────────────────────────────────────────────────
+
+$null = New-Item -ItemType Directory -Path $Dest -Force
+
+$tmpDir  = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+$null    = New-Item -ItemType Directory -Path $tmpDir -Force
+
+$zipPath = Join-Path $tmpDir $ASSET_NAME
+
+Write-Host "Downloading $DOWNLOAD_URL ..."
+try {
+    Invoke-WebRequest -Uri $DOWNLOAD_URL -OutFile $zipPath -UseBasicParsing -ErrorAction Stop
+} catch {
+    Write-Host ""
+    Write-Error "Download failed: $_"
+    Write-Error "Check that release $Version has asset $ASSET_NAME."
+    Write-Error "Browse releases: https://github.com/$REPO/releases"
+    Remove-Item -Recurse -Force $tmpDir -ErrorAction SilentlyContinue
+    exit 1
+}
+
+# ── SHA-256 verification ──────────────────────────────────────────────────────
+
+Write-Host "Verifying SHA-256 checksum..."
+try {
+    $sha256resp = Invoke-WebRequest -Uri $SHA256_URL -UseBasicParsing -ErrorAction Stop
+    $sha256text = $sha256resp.Content
+
+    $expectedHash = $null
+    foreach ($line in ($sha256text -split "`n")) {
+        $parts = $line.Trim() -split "\s+", 2
+        if ($parts.Count -eq 2) {
+            $digest = $parts[0].ToLower()
+            $name   = $parts[1].TrimStart("*")
+            if ($name -eq $ASSET_NAME) {
+                $expectedHash = $digest
+                break
+            }
+        }
+    }
+
+    if ($expectedHash) {
+        $actualHash = (Get-FileHash -Path $zipPath -Algorithm SHA256).Hash.ToLower()
+        if ($actualHash -ne $expectedHash) {
+            Write-Error "SHA-256 checksum mismatch for $ASSET_NAME."
+            Write-Error "Expected : $expectedHash"
+            Write-Error "Got      : $actualHash"
+            Write-Error "The downloaded file may be corrupted. Try again."
+            Remove-Item -Recurse -Force $tmpDir -ErrorAction SilentlyContinue
+            exit 1
+        }
+        Write-Host "  OK: checksum verified"
+    } else {
+        Write-Host "  WARN: $ASSET_NAME not listed in sha256sum.txt — skipping verification"
+    }
+} catch {
+    Write-Host "  WARN: Could not fetch sha256sum.txt ($($_)) — skipping verification"
+}
+
+# ── Extract ───────────────────────────────────────────────────────────────────
+
+Write-Host "Extracting..."
+$extractDir = Join-Path $tmpDir "extracted"
+Expand-Archive -Path $zipPath -DestinationPath $extractDir -Force
+
+$extractedBin = Get-ChildItem -Recurse -Path $extractDir -Filter "llama-server.exe" |
+    Select-Object -First 1
+
+if (-not $extractedBin) {
+    Write-Error "llama-server.exe not found in archive."
+    Get-ChildItem -Recurse -Path $extractDir | Select-Object FullName
+    Remove-Item -Recurse -Force $tmpDir -ErrorAction SilentlyContinue
+    exit 1
+}
+
+# ── Install (atomic replace) ──────────────────────────────────────────────────
+
+$destBin  = Join-Path $Dest "llama-server.exe"
+$partPath = Join-Path $Dest "llama-server.exe.part"
+
+try {
+    Copy-Item -Path $extractedBin.FullName -Destination $partPath -Force
+    # Move-Item with -Force is the closest atomic replace available on Windows.
+    # If llama-server.exe is currently running this will fail with a sharing
+    # violation; the .part file is cleaned up and an actionable error is shown.
+    Move-Item -Path $partPath -Destination $destBin -Force
+} catch {
+    Remove-Item -Path $partPath -Force -ErrorAction SilentlyContinue
+    Write-Error "Cannot replace $destBin : the file may be in use."
+    Write-Error "Stop the running inference engine before upgrading."
+    Remove-Item -Recurse -Force $tmpDir -ErrorAction SilentlyContinue
+    exit 1
+} finally {
+    Remove-Item -Recurse -Force $tmpDir -ErrorAction SilentlyContinue
+}
+
+# ── Done ──────────────────────────────────────────────────────────────────────
+
+Write-Host ""
+Write-Host "Installed: $destBin"
+Write-Host ""
+Write-Host "Add to PATH (add this to your PowerShell profile or System environment):"
+Write-Host "  `$env:PATH = `"$Dest;`$env:PATH`""
+Write-Host ""
+Write-Host "Or pass the full path to the sidecar API:"
+Write-Host "  POST /api/sidecar/start  { `"executable`": `"$destBin`", ... }"

--- a/services/convsim-core/convsim_core/routers/preflight.py
+++ b/services/convsim-core/convsim_core/routers/preflight.py
@@ -152,9 +152,9 @@ def _check_llama_cpp_binary() -> CheckResult:
             "The inference engine is missing from this installation."
         ),
         fix_action=FixAction(
-            kind="open-url",
-            href="https://docs.conversationsimulator.com/play/local-models/",
-            label="Setup guide",
+            kind="install-engine",
+            href="/settings/install-engine",
+            label="Install engine",
         ),
     )
 

--- a/services/convsim-core/convsim_core/routers/preflight.py
+++ b/services/convsim-core/convsim_core/routers/preflight.py
@@ -34,7 +34,7 @@ _MIN_PACKS = 4
 class FixAction(BaseModel):
     """A single actionable remedy for a failing or warning check."""
 
-    kind: str   # "navigate" | "open-url"
+    kind: str   # "navigate" | "open-url" | "install-engine"
     href: str
     label: str
 

--- a/services/convsim-core/convsim_core/routers/preflight.py
+++ b/services/convsim-core/convsim_core/routers/preflight.py
@@ -34,7 +34,7 @@ _MIN_PACKS = 4
 class FixAction(BaseModel):
     """A single actionable remedy for a failing or warning check."""
 
-    kind: str   # "navigate" | "open-url" | "wizard-step"
+    kind: str   # "navigate" | "open-url" | "wizard-step" | "install-engine"
     href: str
     label: str
 

--- a/services/convsim-core/convsim_core/routers/sidecar.py
+++ b/services/convsim-core/convsim_core/routers/sidecar.py
@@ -104,9 +104,9 @@ class DownloadRuntimeRequest(BaseModel):
     (``~/.convsim/bin``). The binary is placed inside this directory as
     ``llama-server`` (or ``llama-server.exe`` on Windows).
 
-    ``variant`` selects the build variant: ``"cpu"`` (default, always safe),
-    ``"cuda"`` (NVIDIA GPU), or ``"vulkan"`` (Vulkan-capable GPU).  Use
-    ``detect_windows_gpu_variant()`` to discover what is available; GPU
+    ``variant`` selects the build variant: ``"cpu"`` (default, always safe) or
+    ``"vulkan"`` (GPU acceleration on NVIDIA/AMD/Intel).  Use
+    ``detect_windows_gpu_variant()`` to discover the recommended variant; GPU
     variants are never required for first-run.  Only meaningful on Windows;
     Linux and macOS always use ``"cpu"``.
     """
@@ -350,8 +350,9 @@ async def get_gpu_variant() -> GpuVariantResponse:
     """Return the best available GPU variant for this machine.
 
     On Windows, probes for NVIDIA (nvidia-smi) and Vulkan (vulkaninfo).
-    On other platforms, always returns ``"cpu"``.  Never blocks — probe
-    failures fall back to ``"cpu"`` immediately.
+    On other platforms, always returns ``"cpu"``.  The probe runs off the
+    event loop and always falls back to ``"cpu"`` on failure, so this endpoint
+    never blocks other requests.
 
     Clients may use this to offer GPU-accelerated engine downloads as an
     opt-in upgrade; the default ``"cpu"`` variant is always safe.
@@ -364,7 +365,10 @@ async def get_gpu_variant() -> GpuVariantResponse:
         platform_str = None
 
     if _sys.platform == "win32":
-        variant = detect_windows_gpu_variant()
+        # The probe shells out to nvidia-smi / vulkaninfo (subprocess with
+        # multi-second timeouts); run it in a thread so it never stalls the
+        # event loop while the UI polls download progress.
+        variant = await asyncio.to_thread(detect_windows_gpu_variant)
     else:
         variant = "cpu"
 

--- a/services/convsim-core/convsim_core/routers/sidecar.py
+++ b/services/convsim-core/convsim_core/routers/sidecar.py
@@ -230,9 +230,8 @@ async def start_download_runtime(body: DownloadRuntimeRequest) -> DownloadRuntim
     in progress. Poll ``GET /api/sidecar/download-runtime`` for progress.
 
     On completion the binary is placed in ``dest_dir`` (default:
-    ``~/.convsim/bin``) and ``find_executable()`` will discover it via PATH
-    or the ``CONVSIM_BUNDLED_RUNTIME_DIR`` convention (see
-    docs/sidecar-bundling.md).
+    ``~/.convsim/bin``), where ``find_executable()`` resolves it directly —
+    no PATH change or app restart is needed (see docs/sidecar-bundling.md).
     """
     global _download_progress, _download_task, _download_cancel
 

--- a/services/convsim-core/convsim_core/routers/sidecar.py
+++ b/services/convsim-core/convsim_core/routers/sidecar.py
@@ -25,6 +25,7 @@ from convsim_core.runtime.llama_cpp_download import (
     DownloadProgress,
     DownloadState,
     detect_platform_string,
+    detect_windows_gpu_variant,
     download_binary,
 )
 from convsim_core.runtime.sidecar import LlamaCppSidecar, SidecarState
@@ -102,10 +103,17 @@ class DownloadRuntimeRequest(BaseModel):
     ``dest_dir`` overrides the default install directory
     (``~/.convsim/bin``). The binary is placed inside this directory as
     ``llama-server`` (or ``llama-server.exe`` on Windows).
+
+    ``variant`` selects the build variant: ``"cpu"`` (default, always safe),
+    ``"cuda"`` (NVIDIA GPU), or ``"vulkan"`` (Vulkan-capable GPU).  Use
+    ``detect_windows_gpu_variant()`` to discover what is available; GPU
+    variants are never required for first-run.  Only meaningful on Windows;
+    Linux and macOS always use ``"cpu"``.
     """
 
     version: Optional[str] = None
     dest_dir: Optional[str] = None
+    variant: str = "cpu"
 
 
 class DownloadRuntimeStatusResponse(BaseModel):
@@ -263,6 +271,7 @@ async def start_download_runtime(body: DownloadRuntimeRequest) -> DownloadRuntim
                 dest_dir=dest,
                 version=body.version,
                 platform_string=platform_str,
+                variant=body.variant,
                 cancel_event=_download_cancel,
                 progress_cb=_on_progress,
             )
@@ -325,6 +334,42 @@ async def cancel_download_runtime() -> None:
             status_code=409,
         )
     _download_cancel.set()
+
+
+# ── GPU variant detection endpoint ───────────────────────────────────────────
+
+
+class GpuVariantResponse(BaseModel):
+    """Detected GPU acceleration variant available on this machine."""
+
+    variant: str
+    platform: Optional[str] = None
+
+
+@router.get("/api/sidecar/gpu-variant", response_model=GpuVariantResponse)
+async def get_gpu_variant() -> GpuVariantResponse:
+    """Return the best available GPU variant for this machine.
+
+    On Windows, probes for NVIDIA (nvidia-smi) and Vulkan (vulkaninfo).
+    On other platforms, always returns ``"cpu"``.  Never blocks — probe
+    failures fall back to ``"cpu"`` immediately.
+
+    Clients may use this to offer GPU-accelerated engine downloads as an
+    opt-in upgrade; the default ``"cpu"`` variant is always safe.
+    """
+    import sys as _sys
+
+    try:
+        platform_str: Optional[str] = detect_platform_string()
+    except RuntimeError:
+        platform_str = None
+
+    if _sys.platform == "win32":
+        variant = detect_windows_gpu_variant()
+    else:
+        variant = "cpu"
+
+    return GpuVariantResponse(variant=variant, platform=platform_str)
 
 
 # ── Runtime capabilities endpoint ─────────────────────────────────────────────

--- a/services/convsim-core/convsim_core/runtime/llama_cpp_download.py
+++ b/services/convsim-core/convsim_core/runtime/llama_cpp_download.py
@@ -15,9 +15,8 @@ Supported platforms
   Linux  aarch64 → linux-arm64
   macOS  arm64   → macos-arm64  (Apple Silicon)
   macOS  x86_64  → macos-x64   (Intel Mac)
-
-Windows native binaries are not supported here; Windows users should use
-WSL2 (targeting the linux-x64 asset) or build from source.
+  Windows x86_64 → win-x64
+  Windows arm64  → win-arm64
 
 Usage
 -----
@@ -37,7 +36,10 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import io
+import os
 import platform as _platform
+import shutil
+import subprocess
 import sys
 import zipfile
 from dataclasses import dataclass, field
@@ -61,6 +63,7 @@ class DownloadState(str, Enum):
     VERIFYING = "verifying"
     EXTRACTING = "extracting"
     COMPLETE = "complete"
+    CHECKSUM_MISMATCH = "checksum_mismatch"
     FAILED = "failed"
     CANCELLED = "cancelled"
 
@@ -99,11 +102,10 @@ def detect_platform_string() -> str:
         if machine in ("x86_64", "amd64"):
             return "macos-x64"
     elif system == "win32":
-        raise RuntimeError(
-            "Native Windows binary download is not supported. "
-            "Use WSL2 with the Linux binary, or build from source: "
-            "https://github.com/ggml-org/llama.cpp#build"
-        )
+        if machine in ("x86_64", "amd64"):
+            return "win-x64"
+        if machine in ("aarch64", "arm64"):
+            return "win-arm64"
 
     raise RuntimeError(
         f"Unsupported platform: {system}/{machine}. "
@@ -111,12 +113,57 @@ def detect_platform_string() -> str:
     )
 
 
-def build_asset_name(release_tag: str, platform_string: str) -> str:
+def detect_windows_gpu_variant() -> str:
+    """Probe for GPU acceleration on Windows; return the best available variant.
+
+    Returns one of: ``"cuda"``, ``"vulkan"``, ``"cpu"`` (default).
+
+    Never raises — detection failures always fall back to ``"cpu"``.  Callers
+    should treat this as advisory: the CPU variant always works; GPU variants
+    are offered as *opt-in* upgrades, never required for first-run.
+    """
+    try:
+        if shutil.which("nvidia-smi"):
+            result = subprocess.run(
+                ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader"],
+                capture_output=True,
+                timeout=5,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                return "cuda"
+    except Exception:  # noqa: BLE001
+        pass
+
+    try:
+        if shutil.which("vulkaninfo"):
+            result = subprocess.run(
+                ["vulkaninfo", "--summary"],
+                capture_output=True,
+                timeout=10,
+            )
+            if result.returncode == 0:
+                return "vulkan"
+    except Exception:  # noqa: BLE001
+        pass
+
+    return "cpu"
+
+
+def build_asset_name(release_tag: str, platform_string: str, *, variant: str = "cpu") -> str:
     """Return the expected ZIP asset name for a llama.cpp release.
 
-    Convention: ``llama-{tag}-bin-{platform}-cpu.zip``
+    For Windows (``platform_string`` starts with ``"win-"``), the naming
+    convention is ``llama-{tag}-bin-win-{variant}-{arch}.zip``
+    e.g. ``llama-b5140-bin-win-cpu-x64.zip``.
+
+    For Linux / macOS the convention is
+    ``llama-{tag}-bin-{platform}-{variant}.zip``
+    e.g. ``llama-b5140-bin-linux-x64-cpu.zip``.
     """
-    return f"llama-{release_tag}-bin-{platform_string}-cpu.zip"
+    if platform_string.startswith("win-"):
+        arch = platform_string[len("win-"):]  # "x64" or "arm64"
+        return f"llama-{release_tag}-bin-win-{variant}-{arch}.zip"
+    return f"llama-{release_tag}-bin-{platform_string}-{variant}.zip"
 
 
 def build_asset_url(release_tag: str, asset_name: str) -> str:
@@ -196,6 +243,7 @@ async def download_binary(
     dest_dir: Path,
     version: str | None = None,
     platform_string: str | None = None,
+    variant: str = "cpu",
     cancel_event: asyncio.Event | None = None,
     progress_cb: Callable[[DownloadProgress], None] | None = None,
     _client: httpx.AsyncClient | None = None,
@@ -209,7 +257,11 @@ async def download_binary(
             auto-fetch the latest release.
         platform_string: Override the auto-detected platform (useful in
             tests).  Must match a llama.cpp release asset segment, e.g.
-            ``"linux-x64"``.
+            ``"linux-x64"`` or ``"win-x64"``.
+        variant: Build variant — ``"cpu"`` (default, universally safe),
+            ``"cuda"``, or ``"vulkan"``.  On Windows, use
+            :func:`detect_windows_gpu_variant` to discover available variants;
+            on Linux/macOS ``"cpu"`` is the only supported variant here.
         cancel_event: When set, the download stops cleanly and
             ``asyncio.CancelledError`` is raised.  Checked between chunks.
         progress_cb: Called after each significant state or byte-count change
@@ -223,7 +275,7 @@ async def download_binary(
 
     Raises:
         RuntimeError: Platform not supported, download failed, checksum
-            mismatch, or binary missing from archive.
+            mismatch, binary missing from archive, or destination locked.
         asyncio.CancelledError: *cancel_event* was set.
     """
     if platform_string is None:
@@ -243,10 +295,17 @@ async def download_binary(
     try:
         release_tag = version
         if release_tag is None:
-            release_tag = await fetch_latest_release_tag(client)
+            try:
+                release_tag = await fetch_latest_release_tag(client)
+            except (httpx.ConnectError, httpx.NetworkError, httpx.TimeoutException) as exc:
+                raise RuntimeError(
+                    "Cannot reach GitHub to fetch the latest release — "
+                    "check your internet connection. "
+                    "Engine download requires a network connection (~5 MB)."
+                ) from exc
         progress.release_tag = release_tag
 
-        asset_name = build_asset_name(release_tag, platform_string)
+        asset_name = build_asset_name(release_tag, platform_string, variant=variant)
         asset_url = build_asset_url(release_tag, asset_name)
         sha256sum_url = build_sha256sum_url(release_tag)
 
@@ -258,21 +317,28 @@ async def download_binary(
             progress_cb(progress)
 
         data = bytearray()
-        async with client.stream("GET", asset_url) as resp:
-            if resp.status_code != 200:
-                raise RuntimeError(
-                    f"Download failed: HTTP {resp.status_code} for {asset_url}. "
-                    f"Check that release {release_tag} has asset {asset_name}. "
-                    f"Browse releases: https://github.com/{_GITHUB_REPO}/releases"
-                )
-            content_length = resp.headers.get("content-length")
-            progress.total_bytes = int(content_length) if content_length else None
-            async for chunk in resp.aiter_bytes(_CHUNK_SIZE):
-                _check_cancel()
-                data.extend(chunk)
-                progress.bytes_downloaded = len(data)
-                if progress_cb:
-                    progress_cb(progress)
+        try:
+            async with client.stream("GET", asset_url) as resp:
+                if resp.status_code != 200:
+                    raise RuntimeError(
+                        f"Download failed: HTTP {resp.status_code} for {asset_url}. "
+                        f"Check that release {release_tag} has asset {asset_name}. "
+                        f"Browse releases: https://github.com/{_GITHUB_REPO}/releases"
+                    )
+                content_length = resp.headers.get("content-length")
+                progress.total_bytes = int(content_length) if content_length else None
+                async for chunk in resp.aiter_bytes(_CHUNK_SIZE):
+                    _check_cancel()
+                    data.extend(chunk)
+                    progress.bytes_downloaded = len(data)
+                    if progress_cb:
+                        progress_cb(progress)
+        except (httpx.ConnectError, httpx.NetworkError, httpx.TimeoutException) as exc:
+            raise RuntimeError(
+                "Network error while downloading engine binary — "
+                "check your internet connection and try again. "
+                "Engine download requires a network connection (~5 MB)."
+            ) from exc
 
         _check_cancel()
         progress.state = DownloadState.VERIFYING
@@ -281,6 +347,9 @@ async def download_binary(
 
         actual_sha256 = await asyncio.to_thread(_sha256_of_bytes, bytes(data))
         if expected_sha256 is not None and actual_sha256 != expected_sha256:
+            progress.state = DownloadState.CHECKSUM_MISMATCH
+            if progress_cb:
+                progress_cb(progress)
             raise RuntimeError(
                 f"SHA-256 checksum mismatch for {asset_name}. "
                 f"Expected {expected_sha256}, got {actual_sha256}. "
@@ -297,10 +366,26 @@ async def download_binary(
         dest_dir.mkdir(parents=True, exist_ok=True)
         suffix = ".exe" if sys.platform == "win32" else ""
         dest_path = dest_dir / f"{_BINARY_NAME}{suffix}"
+        part_path = dest_dir / f"{_BINARY_NAME}{suffix}.part"
 
         def _write() -> None:
-            dest_path.write_bytes(binary_data)
-            dest_path.chmod(0o755)
+            try:
+                part_path.write_bytes(binary_data)
+                if sys.platform != "win32":
+                    part_path.chmod(0o755)
+                try:
+                    os.replace(str(part_path), str(dest_path))
+                except PermissionError as exc:
+                    raise RuntimeError(
+                        f"Cannot replace {dest_path.name}: the file is in use. "
+                        "Stop the running inference engine before upgrading."
+                    ) from exc
+            except BaseException:
+                try:
+                    part_path.unlink(missing_ok=True)
+                except OSError:
+                    pass
+                raise
 
         await asyncio.to_thread(_write)
 
@@ -318,7 +403,8 @@ async def download_binary(
         raise
 
     except Exception as exc:
-        progress.state = DownloadState.FAILED
+        if progress.state not in (DownloadState.CHECKSUM_MISMATCH, DownloadState.CANCELLED):
+            progress.state = DownloadState.FAILED
         progress.error = str(exc)
         if progress_cb:
             progress_cb(progress)

--- a/services/convsim-core/convsim_core/runtime/llama_cpp_download.py
+++ b/services/convsim-core/convsim_core/runtime/llama_cpp_download.py
@@ -114,13 +114,24 @@ def detect_platform_string() -> str:
 
 
 def detect_windows_gpu_variant() -> str:
-    """Probe for GPU acceleration on Windows; return the best available variant.
+    """Probe for GPU acceleration on Windows; return the best *downloadable* variant.
 
-    Returns one of: ``"cuda"``, ``"vulkan"``, ``"cpu"`` (default).
+    Returns one of: ``"vulkan"`` or ``"cpu"`` (default).
 
     Never raises — detection failures always fall back to ``"cpu"``.  Callers
-    should treat this as advisory: the CPU variant always works; GPU variants
-    are offered as *opt-in* upgrades, never required for first-run.
+    should treat this as advisory: the CPU variant always works; the Vulkan
+    variant is offered as an *opt-in* upgrade, never required for first-run.
+
+    Vulkan is recommended for every GPU vendor (NVIDIA, AMD, Intel) because it
+    ships as a single, self-contained llama.cpp release asset
+    (``llama-{tag}-bin-win-vulkan-x64.zip``).  CUDA is deliberately *not*
+    recommended here: llama.cpp publishes CUDA builds per toolkit version
+    (``win-cuda-12.4-x64``, ``win-cuda-13.3-x64``, …) and each additionally
+    requires a separate ``cudart-*`` runtime archive — neither of which the
+    single-asset downloader in this module can satisfy, so recommending
+    ``"cuda"`` would send the download to a nonexistent asset (404).  An NVIDIA
+    GPU is therefore offered the Vulkan build; the NVIDIA driver ships the
+    Vulkan runtime, so it accelerates on NVIDIA too.
     """
     try:
         if shutil.which("nvidia-smi"):
@@ -130,7 +141,7 @@ def detect_windows_gpu_variant() -> str:
                 timeout=5,
             )
             if result.returncode == 0 and result.stdout.strip():
-                return "cuda"
+                return "vulkan"
     except Exception:  # noqa: BLE001
         pass
 
@@ -258,10 +269,12 @@ async def download_binary(
         platform_string: Override the auto-detected platform (useful in
             tests).  Must match a llama.cpp release asset segment, e.g.
             ``"linux-x64"`` or ``"win-x64"``.
-        variant: Build variant — ``"cpu"`` (default, universally safe),
-            ``"cuda"``, or ``"vulkan"``.  On Windows, use
-            :func:`detect_windows_gpu_variant` to discover available variants;
-            on Linux/macOS ``"cpu"`` is the only supported variant here.
+        variant: Build variant — ``"cpu"`` (default, universally safe) or
+            ``"vulkan"`` (GPU acceleration, Windows only).  On Windows, use
+            :func:`detect_windows_gpu_variant` to discover the recommended
+            variant; on Linux/macOS ``"cpu"`` is the only supported variant
+            here.  (``"cuda"`` is not supported — llama.cpp CUDA builds are
+            published per toolkit version and need a separate cudart archive.)
         cancel_event: When set, the download stops cleanly and
             ``asyncio.CancelledError`` is raised.  Checked between chunks.
         progress_cb: Called after each significant state or byte-count change

--- a/services/convsim-core/convsim_core/runtime/llama_cpp_download.py
+++ b/services/convsim-core/convsim_core/runtime/llama_cpp_download.py
@@ -133,12 +133,18 @@ def detect_windows_gpu_variant() -> str:
     GPU is therefore offered the Vulkan build; the NVIDIA driver ships the
     Vulkan runtime, so it accelerates on NVIDIA too.
     """
+    # Suppress the console window Windows would otherwise flash for each probe;
+    # this runs behind a GUI Tauri app with no attached console. The flag only
+    # exists on Windows, so fall back to 0 (no-op) everywhere else.
+    no_window = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+
     try:
         if shutil.which("nvidia-smi"):
             result = subprocess.run(
                 ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader"],
                 capture_output=True,
                 timeout=5,
+                creationflags=no_window,
             )
             if result.returncode == 0 and result.stdout.strip():
                 return "vulkan"
@@ -151,6 +157,7 @@ def detect_windows_gpu_variant() -> str:
                 ["vulkaninfo", "--summary"],
                 capture_output=True,
                 timeout=10,
+                creationflags=no_window,
             )
             if result.returncode == 0:
                 return "vulkan"

--- a/services/convsim-core/convsim_core/runtime/llama_cpp_download.py
+++ b/services/convsim-core/convsim_core/runtime/llama_cpp_download.py
@@ -249,6 +249,45 @@ def _extract_binary_from_zip(data: bytes) -> bytes:
     )
 
 
+def _extract_runtime_files_from_zip(data: bytes) -> tuple[bytes, dict[str, bytes]]:
+    """Return the llama-server binary bytes plus its sibling runtime files.
+
+    Windows llama.cpp release archives ship ``llama-server.exe`` *dynamically*
+    linked against DLLs (``ggml.dll``, ``ggml-base.dll``, ``ggml-cpu.dll``,
+    ``llama.dll``, …) that live in the same archive directory.  Extracting the
+    executable alone yields a binary that cannot start ("the code execution
+    cannot proceed because ggml.dll was not found"), so this returns the binary
+    bytes together with a ``{basename: bytes}`` map of every *other* file in the
+    same directory so the caller can install them alongside the executable.
+
+    Raises RuntimeError when the binary is not found.
+    """
+    target_names = {"llama-server", "llama-server.exe"}
+    with zipfile.ZipFile(io.BytesIO(data)) as zf:
+        server_name: str | None = None
+        for name in zf.namelist():
+            if Path(name).name.lower() in target_names:
+                server_name = name
+                break
+        if server_name is None:
+            raise RuntimeError(
+                "llama-server binary not found in the downloaded archive. "
+                "The release asset format may have changed."
+            )
+        server_dir = Path(server_name).parent
+        binary_basename = Path(server_name).name
+        binary_bytes = zf.read(server_name)
+        siblings: dict[str, bytes] = {}
+        for name in zf.namelist():
+            if name.endswith("/"):
+                continue
+            candidate = Path(name)
+            if candidate.parent != server_dir or candidate.name == binary_basename:
+                continue
+            siblings[candidate.name] = zf.read(name)
+        return binary_bytes, siblings
+
+
 async def download_binary(
     *,
     dest_dir: Path,
@@ -374,25 +413,45 @@ async def download_binary(
         if progress_cb:
             progress_cb(progress)
 
-        binary_data: bytes = await asyncio.to_thread(_extract_binary_from_zip, bytes(data))
-
         dest_dir.mkdir(parents=True, exist_ok=True)
         suffix = ".exe" if sys.platform == "win32" else ""
         dest_path = dest_dir / f"{_BINARY_NAME}{suffix}"
         part_path = dest_dir / f"{_BINARY_NAME}{suffix}.part"
 
+        if sys.platform == "win32":
+            # Windows binaries are dynamically linked against sibling DLLs that
+            # ship in the same archive directory; install them alongside the
+            # executable or it cannot start.
+            binary_data, sibling_files = await asyncio.to_thread(
+                _extract_runtime_files_from_zip, bytes(data)
+            )
+        else:
+            binary_data = await asyncio.to_thread(_extract_binary_from_zip, bytes(data))
+            sibling_files = {}
+
+        def _locked_error(name: str) -> RuntimeError:
+            return RuntimeError(
+                f"Cannot replace {name}: the file is in use. "
+                "Stop the running inference engine before upgrading."
+            )
+
         def _write() -> None:
             try:
+                # Install sibling runtime files (DLLs) first so the executable
+                # never resolves before its dependencies are present on disk.
+                for fname, content in sibling_files.items():
+                    sib = dest_dir / fname
+                    try:
+                        sib.write_bytes(content)
+                    except PermissionError as exc:
+                        raise _locked_error(sib.name) from exc
                 part_path.write_bytes(binary_data)
                 if sys.platform != "win32":
                     part_path.chmod(0o755)
                 try:
                     os.replace(str(part_path), str(dest_path))
                 except PermissionError as exc:
-                    raise RuntimeError(
-                        f"Cannot replace {dest_path.name}: the file is in use. "
-                        "Stop the running inference engine before upgrading."
-                    ) from exc
+                    raise _locked_error(dest_path.name) from exc
             except BaseException:
                 try:
                     part_path.unlink(missing_ok=True)

--- a/services/convsim-core/convsim_core/runtime/sidecar.py
+++ b/services/convsim-core/convsim_core/runtime/sidecar.py
@@ -83,7 +83,10 @@ def find_executable() -> str | None:
     2. Bundled path — ``<CONVSIM_BUNDLED_RUNTIME_DIR>/llama-server`` (Steam
        depot builds). The ``.exe`` suffix is appended on Windows. Only used
        when the file exists and is executable.
-    3. PATH lookup — ``shutil.which("llama-server")`` (developer builds).
+    3. User-installed path — ``~/.convsim/bin/llama-server[.exe]``, the
+       default destination used by ``download_binary()``. Resolves immediately
+       after an in-app install without requiring a PATH change or app restart.
+    4. PATH lookup — ``shutil.which("llama-server")`` (developer builds).
 
     Returns None when no candidate resolves.
     """
@@ -97,6 +100,11 @@ def find_executable() -> str | None:
         candidate = Path(bundled_dir) / f"{_BUNDLED_BINARY_NAME}{suffix}"
         if candidate.is_file() and os.access(candidate, os.X_OK):
             return str(candidate)
+
+    suffix = ".exe" if sys.platform == "win32" else ""
+    user_installed = Path.home() / ".convsim" / "bin" / f"{_BUNDLED_BINARY_NAME}{suffix}"
+    if user_installed.is_file() and os.access(user_installed, os.X_OK):
+        return str(user_installed)
 
     return shutil.which("llama-server") or shutil.which("llama_server")
 

--- a/services/convsim-core/tests/test_llama_cpp_download.py
+++ b/services/convsim-core/tests/test_llama_cpp_download.py
@@ -21,6 +21,7 @@ from convsim_core.runtime.llama_cpp_download import (
     DownloadProgress,
     DownloadState,
     _extract_binary_from_zip,
+    _extract_runtime_files_from_zip,
     _sha256_of_bytes,
     build_asset_name,
     build_asset_url,
@@ -403,6 +404,53 @@ def test_extract_binary_from_zip_missing_raises():
 
 
 # ---------------------------------------------------------------------------
+# _extract_runtime_files_from_zip — binary + sibling DLLs
+# ---------------------------------------------------------------------------
+
+
+def _make_zip_multi(files: dict[str, bytes]) -> bytes:
+    """Return a ZIP archive containing every ``{path: content}`` entry."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, content in files.items():
+            zf.writestr(name, content)
+    return buf.getvalue()
+
+
+def test_extract_runtime_files_returns_binary_and_siblings():
+    data = _make_zip_multi(
+        {
+            "llama-server.exe": b"exe",
+            "ggml.dll": b"ggml",
+            "llama.dll": b"llama",
+        }
+    )
+    binary, siblings = _extract_runtime_files_from_zip(data)
+    assert binary == b"exe"
+    assert siblings == {"ggml.dll": b"ggml", "llama.dll": b"llama"}
+
+
+def test_extract_runtime_files_only_same_directory():
+    """Siblings from unrelated archive directories are not collected."""
+    data = _make_zip_multi(
+        {
+            "build/bin/llama-server.exe": b"exe",
+            "build/bin/ggml.dll": b"ggml",
+            "docs/README.txt": b"readme",
+        }
+    )
+    binary, siblings = _extract_runtime_files_from_zip(data)
+    assert binary == b"exe"
+    assert siblings == {"ggml.dll": b"ggml"}
+
+
+def test_extract_runtime_files_missing_binary_raises():
+    data = _make_zip_multi({"ggml.dll": b"ggml"})
+    with pytest.raises(RuntimeError, match="not found"):
+        _extract_runtime_files_from_zip(data)
+
+
+# ---------------------------------------------------------------------------
 # detect_windows_gpu_variant
 # ---------------------------------------------------------------------------
 
@@ -650,6 +698,42 @@ async def test_download_binary_windows_uses_exe_suffix(tmp_path, monkeypatch):
 
     assert result.endswith("llama-server.exe")
     assert Path(result).read_bytes() == b"win-binary"
+
+
+@pytest.mark.asyncio
+async def test_download_binary_windows_installs_sibling_dlls(tmp_path, monkeypatch):
+    """On win32, the DLLs shipped next to llama-server.exe must be installed too.
+
+    Windows llama.cpp archives ship the executable dynamically linked against
+    ggml*.dll / llama.dll; without them the engine cannot start.
+    """
+    monkeypatch.setattr("sys.platform", "win32")
+
+    zip_data = _make_zip_multi(
+        {
+            "llama-server.exe": b"win-binary",
+            "ggml.dll": b"ggml-bytes",
+            "ggml-base.dll": b"ggml-base-bytes",
+            "llama.dll": b"llama-bytes",
+        }
+    )
+    client = _mock_async_client(latest_tag="b1", asset_data=zip_data)
+
+    dest = tmp_path / "bin"
+    with patch("convsim_core.runtime.llama_cpp_download.httpx.AsyncClient", return_value=client):
+        result = await download_binary(
+            dest_dir=dest,
+            version="b1",
+            platform_string="win-x64",
+        )
+
+    assert result.endswith("llama-server.exe")
+    assert Path(result).read_bytes() == b"win-binary"
+    assert (dest / "ggml.dll").read_bytes() == b"ggml-bytes"
+    assert (dest / "ggml-base.dll").read_bytes() == b"ggml-base-bytes"
+    assert (dest / "llama.dll").read_bytes() == b"llama-bytes"
+    # No stray .part file remains.
+    assert not list(dest.glob("*.part"))
 
 
 @pytest.mark.asyncio

--- a/services/convsim-core/tests/test_llama_cpp_download.py
+++ b/services/convsim-core/tests/test_llama_cpp_download.py
@@ -733,6 +733,79 @@ async def test_download_binary_asset_404_raises(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_download_binary_offline_fetching_release_raises_friendly(tmp_path):
+    """A network error while fetching the latest tag surfaces an offline message."""
+    import httpx
+
+    client = _mock_async_client(api_error=httpx.ConnectError("no route to host"))
+
+    with patch("convsim_core.runtime.llama_cpp_download.httpx.AsyncClient", return_value=client):
+        with pytest.raises(RuntimeError, match="internet connection") as excinfo:
+            await download_binary(
+                dest_dir=tmp_path / "bin",
+                version=None,  # force the latest-release lookup
+                platform_string="linux-x64",
+            )
+
+    # The raw httpx error must be wrapped, not leaked to the user.
+    assert "Cannot reach GitHub" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_download_binary_offline_during_download_raises_friendly(tmp_path):
+    """A network drop mid-download surfaces an offline message and FAILED state."""
+    import httpx
+
+    client = _mock_async_client(
+        latest_tag="b1",
+        download_error=httpx.ConnectError("connection reset"),
+    )
+
+    states: list[str] = []
+
+    def _cb(p: DownloadProgress) -> None:
+        states.append(p.state.value)
+
+    with patch("convsim_core.runtime.llama_cpp_download.httpx.AsyncClient", return_value=client):
+        with pytest.raises(RuntimeError, match="Network error while downloading"):
+            await download_binary(
+                dest_dir=tmp_path / "bin",
+                version="b1",
+                platform_string="linux-x64",
+                progress_cb=_cb,
+            )
+
+    assert states[-1] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_download_binary_locked_destination_raises_and_cleans_part(tmp_path, monkeypatch):
+    """A locked destination (PermissionError on replace) is reported and the .part removed."""
+    zip_data = _make_zip("llama-server", b"bin")
+    client = _mock_async_client(latest_tag="b1", asset_data=zip_data)
+
+    def _raise_locked(src, dst):
+        raise PermissionError("[WinError 5] Access is denied")
+
+    monkeypatch.setattr(
+        "convsim_core.runtime.llama_cpp_download.os.replace", _raise_locked
+    )
+
+    dest = tmp_path / "bin"
+    with patch("convsim_core.runtime.llama_cpp_download.httpx.AsyncClient", return_value=client):
+        with pytest.raises(RuntimeError, match="in use"):
+            await download_binary(
+                dest_dir=dest,
+                version="b1",
+                platform_string="linux-x64",
+            )
+
+    # The failed .part write must not leave a stray file behind.
+    assert not list(dest.glob("*.part"))
+    assert not (dest / "llama-server").exists()
+
+
+@pytest.mark.asyncio
 async def test_download_binary_binary_missing_from_zip_raises(tmp_path):
     """If the ZIP doesn't contain llama-server, RuntimeError must be raised."""
     zip_data = _make_zip("README.txt", b"nope")

--- a/services/convsim-core/tests/test_llama_cpp_download.py
+++ b/services/convsim-core/tests/test_llama_cpp_download.py
@@ -413,8 +413,14 @@ def test_detect_windows_gpu_variant_returns_cpu_by_default(monkeypatch):
     assert detect_windows_gpu_variant() == "cpu"
 
 
-def test_detect_windows_gpu_variant_cuda_when_nvidia_smi_succeeds(monkeypatch):
-    """Returns 'cuda' when nvidia-smi is present and reports a GPU name."""
+def test_detect_windows_gpu_variant_vulkan_when_nvidia_smi_succeeds(monkeypatch):
+    """Returns 'vulkan' when nvidia-smi reports a GPU.
+
+    CUDA is intentionally not recommended: llama.cpp CUDA builds are published
+    per toolkit version and need a separate cudart archive, so the single-asset
+    downloader can't fetch one. The NVIDIA driver ships the Vulkan runtime, so
+    the Vulkan build accelerates on NVIDIA too.
+    """
     import subprocess as _subprocess
 
     monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/nvidia-smi" if name == "nvidia-smi" else None)
@@ -424,7 +430,7 @@ def test_detect_windows_gpu_variant_cuda_when_nvidia_smi_succeeds(monkeypatch):
     fake_result.stdout = b"NVIDIA GeForce RTX 4090\n"
     monkeypatch.setattr(_subprocess, "run", lambda *a, **kw: fake_result)
 
-    assert detect_windows_gpu_variant() == "cuda"
+    assert detect_windows_gpu_variant() == "vulkan"
 
 
 def test_detect_windows_gpu_variant_cpu_when_nvidia_smi_fails(monkeypatch):

--- a/services/convsim-core/tests/test_llama_cpp_download.py
+++ b/services/convsim-core/tests/test_llama_cpp_download.py
@@ -26,6 +26,7 @@ from convsim_core.runtime.llama_cpp_download import (
     build_asset_url,
     build_sha256sum_url,
     detect_platform_string,
+    detect_windows_gpu_variant,
     download_binary,
     fetch_expected_sha256,
     fetch_latest_release_tag,
@@ -166,11 +167,22 @@ def test_detect_platform_macos_amd64(monkeypatch):
     assert detect_platform_string() == "macos-x64"
 
 
-def test_detect_platform_windows_raises(monkeypatch):
+def test_detect_platform_windows_x64(monkeypatch):
     monkeypatch.setattr("sys.platform", "win32")
     monkeypatch.setattr("platform.machine", lambda: "amd64")
-    with pytest.raises(RuntimeError, match="Windows"):
-        detect_platform_string()
+    assert detect_platform_string() == "win-x64"
+
+
+def test_detect_platform_windows_x86_64(monkeypatch):
+    monkeypatch.setattr("sys.platform", "win32")
+    monkeypatch.setattr("platform.machine", lambda: "x86_64")
+    assert detect_platform_string() == "win-x64"
+
+
+def test_detect_platform_windows_arm64(monkeypatch):
+    monkeypatch.setattr("sys.platform", "win32")
+    monkeypatch.setattr("platform.machine", lambda: "arm64")
+    assert detect_platform_string() == "win-arm64"
 
 
 def test_detect_platform_unsupported_os_raises(monkeypatch):
@@ -200,6 +212,26 @@ def test_build_asset_name():
 def test_build_asset_name_macos():
     name = build_asset_name("b1234", "macos-arm64")
     assert name == "llama-b1234-bin-macos-arm64-cpu.zip"
+
+
+def test_build_asset_name_windows_x64_cpu():
+    name = build_asset_name("b5140", "win-x64")
+    assert name == "llama-b5140-bin-win-cpu-x64.zip"
+
+
+def test_build_asset_name_windows_arm64_cpu():
+    name = build_asset_name("b5140", "win-arm64")
+    assert name == "llama-b5140-bin-win-cpu-arm64.zip"
+
+
+def test_build_asset_name_windows_cuda():
+    name = build_asset_name("b5140", "win-x64", variant="cuda")
+    assert name == "llama-b5140-bin-win-cuda-x64.zip"
+
+
+def test_build_asset_name_windows_vulkan():
+    name = build_asset_name("b5140", "win-x64", variant="vulkan")
+    assert name == "llama-b5140-bin-win-vulkan-x64.zip"
 
 
 def test_build_asset_url():
@@ -371,6 +403,73 @@ def test_extract_binary_from_zip_missing_raises():
 
 
 # ---------------------------------------------------------------------------
+# detect_windows_gpu_variant
+# ---------------------------------------------------------------------------
+
+
+def test_detect_windows_gpu_variant_returns_cpu_by_default(monkeypatch):
+    """Without nvidia-smi or vulkaninfo, must return 'cpu'."""
+    monkeypatch.setattr("shutil.which", lambda _: None)
+    assert detect_windows_gpu_variant() == "cpu"
+
+
+def test_detect_windows_gpu_variant_cuda_when_nvidia_smi_succeeds(monkeypatch):
+    """Returns 'cuda' when nvidia-smi is present and reports a GPU name."""
+    import subprocess as _subprocess
+
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/nvidia-smi" if name == "nvidia-smi" else None)
+
+    fake_result = MagicMock()
+    fake_result.returncode = 0
+    fake_result.stdout = b"NVIDIA GeForce RTX 4090\n"
+    monkeypatch.setattr(_subprocess, "run", lambda *a, **kw: fake_result)
+
+    assert detect_windows_gpu_variant() == "cuda"
+
+
+def test_detect_windows_gpu_variant_cpu_when_nvidia_smi_fails(monkeypatch):
+    """Returns 'cpu' when nvidia-smi is present but returns no GPU name."""
+    import subprocess as _subprocess
+
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/nvidia-smi" if name == "nvidia-smi" else None)
+
+    fake_result = MagicMock()
+    fake_result.returncode = 1
+    fake_result.stdout = b""
+    monkeypatch.setattr(_subprocess, "run", lambda *a, **kw: fake_result)
+
+    assert detect_windows_gpu_variant() == "cpu"
+
+
+def test_detect_windows_gpu_variant_vulkan_fallback(monkeypatch):
+    """Returns 'vulkan' when vulkaninfo succeeds but nvidia-smi is absent."""
+    import subprocess as _subprocess
+
+    monkeypatch.setattr(
+        "shutil.which",
+        lambda name: "/usr/bin/vulkaninfo" if name == "vulkaninfo" else None,
+    )
+
+    fake_result = MagicMock()
+    fake_result.returncode = 0
+    fake_result.stdout = b"GPU info..."
+    monkeypatch.setattr(_subprocess, "run", lambda *a, **kw: fake_result)
+
+    assert detect_windows_gpu_variant() == "vulkan"
+
+
+def test_detect_windows_gpu_variant_never_raises(monkeypatch):
+    """detect_windows_gpu_variant() must not propagate exceptions."""
+    import subprocess as _subprocess
+
+    monkeypatch.setattr("shutil.which", lambda _: "/fake/nvidia-smi")
+    monkeypatch.setattr(_subprocess, "run", MagicMock(side_effect=OSError("no such file")))
+
+    result = detect_windows_gpu_variant()
+    assert result in ("cpu", "cuda", "vulkan")
+
+
+# ---------------------------------------------------------------------------
 # download_binary — happy path (mock client)
 # ---------------------------------------------------------------------------
 
@@ -469,6 +568,148 @@ async def test_download_binary_checksum_mismatch_raises(tmp_path):
 
     # Binary must not have been written
     assert not (dest / "llama-server").exists()
+
+
+@pytest.mark.asyncio
+async def test_download_binary_checksum_mismatch_sets_checksum_mismatch_state(tmp_path):
+    """A mismatched SHA-256 must set the progress state to checksum_mismatch."""
+    zip_data = _make_zip("llama-server", b"bin")
+    wrong_sha = "a" * 64
+    sha256sum_text = f"{wrong_sha}  llama-b1-bin-linux-x64-cpu.zip\n"
+    client = _mock_async_client(
+        latest_tag="b1",
+        sha256sum_text=sha256sum_text,
+        asset_data=zip_data,
+    )
+
+    states: list[str] = []
+
+    def _cb(p: DownloadProgress) -> None:
+        states.append(p.state.value)
+
+    dest = tmp_path / "bin"
+    with patch("convsim_core.runtime.llama_cpp_download.httpx.AsyncClient", return_value=client):
+        with pytest.raises(RuntimeError, match="checksum mismatch"):
+            await download_binary(
+                dest_dir=dest,
+                version="b1",
+                platform_string="linux-x64",
+                progress_cb=_cb,
+            )
+
+    assert "checksum_mismatch" in states
+    assert "failed" not in states  # checksum_mismatch is its own distinct terminal state
+
+
+@pytest.mark.asyncio
+async def test_download_binary_part_file_cleaned_on_checksum_mismatch(tmp_path):
+    """The .part file must be removed when a checksum mismatch occurs."""
+    zip_data = _make_zip("llama-server", b"bin")
+    wrong_sha = "a" * 64
+    sha256sum_text = f"{wrong_sha}  llama-b1-bin-linux-x64-cpu.zip\n"
+    client = _mock_async_client(
+        latest_tag="b1",
+        sha256sum_text=sha256sum_text,
+        asset_data=zip_data,
+    )
+
+    dest = tmp_path / "bin"
+    with patch("convsim_core.runtime.llama_cpp_download.httpx.AsyncClient", return_value=client):
+        with pytest.raises(RuntimeError, match="checksum mismatch"):
+            await download_binary(
+                dest_dir=dest,
+                version="b1",
+                platform_string="linux-x64",
+            )
+
+    # Neither the final binary nor any .part file should remain
+    assert not list(dest.glob("*.part"))
+    assert not (dest / "llama-server").exists()
+
+
+@pytest.mark.asyncio
+async def test_download_binary_windows_uses_exe_suffix(tmp_path, monkeypatch):
+    """On win32, the installed binary must be named llama-server.exe."""
+    monkeypatch.setattr("sys.platform", "win32")
+
+    zip_data = _make_zip("llama-server.exe", b"win-binary")
+    client = _mock_async_client(latest_tag="b1", asset_data=zip_data)
+
+    with patch("convsim_core.runtime.llama_cpp_download.httpx.AsyncClient", return_value=client):
+        result = await download_binary(
+            dest_dir=tmp_path / "bin",
+            version="b1",
+            platform_string="win-x64",
+        )
+
+    assert result.endswith("llama-server.exe")
+    assert Path(result).read_bytes() == b"win-binary"
+
+
+@pytest.mark.asyncio
+async def test_download_binary_windows_asset_name(tmp_path):
+    """download_binary with win-x64 requests the correct win-cpu-x64 asset."""
+    binary_content = b"windows-binary"
+    # The asset name for win-x64 default variant is llama-b1-bin-win-cpu-x64.zip
+    zip_data = _make_zip("llama-server.exe", binary_content)
+    sha256sum_text = f"{_sha256_of_bytes(zip_data)}  llama-b1-bin-win-cpu-x64.zip\n"
+    client = _mock_async_client(
+        latest_tag="b1",
+        sha256sum_text=sha256sum_text,
+        asset_data=zip_data,
+    )
+
+    captured_stream_url: list[str] = []
+    orig_stream = client.stream
+
+    def _recording_stream(method, url, **kw):
+        captured_stream_url.append(url)
+        return orig_stream(method, url, **kw)
+
+    client.stream = _recording_stream
+
+    with patch("convsim_core.runtime.llama_cpp_download.httpx.AsyncClient", return_value=client):
+        await download_binary(
+            dest_dir=tmp_path / "bin",
+            version="b1",
+            platform_string="win-x64",
+        )
+
+    assert len(captured_stream_url) == 1
+    assert "win-cpu-x64" in captured_stream_url[0]
+
+
+@pytest.mark.asyncio
+async def test_download_binary_variant_passed_to_asset_name(tmp_path):
+    """Passing variant='vulkan' selects the correct Vulkan asset for Windows."""
+    binary_content = b"vulkan-binary"
+    zip_data = _make_zip("llama-server.exe", binary_content)
+    sha256sum_text = f"{_sha256_of_bytes(zip_data)}  llama-b1-bin-win-vulkan-x64.zip\n"
+    client = _mock_async_client(
+        latest_tag="b1",
+        sha256sum_text=sha256sum_text,
+        asset_data=zip_data,
+    )
+
+    captured_stream_url: list[str] = []
+    orig_stream = client.stream
+
+    def _recording_stream(method, url, **kw):
+        captured_stream_url.append(url)
+        return orig_stream(method, url, **kw)
+
+    client.stream = _recording_stream
+
+    with patch("convsim_core.runtime.llama_cpp_download.httpx.AsyncClient", return_value=client):
+        await download_binary(
+            dest_dir=tmp_path / "bin",
+            version="b1",
+            platform_string="win-x64",
+            variant="vulkan",
+        )
+
+    assert len(captured_stream_url) == 1
+    assert "win-vulkan-x64" in captured_stream_url[0]
 
 
 @pytest.mark.asyncio

--- a/services/convsim-core/tests/test_preflight.py
+++ b/services/convsim-core/tests/test_preflight.py
@@ -156,7 +156,8 @@ def test_llama_cpp_binary_fails_when_missing(client):
         result = _check_llama_cpp_binary()
     assert result.status == "fail"
     assert result.fix_action is not None
-    assert result.fix_action.kind == "open-url"
+    assert result.fix_action.kind == "install-engine"
+    assert result.fix_action.href == "/settings/install-engine"
 
 
 def test_llama_cpp_binary_passes_when_found(tmp_path):

--- a/services/convsim-core/tests/test_sidecar.py
+++ b/services/convsim-core/tests/test_sidecar.py
@@ -273,7 +273,58 @@ def test_find_executable_bundled_dir_missing_binary_falls_through(monkeypatch, t
     monkeypatch.setenv("CONVSIM_BUNDLED_RUNTIME_DIR", str(tmp_path))  # empty dir
     from unittest.mock import patch
     with patch("convsim_core.runtime.sidecar.shutil.which", return_value=None):
-        assert find_executable() is None
+        # Also patch Path.home so user-installed path doesn't accidentally exist.
+        with patch("convsim_core.runtime.sidecar.Path.home", return_value=tmp_path / "home"):
+            assert find_executable() is None
+
+
+def test_find_executable_finds_user_installed_path(monkeypatch, tmp_path):
+    """find_executable() resolves a binary installed to ~/.convsim/bin/ without PATH."""
+    monkeypatch.delenv("CONVSIM_LLAMA_CPP_EXECUTABLE", raising=False)
+    monkeypatch.delenv("CONVSIM_BUNDLED_RUNTIME_DIR", raising=False)
+
+    binary_name = "llama-server.exe" if sys.platform == "win32" else "llama-server"
+    user_bin = tmp_path / ".convsim" / "bin"
+    user_bin.mkdir(parents=True)
+    binary = user_bin / binary_name
+    binary.write_text("#!/bin/sh\n")
+    binary.chmod(0o755)
+
+    from unittest.mock import patch
+    with patch("convsim_core.runtime.sidecar.Path.home", return_value=tmp_path):
+        with patch("convsim_core.runtime.sidecar.shutil.which", return_value=None):
+            result = find_executable()
+
+    assert result == str(binary)
+
+
+def test_find_executable_user_installed_does_not_shadow_bundled(monkeypatch, tmp_path):
+    """The bundled dir (step 2) takes priority over user-installed (step 3)."""
+    monkeypatch.delenv("CONVSIM_LLAMA_CPP_EXECUTABLE", raising=False)
+
+    binary_name = "llama-server.exe" if sys.platform == "win32" else "llama-server"
+
+    # Bundled binary
+    bundled_bin = tmp_path / "bundled"
+    bundled_bin.mkdir()
+    bundled = bundled_bin / binary_name
+    bundled.write_text("bundled")
+    bundled.chmod(0o755)
+    monkeypatch.setenv("CONVSIM_BUNDLED_RUNTIME_DIR", str(bundled_bin))
+
+    # User-installed binary (should be shadowed)
+    user_home = tmp_path / "home"
+    user_bin = user_home / ".convsim" / "bin"
+    user_bin.mkdir(parents=True)
+    user_binary = user_bin / binary_name
+    user_binary.write_text("user-installed")
+    user_binary.chmod(0o755)
+
+    from unittest.mock import patch
+    with patch("convsim_core.runtime.sidecar.Path.home", return_value=user_home):
+        result = find_executable()
+
+    assert result == str(bundled)
 
 
 # ---------------------------------------------------------------------------

--- a/services/convsim-core/tests/test_sidecar.py
+++ b/services/convsim-core/tests/test_sidecar.py
@@ -429,6 +429,31 @@ def test_sidecar_start_returns_409_when_already_running(client):
     assert resp.json()["error"]["code"] == "SIDECAR_ALREADY_RUNNING"
 
 
+def test_gpu_variant_endpoint_non_windows_returns_cpu(client, monkeypatch):
+    """On non-Windows platforms the GPU-variant probe is skipped and returns cpu."""
+    # The endpoint reads platform via a local ``import sys as _sys``, which
+    # aliases the real sys module, so patch sys.platform directly.
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    resp = client.get("/api/sidecar/gpu-variant")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["variant"] == "cpu"
+
+
+def test_gpu_variant_endpoint_windows_reports_probe_result(client, monkeypatch):
+    """On Windows the endpoint surfaces detect_windows_gpu_variant()'s result."""
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(
+        "convsim_core.routers.sidecar.detect_windows_gpu_variant",
+        lambda: "vulkan",
+    )
+
+    resp = client.get("/api/sidecar/gpu-variant")
+    assert resp.status_code == 200
+    assert resp.json()["variant"] == "vulkan"
+
+
 def test_sidecar_start_returns_409_when_starting(client):
     """POST /api/sidecar/start must return 409 if the sidecar is still STARTING.
 


### PR DESCRIPTION
## Summary

This PR brings Windows to feature parity with macOS and Linux for engine provisioning, enabling one-click binary install from the Settings screen across all platforms.

### Key changes

**Windows platform support** — `detect_platform_string()` now returns `win-x64` or `win-arm64` instead of raising `RuntimeError`, unblocking the `POST /api/sidecar/download-runtime` endpoint on Windows without router changes.

**GPU variant auto-detection** — `detect_windows_gpu_variant()` probes `nvidia-smi` and `vulkaninfo` to recommend Vulkan acceleration (or default to CPU). A new `GET /api/sidecar/gpu-variant` endpoint surfaces this advisory to the UI. GPU variants are optional; CPU is always the default.

**Variant parameter** — Both `build_asset_name()` and `download_binary()` accept `variant=` (default `"cpu"`). Windows naming follows llama.cpp convention: `llama-{tag}-bin-win-{variant}-{arch}.zip`.

**Atomic install** — Downloads write to `.part` then atomically replace the final destination with `os.replace()`. Locked-file contention raises a clear error instead of crashing. SHA-256 mismatches set a dedicated `CHECKSUM_MISMATCH` state and cleanup the `.part` file immediately.

**Offline resilience** — Network errors (connect, timeout, DNS) raise human-readable messages explaining the connection requirement and suggesting retry.

**User-installed path resolution** — `find_executable()` gains step 3: `~/.convsim/bin/llama-server[.exe]`. After in-app install it resolves immediately without PATH changes or app restart.

**Preflight fix action** — `_check_llama_cpp_binary()` now returns `fix_action(kind="install-engine", href="/settings/install-engine")` on all platforms, replacing the `open-url` → external docs dead-end.

**Windows PowerShell script** — New `download-runtime.ps1` is the Windows equivalent of `download-runtime.sh`, supporting `-Version`, `-Dest`, and `-Variant` parameters with SHA-256 verification and atomic install.

**CI: platform detection smoke test** — `binary-health-check.yml` now triggers on `runtimes/llama_cpp/**` changes and runs engine platform detection tests on all three OS runners.

**CI: Steam bundling** — `release.yml` adds platform-specific bundle steps (bash on Linux/macOS, PowerShell on Windows) that copy `llama-server[.exe]` into `src-tauri/resources/runtimes/` for Steam depot builds. Gated on the `BUNDLE_LLAMA_SERVER` repository variable.

**Documentation** — `sidecar-bundling.md` now covers Windows developer setup and `find_executable()` resolution order. `model-download-policy.md` Section 8 documents engine binary download policy (trigger, source, integrity, variants, offline behavior, Steam bundling).

### Testing

131 unit/integration tests pass across three test files:

**New Windows platform detection cases:**
- `detect_platform_string()` returns `win-x64` for `amd64` and `x86_64`; `win-arm64` for ARM64
- `build_asset_name()` assertions for Windows CPU/CUDA/Vulkan variants

**GPU variant detection suite:**
- CPU fallback (default)
- Vulkan via `nvidia-smi` probe
- Vulkan via `vulkaninfo` probe
- Never-raises guard

**Download and install assertions:**
- Checksum mismatch transitions to `CHECKSUM_MISMATCH` state with `.part` cleanup
- Windows `.exe` suffix and DLL extraction
- Asset URL correctness for `win-cpu-x64` and `win-vulkan-x64`
- User-installed path resolution at `~/.convsim/bin/`
- Bundled-dir priority ordering

**Offline and error handling:**
- Network error messages explain connection requirement
- Locked-file replacement raises clear error

**Preflight:**
- `install-engine` fix-action assertion

Closes #379