### PR TITLE
Hero carousel auto-transition cuts between slides instead of fading

### DIFF
--- a/website/assets/css/main.css
+++ b/website/assets/css/main.css
@@ -239,7 +239,6 @@ h3 { font-size: 1.12rem; margin: 0 0 0.4em; }
 .demo-slides .demo-card {
   grid-area: 1 / 1;
   opacity: 0;
-  transition: opacity 500ms ease;
   pointer-events: none;
 }
 
@@ -260,10 +259,6 @@ h3 { font-size: 1.12rem; margin: 0 0 0.4em; }
 
 .carousel-dot.is-active { background: var(--violet); transform: scale(1.4); }
 .carousel-dot:hover:not(.is-active) { background: var(--text-faint); }
-
-@media (prefers-reduced-motion: reduce) {
-  .demo-slides .demo-card { transition: none; }
-}
 
 /* ---------- guarantee strip ---------- */
 


### PR DESCRIPTION
## Summary

Remove the 500ms opacity transition from the hero carousel's `.demo-card` elements so slide changes display as an instant cut rather than a gradual cross-fade.

## Changes

- **website/assets/css/main.css**: Removed `transition: opacity 500ms ease` from `.demo-slides .demo-card` to make auto-advance between slides instantaneous
- **website/assets/css/main.css**: Removed the now-redundant `@media (prefers-reduced-motion: reduce)` rule that was suppressing the same transition

## Rationale

The previous fade effect slowed down the carousel's visual feedback, creating a sluggish feel as users navigate through slides. The instant cut provides a snappier, more responsive user experience while still maintaining the carousel's functionality.

## Testing

Verified the auto-advance timer cycles through the hero carousel slides with no visible fade—each slide change is instantaneous.

Closes #401