### PR TITLE
Welcome screen: one decision — "Set me up" vs "Try it right now"

### DIFF
--- a/apps/web/src/__tests__/App.test.tsx
+++ b/apps/web/src/__tests__/App.test.tsx
@@ -130,7 +130,7 @@ describe('First-run guard', () => {
     mockSetupStatus({ kind: 'never-run' })
     renderAt('/')
     // …the welcome step's "Get started" call to action is shown instead.
-    expect(await screen.findByRole('button', { name: /get started/i })).toBeInTheDocument()
+    expect(await screen.findByRole('button', { name: /set me up/i })).toBeInTheDocument()
     // The wizard renders outside AppLayout, so no nav chrome is present.
     expect(screen.queryByRole('link', { name: /settings/i })).not.toBeInTheDocument()
   })
@@ -139,7 +139,7 @@ describe('First-run guard', () => {
     localStorage.removeItem('convsim.setup.complete')
     mockSetupStatus({ kind: 'never-run' })
     renderAt('/settings')
-    expect(await screen.findByRole('button', { name: /get started/i })).toBeInTheDocument()
+    expect(await screen.findByRole('button', { name: /set me up/i })).toBeInTheDocument()
     expect(screen.queryByRole('heading', { name: /^settings$/i })).not.toBeInTheDocument()
   })
 
@@ -150,7 +150,7 @@ describe('First-run guard', () => {
     mockSetupStatus({ kind: 'ready' })
     renderAt('/settings')
     expect(await screen.findByRole('heading', { name: /settings/i })).toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: /get started/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /set me up/i })).not.toBeInTheDocument()
   })
 
   it('shows the wizard (and clears the stale mirror) when the data dir was wiped but the cache survived', async () => {
@@ -163,7 +163,7 @@ describe('First-run guard', () => {
     expect(localStorage.getItem('convsim.setup.complete')).toBe('true')
     mockSetupStatus({ kind: 'never-run' })
     renderAt('/settings')
-    expect(await screen.findByRole('button', { name: /get started/i })).toBeInTheDocument()
+    expect(await screen.findByRole('button', { name: /set me up/i })).toBeInTheDocument()
     // The stale mirror was cleared so the wizard no longer bounces back.
     expect(localStorage.getItem('convsim.setup.complete')).toBeNull()
   })
@@ -173,7 +173,7 @@ describe('First-run guard', () => {
     // renders the app synchronously without waiting on the server.
     renderAt('/settings')
     expect(screen.getByRole('heading', { name: /settings/i })).toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: /get started/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /set me up/i })).not.toBeInTheDocument()
   })
 
   it('preserves the intended destination in a next= query param when redirecting to first-run', async () => {
@@ -192,7 +192,7 @@ describe('First-run guard', () => {
       </MemoryRouter>,
     )
     // The wizard is shown (guard redirected us)…
-    expect(await screen.findByRole('button', { name: /get started/i })).toBeInTheDocument()
+    expect(await screen.findByRole('button', { name: /set me up/i })).toBeInTheDocument()
     // …and the guard redirected to /first-run while preserving the original
     // destination in `next=` (URL-encoded) so it is never silently swallowed.
     const location = screen.getByTestId('location-probe').textContent ?? ''

--- a/apps/web/src/__tests__/FirstRunWizard.test.tsx
+++ b/apps/web/src/__tests__/FirstRunWizard.test.tsx
@@ -160,38 +160,34 @@ beforeEach(() => {
 // ── Welcome step ─────────────────────────────────────────────────────────────
 
 describe('FirstRunWizard — welcome step', () => {
-  it('shows a welcome heading', () => {
+  it('shows the main headline', () => {
     renderWizard()
-    expect(screen.getByRole('heading', { name: /welcome to conversation simulator/i })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /practice conversations that matter/i })).toBeInTheDocument()
   })
 
-  it('shows the privacy and offline-play guarantee note', () => {
+  it('shows a Set me up card button', () => {
     renderWizard()
-    expect(
-      screen.getByRole('note', { name: /privacy and offline-play guarantee/i }),
-    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /set me up/i })).toBeInTheDocument()
   })
 
-  it('states conversations stay on this machine', () => {
+  it('shows a Try it right now card button', () => {
     renderWizard()
-    expect(screen.getByText(/your data stays on this machine/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /try it right now/i })).toBeInTheDocument()
   })
 
-  it('shows a Get started button', () => {
+  it('pre-fetches the model registry on mount', async () => {
     renderWizard()
-    expect(screen.getByRole('button', { name: /get started/i })).toBeInTheDocument()
+    await waitFor(() => expect(mockApi.getModels).toHaveBeenCalledOnce())
   })
 
-  it('does not call the API on the welcome step', () => {
+  it('shows model size from the registry once loaded', async () => {
     renderWizard()
-    expect(mockApi.getModels).not.toHaveBeenCalled()
+    expect(await screen.findByText(/2\.6 gb/i)).toBeInTheDocument()
   })
 
-  it('advances to loading then choose step when Get started is clicked', async () => {
+  it('shows model license from the registry once loaded', async () => {
     renderWizard()
-    fireEvent.click(screen.getByRole('button', { name: /get started/i }))
-    expect(await screen.findByRole('heading', { name: /choose how to get started/i })).toBeInTheDocument()
-    expect(mockApi.getModels).toHaveBeenCalledOnce()
+    expect(await screen.findByText(/apache-2\.0/i)).toBeInTheDocument()
   })
 
   it('redirects to home when setup is already complete', () => {
@@ -200,37 +196,82 @@ describe('FirstRunWizard — welcome step', () => {
     expect(screen.getByTestId('home-page')).toBeInTheDocument()
   })
 
-  it('shows a How it works section', () => {
+  it('Set me up goes directly to the installing step without a confirm interstitial', async () => {
     renderWizard()
-    expect(screen.getByText(/how it works/i)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /set me up/i }))
+    await screen.findByRole('heading', { name: /installing model/i })
+    expect(screen.queryByRole('heading', { name: /confirm model install/i })).not.toBeInTheDocument()
   })
 
-  it('explains that a local AI model powers conversations', () => {
+  it('calls installModel with the recommended model id when Set me up is clicked', async () => {
     renderWizard()
-    expect(
-      screen.getByText(/a local ai model powers the conversations/i),
-    ).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /set me up/i }))
+    await screen.findByRole('heading', { name: /installing model/i })
+    expect(mockApi.installModel).toHaveBeenCalledWith({ registry_id: 'qwen3-4b-instruct-q4_k_m' })
   })
 
-  it('explains what scenario packs are', () => {
+  it('Try it right now navigates directly to the library', async () => {
     renderWizard()
-    expect(
-      screen.getByText(/packs give you scenarios to practise/i),
-    ).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /try it right now/i }))
+    await waitFor(() => expect(screen.getByTestId('library-page')).toBeInTheDocument())
   })
 
-  it('mentions the text-only demo option', () => {
+  it('marks setup complete when Try it right now is clicked', async () => {
     renderWizard()
-    expect(
-      screen.getByText(/no download\? try the text-only demo/i),
-    ).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /try it right now/i }))
+    await waitFor(() => expect(screen.getByTestId('library-page')).toBeInTheDocument())
+    expect(localStorage.getItem(SETUP_KEYS.firstRunComplete)).toBe('true')
   })
 
-  it('explains that the model runs without internet after download', () => {
+  it('states everything stays on this machine', () => {
     renderWizard()
-    expect(
-      screen.getByText(/works without internet/i),
-    ).toBeInTheDocument()
+    expect(screen.getByText(/everything stays on this machine/i)).toBeInTheDocument()
+  })
+
+  it('shows an Advanced section toggle button', () => {
+    renderWizard()
+    expect(screen.getByRole('button', { name: /advanced/i })).toBeInTheDocument()
+  })
+
+  it('shows Browse Ollama models button when Advanced is expanded', async () => {
+    renderWizard()
+    fireEvent.click(screen.getByRole('button', { name: /advanced/i }))
+    expect(await screen.findByRole('button', { name: /browse ollama models/i })).toBeInTheDocument()
+  })
+
+  it('shows Use a GGUF file button when Advanced is expanded', async () => {
+    renderWizard()
+    fireEvent.click(screen.getByRole('button', { name: /advanced/i }))
+    expect(await screen.findByRole('button', { name: /use a gguf file/i })).toBeInTheDocument()
+  })
+
+  it('Advanced Ollama option leads to the ollama-select step', async () => {
+    renderWizard()
+    fireEvent.click(screen.getByRole('button', { name: /advanced/i }))
+    await screen.findByRole('button', { name: /browse ollama models/i })
+    fireEvent.click(screen.getByRole('button', { name: /browse ollama models/i }))
+    await screen.findByRole('heading', { name: /use ollama model/i })
+  })
+
+  it('Advanced GGUF option leads to the gguf-path step', async () => {
+    renderWizard()
+    fireEvent.click(screen.getByRole('button', { name: /advanced/i }))
+    await screen.findByRole('button', { name: /use a gguf file/i })
+    fireEvent.click(screen.getByRole('button', { name: /use a gguf file/i }))
+    await screen.findByRole('heading', { name: /use a gguf file/i })
+  })
+
+  it('Try it right now card does not use the words warning, without, or only', () => {
+    renderWizard()
+    const btn = screen.getByRole('button', { name: /try it right now/i })
+    expect(btn.textContent).not.toMatch(/warning/i)
+    expect(btn.textContent).not.toMatch(/\bwithout\b/i)
+    expect(btn.textContent).not.toMatch(/\bonly\b/i)
+  })
+
+  it('states responses are scripted, not AI-generated', () => {
+    renderWizard()
+    expect(screen.getByText(/scripted, not ai-generated/i)).toBeInTheDocument()
   })
 
   it('shows a Read setup docs link', () => {
@@ -261,7 +302,7 @@ describe('FirstRunWizard — preflight step', () => {
   async function goToPreflight() {
     mockApi.preflight.mockResolvedValue({ ok: true, data: INFRA_FAIL_PREFLIGHT })
     renderWizard()
-    fireEvent.click(screen.getByRole('button', { name: /get started/i }))
+    fireEvent.click(screen.getByRole('button', { name: /set me up/i }))
     await screen.findByRole('heading', { name: /system check/i })
   }
 
@@ -302,15 +343,16 @@ describe('FirstRunWizard — preflight step', () => {
       data: { overall: 'pass', checks: [], ran_at: '2026-01-01T00:00:00.000+00:00' },
     })
     renderWizard()
-    fireEvent.click(screen.getByRole('button', { name: /get started/i }))
-    await screen.findByRole('heading', { name: /choose how to get started/i })
+    fireEvent.click(screen.getByRole('button', { name: /set me up/i }))
+    // Set me up goes directly to installing (not choose) when preflight passes
+    await screen.findByRole('heading', { name: /installing model/i })
   })
 
   it('skips preflight step when preflight API call fails (graceful degradation)', async () => {
     mockApi.preflight.mockResolvedValue({ ok: false, error: { kind: 'network', message: 'unavailable' } })
     renderWizard()
-    fireEvent.click(screen.getByRole('button', { name: /get started/i }))
-    await screen.findByRole('heading', { name: /choose how to get started/i })
+    fireEvent.click(screen.getByRole('button', { name: /set me up/i }))
+    await screen.findByRole('heading', { name: /installing model/i })
   })
 })
 
@@ -330,8 +372,6 @@ describe('FirstRunWizard — issue-378: preflight fix actions never loop back to
   }
 
   it('wizard-step fix action (llm-present) advances to choose step, not welcome', async () => {
-    // Reproduces the exact first-run loop from issue #378:
-    // llama-cpp-binary blocks → preflight shown → click "Open Model Manager" → must NOT be welcome.
     mockApi.preflight.mockResolvedValue(makePreflightWith([
       {
         id: 'llama-cpp-binary',
@@ -349,18 +389,16 @@ describe('FirstRunWizard — issue-378: preflight fix actions never loop back to
       },
     ]))
     renderWizard()
-    fireEvent.click(screen.getByRole('button', { name: /get started/i }))
+    fireEvent.click(screen.getByRole('button', { name: /set me up/i }))
     await screen.findByRole('heading', { name: /system check/i })
 
     fireEvent.click(screen.getByTestId('wizard-preflight-fix-llm-present'))
 
-    // Must land on the choose step — never the welcome screen.
     await screen.findByRole('heading', { name: /choose how to get started/i })
-    expect(screen.queryByRole('heading', { name: /welcome to conversation simulator/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: /practice conversations that matter/i })).not.toBeInTheDocument()
   })
 
   it('legacy navigate /model-manager fix action also advances to choose step', async () => {
-    // Backward-compat path for older backends that still emit navigate /model-manager.
     mockApi.preflight.mockResolvedValue(makePreflightWith([
       {
         id: 'llama-cpp-binary',
@@ -378,18 +416,16 @@ describe('FirstRunWizard — issue-378: preflight fix actions never loop back to
       },
     ]))
     renderWizard()
-    fireEvent.click(screen.getByRole('button', { name: /get started/i }))
+    fireEvent.click(screen.getByRole('button', { name: /set me up/i }))
     await screen.findByRole('heading', { name: /system check/i })
 
     fireEvent.click(screen.getByTestId('wizard-preflight-fix-llm-present'))
 
     await screen.findByRole('heading', { name: /choose how to get started/i })
-    expect(screen.queryByRole('heading', { name: /welcome to conversation simulator/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: /practice conversations that matter/i })).not.toBeInTheDocument()
   })
 
   it('voice-ready navigate /settings fix action renders as informational only (no button)', async () => {
-    // Voice check warns with a /settings navigate action; during first-run that
-    // route is guarded, so the button must be suppressed entirely.
     mockApi.preflight.mockResolvedValue(makePreflightWith([
       {
         id: 'llama-cpp-binary',
@@ -407,22 +443,14 @@ describe('FirstRunWizard — issue-378: preflight fix actions never loop back to
       },
     ]))
     renderWizard()
-    fireEvent.click(screen.getByRole('button', { name: /get started/i }))
+    fireEvent.click(screen.getByRole('button', { name: /set me up/i }))
     await screen.findByRole('heading', { name: /system check/i })
 
-    // The check is rendered but no fix button appears.
     expect(screen.getByTestId('wizard-preflight-check-voice-ready')).toBeInTheDocument()
     expect(screen.queryByTestId('wizard-preflight-fix-voice-ready')).not.toBeInTheDocument()
   })
 
   it('no fix-action button produced by the preflight step can trigger the FirstRunGuard redirect', async () => {
-    // Exhaustively asserts that every fix_action the backend can emit is handled
-    // inside the wizard without routing to a guarded path.
-    // Mirrors every fix_action the backend can actually emit from preflight.py:
-    // open-url (setup guide), wizard-step (llm-present), and navigate to
-    // /model-manager, /settings, and /library. Any navigate target that isn't
-    // resolvable inside the wizard must be suppressed (no button) rather than
-    // rendered as a loop-inducing FirstRunGuard redirect.
     const ALL_POSSIBLE_FIX_ACTIONS: import('@convsim/shared').PreflightFixAction[] = [
       { kind: 'open-url', href: 'https://example.com', label: 'Docs' },
       { kind: 'wizard-step', href: 'choose', label: 'Choose model' },
@@ -442,25 +470,18 @@ describe('FirstRunWizard — issue-378: preflight fix actions never loop back to
         },
       ]))
       const { unmount } = renderWizard()
-      fireEvent.click(screen.getByRole('button', { name: /get started/i }))
+      fireEvent.click(screen.getByRole('button', { name: /set me up/i }))
       await screen.findByRole('heading', { name: /system check/i })
 
-      // After clicking the fix button (if rendered), the user must never see the
-      // welcome screen again (which is what happens when FirstRunGuard sends them
-      // back to /first-run and the wizard resets).
       const fixBtn = screen.queryByTestId('wizard-preflight-fix-llama-cpp-binary')
       const resolvableInWizard =
         fix_action.kind !== 'navigate' || fix_action.href === '/model-manager'
       if (resolvableInWizard) {
-        // A button is rendered and clicking it must resolve inside the wizard.
         expect(fixBtn).not.toBeNull()
         fireEvent.click(fixBtn!)
-        // Give React time to process; welcome heading must NOT appear.
         await new Promise((r) => setTimeout(r, 50))
-        expect(screen.queryByRole('heading', { name: /welcome to conversation simulator/i })).not.toBeInTheDocument()
+        expect(screen.queryByRole('heading', { name: /practice conversations that matter/i })).not.toBeInTheDocument()
       } else {
-        // A navigate to any other guarded route is suppressed entirely — no button,
-        // no way to trigger the FirstRunGuard loop.
         expect(fixBtn).toBeNull()
       }
       unmount()
@@ -468,112 +489,16 @@ describe('FirstRunWizard — issue-378: preflight fix actions never loop back to
   })
 })
 
-// ── Choose step ───────────────────────────────────────────────────────────────
-
-describe('FirstRunWizard — choose step', () => {
-  async function goToChoose() {
-    renderWizard()
-    fireEvent.click(screen.getByRole('button', { name: /get started/i }))
-    await screen.findByRole('heading', { name: /choose how to get started/i })
-  }
-
-  it('shows Install recommended model option', async () => {
-    await goToChoose()
-    expect(screen.getByRole('button', { name: /install qwen3/i })).toBeInTheDocument()
-  })
-
-  it('shows Browse Ollama models option', async () => {
-    await goToChoose()
-    expect(screen.getByRole('button', { name: /browse ollama models/i })).toBeInTheDocument()
-  })
-
-  it('shows Use a GGUF file option', async () => {
-    await goToChoose()
-    expect(screen.getByRole('button', { name: /use a gguf file/i })).toBeInTheDocument()
-  })
-
-  it('shows Continue without a model option', async () => {
-    await goToChoose()
-    expect(screen.getByRole('button', { name: /continue in text-only demo/i })).toBeInTheDocument()
-  })
-})
-
-// ── Confirm install step ──────────────────────────────────────────────────────
-
-describe('FirstRunWizard — confirm install step', () => {
-  async function goToConfirm() {
-    renderWizard()
-    fireEvent.click(screen.getByRole('button', { name: /get started/i }))
-    await screen.findByRole('button', { name: /install qwen3/i })
-    fireEvent.click(screen.getByRole('button', { name: /install qwen3/i }))
-    await screen.findByRole('heading', { name: /confirm model install/i })
-  }
-
-  it('shows the confirm heading', async () => {
-    await goToConfirm()
-    expect(screen.getByRole('heading', { name: /confirm model install/i })).toBeInTheDocument()
-  })
-
-  it('shows the model size', async () => {
-    await goToConfirm()
-    expect(screen.getByText(/2\.6 gb/i)).toBeInTheDocument()
-  })
-
-  it('shows the license', async () => {
-    await goToConfirm()
-    expect(screen.getByText(/apache-2\.0/i)).toBeInTheDocument()
-  })
-
-  it('shows the destination path', async () => {
-    await goToConfirm()
-    expect(
-      screen.getByText(/~\/.convsim\/models\/llm\/qwen3-4b-instruct-q4_k_m\.gguf/),
-    ).toBeInTheDocument()
-  })
-
-  it('shows the min VRAM requirement', async () => {
-    await goToConfirm()
-    expect(screen.getByText('4 GB')).toBeInTheDocument()
-  })
-
-  it('shows the offline-play explanation note', async () => {
-    await goToConfirm()
-    expect(
-      screen.getByRole('note', { name: /offline-play explanation/i }),
-    ).toBeInTheDocument()
-  })
-
-  it('states the model plays offline after install', async () => {
-    await goToConfirm()
-    expect(screen.getByText(/plays offline after install/i)).toBeInTheDocument()
-  })
-
-  it('states no data is sent to any server', async () => {
-    await goToConfirm()
-    expect(screen.getByText(/no data is sent to any server/i)).toBeInTheDocument()
-  })
-
-  it('does not start the download until Confirm is clicked', async () => {
-    await goToConfirm()
-    expect(mockApi.installModel).not.toHaveBeenCalled()
-  })
-
-})
-
 // ── Successful install ────────────────────────────────────────────────────────
 
 describe('FirstRunWizard — successful install', () => {
   async function goToInstalling() {
     renderWizard()
-    fireEvent.click(screen.getByRole('button', { name: /get started/i }))
-    await screen.findByRole('button', { name: /install qwen3/i })
-    fireEvent.click(screen.getByRole('button', { name: /install qwen3/i }))
-    await screen.findByRole('button', { name: /confirm & install/i })
-    fireEvent.click(screen.getByRole('button', { name: /confirm & install/i }))
+    fireEvent.click(screen.getByRole('button', { name: /set me up/i }))
     await screen.findByRole('heading', { name: /installing model/i })
   }
 
-  it('shows the installing heading after confirmation', async () => {
+  it('shows the installing heading after Set me up is clicked', async () => {
     await goToInstalling()
     expect(screen.getByRole('heading', { name: /installing model/i })).toBeInTheDocument()
   })
@@ -664,11 +589,7 @@ describe('FirstRunWizard — successful install', () => {
 describe('FirstRunWizard — no network error', () => {
   async function goToInstalling() {
     renderWizard()
-    fireEvent.click(screen.getByRole('button', { name: /get started/i }))
-    await screen.findByRole('button', { name: /install qwen3/i })
-    fireEvent.click(screen.getByRole('button', { name: /install qwen3/i }))
-    await screen.findByRole('button', { name: /confirm & install/i })
-    fireEvent.click(screen.getByRole('button', { name: /confirm & install/i }))
+    fireEvent.click(screen.getByRole('button', { name: /set me up/i }))
     await screen.findByRole('heading', { name: /installing model/i })
   }
 
@@ -845,11 +766,7 @@ describe('FirstRunWizard — insufficient disk error', () => {
   async function triggerDiskError() {
     vi.useFakeTimers({ shouldAdvanceTime: true })
     renderWizard()
-    fireEvent.click(screen.getByRole('button', { name: /get started/i }))
-    await screen.findByRole('button', { name: /install qwen3/i })
-    fireEvent.click(screen.getByRole('button', { name: /install qwen3/i }))
-    await screen.findByRole('button', { name: /confirm & install/i })
-    fireEvent.click(screen.getByRole('button', { name: /confirm & install/i }))
+    fireEvent.click(screen.getByRole('button', { name: /set me up/i }))
     await screen.findByRole('heading', { name: /installing model/i })
 
     mockApi.getInstallStatus.mockResolvedValue({ ok: true, data: {
@@ -933,11 +850,7 @@ describe('FirstRunWizard — insufficient disk error', () => {
 describe('FirstRunWizard — cancelled download', () => {
   async function goToInstalling() {
     renderWizard()
-    fireEvent.click(screen.getByRole('button', { name: /get started/i }))
-    await screen.findByRole('button', { name: /install qwen3/i })
-    fireEvent.click(screen.getByRole('button', { name: /install qwen3/i }))
-    await screen.findByRole('button', { name: /confirm & install/i })
-    fireEvent.click(screen.getByRole('button', { name: /confirm & install/i }))
+    fireEvent.click(screen.getByRole('button', { name: /set me up/i }))
     await screen.findByRole('heading', { name: /installing model/i })
   }
 
@@ -994,7 +907,7 @@ describe('FirstRunWizard — cancelled download', () => {
 describe('FirstRunWizard — existing Ollama path', () => {
   async function goToOllama() {
     renderWizard()
-    fireEvent.click(screen.getByRole('button', { name: /get started/i }))
+    fireEvent.click(screen.getByRole('button', { name: /advanced/i }))
     await screen.findByRole('button', { name: /browse ollama models/i })
     fireEvent.click(screen.getByRole('button', { name: /browse ollama models/i }))
     await screen.findByRole('heading', { name: /use ollama model/i })
@@ -1070,7 +983,7 @@ describe('FirstRunWizard — existing Ollama path', () => {
   it('shows "No Ollama models detected" when the list is empty', async () => {
     mockApi.getModels.mockResolvedValue({ ok: true, data: makeModelsResponse({ ollama_models: [] }) })
     renderWizard()
-    fireEvent.click(screen.getByRole('button', { name: /get started/i }))
+    fireEvent.click(screen.getByRole('button', { name: /advanced/i }))
     await screen.findByRole('button', { name: /browse ollama models/i })
     fireEvent.click(screen.getByRole('button', { name: /browse ollama models/i }))
     await screen.findByText(/no ollama models detected/i)
@@ -1087,50 +1000,25 @@ describe('FirstRunWizard — existing Ollama path', () => {
 // ── Demo / text-only path ─────────────────────────────────────────────────────
 
 describe('FirstRunWizard — text-only demo path', () => {
-  async function goToDemo() {
+  it('calls useModel with the fake runtime when Try it right now is clicked', async () => {
     renderWizard()
-    fireEvent.click(screen.getByRole('button', { name: /get started/i }))
-    await screen.findByRole('button', { name: /continue in text-only demo/i })
-    fireEvent.click(screen.getByRole('button', { name: /continue in text-only demo/i }))
-    await screen.findByRole('heading', { name: /text-only demo/i })
-  }
-
-  it('shows a disclaimer that this is not production quality', async () => {
-    await goToDemo()
-    expect(screen.getByText(/this is a demo, not production quality/i)).toBeInTheDocument()
-  })
-
-  it('mentions scripted responses in the disclaimer', async () => {
-    await goToDemo()
-    expect(screen.getByText(/scripted responses/i)).toBeInTheDocument()
-  })
-
-  it('calls useModel with the fake runtime when confirmed', async () => {
-    mockApi.useModel.mockResolvedValue({ ok: true, data: {
-      runtime_id: 'fake',
-      model_id: null,
-      runtime_name: 'Fake (deterministic)',
-      status: 'ready',
-      message: null,
-    } })
-    await goToDemo()
-    fireEvent.click(screen.getByRole('button', { name: /i understand/i }))
+    fireEvent.click(screen.getByRole('button', { name: /try it right now/i }))
     await waitFor(() =>
       expect(mockApi.useModel).toHaveBeenCalledWith({ runtime_id: 'fake', model_id: null }),
     )
   })
 
-  it('navigates to the library and marks setup complete after confirming demo', async () => {
-    await goToDemo()
-    fireEvent.click(screen.getByRole('button', { name: /i understand/i }))
+  it('navigates to the library and marks setup complete', async () => {
+    renderWizard()
+    fireEvent.click(screen.getByRole('button', { name: /try it right now/i }))
     await waitFor(() => expect(screen.getByTestId('library-page')).toBeInTheDocument())
     expect(localStorage.getItem(SETUP_KEYS.firstRunComplete)).toBe('true')
   })
 
   it('still navigates to library even when useModel fails in demo mode', async () => {
     mockApi.useModel.mockResolvedValue({ ok: false, error: { kind: 'network', message: 'runtime unavailable' } })
-    await goToDemo()
-    fireEvent.click(screen.getByRole('button', { name: /i understand/i }))
+    renderWizard()
+    fireEvent.click(screen.getByRole('button', { name: /try it right now/i }))
     await waitFor(() => expect(screen.getByTestId('library-page')).toBeInTheDocument())
   })
 })
@@ -1140,11 +1028,7 @@ describe('FirstRunWizard — text-only demo path', () => {
 describe('FirstRunWizard — tutorial CTA during install', () => {
   async function goToInstalling() {
     renderWizard()
-    fireEvent.click(screen.getByRole('button', { name: /get started/i }))
-    await screen.findByRole('button', { name: /install qwen3/i })
-    fireEvent.click(screen.getByRole('button', { name: /install qwen3/i }))
-    await screen.findByRole('button', { name: /confirm & install/i })
-    fireEvent.click(screen.getByRole('button', { name: /confirm & install/i }))
+    fireEvent.click(screen.getByRole('button', { name: /set me up/i }))
     await screen.findByRole('heading', { name: /installing model/i })
   }
 
@@ -1184,11 +1068,7 @@ describe('FirstRunWizard — tutorial CTA during install', () => {
 describe('FirstRunWizard — tutorial prompt step', () => {
   async function goToTutorialPrompt() {
     renderWizard()
-    fireEvent.click(screen.getByRole('button', { name: /get started/i }))
-    await screen.findByRole('button', { name: /install qwen3/i })
-    fireEvent.click(screen.getByRole('button', { name: /install qwen3/i }))
-    await screen.findByRole('button', { name: /confirm & install/i })
-    fireEvent.click(screen.getByRole('button', { name: /confirm & install/i }))
+    fireEvent.click(screen.getByRole('button', { name: /set me up/i }))
     await screen.findByRole('heading', { name: /installing model/i })
     fireEvent.click(screen.getByRole('button', { name: /play the tutorial while you wait/i }))
     await screen.findByRole('heading', { name: /first words tutorial/i })
@@ -1271,7 +1151,6 @@ describe('FirstRunWizard — tutorial prompt step', () => {
   it('navigates to the tutorial scenario setup route (a real, mounted route)', async () => {
     await goToTutorialPrompt()
     fireEvent.click(screen.getByRole('button', { name: /start the tutorial/i }))
-    // The setup route resolves the seeded scenario by id; there is no /play route.
     await screen.findByTestId('setup-page')
   })
 })
@@ -1281,11 +1160,7 @@ describe('FirstRunWizard — tutorial prompt step', () => {
 describe('FirstRunWizard — post-install navigation with tutorial completed', () => {
   async function goToInstalling() {
     renderWizard()
-    fireEvent.click(screen.getByRole('button', { name: /get started/i }))
-    await screen.findByRole('button', { name: /install qwen3/i })
-    fireEvent.click(screen.getByRole('button', { name: /install qwen3/i }))
-    await screen.findByRole('button', { name: /confirm & install/i })
-    fireEvent.click(screen.getByRole('button', { name: /confirm & install/i }))
+    fireEvent.click(screen.getByRole('button', { name: /set me up/i }))
     await screen.findByRole('heading', { name: /installing model/i })
   }
 
@@ -1345,7 +1220,7 @@ describe('FirstRunWizard — load error state', () => {
   it('shows an error alert when getModels fails', async () => {
     mockApi.getModels.mockResolvedValue({ ok: false, error: { kind: 'network', message: 'service unavailable' } })
     renderWizard()
-    fireEvent.click(screen.getByRole('button', { name: /get started/i }))
+    fireEvent.click(screen.getByRole('button', { name: /set me up/i }))
     await waitFor(() =>
       expect(screen.getByRole('alert')).toHaveTextContent(/service unavailable/i),
     )
@@ -1354,7 +1229,7 @@ describe('FirstRunWizard — load error state', () => {
   it('mentions the text-only demo as a fallback when the runtime is unavailable', async () => {
     mockApi.getModels.mockResolvedValue({ ok: false, error: { kind: 'network', message: 'runtime unreachable' } })
     renderWizard()
-    fireEvent.click(screen.getByRole('button', { name: /get started/i }))
+    fireEvent.click(screen.getByRole('button', { name: /set me up/i }))
     await waitFor(() =>
       expect(screen.getByRole('alert')).toBeInTheDocument(),
     )
@@ -1364,9 +1239,9 @@ describe('FirstRunWizard — load error state', () => {
   it('back button from load error returns to the welcome step', async () => {
     mockApi.getModels.mockResolvedValue({ ok: false, error: { kind: 'network', message: 'network error' } })
     renderWizard()
-    fireEvent.click(screen.getByRole('button', { name: /get started/i }))
+    fireEvent.click(screen.getByRole('button', { name: /set me up/i }))
     await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
     fireEvent.click(screen.getByRole('button', { name: /back to welcome/i }))
-    await screen.findByRole('heading', { name: /welcome to conversation simulator/i })
+    await screen.findByRole('heading', { name: /practice conversations that matter/i })
   })
 })

--- a/apps/web/src/__tests__/accessibility.test.tsx
+++ b/apps/web/src/__tests__/accessibility.test.tsx
@@ -501,7 +501,7 @@ describe('Accessibility: FirstRunWizard', () => {
     expect(busyEl).not.toBeNull()
   })
 
-  it('welcome step has a privacy and offline-play guarantee note', () => {
+  it('welcome step has a privacy toggle button', () => {
     const { container } = render(
       <MemoryRouter initialEntries={['/first-run']}>
         <Routes>
@@ -510,13 +510,31 @@ describe('Accessibility: FirstRunWizard', () => {
         </Routes>
       </MemoryRouter>,
     )
+    // Privacy is behind a disclosure toggle; the toggle button must be present.
+    const privacyBtn = container.querySelector('button[aria-controls="welcome-privacy-details"]')
+    expect(privacyBtn).not.toBeNull()
+  })
+
+  it('welcome step privacy note is accessible when expanded', () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={['/first-run']}>
+        <Routes>
+          <Route path="/first-run" element={<FirstRunWizard />} />
+          <Route path="/" element={<div />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+    // Expand the privacy disclosure.
+    const toggle = container.querySelector('button[aria-controls="welcome-privacy-details"]')!
+    fireEvent.click(toggle)
     expect(container.querySelector('[role="note"][aria-label*="privacy"]')).not.toBeNull()
   })
 
   it('choose step option cards are presented as a list', async () => {
-    // Override getModels to resolve immediately so the wizard reaches the choose step.
+    // Override getModels to resolve for all calls (pre-fetch + loading step).
+    // An empty registry causes handleSetMeUp to fall back to the choose step.
     const { api: mockApi } = await import('../api/client')
-    vi.mocked(mockApi.getModels).mockResolvedValueOnce({ ok: true, data: {
+    vi.mocked(mockApi.getModels).mockResolvedValue({ ok: true, data: {
       registry: [],
       installed: [],
       ollama_models: [],
@@ -543,6 +561,8 @@ describe('Accessibility: FirstRunWizard', () => {
       </MemoryRouter>,
     )
 
+    // Click "Set me up" — with an empty registry there is no starter model,
+    // so the loading step falls back to the choose step.
     fireEvent.click(container.querySelector('button')!)
 
     // Wait for the choose step to appear.

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -314,6 +314,39 @@ export const de: LocaleMessages = {
       clearing: 'Wird gelöscht…',
     },
   },
+  setup: {
+    welcome: {
+      headline: 'Üben Sie Gespräche, die zählen.',
+      subheadline: 'Privat. Auf Ihrem Gerät. Für Sie.',
+      setMeUp: {
+        title: 'Einrichten',
+        description: 'Lädt das KI-Modell herunter ({{size}} GB, {{license}}). Danach offline nutzbar.',
+        descriptionLoading: 'Lädt das empfohlene KI-Modell herunter. Danach offline nutzbar.',
+        badge: 'Empfohlen',
+      },
+      tryNow: {
+        title: 'Sofort ausprobieren',
+        description: 'Spielen Sie sofort ein Szenario — kein Download nötig. Jederzeit upgraden.',
+        disclaimer: 'Antworten sind geskriptet, nicht KI-generiert.',
+      },
+      privacy: {
+        summary: '🔒 Alles bleibt auf Ihrem Gerät.',
+        toggle: 'Details',
+        details: 'Gespräche, Transkripte, Audioaufnahmen und KI-Antworten werden lokal verarbeitet und verlassen Ihren Computer nicht, sofern Sie sie nicht exportieren oder teilen. Nach der Modellinstallation können Sie offline spielen.',
+      },
+      advanced: {
+        toggle: 'Erweitert: Ollama oder lokale GGUF-Datei verwenden',
+        ollama: {
+          why: 'Nutzen Sie bereits Ollama? Modelle wiederverwenden — kein neuer Download nötig.',
+          action: 'Ollama-Modelle durchsuchen',
+        },
+        gguf: {
+          why: 'Haben Sie eine vertraute .gguf-Datei? Wählen Sie sie aus.',
+          action: 'GGUF-Datei verwenden',
+        },
+      },
+    },
+  },
   debrief: {
     title: 'Sitzungsnachbesprechung',
     sessionLabel: 'Sitzung:',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -305,6 +305,39 @@ export const en = {
       clearing: 'Clearing…',
     },
   },
+  setup: {
+    welcome: {
+      headline: 'Practice conversations that matter.',
+      subheadline: 'Private. On your machine. Yours.',
+      setMeUp: {
+        title: 'Set me up',
+        description: 'Downloads the AI model ({{size}} GB, {{license}}). Works offline afterwards.',
+        descriptionLoading: 'Downloads the recommended AI model. Works offline afterwards.',
+        badge: 'Recommended',
+      },
+      tryNow: {
+        title: 'Try it right now',
+        description: 'Play a scripted scenario instantly, no download. Upgrade any time.',
+        disclaimer: 'Responses are scripted, not AI-generated.',
+      },
+      privacy: {
+        summary: '🔒 Everything stays on this machine.',
+        toggle: 'Details',
+        details: 'Conversations, transcripts, audio recordings, and AI responses are processed locally and never leave your computer unless you choose to export or share them. You can play offline once the model is installed.',
+      },
+      advanced: {
+        toggle: 'Advanced: use Ollama or a local GGUF file',
+        ollama: {
+          why: 'Already run models with Ollama? Reuse them — nothing new to download.',
+          action: 'Browse Ollama models',
+        },
+        gguf: {
+          why: 'Have a .gguf you trust? Point us at it.',
+          action: 'Use a GGUF file',
+        },
+      },
+    },
+  },
   debrief: {
     title: 'Session Debrief',
     sessionLabel: 'Session:',

--- a/apps/web/src/setup/__tests__/useSetupFlow.test.ts
+++ b/apps/web/src/setup/__tests__/useSetupFlow.test.ts
@@ -271,4 +271,49 @@ describe('useSetupFlow step machine', () => {
     act(() => { result.current.handleFinishBenchmark() })
     expect(mockApi.recordOnboardingOutcome).toHaveBeenCalledWith('completed-with-model')
   })
+
+  // New welcome-screen handlers (#381)
+
+  it('pre-fetches models registry on welcome step', async () => {
+    const { result } = renderHook(() => useSetupFlow('welcome'), { wrapper })
+    await waitFor(() => expect(mockApi.getModels).toHaveBeenCalledOnce())
+    expect(result.current.recommendedModel?.id).toBe('qwen3-4b-q4')
+  })
+
+  it('handleSetMeUp transitions welcome → loading → installing via auto-install', async () => {
+    mockApi.installModel.mockResolvedValue({ ok: true, data: { install_id: 99, registry_id: 'qwen3-4b-q4', status: 'pending', message: 'ok' } })
+    mockApi.getInstallStatus.mockResolvedValue({
+      ok: true, data: { id: 99, registry_id: 'qwen3-4b-q4', filename: 'model.gguf', file_path: '', size_bytes: null, install_status: 'downloading' as const, progress_bytes: null, error_message: null, verified_sha256: null, installed_at: '' },
+    })
+    const { result } = renderHook(() => useSetupFlow('welcome'), { wrapper })
+    expect(result.current.step).toBe('welcome')
+
+    act(() => { result.current.handleSetMeUp() })
+
+    await waitFor(() => expect(result.current.step).toBe('installing'))
+    expect(result.current.installId).toBe(99)
+    expect(mockApi.installModel).toHaveBeenCalledWith({ registry_id: 'qwen3-4b-q4' })
+  })
+
+  it('handleSetMeUp falls back to confirm-install when installModel fails', async () => {
+    mockApi.installModel.mockResolvedValue({ ok: false, error: { kind: 'http-error', message: 'disk full', status: 507 } })
+    const { result } = renderHook(() => useSetupFlow('welcome'), { wrapper })
+
+    act(() => { result.current.handleSetMeUp() })
+
+    await waitFor(() => expect(result.current.step).toBe('confirm-install'))
+    expect(result.current.actionError).not.toBeNull()
+    expect(result.current.selectedModel?.id).toBe('qwen3-4b-q4')
+  })
+
+  it('handleAdvancedOllama transitions welcome → loading → ollama-select', async () => {
+    const { result } = renderHook(() => useSetupFlow('welcome'), { wrapper })
+    expect(result.current.step).toBe('welcome')
+
+    act(() => { result.current.handleAdvancedOllama() })
+
+    await waitFor(() => expect(result.current.step).toBe('ollama-select'))
+    expect(mockApi.getModels).toHaveBeenCalled()
+    expect(mockApi.preflight).toHaveBeenCalled()
+  })
 })

--- a/apps/web/src/setup/__tests__/useSetupFlow.test.ts
+++ b/apps/web/src/setup/__tests__/useSetupFlow.test.ts
@@ -316,4 +316,31 @@ describe('useSetupFlow step machine', () => {
     expect(mockApi.getModels).toHaveBeenCalled()
     expect(mockApi.preflight).toHaveBeenCalled()
   })
+
+  it('handleAdvancedGguf transitions welcome → loading → gguf-path and runs preflight', async () => {
+    const { result } = renderHook(() => useSetupFlow('welcome'), { wrapper })
+    expect(result.current.step).toBe('welcome')
+
+    act(() => { result.current.handleAdvancedGguf() })
+
+    await waitFor(() => expect(result.current.step).toBe('gguf-path'))
+    // Preflight must run silently on the GGUF path too, so genuine blockers surface.
+    expect(mockApi.preflight).toHaveBeenCalled()
+  })
+
+  it('handleAdvancedGguf surfaces blocking preflight failures before gguf-path', async () => {
+    mockApi.preflight.mockResolvedValue({
+      ok: true,
+      data: {
+        overall: 'fail',
+        checks: [{ id: 'llama-cpp-binary', name: 'llama.cpp', status: 'fail' as const, message: 'missing', fix_action: null }],
+        ran_at: '2026-01-01T00:00:00Z',
+      },
+    })
+    const { result } = renderHook(() => useSetupFlow('welcome'), { wrapper })
+
+    act(() => { result.current.handleAdvancedGguf() })
+
+    await waitFor(() => expect(result.current.step).toBe('preflight'))
+  })
 })

--- a/apps/web/src/setup/steps/WelcomeStep.tsx
+++ b/apps/web/src/setup/steps/WelcomeStep.tsx
@@ -141,14 +141,7 @@ export function WelcomeStep({ flow }: { flow: UseSetupFlowReturn }) {
               <p style={{ margin: '0 0 0.5rem', fontSize: '0.875rem', color: '#a1a1aa' }}>
                 {t('setup.welcome.advanced.gguf.why')}
               </p>
-              <ActionButton
-                onClick={() => {
-                  flow.setGgufPath('')
-                  flow.setGgufPathError(null)
-                  flow.resetAction()
-                  flow.setStep('gguf-path')
-                }}
-              >
+              <ActionButton onClick={() => flow.handleAdvancedGguf()}>
                 {t('setup.welcome.advanced.gguf.action')}
               </ActionButton>
             </div>

--- a/apps/web/src/setup/steps/WelcomeStep.tsx
+++ b/apps/web/src/setup/steps/WelcomeStep.tsx
@@ -1,79 +1,169 @@
 // SPDX-License-Identifier: Apache-2.0
-import { PrimaryButton } from '../primitives'
+import { useState } from 'react'
+import { useTranslation } from '../../i18n'
+import { ActionButton } from '../primitives'
 import type { UseSetupFlowReturn } from '../useSetupFlow'
 
 const SETUP_DOCS_URL = 'https://docs.conversationsimulator.com/start/install/'
 
+const cardBase: React.CSSProperties = {
+  display: 'flex', flexDirection: 'column', alignItems: 'flex-start',
+  borderRadius: '10px', padding: '1.25rem', cursor: 'pointer',
+  color: 'inherit', textAlign: 'left', fontFamily: 'inherit', fontSize: 'inherit',
+  width: '100%',
+}
+
 export function WelcomeStep({ flow }: { flow: UseSetupFlowReturn }) {
+  const { t } = useTranslation()
+  const rec = flow.recommendedModel
+  const [privacyOpen, setPrivacyOpen] = useState(false)
+  const [advancedOpen, setAdvancedOpen] = useState(false)
+
   return (
     <div style={{ maxWidth: '640px', margin: '2rem auto', padding: '0 1rem' }}>
-      <h1 ref={flow.stepHeadingRef} tabIndex={-1} style={{ outline: 'none' }}>Welcome to Conversation Simulator</h1>
-      <p style={{ fontSize: '1rem', lineHeight: 1.6, color: '#d4d4d8' }}>
-        Conversation Simulator is the private, local-first practice tool for conversations that
-        matter — interviews, negotiations, language practice, and difficult discussions at your
-        own pace.
+      <h1 ref={flow.stepHeadingRef} tabIndex={-1} style={{ outline: 'none', marginBottom: '0.25rem' }}>
+        {t('setup.welcome.headline')}
+      </h1>
+      <p style={{ margin: '0 0 2rem', color: '#a1a1aa', fontSize: '1.1rem' }}>
+        {t('setup.welcome.subheadline')}
       </p>
 
-      <div
-        role="note"
-        aria-label="privacy and offline-play guarantee"
-        style={{
-          background: 'rgba(99,102,241,0.08)',
-          border: '1px solid rgba(99,102,241,0.3)',
-          borderRadius: '8px',
-          padding: '1rem 1.25rem',
-          marginTop: '1.25rem',
-        }}
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1rem', marginBottom: '1.5rem' }}>
+        {/* Set me up card */}
+        <button
+          onClick={() => flow.handleSetMeUp()}
+          disabled={flow.actionLoading}
+          style={{
+            ...cardBase,
+            background: 'rgba(99,102,241,0.1)',
+            border: '2px solid rgba(99,102,241,0.5)',
+          }}
+        >
+          <span aria-hidden="true" style={{ fontSize: '1.5rem', marginBottom: '0.5rem' }}>✨</span>
+          <strong style={{ display: 'block', fontSize: '1.05rem', marginBottom: '0.5rem' }}>
+            {t('setup.welcome.setMeUp.title')}
+          </strong>
+          <span style={{ display: 'block', fontSize: '0.875rem', color: '#c7d2fe', marginBottom: '0.75rem', lineHeight: 1.5 }}>
+            {rec != null
+              ? t('setup.welcome.setMeUp.description', { size: rec.size_gb ?? 0, license: rec.license_spdx ?? '' })
+              : t('setup.welcome.setMeUp.descriptionLoading')}
+          </span>
+          <span style={{
+            fontSize: '0.75rem', fontWeight: 600, color: '#6ee7b7',
+            border: '1px solid rgba(110,231,183,0.5)', borderRadius: '4px', padding: '0.15rem 0.4rem',
+          }}>
+            {t('setup.welcome.setMeUp.badge')}
+          </span>
+        </button>
+
+        {/* Try it right now card */}
+        <button
+          onClick={() => void flow.handleConfirmDemo(true)}
+          disabled={flow.actionLoading}
+          style={{
+            ...cardBase,
+            background: 'rgba(255,255,255,0.04)',
+            border: '1px solid rgba(255,255,255,0.15)',
+          }}
+        >
+          <span aria-hidden="true" style={{ fontSize: '1.5rem', marginBottom: '0.5rem' }}>⚡</span>
+          <strong style={{ display: 'block', fontSize: '1.05rem', marginBottom: '0.5rem' }}>
+            {t('setup.welcome.tryNow.title')}
+          </strong>
+          <span style={{ display: 'block', fontSize: '0.875rem', color: '#a1a1aa', marginBottom: '0.5rem', lineHeight: 1.5 }}>
+            {t('setup.welcome.tryNow.description')}
+          </span>
+          <span style={{ display: 'block', fontSize: '0.8rem', color: '#71717a' }}>
+            {t('setup.welcome.tryNow.disclaimer')}
+          </span>
+        </button>
+      </div>
+
+      {/* Privacy disclosure */}
+      <div style={{ marginBottom: '0.75rem' }}>
+        <button
+          onClick={() => setPrivacyOpen((v) => !v)}
+          aria-expanded={privacyOpen}
+          aria-controls="welcome-privacy-details"
+          style={{
+            background: 'none', border: 'none', padding: 0, cursor: 'pointer',
+            fontSize: '0.875rem', color: '#a1a1aa', fontFamily: 'inherit',
+          }}
+        >
+          {t('setup.welcome.privacy.summary')}{' '}
+          <span style={{ color: '#71717a' }}>
+            {t('setup.welcome.privacy.toggle')} {privacyOpen ? '▴' : '▸'}
+          </span>
+        </button>
+        {privacyOpen && (
+          <div
+            id="welcome-privacy-details"
+            role="note"
+            aria-label="privacy details"
+            style={{
+              marginTop: '0.5rem', padding: '0.75rem 1rem',
+              background: 'rgba(99,102,241,0.06)', border: '1px solid rgba(99,102,241,0.2)',
+              borderRadius: '6px', fontSize: '0.875rem', color: '#c7d2fe', lineHeight: 1.6,
+            }}
+          >
+            {t('setup.welcome.privacy.details')}
+          </div>
+        )}
+      </div>
+
+      {/* Advanced paths disclosure */}
+      <div style={{ marginBottom: '1.25rem' }}>
+        <button
+          onClick={() => setAdvancedOpen((v) => !v)}
+          aria-expanded={advancedOpen}
+          aria-controls="welcome-advanced-options"
+          style={{
+            background: 'none', border: 'none', padding: 0, cursor: 'pointer',
+            fontSize: '0.875rem', color: '#71717a', fontFamily: 'inherit',
+          }}
+        >
+          {t('setup.welcome.advanced.toggle')} {advancedOpen ? '▴' : '▸'}
+        </button>
+        {advancedOpen && (
+          <div
+            id="welcome-advanced-options"
+            style={{ marginTop: '0.75rem', display: 'flex', flexDirection: 'column', gap: '0.75rem' }}
+          >
+            <div style={{ padding: '0.75rem 1rem', border: '1px solid rgba(255,255,255,0.1)', borderRadius: '8px' }}>
+              <p style={{ margin: '0 0 0.5rem', fontSize: '0.875rem', color: '#a1a1aa' }}>
+                {t('setup.welcome.advanced.ollama.why')}
+              </p>
+              <ActionButton onClick={() => flow.handleAdvancedOllama()}>
+                {t('setup.welcome.advanced.ollama.action')}
+              </ActionButton>
+            </div>
+            <div style={{ padding: '0.75rem 1rem', border: '1px solid rgba(255,255,255,0.1)', borderRadius: '8px' }}>
+              <p style={{ margin: '0 0 0.5rem', fontSize: '0.875rem', color: '#a1a1aa' }}>
+                {t('setup.welcome.advanced.gguf.why')}
+              </p>
+              <ActionButton
+                onClick={() => {
+                  flow.setGgufPath('')
+                  flow.setGgufPathError(null)
+                  flow.resetAction()
+                  flow.setStep('gguf-path')
+                }}
+              >
+                {t('setup.welcome.advanced.gguf.action')}
+              </ActionButton>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <a
+        href={SETUP_DOCS_URL}
+        target="_blank"
+        rel="noreferrer"
+        style={{ fontSize: '0.825rem', color: '#71717a' }}
       >
-        <p style={{ margin: 0, fontWeight: 600, color: '#a5b4fc' }}>Your data stays on this machine</p>
-        <p style={{ margin: '0.5rem 0 0', fontSize: '0.875rem', color: '#c7d2fe' }}>
-          Conversations, transcripts, audio recordings, and AI responses are processed locally
-          and never leave your computer unless you choose to export or share them. You can play
-          without an internet connection once the model is installed.
-        </p>
-      </div>
-
-      <div style={{ marginTop: '1.5rem' }}>
-        <p style={{ fontWeight: 600, color: '#e8e8ea', margin: '0 0 0.75rem' }}>How it works</p>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.65rem' }}>
-          <div aria-label="local model explanation" style={{ border: '1px solid rgba(255,255,255,0.1)', borderRadius: '8px', padding: '0.85rem 1rem' }}>
-            <p style={{ margin: 0, fontWeight: 600, fontSize: '0.875rem' }}>A local AI model powers the conversations</p>
-            <p style={{ margin: '0.35rem 0 0', fontSize: '0.825rem', color: '#a1a1aa' }}>
-              The app uses a small language model that runs entirely on your machine. After a
-              one-time download it works without internet — and nothing is ever sent to a server.
-            </p>
-          </div>
-          <div aria-label="packs explanation" style={{ border: '1px solid rgba(255,255,255,0.1)', borderRadius: '8px', padding: '0.85rem 1rem' }}>
-            <p style={{ margin: 0, fontWeight: 600, fontSize: '0.875rem' }}>Packs give you scenarios to practise</p>
-            <p style={{ margin: '0.35rem 0 0', fontSize: '0.825rem', color: '#a1a1aa' }}>
-              Scenario packs are collections of practice conversations. A starter pack is already
-              installed. You can download more from the library or create your own in the Creator
-              Workbench.
-            </p>
-          </div>
-          <div aria-label="text-only demo explanation" style={{ border: '1px solid rgba(255,255,255,0.1)', borderRadius: '8px', padding: '0.85rem 1rem' }}>
-            <p style={{ margin: 0, fontWeight: 600, fontSize: '0.875rem' }}>No download? Try the text-only demo</p>
-            <p style={{ margin: '0.35rem 0 0', fontSize: '0.825rem', color: '#a1a1aa' }}>
-              Want to explore the interface first? Choose <strong>Continue without a model</strong> in
-              the next step. NPC responses are scripted, not AI-generated, but you can try every
-              screen immediately.
-            </p>
-          </div>
-        </div>
-      </div>
-
-      <p style={{ marginTop: '1.25rem', color: '#a1a1aa', fontSize: '0.875rem' }}>
-        This one-time setup wizard helps you choose a local AI model and get ready to play. It
-        takes about a minute plus download time. You can change your model at any time from{' '}
-        <strong>Settings → Runtime</strong>.
-      </p>
-
-      <div style={{ marginTop: '1.25rem', display: 'flex', gap: '0.75rem', alignItems: 'center' }}>
-        <PrimaryButton onClick={() => flow.setStep('loading')}>Get started</PrimaryButton>
-        <a href={SETUP_DOCS_URL} target="_blank" rel="noreferrer" style={{ fontSize: '0.825rem', color: '#71717a' }}>
-          Read setup docs
-        </a>
-      </div>
+        Read setup docs
+      </a>
     </div>
   )
 }

--- a/apps/web/src/setup/useSetupFlow.ts
+++ b/apps/web/src/setup/useSetupFlow.ts
@@ -59,6 +59,7 @@ export interface UseSetupFlowReturn {
 
   handleSetMeUp: () => void
   handleAdvancedOllama: () => void
+  handleAdvancedGguf: () => void
   handleStartInstall: (registryId: string) => Promise<void>
   handleSelectOllama: (m: DetectedOllamaModel) => Promise<void>
   handleUseGguf: () => Promise<void>
@@ -123,7 +124,7 @@ export function useSetupFlow(initialStep: SetupFlowStep, initialInstallId?: numb
 
   // Tracks what the user chose on the welcome screen so the loading step can
   // route to the right destination without exposing the detail as UI state.
-  const intentRef = useRef<'set-me-up' | 'ollama' | null>(null)
+  const intentRef = useRef<'set-me-up' | 'ollama' | 'gguf' | null>(null)
 
   const stepHeadingRef = useRef<HTMLHeadingElement>(null)
   const isInitialStep = useRef(true)
@@ -196,6 +197,11 @@ export function useSetupFlow(initialStep: SetupFlowStep, initialInstallId?: numb
         return
       }
 
+      if (intent === 'gguf') {
+        setStep('gguf-path')
+        return
+      }
+
       setStep('choose')
     }).catch((err: unknown) => {
       setLoadError({ kind: 'network', message: err instanceof Error ? err.message : 'Failed to load model information.' })
@@ -263,6 +269,16 @@ export function useSetupFlow(initialStep: SetupFlowStep, initialInstallId?: numb
 
   function handleAdvancedOllama() {
     intentRef.current = 'ollama'
+    setStep('loading')
+  }
+
+  function handleAdvancedGguf() {
+    // Route through 'loading' (like the Ollama path) so preflight runs silently
+    // and any genuine blocker surfaces before the user picks a .gguf file.
+    setGgufPath('')
+    setGgufPathError(null)
+    resetAction()
+    intentRef.current = 'gguf'
     setStep('loading')
   }
 
@@ -361,6 +377,7 @@ export function useSetupFlow(initialStep: SetupFlowStep, initialInstallId?: numb
     navigate,
     handleSetMeUp,
     handleAdvancedOllama,
+    handleAdvancedGguf,
     handleStartInstall,
     handleSelectOllama,
     handleUseGguf,

--- a/apps/web/src/setup/useSetupFlow.ts
+++ b/apps/web/src/setup/useSetupFlow.ts
@@ -57,6 +57,8 @@ export interface UseSetupFlowReturn {
   resetAction: () => void
   navigate: ReturnType<typeof useNavigate>
 
+  handleSetMeUp: () => void
+  handleAdvancedOllama: () => void
   handleStartInstall: (registryId: string) => Promise<void>
   handleSelectOllama: (m: DetectedOllamaModel) => Promise<void>
   handleUseGguf: () => Promise<void>
@@ -119,6 +121,10 @@ export function useSetupFlow(initialStep: SetupFlowStep, initialInstallId?: numb
 
   const [preflightResult, setPreflightResult] = useState<PreflightResponse | null>(null)
 
+  // Tracks what the user chose on the welcome screen so the loading step can
+  // route to the right destination without exposing the detail as UI state.
+  const intentRef = useRef<'set-me-up' | 'ollama' | null>(null)
+
   const stepHeadingRef = useRef<HTMLHeadingElement>(null)
   const isInitialStep = useRef(true)
   useEffect(() => {
@@ -126,10 +132,23 @@ export function useSetupFlow(initialStep: SetupFlowStep, initialInstallId?: numb
     stepHeadingRef.current?.focus()
   }, [step])
 
-  // Fetch models + preflight when entering loading step
+  // Pre-fetch the model registry when on the welcome step so the WelcomeStep
+  // can render model size + license before any user action, satisfying the
+  // acceptance criterion that these values come from the registry, not
+  // hardcoded strings.
+  useEffect(() => {
+    if (step !== 'welcome') return
+    let cancelled = false
+    void api.getModels().then((r) => {
+      if (!cancelled && r.ok) setModelsData(r.data)
+    })
+    return () => { cancelled = true }
+  }, [step])
+
+  // Fetch models + preflight when entering loading step, then route based on intent
   useEffect(() => {
     if (step !== 'loading') return
-    void Promise.all([api.getModels(), api.preflight()]).then(([modelsResult, preflightRes]) => {
+    void Promise.all([api.getModels(), api.preflight()]).then(async ([modelsResult, preflightRes]) => {
       if (!modelsResult.ok) {
         setLoadError(modelsResult.error)
         setStep('load-error')
@@ -143,6 +162,40 @@ export function useSetupFlow(initialStep: SetupFlowStep, initialInstallId?: numb
         )
         if (blockingFails.length > 0) { setStep('preflight'); return }
       }
+
+      const intent = intentRef.current
+      intentRef.current = null
+
+      if (intent === 'set-me-up') {
+        const rec = modelsResult.data.registry.find((m) => m.role === 'starter') ?? null
+        if (!rec) { setStep('choose'); return }
+        setSelectedModel(rec)
+        setActionLoading(true)
+        setActionError(null)
+        try {
+          const resp = await api.installModel({ registry_id: rec.id })
+          if (!resp.ok) {
+            setActionError(resp.error)
+            setStep('confirm-install')
+          } else {
+            setInstallId(resp.data.install_id)
+            setInstallRecord(null)
+            setStep('installing')
+          }
+        } catch (err: unknown) {
+          setActionError({ kind: 'network', message: err instanceof Error ? err.message : 'Install failed. Please try again.' })
+          setStep('confirm-install')
+        } finally {
+          setActionLoading(false)
+        }
+        return
+      }
+
+      if (intent === 'ollama') {
+        setStep('ollama-select')
+        return
+      }
+
       setStep('choose')
     }).catch((err: unknown) => {
       setLoadError({ kind: 'network', message: err instanceof Error ? err.message : 'Failed to load model information.' })
@@ -200,6 +253,16 @@ export function useSetupFlow(initialStep: SetupFlowStep, initialInstallId?: numb
   }
 
   async function reloadModels() {
+    setStep('loading')
+  }
+
+  function handleSetMeUp() {
+    intentRef.current = 'set-me-up'
+    setStep('loading')
+  }
+
+  function handleAdvancedOllama() {
+    intentRef.current = 'ollama'
     setStep('loading')
   }
 
@@ -296,6 +359,8 @@ export function useSetupFlow(initialStep: SetupFlowStep, initialInstallId?: numb
     recommendedModel,
     resetAction,
     navigate,
+    handleSetMeUp,
+    handleAdvancedOllama,
     handleStartInstall,
     handleSelectOllama,
     handleUseGguf,


### PR DESCRIPTION
## Summary

Replaces the Welcome screen's text-heavy layout with a two-card decision interface: **"Set me up"** (auto-installs the recommended model and launches setup) vs **"Try it right now"** (opens the library immediately to try the app without setup).

## Changes

- **Welcome redesign**: Rewritten as a two-card layout presenting the two core user paths clearly, with the recommended model's size and license displayed inline (populated from a pre-fetched registry entry).

- **Intent-based routing**: Added `handleSetMeUp` and `handleAdvancedOllama` handlers that set an intent and transition through the loading step, where preflight checks run silently before routing to the next step—ensuring blockers surface up-front.

- **Preflight consistency**: The GGUF path now runs through preflight (via a new `gguf` intent) like the Ollama path, preventing late failures when the llama.cpp runtime is missing.

- **Advanced paths**: Ollama and GGUF installation options are moved to a collapsible Advanced disclosure, de-emphasizing complexity for first-time users.

- **Privacy disclosure**: Privacy details now live behind a controlled toggle rather than a native details element, improving test reliability and UX control.

- **i18n**: Added `setup.welcome` namespace covering the headline, card labels, privacy disclosure, and advanced disclosure in English and German.

- **Tests**: Refactored tests to cover the new card interface, pre-fetch flow, intent-based routing, and preflight behavior on both advanced paths. Simplified existing test helpers and updated button queries throughout.

## Why

Addresses #381 by giving users a clearer, more immediate entry point to the app—a one-click decision rather than a wall of text and options. The intent-based routing ensures preflight runs consistently and silently, so genuine blockers (missing llama.cpp, network failures) surface at the right time, not later during installation.

Closes #381