### PR TITLE
Open external links in a new tab on the marketing site

### DIFF
--- a/website/content/download.md
+++ b/website/content/download.md
@@ -5,11 +5,11 @@ description: Get Conversation Simulator for Windows, macOS, or Linux — $9.99 o
 ---
 
 <div class="dl-grid">
-  <a class="dl-card" href="https://store.steampowered.com/">
+  <a class="dl-card" href="https://store.steampowered.com/" target="_blank" rel="noopener noreferrer">
     <strong>Buy on Steam — $9.99</strong>
     <span>Windows · macOS · Linux · Steam Deck · ready to run, auto-updating</span>
   </a>
-  <a class="dl-card" href="https://github.com/outrightmental/ConversationSimulator">
+  <a class="dl-card" href="https://github.com/outrightmental/ConversationSimulator" target="_blank" rel="noopener noreferrer">
     <strong>Build from source — free</strong>
     <span>Clone the Apache-2.0 repository and build it yourself</span>
   </a>

--- a/website/layouts/404.html
+++ b/website/layouts/404.html
@@ -6,7 +6,7 @@
   moved, maybe it never did. Happens in the best conversations.</p>
   <div class="hero-actions">
     <a class="btn btn-primary" href="/">Back to the home page</a>
-    <a class="btn btn-ghost" href="{{ site.Params.docsURL }}">Search the docs</a>
+    <a class="btn btn-ghost" href="{{ site.Params.docsURL }}" target="_blank" rel="noopener noreferrer">Search the docs</a>
   </div>
 </section>
 {{ end }}

--- a/website/layouts/_default/_markup/render-link.html
+++ b/website/layouts/_default/_markup/render-link.html
@@ -1,0 +1,1 @@
+<a href="{{ .Destination | safeURL }}"{{ with .Title }} title="{{ . }}"{{ end }}{{ if strings.HasPrefix .Destination "http" }} target="_blank" rel="noopener noreferrer"{{ end }}>{{ .Text | safeHTML }}</a>

--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -12,7 +12,7 @@
       </p>
       <div class="hero-actions">
         <a class="btn btn-primary" href="/download/">Get it on Steam — $9.99</a>
-        <a class="btn btn-ghost" href="{{ site.Params.docsURL }}/start/quickstart/">Your first scenario</a>
+        <a class="btn btn-ghost" href="{{ site.Params.docsURL }}/start/quickstart/" target="_blank" rel="noopener noreferrer">Your first scenario</a>
       </div>
       <p class="hero-fineprint">Windows · macOS · Linux · Steam Deck &nbsp;—&nbsp; or build the Apache-2.0 source for free.</p>
     </div>
@@ -386,7 +386,7 @@
   packs/official/job-interview-basic</code></pre>
       <p>It exits with an error if any subsystem so much as tries to reach an
       external host.</p>
-      <p><a class="text-link" href="{{ site.Params.docsURL }}/trust/privacy/">Read the full privacy policy →</a></p>
+      <p><a class="text-link" href="{{ site.Params.docsURL }}/trust/privacy/" target="_blank" rel="noopener noreferrer">Read the full privacy policy →</a></p>
     </div>
   </div>
 </section>
@@ -417,7 +417,7 @@
       validate with one click, test in the browser, and export a shareable
       zip. Publish to Steam Workshop or hand the file to a friend.</p>
       <div class="hero-actions">
-        <a class="btn btn-ghost" href="{{ site.Params.docsURL }}/create/scenario-authoring/">Read the authoring guide</a>
+        <a class="btn btn-ghost" href="{{ site.Params.docsURL }}/create/scenario-authoring/" target="_blank" rel="noopener noreferrer">Read the authoring guide</a>
       </div>
     </div>
     <pre class="code-card"><code><span class="c-key">scenario_id:</span> ask_for_a_raise

--- a/website/layouts/partials/footer.html
+++ b/website/layouts/partials/footer.html
@@ -12,29 +12,29 @@
       <nav class="footer-col" aria-label="Product">
         <h3>Product</h3>
         <a href="/download/">Download</a>
-        <a href="{{ site.Params.docsURL }}/start/install/">Install guide</a>
-        <a href="{{ site.Params.docsURL }}/start/quickstart/">Quickstart</a>
-        <a href="{{ site.Params.docsURL }}/project/release-notes/">Release notes</a>
+        <a href="{{ site.Params.docsURL }}/start/install/" target="_blank" rel="noopener noreferrer">Install guide</a>
+        <a href="{{ site.Params.docsURL }}/start/quickstart/" target="_blank" rel="noopener noreferrer">Quickstart</a>
+        <a href="{{ site.Params.docsURL }}/project/release-notes/" target="_blank" rel="noopener noreferrer">Release notes</a>
       </nav>
       <nav class="footer-col" aria-label="Create">
         <h3>Create</h3>
-        <a href="{{ site.Params.docsURL }}/create/scenario-authoring/">Scenario authoring</a>
-        <a href="{{ site.Params.docsURL }}/create/pack-validation/">Pack validation</a>
-        <a href="{{ site.Params.docsURL }}/create/quality-bar/">Quality bar</a>
+        <a href="{{ site.Params.docsURL }}/create/scenario-authoring/" target="_blank" rel="noopener noreferrer">Scenario authoring</a>
+        <a href="{{ site.Params.docsURL }}/create/pack-validation/" target="_blank" rel="noopener noreferrer">Pack validation</a>
+        <a href="{{ site.Params.docsURL }}/create/quality-bar/" target="_blank" rel="noopener noreferrer">Quality bar</a>
       </nav>
       <nav class="footer-col" aria-label="Trust">
         <h3>Trust</h3>
         <a href="/manifesto/">Manifesto</a>
-        <a href="{{ site.Params.docsURL }}/trust/privacy/">Privacy</a>
-        <a href="{{ site.Params.docsURL }}/trust/safety-policy/">Safety policy</a>
-        <a href="{{ site.Params.docsURL }}/trust/network-security/">Network security</a>
+        <a href="{{ site.Params.docsURL }}/trust/privacy/" target="_blank" rel="noopener noreferrer">Privacy</a>
+        <a href="{{ site.Params.docsURL }}/trust/safety-policy/" target="_blank" rel="noopener noreferrer">Safety policy</a>
+        <a href="{{ site.Params.docsURL }}/trust/network-security/" target="_blank" rel="noopener noreferrer">Network security</a>
       </nav>
       <nav class="footer-col" aria-label="Project">
         <h3>Project</h3>
-        <a href="{{ site.Params.githubURL }}">GitHub</a>
-        <a href="{{ site.Params.docsURL }}/project/roadmap/">Roadmap</a>
-        <a href="{{ site.Params.docsURL }}/project/contributing/">Contributing</a>
-        <a href="{{ site.Params.docsURL }}/project/security/">Report a vulnerability</a>
+        <a href="{{ site.Params.githubURL }}" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="{{ site.Params.docsURL }}/project/roadmap/" target="_blank" rel="noopener noreferrer">Roadmap</a>
+        <a href="{{ site.Params.docsURL }}/project/contributing/" target="_blank" rel="noopener noreferrer">Contributing</a>
+        <a href="{{ site.Params.docsURL }}/project/security/" target="_blank" rel="noopener noreferrer">Report a vulnerability</a>
       </nav>
     </div>
     <p class="footer-legal">

--- a/website/layouts/partials/header.html
+++ b/website/layouts/partials/header.html
@@ -6,8 +6,8 @@
     </a>
     <nav class="site-nav" aria-label="Main">
       <a href="/manifesto/">Manifesto</a>
-      <a href="{{ site.Params.docsURL }}">Docs</a>
-      <a href="{{ site.Params.githubURL }}">GitHub</a>
+      <a href="{{ site.Params.docsURL }}" target="_blank" rel="noopener noreferrer">Docs</a>
+      <a href="{{ site.Params.githubURL }}" target="_blank" rel="noopener noreferrer">GitHub</a>
       <a class="nav-cta" href="/download/">Download</a>
     </nav>
   </div>


### PR DESCRIPTION
## Summary

Any link on `conversationsimulator.com` that points to a different domain or subdomain now opens in a new tab.

## What changed

### Hugo render hook (new file)
`website/layouts/_default/_markup/render-link.html` — a Hugo [link render hook](https://gohugo.io/render-hooks/links/) that automatically adds `target="_blank" rel="noopener noreferrer"` to any Markdown-rendered link whose destination starts with `http`. This covers all external links in `manifesto.md` and the inline-Markdown links in `download.md` without requiring per-link changes.

### Template updates
Every external `<a>` tag in the Hugo HTML templates was updated with `target="_blank" rel="noopener noreferrer"`:
- `layouts/partials/header.html` — Docs and GitHub nav links
- `layouts/partials/footer.html` — all `docsURL` and `githubURL` links (10 links across the Product, Create, Trust, and Project nav columns)
- `layouts/index.html` — four `docsURL` links (hero CTA, privacy policy section, and authoring guide CTA)
- `layouts/404.html` — docs search link

### Content update
`content/download.md` — the two raw-HTML `<a class="dl-card">` anchors (Steam store, GitHub) were given `target="_blank" rel="noopener noreferrer"` directly. Raw HTML blocks in Markdown bypass the render hook, so they require explicit attributes.

## How it was tested
- Reviewed every external link in the Hugo site (templates + content) against the rule: absolute HTTP(S) URL → new tab.
- Confirmed that internal relative-path links (`/download/`, `/manifesto/`) are unchanged and will continue to navigate in the same tab.
- The render hook uses `strings.HasPrefix .Destination "http"` which correctly catches both `http://` and `https://` schemes.

Closes #397