### PR TITLE
Add seven-slide auto-rotating carousel to marketing site hero

### DIFF
--- a/website/assets/css/main.css
+++ b/website/assets/css/main.css
@@ -226,27 +226,8 @@ h3 { font-size: 1.12rem; margin: 0 0 0.4em; }
 .fill-violet { background: var(--violet-deep); }
 .fill-amber { background: var(--amber); }
 
-/* demo animation timeline */
-.anim { opacity: 0; transform: translateY(8px); animation: rise 500ms ease forwards; }
-.anim-1 { animation-delay: 300ms; }
-.anim-2 { animation-delay: 1150ms; }
-.anim-3 { animation-delay: 2050ms; }
-.anim-4 { animation-delay: 2500ms; }
-.w-74 { animation: grow74 900ms ease-out 2650ms forwards; }
-.w-65 { animation: grow65 900ms ease-out 2800ms forwards; }
-.w-40 { animation: grow40 900ms ease-out 2950ms forwards; }
-
-@keyframes rise { to { opacity: 1; transform: none; } }
-@keyframes grow74 { to { width: 74%; } }
-@keyframes grow65 { to { width: 65%; } }
-@keyframes grow40 { to { width: 40%; } }
-
 @media (prefers-reduced-motion: reduce) {
   html { scroll-behavior: auto; }
-  .anim { animation: none; opacity: 1; transform: none; }
-  .w-74 { animation: none; width: 74%; }
-  .w-65 { animation: none; width: 65%; }
-  .w-40 { animation: none; width: 40%; }
 }
 
 /* ---------- hero carousel ---------- */

--- a/website/assets/css/main.css
+++ b/website/assets/css/main.css
@@ -249,6 +249,41 @@ h3 { font-size: 1.12rem; margin: 0 0 0.4em; }
   .w-40 { animation: none; width: 40%; }
 }
 
+/* ---------- hero carousel ---------- */
+
+.demo-carousel { display: flex; flex-direction: column; gap: 0.85rem; }
+
+.demo-slides { display: grid; }
+
+.demo-slides .demo-card {
+  grid-area: 1 / 1;
+  opacity: 0;
+  transition: opacity 500ms ease;
+  pointer-events: none;
+}
+
+.demo-slides .demo-card.is-active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.carousel-dots {
+  display: flex; justify-content: center; gap: 0.5rem; padding: 0.15rem 0;
+}
+
+.carousel-dot {
+  width: 0.45rem; height: 0.45rem; border-radius: 50%;
+  background: var(--border); border: none; padding: 0; cursor: pointer;
+  transition: background 200ms ease, transform 200ms ease;
+}
+
+.carousel-dot.is-active { background: var(--violet); transform: scale(1.4); }
+.carousel-dot:hover:not(.is-active) { background: var(--text-faint); }
+
+@media (prefers-reduced-motion: reduce) {
+  .demo-slides .demo-card { transition: none; }
+}
+
 /* ---------- guarantee strip ---------- */
 
 .strip { border-block: 1px solid var(--border-soft); background: var(--bg-raise); }

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -467,8 +467,8 @@
     dots[current].setAttribute('aria-current', 'true');
   }
 
-  function startTimer() { timer = setInterval(function () { goTo(current + 1); }, INTERVAL); }
   function stopTimer()  { clearInterval(timer); timer = null; }
+  function startTimer() { stopTimer(); timer = setInterval(function () { goTo(current + 1); }, INTERVAL); }
 
   dots.forEach(function (dot, i) {
     dot.addEventListener('click', function () {

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -17,42 +17,266 @@
       <p class="hero-fineprint">Windows · macOS · Linux · Steam Deck &nbsp;—&nbsp; or build the Apache-2.0 source for free.</p>
     </div>
 
-    <figure class="demo-card" aria-label="A practice interview in progress. The NPC challenges a claim, the player answers, a scenario event fires, and the NPC state meters shift.">
-      <figcaption class="demo-head">
-        <span class="demo-title">The Executive Gauntlet</span>
-        <span class="demo-meta">Job Interview Basics · Turn 4</span>
-      </figcaption>
-      <div class="demo-lines">
-        <div class="demo-line demo-npc anim anim-1">
-          <span class="demo-speaker speaker-npc">Victor · NPC</span>
-          <p>“That’s a headline number. Walk me through the trade-off you made
-          to get there. What did you give up — and was it the right call?”</p>
-        </div>
-        <div class="demo-line demo-you anim anim-2">
-          <span class="demo-speaker speaker-you">You</span>
-          <p>“We gave up real-time freshness — reports now lag five minutes
-          behind. For nightly analytics, that was the right trade.”</p>
-        </div>
-        <div class="demo-event anim anim-3">Scenario event: <code>grudging_respect</code> triggered</div>
+    <div class=”demo-carousel” aria-label=”Use case examples” aria-roledescription=”carousel”>
+      <div class=”demo-slides”>
+
+        <figure class=”demo-card is-active” role=”group” aria-roledescription=”slide” aria-label=”Slide 1 of 7: The Executive Gauntlet”>
+          <figcaption class=”demo-head”>
+            <span class=”demo-title”>The Executive Gauntlet</span>
+            <span class=”demo-meta”>Job Interview Basics · Turn 4</span>
+          </figcaption>
+          <div class=”demo-lines”>
+            <div class=”demo-line demo-npc”>
+              <span class=”demo-speaker speaker-npc”>Victor · NPC</span>
+              <p>”That’s a headline number. Walk me through the trade-off you made to get there. What did you give up — and was it the right call?”</p>
+            </div>
+            <div class=”demo-line demo-you”>
+              <span class=”demo-speaker speaker-you”>You</span>
+              <p>”We gave up real-time freshness — reports now lag five minutes behind. For nightly analytics, that was the right trade.”</p>
+            </div>
+            <div class=”demo-event”>Scenario event: <code>grudging_respect</code> triggered</div>
+          </div>
+          <div class=”demo-meters”>
+            <div class=”meter”>
+              <span class=”meter-name”>credibility</span>
+              <span class=”meter-bar”><span class=”meter-fill fill-emerald” style=”width:74%”></span></span>
+              <span class=”meter-val”>74</span>
+            </div>
+            <div class=”meter”>
+              <span class=”meter-name”>composure</span>
+              <span class=”meter-bar”><span class=”meter-fill fill-violet” style=”width:65%”></span></span>
+              <span class=”meter-val”>65</span>
+            </div>
+            <div class=”meter”>
+              <span class=”meter-name”>pressure</span>
+              <span class=”meter-bar”><span class=”meter-fill fill-amber” style=”width:40%”></span></span>
+              <span class=”meter-val”>40</span>
+            </div>
+          </div>
+        </figure>
+
+        <figure class=”demo-card” role=”group” aria-roledescription=”slide” aria-label=”Slide 2 of 7: The Salary Conversation”>
+          <figcaption class=”demo-head”>
+            <span class=”demo-title”>The Salary Conversation</span>
+            <span class=”demo-meta”>Difficult Conversations · Turn 6</span>
+          </figcaption>
+          <div class=”demo-lines”>
+            <div class=”demo-line demo-npc”>
+              <span class=”demo-speaker speaker-npc”>Dana · NPC</span>
+              <p>”Your work has been solid. But we’re at band ceiling for your level. What’s your thinking here?”</p>
+            </div>
+            <div class=”demo-line demo-you”>
+              <span class=”demo-speaker speaker-you”>You</span>
+              <p>”I’ve checked market data — my comp sits 18% below median for this scope. I’d like to talk about a path to close that gap.”</p>
+            </div>
+            <div class=”demo-event”>Scenario event: <code>case_acknowledged</code> triggered</div>
+          </div>
+          <div class=”demo-meters”>
+            <div class=”meter”>
+              <span class=”meter-name”>rapport</span>
+              <span class=”meter-bar”><span class=”meter-fill fill-emerald” style=”width:65%”></span></span>
+              <span class=”meter-val”>65</span>
+            </div>
+            <div class=”meter”>
+              <span class=”meter-name”>confidence</span>
+              <span class=”meter-bar”><span class=”meter-fill fill-violet” style=”width:71%”></span></span>
+              <span class=”meter-val”>71</span>
+            </div>
+            <div class=”meter”>
+              <span class=”meter-name”>resolve</span>
+              <span class=”meter-bar”><span class=”meter-fill fill-amber” style=”width:58%”></span></span>
+              <span class=”meter-val”>58</span>
+            </div>
+          </div>
+        </figure>
+
+        <figure class=”demo-card” role=”group” aria-roledescription=”slide” aria-label=”Slide 3 of 7: The Car Lot”>
+          <figcaption class=”demo-head”>
+            <span class=”demo-title”>The Car Lot</span>
+            <span class=”demo-meta”>Everyday Negotiation · Turn 3</span>
+          </figcaption>
+          <div class=”demo-lines”>
+            <div class=”demo-line demo-npc”>
+              <span class=”demo-speaker speaker-npc”>Dale · NPC</span>
+              <p>”That’s already our best number — I’m basically handing you this car. We can’t go lower and keep the lights on.”</p>
+            </div>
+            <div class=”demo-line demo-you”>
+              <span class=”demo-speaker speaker-you”>You</span>
+              <p>”I’ve got a check from my credit union for the out-the-door price, minus the two recalls that are still open.”</p>
+            </div>
+            <div class=”demo-event”>Scenario event: <code>sticker_shock_override</code> triggered</div>
+          </div>
+          <div class=”demo-meters”>
+            <div class=”meter”>
+              <span class=”meter-name”>leverage</span>
+              <span class=”meter-bar”><span class=”meter-fill fill-emerald” style=”width:52%”></span></span>
+              <span class=”meter-val”>52</span>
+            </div>
+            <div class=”meter”>
+              <span class=”meter-name”>patience</span>
+              <span class=”meter-bar”><span class=”meter-fill fill-violet” style=”width:68%”></span></span>
+              <span class=”meter-val”>68</span>
+            </div>
+            <div class=”meter”>
+              <span class=”meter-name”>firmness</span>
+              <span class=”meter-bar”><span class=”meter-fill fill-amber” style=”width:75%”></span></span>
+              <span class=”meter-val”>75</span>
+            </div>
+          </div>
+        </figure>
+
+        <figure class=”demo-card” role=”group” aria-roledescription=”slide” aria-label=”Slide 4 of 7: Feedback Without Fallout”>
+          <figcaption class=”demo-head”>
+            <span class=”demo-title”>Feedback Without Fallout</span>
+            <span class=”demo-meta”>Difficult Conversations · Turn 5</span>
+          </figcaption>
+          <div class=”demo-lines”>
+            <div class=”demo-line demo-npc”>
+              <span class=”demo-speaker speaker-npc”>Morgan · NPC</span>
+              <p>”I don’t even know what you mean by ‘interrupting the meeting.’ I was just being enthusiastic.”</p>
+            </div>
+            <div class=”demo-line demo-you”>
+              <span class=”demo-speaker speaker-you”>You</span>
+              <p>”Your energy is one of the best things about working with you. It’s specifically the part where others stop finishing their sentences.”</p>
+            </div>
+            <div class=”demo-event”>Scenario event: <code>defensiveness_spike</code> triggered</div>
+          </div>
+          <div class=”demo-meters”>
+            <div class=”meter”>
+              <span class=”meter-name”>openness</span>
+              <span class=”meter-bar”><span class=”meter-fill fill-emerald” style=”width:42%”></span></span>
+              <span class=”meter-val”>42</span>
+            </div>
+            <div class=”meter”>
+              <span class=”meter-name”>tension</span>
+              <span class=”meter-bar”><span class=”meter-fill fill-violet” style=”width:71%”></span></span>
+              <span class=”meter-val”>71</span>
+            </div>
+            <div class=”meter”>
+              <span class=”meter-name”>clarity</span>
+              <span class=”meter-bar”><span class=”meter-fill fill-amber” style=”width:58%”></span></span>
+              <span class=”meter-val”>58</span>
+            </div>
+          </div>
+        </figure>
+
+        <figure class=”demo-card” role=”group” aria-roledescription=”slide” aria-label=”Slide 5 of 7: Spanish Coffee Shop”>
+          <figcaption class=”demo-head”>
+            <span class=”demo-title”>Spanish Coffee Shop</span>
+            <span class=”demo-meta”>Language Café · Turn 2</span>
+          </figcaption>
+          <div class=”demo-lines”>
+            <div class=”demo-line demo-npc”>
+              <span class=”demo-speaker speaker-npc”>Sofía · NPC</span>
+              <p>”¿Qué le pongo? ¿Lo quiere solo o cortado?”</p>
+            </div>
+            <div class=”demo-line demo-you”>
+              <span class=”demo-speaker speaker-you”>You</span>
+              <p>”Un cortado, por favor. Y — ¿tiene algo dulce para el desayuno?”</p>
+            </div>
+            <div class=”demo-event”>Scenario event: <code>vocabulary_gap_detected</code> triggered</div>
+          </div>
+          <div class=”demo-meters”>
+            <div class=”meter”>
+              <span class=”meter-name”>fluency</span>
+              <span class=”meter-bar”><span class=”meter-fill fill-emerald” style=”width:48%”></span></span>
+              <span class=”meter-val”>48</span>
+            </div>
+            <div class=”meter”>
+              <span class=”meter-name”>confidence</span>
+              <span class=”meter-bar”><span class=”meter-fill fill-violet” style=”width:55%”></span></span>
+              <span class=”meter-val”>55</span>
+            </div>
+            <div class=”meter”>
+              <span class=”meter-name”>rapport</span>
+              <span class=”meter-bar”><span class=”meter-fill fill-amber” style=”width:72%”></span></span>
+              <span class=”meter-val”>72</span>
+            </div>
+          </div>
+        </figure>
+
+        <figure class=”demo-card” role=”group” aria-roledescription=”slide” aria-label=”Slide 6 of 7: The Missed Deadline”>
+          <figcaption class=”demo-head”>
+            <span class=”demo-title”>The Missed Deadline</span>
+            <span class=”demo-meta”>Difficult Conversations · Turn 4</span>
+          </figcaption>
+          <div class=”demo-lines”>
+            <div class=”demo-line demo-npc”>
+              <span class=”demo-speaker speaker-npc”>Alex · NPC</span>
+              <p>”The sprint ends Friday. You told me yesterday it’d be done. I had to tell the client something. Help me understand.”</p>
+            </div>
+            <div class=”demo-line demo-you”>
+              <span class=”demo-speaker speaker-you”>You</span>
+              <p>”You’re right to be frustrated. I underestimated the integration work. It ships Tuesday — here’s what changed and why.”</p>
+            </div>
+            <div class=”demo-event”>Scenario event: <code>trust_repair_initiated</code> triggered</div>
+          </div>
+          <div class=”demo-meters”>
+            <div class=”meter”>
+              <span class=”meter-name”>trust</span>
+              <span class=”meter-bar”><span class=”meter-fill fill-emerald” style=”width:35%”></span></span>
+              <span class=”meter-val”>35</span>
+            </div>
+            <div class=”meter”>
+              <span class=”meter-name”>clarity</span>
+              <span class=”meter-bar”><span class=”meter-fill fill-violet” style=”width:79%”></span></span>
+              <span class=”meter-val”>79</span>
+            </div>
+            <div class=”meter”>
+              <span class=”meter-name”>tension</span>
+              <span class=”meter-bar”><span class=”meter-fill fill-amber” style=”width:61%”></span></span>
+              <span class=”meter-val”>61</span>
+            </div>
+          </div>
+        </figure>
+
+        <figure class=”demo-card” role=”group” aria-roledescription=”slide” aria-label=”Slide 7 of 7: Scope Creep Defense”>
+          <figcaption class=”demo-head”>
+            <span class=”demo-title”>Scope Creep Defense</span>
+            <span class=”demo-meta”>Everyday Negotiation · Turn 7</span>
+          </figcaption>
+          <div class=”demo-lines”>
+            <div class=”demo-line demo-npc”>
+              <span class=”demo-speaker speaker-npc”>Client · NPC</span>
+              <p>”While you’re in there, can you also rework the onboarding flow? It shouldn’t take long.”</p>
+            </div>
+            <div class=”demo-line demo-you”>
+              <span class=”demo-speaker speaker-you”>You</span>
+              <p>”I’ve flagged it for a future phase. Adding it to this contract shifts delivery by two weeks and adds roughly 40 hours.”</p>
+            </div>
+            <div class=”demo-event”>Scenario event: <code>boundary_held</code> triggered</div>
+          </div>
+          <div class=”demo-meters”>
+            <div class=”meter”>
+              <span class=”meter-name”>clarity</span>
+              <span class=”meter-bar”><span class=”meter-fill fill-emerald” style=”width:83%”></span></span>
+              <span class=”meter-val”>83</span>
+            </div>
+            <div class=”meter”>
+              <span class=”meter-name”>firmness</span>
+              <span class=”meter-bar”><span class=”meter-fill fill-violet” style=”width:70%”></span></span>
+              <span class=”meter-val”>70</span>
+            </div>
+            <div class=”meter”>
+              <span class=”meter-name”>goodwill</span>
+              <span class=”meter-bar”><span class=”meter-fill fill-amber” style=”width:52%”></span></span>
+              <span class=”meter-val”>52</span>
+            </div>
+          </div>
+        </figure>
+
       </div>
-      <div class="demo-meters anim anim-4">
-        <div class="meter">
-          <span class="meter-name">credibility</span>
-          <span class="meter-bar"><span class="meter-fill fill-emerald w-74"></span></span>
-          <span class="meter-val">74</span>
-        </div>
-        <div class="meter">
-          <span class="meter-name">composure</span>
-          <span class="meter-bar"><span class="meter-fill fill-violet w-65"></span></span>
-          <span class="meter-val">65</span>
-        </div>
-        <div class="meter">
-          <span class="meter-name">pressure</span>
-          <span class="meter-bar"><span class="meter-fill fill-amber w-40"></span></span>
-          <span class="meter-val">40</span>
-        </div>
+
+      <div class=”carousel-dots” role=”group” aria-label=”Slide navigation”>
+        <button class=”carousel-dot is-active” aria-label=”Go to slide 1” aria-current=”true” data-slide=”0”></button>
+        <button class=”carousel-dot” aria-label=”Go to slide 2” data-slide=”1”></button>
+        <button class=”carousel-dot” aria-label=”Go to slide 3” data-slide=”2”></button>
+        <button class=”carousel-dot” aria-label=”Go to slide 4” data-slide=”3”></button>
+        <button class=”carousel-dot” aria-label=”Go to slide 5” data-slide=”4”></button>
+        <button class=”carousel-dot” aria-label=”Go to slide 6” data-slide=”5”></button>
+        <button class=”carousel-dot” aria-label=”Go to slide 7” data-slide=”6”></button>
       </div>
-    </figure>
+    </div>
   </div>
 </section>
 
@@ -220,5 +444,50 @@
     </div>
   </div>
 </section>
+
+<script>
+(function () {
+  'use strict';
+  var slides = Array.prototype.slice.call(document.querySelectorAll('.demo-slides .demo-card'));
+  var dots   = Array.prototype.slice.call(document.querySelectorAll('.carousel-dot'));
+  if (!slides.length) return;
+
+  var current  = 0;
+  var timer    = null;
+  var INTERVAL = 4500;
+  var reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  function goTo(n) {
+    slides[current].classList.remove('is-active');
+    dots[current].classList.remove('is-active');
+    dots[current].removeAttribute('aria-current');
+    current = ((n % slides.length) + slides.length) % slides.length;
+    slides[current].classList.add('is-active');
+    dots[current].classList.add('is-active');
+    dots[current].setAttribute('aria-current', 'true');
+  }
+
+  function startTimer() { timer = setInterval(function () { goTo(current + 1); }, INTERVAL); }
+  function stopTimer()  { clearInterval(timer); timer = null; }
+
+  dots.forEach(function (dot, i) {
+    dot.addEventListener('click', function () {
+      stopTimer();
+      goTo(i);
+      if (!reducedMotion) startTimer();
+    });
+  });
+
+  var carousel = document.querySelector('.demo-carousel');
+  if (carousel) {
+    carousel.addEventListener('mouseenter', stopTimer);
+    carousel.addEventListener('mouseleave', function () { if (!reducedMotion) startTimer(); });
+    carousel.addEventListener('focusin',    stopTimer);
+    carousel.addEventListener('focusout',   function () { if (!reducedMotion) startTimer(); });
+  }
+
+  if (!reducedMotion) startTimer();
+}());
+</script>
 
 {{ end }}

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -55,7 +55,7 @@
           </div>
         </figure>
 
-        <figure class="demo-card" role="group" aria-roledescription="slide" aria-label="Slide 2 of 7: The Salary Conversation">
+        <figure class="demo-card" role="group" aria-roledescription="slide" aria-label="Slide 2 of 7: The Salary Conversation" aria-hidden="true">
           <figcaption class="demo-head">
             <span class="demo-title">The Salary Conversation</span>
             <span class="demo-meta">Difficult Conversations · Turn 6</span>
@@ -90,7 +90,7 @@
           </div>
         </figure>
 
-        <figure class="demo-card" role="group" aria-roledescription="slide" aria-label="Slide 3 of 7: The Car Lot">
+        <figure class="demo-card" role="group" aria-roledescription="slide" aria-label="Slide 3 of 7: The Car Lot" aria-hidden="true">
           <figcaption class="demo-head">
             <span class="demo-title">The Car Lot</span>
             <span class="demo-meta">Everyday Negotiation · Turn 3</span>
@@ -125,7 +125,7 @@
           </div>
         </figure>
 
-        <figure class="demo-card" role="group" aria-roledescription="slide" aria-label="Slide 4 of 7: Feedback Without Fallout">
+        <figure class="demo-card" role="group" aria-roledescription="slide" aria-label="Slide 4 of 7: Feedback Without Fallout" aria-hidden="true">
           <figcaption class="demo-head">
             <span class="demo-title">Feedback Without Fallout</span>
             <span class="demo-meta">Difficult Conversations · Turn 5</span>
@@ -160,7 +160,7 @@
           </div>
         </figure>
 
-        <figure class="demo-card" role="group" aria-roledescription="slide" aria-label="Slide 5 of 7: Spanish Coffee Shop">
+        <figure class="demo-card" role="group" aria-roledescription="slide" aria-label="Slide 5 of 7: Spanish Coffee Shop" aria-hidden="true">
           <figcaption class="demo-head">
             <span class="demo-title">Spanish Coffee Shop</span>
             <span class="demo-meta">Language Café · Turn 2</span>
@@ -195,7 +195,7 @@
           </div>
         </figure>
 
-        <figure class="demo-card" role="group" aria-roledescription="slide" aria-label="Slide 6 of 7: The Missed Deadline">
+        <figure class="demo-card" role="group" aria-roledescription="slide" aria-label="Slide 6 of 7: The Missed Deadline" aria-hidden="true">
           <figcaption class="demo-head">
             <span class="demo-title">The Missed Deadline</span>
             <span class="demo-meta">Difficult Conversations · Turn 4</span>
@@ -230,7 +230,7 @@
           </div>
         </figure>
 
-        <figure class="demo-card" role="group" aria-roledescription="slide" aria-label="Slide 7 of 7: Scope Creep Defense">
+        <figure class="demo-card" role="group" aria-roledescription="slide" aria-label="Slide 7 of 7: Scope Creep Defense" aria-hidden="true">
           <figcaption class="demo-head">
             <span class="demo-title">Scope Creep Defense</span>
             <span class="demo-meta">Everyday Negotiation · Turn 7</span>
@@ -459,10 +459,12 @@
 
   function goTo(n) {
     slides[current].classList.remove('is-active');
+    slides[current].setAttribute('aria-hidden', 'true');
     dots[current].classList.remove('is-active');
     dots[current].removeAttribute('aria-current');
     current = ((n % slides.length) + slides.length) % slides.length;
     slides[current].classList.add('is-active');
+    slides[current].removeAttribute('aria-hidden');
     dots[current].classList.add('is-active');
     dots[current].setAttribute('aria-current', 'true');
   }

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -17,264 +17,264 @@
       <p class="hero-fineprint">Windows · macOS · Linux · Steam Deck &nbsp;—&nbsp; or build the Apache-2.0 source for free.</p>
     </div>
 
-    <div class=”demo-carousel” aria-label=”Use case examples” aria-roledescription=”carousel”>
-      <div class=”demo-slides”>
+    <div class="demo-carousel" aria-label="Use case examples" aria-roledescription="carousel">
+      <div class="demo-slides">
 
-        <figure class=”demo-card is-active” role=”group” aria-roledescription=”slide” aria-label=”Slide 1 of 7: The Executive Gauntlet”>
-          <figcaption class=”demo-head”>
-            <span class=”demo-title”>The Executive Gauntlet</span>
-            <span class=”demo-meta”>Job Interview Basics · Turn 4</span>
+        <figure class="demo-card is-active" role="group" aria-roledescription="slide" aria-label="Slide 1 of 7: The Executive Gauntlet">
+          <figcaption class="demo-head">
+            <span class="demo-title">The Executive Gauntlet</span>
+            <span class="demo-meta">Job Interview Basics · Turn 4</span>
           </figcaption>
-          <div class=”demo-lines”>
-            <div class=”demo-line demo-npc”>
-              <span class=”demo-speaker speaker-npc”>Victor · NPC</span>
-              <p>”That’s a headline number. Walk me through the trade-off you made to get there. What did you give up — and was it the right call?”</p>
+          <div class="demo-lines">
+            <div class="demo-line demo-npc">
+              <span class="demo-speaker speaker-npc">Victor · NPC</span>
+              <p>“That’s a headline number. Walk me through the trade-off you made to get there. What did you give up — and was it the right call?”</p>
             </div>
-            <div class=”demo-line demo-you”>
-              <span class=”demo-speaker speaker-you”>You</span>
-              <p>”We gave up real-time freshness — reports now lag five minutes behind. For nightly analytics, that was the right trade.”</p>
+            <div class="demo-line demo-you">
+              <span class="demo-speaker speaker-you">You</span>
+              <p>“We gave up real-time freshness — reports now lag five minutes behind. For nightly analytics, that was the right trade.”</p>
             </div>
-            <div class=”demo-event”>Scenario event: <code>grudging_respect</code> triggered</div>
+            <div class="demo-event">Scenario event: <code>grudging_respect</code> triggered</div>
           </div>
-          <div class=”demo-meters”>
-            <div class=”meter”>
-              <span class=”meter-name”>credibility</span>
-              <span class=”meter-bar”><span class=”meter-fill fill-emerald” style=”width:74%”></span></span>
-              <span class=”meter-val”>74</span>
+          <div class="demo-meters">
+            <div class="meter">
+              <span class="meter-name">credibility</span>
+              <span class="meter-bar"><span class="meter-fill fill-emerald" style="width:74%"></span></span>
+              <span class="meter-val">74</span>
             </div>
-            <div class=”meter”>
-              <span class=”meter-name”>composure</span>
-              <span class=”meter-bar”><span class=”meter-fill fill-violet” style=”width:65%”></span></span>
-              <span class=”meter-val”>65</span>
+            <div class="meter">
+              <span class="meter-name">composure</span>
+              <span class="meter-bar"><span class="meter-fill fill-violet" style="width:65%"></span></span>
+              <span class="meter-val">65</span>
             </div>
-            <div class=”meter”>
-              <span class=”meter-name”>pressure</span>
-              <span class=”meter-bar”><span class=”meter-fill fill-amber” style=”width:40%”></span></span>
-              <span class=”meter-val”>40</span>
+            <div class="meter">
+              <span class="meter-name">pressure</span>
+              <span class="meter-bar"><span class="meter-fill fill-amber" style="width:40%"></span></span>
+              <span class="meter-val">40</span>
             </div>
           </div>
         </figure>
 
-        <figure class=”demo-card” role=”group” aria-roledescription=”slide” aria-label=”Slide 2 of 7: The Salary Conversation”>
-          <figcaption class=”demo-head”>
-            <span class=”demo-title”>The Salary Conversation</span>
-            <span class=”demo-meta”>Difficult Conversations · Turn 6</span>
+        <figure class="demo-card" role="group" aria-roledescription="slide" aria-label="Slide 2 of 7: The Salary Conversation">
+          <figcaption class="demo-head">
+            <span class="demo-title">The Salary Conversation</span>
+            <span class="demo-meta">Difficult Conversations · Turn 6</span>
           </figcaption>
-          <div class=”demo-lines”>
-            <div class=”demo-line demo-npc”>
-              <span class=”demo-speaker speaker-npc”>Dana · NPC</span>
-              <p>”Your work has been solid. But we’re at band ceiling for your level. What’s your thinking here?”</p>
+          <div class="demo-lines">
+            <div class="demo-line demo-npc">
+              <span class="demo-speaker speaker-npc">Dana · NPC</span>
+              <p>“Your work has been solid. But we’re at band ceiling for your level. What’s your thinking here?”</p>
             </div>
-            <div class=”demo-line demo-you”>
-              <span class=”demo-speaker speaker-you”>You</span>
-              <p>”I’ve checked market data — my comp sits 18% below median for this scope. I’d like to talk about a path to close that gap.”</p>
+            <div class="demo-line demo-you">
+              <span class="demo-speaker speaker-you">You</span>
+              <p>“I’ve checked market data — my comp sits 18% below median for this scope. I’d like to talk about a path to close that gap.”</p>
             </div>
-            <div class=”demo-event”>Scenario event: <code>case_acknowledged</code> triggered</div>
+            <div class="demo-event">Scenario event: <code>case_acknowledged</code> triggered</div>
           </div>
-          <div class=”demo-meters”>
-            <div class=”meter”>
-              <span class=”meter-name”>rapport</span>
-              <span class=”meter-bar”><span class=”meter-fill fill-emerald” style=”width:65%”></span></span>
-              <span class=”meter-val”>65</span>
+          <div class="demo-meters">
+            <div class="meter">
+              <span class="meter-name">rapport</span>
+              <span class="meter-bar"><span class="meter-fill fill-emerald" style="width:65%"></span></span>
+              <span class="meter-val">65</span>
             </div>
-            <div class=”meter”>
-              <span class=”meter-name”>confidence</span>
-              <span class=”meter-bar”><span class=”meter-fill fill-violet” style=”width:71%”></span></span>
-              <span class=”meter-val”>71</span>
+            <div class="meter">
+              <span class="meter-name">confidence</span>
+              <span class="meter-bar"><span class="meter-fill fill-violet" style="width:71%"></span></span>
+              <span class="meter-val">71</span>
             </div>
-            <div class=”meter”>
-              <span class=”meter-name”>resolve</span>
-              <span class=”meter-bar”><span class=”meter-fill fill-amber” style=”width:58%”></span></span>
-              <span class=”meter-val”>58</span>
+            <div class="meter">
+              <span class="meter-name">resolve</span>
+              <span class="meter-bar"><span class="meter-fill fill-amber" style="width:58%"></span></span>
+              <span class="meter-val">58</span>
             </div>
           </div>
         </figure>
 
-        <figure class=”demo-card” role=”group” aria-roledescription=”slide” aria-label=”Slide 3 of 7: The Car Lot”>
-          <figcaption class=”demo-head”>
-            <span class=”demo-title”>The Car Lot</span>
-            <span class=”demo-meta”>Everyday Negotiation · Turn 3</span>
+        <figure class="demo-card" role="group" aria-roledescription="slide" aria-label="Slide 3 of 7: The Car Lot">
+          <figcaption class="demo-head">
+            <span class="demo-title">The Car Lot</span>
+            <span class="demo-meta">Everyday Negotiation · Turn 3</span>
           </figcaption>
-          <div class=”demo-lines”>
-            <div class=”demo-line demo-npc”>
-              <span class=”demo-speaker speaker-npc”>Dale · NPC</span>
-              <p>”That’s already our best number — I’m basically handing you this car. We can’t go lower and keep the lights on.”</p>
+          <div class="demo-lines">
+            <div class="demo-line demo-npc">
+              <span class="demo-speaker speaker-npc">Dale · NPC</span>
+              <p>“That’s already our best number — I’m basically handing you this car. We can’t go lower and keep the lights on.”</p>
             </div>
-            <div class=”demo-line demo-you”>
-              <span class=”demo-speaker speaker-you”>You</span>
-              <p>”I’ve got a check from my credit union for the out-the-door price, minus the two recalls that are still open.”</p>
+            <div class="demo-line demo-you">
+              <span class="demo-speaker speaker-you">You</span>
+              <p>“I’ve got a check from my credit union for the out-the-door price, minus the two recalls that are still open.”</p>
             </div>
-            <div class=”demo-event”>Scenario event: <code>sticker_shock_override</code> triggered</div>
+            <div class="demo-event">Scenario event: <code>sticker_shock_override</code> triggered</div>
           </div>
-          <div class=”demo-meters”>
-            <div class=”meter”>
-              <span class=”meter-name”>leverage</span>
-              <span class=”meter-bar”><span class=”meter-fill fill-emerald” style=”width:52%”></span></span>
-              <span class=”meter-val”>52</span>
+          <div class="demo-meters">
+            <div class="meter">
+              <span class="meter-name">leverage</span>
+              <span class="meter-bar"><span class="meter-fill fill-emerald" style="width:52%"></span></span>
+              <span class="meter-val">52</span>
             </div>
-            <div class=”meter”>
-              <span class=”meter-name”>patience</span>
-              <span class=”meter-bar”><span class=”meter-fill fill-violet” style=”width:68%”></span></span>
-              <span class=”meter-val”>68</span>
+            <div class="meter">
+              <span class="meter-name">patience</span>
+              <span class="meter-bar"><span class="meter-fill fill-violet" style="width:68%"></span></span>
+              <span class="meter-val">68</span>
             </div>
-            <div class=”meter”>
-              <span class=”meter-name”>firmness</span>
-              <span class=”meter-bar”><span class=”meter-fill fill-amber” style=”width:75%”></span></span>
-              <span class=”meter-val”>75</span>
+            <div class="meter">
+              <span class="meter-name">firmness</span>
+              <span class="meter-bar"><span class="meter-fill fill-amber" style="width:75%"></span></span>
+              <span class="meter-val">75</span>
             </div>
           </div>
         </figure>
 
-        <figure class=”demo-card” role=”group” aria-roledescription=”slide” aria-label=”Slide 4 of 7: Feedback Without Fallout”>
-          <figcaption class=”demo-head”>
-            <span class=”demo-title”>Feedback Without Fallout</span>
-            <span class=”demo-meta”>Difficult Conversations · Turn 5</span>
+        <figure class="demo-card" role="group" aria-roledescription="slide" aria-label="Slide 4 of 7: Feedback Without Fallout">
+          <figcaption class="demo-head">
+            <span class="demo-title">Feedback Without Fallout</span>
+            <span class="demo-meta">Difficult Conversations · Turn 5</span>
           </figcaption>
-          <div class=”demo-lines”>
-            <div class=”demo-line demo-npc”>
-              <span class=”demo-speaker speaker-npc”>Morgan · NPC</span>
-              <p>”I don’t even know what you mean by ‘interrupting the meeting.’ I was just being enthusiastic.”</p>
+          <div class="demo-lines">
+            <div class="demo-line demo-npc">
+              <span class="demo-speaker speaker-npc">Morgan · NPC</span>
+              <p>“I don’t even know what you mean by ‘interrupting the meeting.’ I was just being enthusiastic.”</p>
             </div>
-            <div class=”demo-line demo-you”>
-              <span class=”demo-speaker speaker-you”>You</span>
-              <p>”Your energy is one of the best things about working with you. It’s specifically the part where others stop finishing their sentences.”</p>
+            <div class="demo-line demo-you">
+              <span class="demo-speaker speaker-you">You</span>
+              <p>“Your energy is one of the best things about working with you. It’s specifically the part where others stop finishing their sentences.”</p>
             </div>
-            <div class=”demo-event”>Scenario event: <code>defensiveness_spike</code> triggered</div>
+            <div class="demo-event">Scenario event: <code>defensiveness_spike</code> triggered</div>
           </div>
-          <div class=”demo-meters”>
-            <div class=”meter”>
-              <span class=”meter-name”>openness</span>
-              <span class=”meter-bar”><span class=”meter-fill fill-emerald” style=”width:42%”></span></span>
-              <span class=”meter-val”>42</span>
+          <div class="demo-meters">
+            <div class="meter">
+              <span class="meter-name">openness</span>
+              <span class="meter-bar"><span class="meter-fill fill-emerald" style="width:42%"></span></span>
+              <span class="meter-val">42</span>
             </div>
-            <div class=”meter”>
-              <span class=”meter-name”>tension</span>
-              <span class=”meter-bar”><span class=”meter-fill fill-violet” style=”width:71%”></span></span>
-              <span class=”meter-val”>71</span>
+            <div class="meter">
+              <span class="meter-name">tension</span>
+              <span class="meter-bar"><span class="meter-fill fill-violet" style="width:71%"></span></span>
+              <span class="meter-val">71</span>
             </div>
-            <div class=”meter”>
-              <span class=”meter-name”>clarity</span>
-              <span class=”meter-bar”><span class=”meter-fill fill-amber” style=”width:58%”></span></span>
-              <span class=”meter-val”>58</span>
+            <div class="meter">
+              <span class="meter-name">clarity</span>
+              <span class="meter-bar"><span class="meter-fill fill-amber" style="width:58%"></span></span>
+              <span class="meter-val">58</span>
             </div>
           </div>
         </figure>
 
-        <figure class=”demo-card” role=”group” aria-roledescription=”slide” aria-label=”Slide 5 of 7: Spanish Coffee Shop”>
-          <figcaption class=”demo-head”>
-            <span class=”demo-title”>Spanish Coffee Shop</span>
-            <span class=”demo-meta”>Language Café · Turn 2</span>
+        <figure class="demo-card" role="group" aria-roledescription="slide" aria-label="Slide 5 of 7: Spanish Coffee Shop">
+          <figcaption class="demo-head">
+            <span class="demo-title">Spanish Coffee Shop</span>
+            <span class="demo-meta">Language Café · Turn 2</span>
           </figcaption>
-          <div class=”demo-lines”>
-            <div class=”demo-line demo-npc”>
-              <span class=”demo-speaker speaker-npc”>Sofía · NPC</span>
-              <p>”¿Qué le pongo? ¿Lo quiere solo o cortado?”</p>
+          <div class="demo-lines">
+            <div class="demo-line demo-npc">
+              <span class="demo-speaker speaker-npc">Sofía · NPC</span>
+              <p>“¿Qué le pongo? ¿Lo quiere solo o cortado?”</p>
             </div>
-            <div class=”demo-line demo-you”>
-              <span class=”demo-speaker speaker-you”>You</span>
-              <p>”Un cortado, por favor. Y — ¿tiene algo dulce para el desayuno?”</p>
+            <div class="demo-line demo-you">
+              <span class="demo-speaker speaker-you">You</span>
+              <p>“Un cortado, por favor. Y — ¿tiene algo dulce para el desayuno?”</p>
             </div>
-            <div class=”demo-event”>Scenario event: <code>vocabulary_gap_detected</code> triggered</div>
+            <div class="demo-event">Scenario event: <code>vocabulary_gap_detected</code> triggered</div>
           </div>
-          <div class=”demo-meters”>
-            <div class=”meter”>
-              <span class=”meter-name”>fluency</span>
-              <span class=”meter-bar”><span class=”meter-fill fill-emerald” style=”width:48%”></span></span>
-              <span class=”meter-val”>48</span>
+          <div class="demo-meters">
+            <div class="meter">
+              <span class="meter-name">fluency</span>
+              <span class="meter-bar"><span class="meter-fill fill-emerald" style="width:48%"></span></span>
+              <span class="meter-val">48</span>
             </div>
-            <div class=”meter”>
-              <span class=”meter-name”>confidence</span>
-              <span class=”meter-bar”><span class=”meter-fill fill-violet” style=”width:55%”></span></span>
-              <span class=”meter-val”>55</span>
+            <div class="meter">
+              <span class="meter-name">confidence</span>
+              <span class="meter-bar"><span class="meter-fill fill-violet" style="width:55%"></span></span>
+              <span class="meter-val">55</span>
             </div>
-            <div class=”meter”>
-              <span class=”meter-name”>rapport</span>
-              <span class=”meter-bar”><span class=”meter-fill fill-amber” style=”width:72%”></span></span>
-              <span class=”meter-val”>72</span>
+            <div class="meter">
+              <span class="meter-name">rapport</span>
+              <span class="meter-bar"><span class="meter-fill fill-amber" style="width:72%"></span></span>
+              <span class="meter-val">72</span>
             </div>
           </div>
         </figure>
 
-        <figure class=”demo-card” role=”group” aria-roledescription=”slide” aria-label=”Slide 6 of 7: The Missed Deadline”>
-          <figcaption class=”demo-head”>
-            <span class=”demo-title”>The Missed Deadline</span>
-            <span class=”demo-meta”>Difficult Conversations · Turn 4</span>
+        <figure class="demo-card" role="group" aria-roledescription="slide" aria-label="Slide 6 of 7: The Missed Deadline">
+          <figcaption class="demo-head">
+            <span class="demo-title">The Missed Deadline</span>
+            <span class="demo-meta">Difficult Conversations · Turn 4</span>
           </figcaption>
-          <div class=”demo-lines”>
-            <div class=”demo-line demo-npc”>
-              <span class=”demo-speaker speaker-npc”>Alex · NPC</span>
-              <p>”The sprint ends Friday. You told me yesterday it’d be done. I had to tell the client something. Help me understand.”</p>
+          <div class="demo-lines">
+            <div class="demo-line demo-npc">
+              <span class="demo-speaker speaker-npc">Alex · NPC</span>
+              <p>“The sprint ends Friday. You told me yesterday it’d be done. I had to tell the client something. Help me understand.”</p>
             </div>
-            <div class=”demo-line demo-you”>
-              <span class=”demo-speaker speaker-you”>You</span>
-              <p>”You’re right to be frustrated. I underestimated the integration work. It ships Tuesday — here’s what changed and why.”</p>
+            <div class="demo-line demo-you">
+              <span class="demo-speaker speaker-you">You</span>
+              <p>“You’re right to be frustrated. I underestimated the integration work. It ships Tuesday — here’s what changed and why.”</p>
             </div>
-            <div class=”demo-event”>Scenario event: <code>trust_repair_initiated</code> triggered</div>
+            <div class="demo-event">Scenario event: <code>trust_repair_initiated</code> triggered</div>
           </div>
-          <div class=”demo-meters”>
-            <div class=”meter”>
-              <span class=”meter-name”>trust</span>
-              <span class=”meter-bar”><span class=”meter-fill fill-emerald” style=”width:35%”></span></span>
-              <span class=”meter-val”>35</span>
+          <div class="demo-meters">
+            <div class="meter">
+              <span class="meter-name">trust</span>
+              <span class="meter-bar"><span class="meter-fill fill-emerald" style="width:35%"></span></span>
+              <span class="meter-val">35</span>
             </div>
-            <div class=”meter”>
-              <span class=”meter-name”>clarity</span>
-              <span class=”meter-bar”><span class=”meter-fill fill-violet” style=”width:79%”></span></span>
-              <span class=”meter-val”>79</span>
+            <div class="meter">
+              <span class="meter-name">clarity</span>
+              <span class="meter-bar"><span class="meter-fill fill-violet" style="width:79%"></span></span>
+              <span class="meter-val">79</span>
             </div>
-            <div class=”meter”>
-              <span class=”meter-name”>tension</span>
-              <span class=”meter-bar”><span class=”meter-fill fill-amber” style=”width:61%”></span></span>
-              <span class=”meter-val”>61</span>
+            <div class="meter">
+              <span class="meter-name">tension</span>
+              <span class="meter-bar"><span class="meter-fill fill-amber" style="width:61%"></span></span>
+              <span class="meter-val">61</span>
             </div>
           </div>
         </figure>
 
-        <figure class=”demo-card” role=”group” aria-roledescription=”slide” aria-label=”Slide 7 of 7: Scope Creep Defense”>
-          <figcaption class=”demo-head”>
-            <span class=”demo-title”>Scope Creep Defense</span>
-            <span class=”demo-meta”>Everyday Negotiation · Turn 7</span>
+        <figure class="demo-card" role="group" aria-roledescription="slide" aria-label="Slide 7 of 7: Scope Creep Defense">
+          <figcaption class="demo-head">
+            <span class="demo-title">Scope Creep Defense</span>
+            <span class="demo-meta">Everyday Negotiation · Turn 7</span>
           </figcaption>
-          <div class=”demo-lines”>
-            <div class=”demo-line demo-npc”>
-              <span class=”demo-speaker speaker-npc”>Client · NPC</span>
-              <p>”While you’re in there, can you also rework the onboarding flow? It shouldn’t take long.”</p>
+          <div class="demo-lines">
+            <div class="demo-line demo-npc">
+              <span class="demo-speaker speaker-npc">Client · NPC</span>
+              <p>“While you’re in there, can you also rework the onboarding flow? It shouldn’t take long.”</p>
             </div>
-            <div class=”demo-line demo-you”>
-              <span class=”demo-speaker speaker-you”>You</span>
-              <p>”I’ve flagged it for a future phase. Adding it to this contract shifts delivery by two weeks and adds roughly 40 hours.”</p>
+            <div class="demo-line demo-you">
+              <span class="demo-speaker speaker-you">You</span>
+              <p>“I’ve flagged it for a future phase. Adding it to this contract shifts delivery by two weeks and adds roughly 40 hours.”</p>
             </div>
-            <div class=”demo-event”>Scenario event: <code>boundary_held</code> triggered</div>
+            <div class="demo-event">Scenario event: <code>boundary_held</code> triggered</div>
           </div>
-          <div class=”demo-meters”>
-            <div class=”meter”>
-              <span class=”meter-name”>clarity</span>
-              <span class=”meter-bar”><span class=”meter-fill fill-emerald” style=”width:83%”></span></span>
-              <span class=”meter-val”>83</span>
+          <div class="demo-meters">
+            <div class="meter">
+              <span class="meter-name">clarity</span>
+              <span class="meter-bar"><span class="meter-fill fill-emerald" style="width:83%"></span></span>
+              <span class="meter-val">83</span>
             </div>
-            <div class=”meter”>
-              <span class=”meter-name”>firmness</span>
-              <span class=”meter-bar”><span class=”meter-fill fill-violet” style=”width:70%”></span></span>
-              <span class=”meter-val”>70</span>
+            <div class="meter">
+              <span class="meter-name">firmness</span>
+              <span class="meter-bar"><span class="meter-fill fill-violet" style="width:70%"></span></span>
+              <span class="meter-val">70</span>
             </div>
-            <div class=”meter”>
-              <span class=”meter-name”>goodwill</span>
-              <span class=”meter-bar”><span class=”meter-fill fill-amber” style=”width:52%”></span></span>
-              <span class=”meter-val”>52</span>
+            <div class="meter">
+              <span class="meter-name">goodwill</span>
+              <span class="meter-bar"><span class="meter-fill fill-amber" style="width:52%"></span></span>
+              <span class="meter-val">52</span>
             </div>
           </div>
         </figure>
 
       </div>
 
-      <div class=”carousel-dots” role=”group” aria-label=”Slide navigation”>
-        <button class=”carousel-dot is-active” aria-label=”Go to slide 1” aria-current=”true” data-slide=”0”></button>
-        <button class=”carousel-dot” aria-label=”Go to slide 2” data-slide=”1”></button>
-        <button class=”carousel-dot” aria-label=”Go to slide 3” data-slide=”2”></button>
-        <button class=”carousel-dot” aria-label=”Go to slide 4” data-slide=”3”></button>
-        <button class=”carousel-dot” aria-label=”Go to slide 5” data-slide=”4”></button>
-        <button class=”carousel-dot” aria-label=”Go to slide 6” data-slide=”5”></button>
-        <button class=”carousel-dot” aria-label=”Go to slide 7” data-slide=”6”></button>
+      <div class="carousel-dots" role="group" aria-label="Slide navigation">
+        <button class="carousel-dot is-active" aria-label="Go to slide 1" aria-current="true" data-slide="0"></button>
+        <button class="carousel-dot" aria-label="Go to slide 2" data-slide="1"></button>
+        <button class="carousel-dot" aria-label="Go to slide 3" data-slide="2"></button>
+        <button class="carousel-dot" aria-label="Go to slide 4" data-slide="3"></button>
+        <button class="carousel-dot" aria-label="Go to slide 5" data-slide="4"></button>
+        <button class="carousel-dot" aria-label="Go to slide 6" data-slide="5"></button>
+        <button class="carousel-dot" aria-label="Go to slide 7" data-slide="6"></button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## What changed

The marketing site hero previously showed a single static demo card. This replaces it with a seven-slide carousel that auto-rotates every 4.5 seconds and supports manual navigation via dot indicators.

### Seven slides

The carousel showcases use cases across four official scenario packs:

1. **The Executive Gauntlet** — Job Interview Basics
2. **The Salary Conversation** — Difficult Conversations
3. **The Car Lot** — Everyday Negotiation
4. **Feedback Without Fallout** — Difficult Conversations
5. **Spanish Coffee Shop** — Language Café
6. **The Missed Deadline** — Difficult Conversations
7. **Scope Creep Defense** — Everyday Negotiation

Each slide displays authentic NPC/player dialogue (turn reference included), a scenario event triggered, and three live state meters with realistic values drawn from each scenario pack.

### Carousel mechanics

- **Auto-rotates** every 4.5 seconds
- **Pauses on interaction:** stops on mouse hover or keyboard focus, resumes when attention leaves (respects `prefers-reduced-motion`)
- **Dot navigation:** seven centered dot indicators below the card; the active dot is lit in violet and scaled up; clicking a dot jumps directly to that slide and resets the timer
- **Smooth transitions:** CSS grid stacking keeps the container height stable as slides change; slides crossfade via 500 ms opacity transition
- **No dependencies:** vanilla JavaScript inline in the template, no build step or external libraries

### Markup & accessibility

- Carousel container marked as `aria-roledescription="carousel"` for screen readers
- Each slide is a `<figure>` with `aria-roledescription="slide"`, descriptive `aria-label`, and `aria-hidden` toggled to hide inactive slides from assistive tech
- Dot buttons have descriptive labels ("Go to slide N") and `aria-current="true"` on the active dot
- Navigation group explicitly labeled with `aria-label="Slide navigation"`

### Files changed

- **`website/layouts/index.html`** — replaced single `<figure>` with `.demo-carousel` wrapper containing `.demo-slides` (seven `.demo-card` figures) and `.carousel-dots` (navigation buttons); added inline `<script>` for rotation/pause/navigation logic
- **`website/assets/css/main.css`** — removed orphaned animation CSS (staggered rise/grow keyframes no longer used by static card); added `.demo-carousel`, `.demo-slides`, `.carousel-dots`, and `.carousel-dot` rules for layout and interaction states

### Testing notes

- All seven slides render in the correct order with accurate content from scenario packs
- First slide has `is-active` class and correct initial state
- Inactive slides have `aria-hidden="true"` for screen reader users
- Dot clicks trigger slide transitions and reset the auto-rotation timer
- Hover and focus pause auto-rotation; blur and mouse-leave resume (unless `prefers-reduced-motion` is set)
- With reduced-motion enabled, auto-rotation is disabled but manual dot navigation remains fully functional

Closes #394