### PR TITLE
Document outrightmental org-level Actions secrets for signing, scanning, and Steam credentials

### DIFF
--- a/publishing/MACOS_SIGNING_AND_NOTARIZATION.md
+++ b/publishing/MACOS_SIGNING_AND_NOTARIZATION.md
@@ -87,17 +87,36 @@ password** (not the Apple ID login password).
 
 ## CI setup (GitHub Actions secrets)
 
-Store the following as **GitHub Actions secrets** (Settings → Secrets and
-variables → Actions → Secrets):
+These secrets are stored at the **outrightmental organisation level**, scoped to
+`ConversationSimulator` and `FeverTilt`. They are entered once and rotated in one
+place — all scoped repositories pick up the change automatically.
 
-| Secret name | Contents |
-|-------------|----------|
-| `APPLE_CERTIFICATE` | Base64-encoded `.p12` file (the output of the `base64` command above) |
-| `APPLE_CERTIFICATE_PASSWORD` | Passphrase for the `.p12` file |
-| `APPLE_SIGNING_IDENTITY` | Full identity string: `Developer ID Application: Outright Mental (TEAMID)` |
-| `APPLE_ID` | Apple ID email used for notarisation |
-| `APPLE_PASSWORD` | App-specific password generated above |
-| `APPLE_TEAM_ID` | Ten-character Outright Mental team ID (visible in the Apple Developer portal) |
+| Secret name | Contents | Source |
+|-------------|----------|--------|
+| `APPLE_CERTIFICATE` | Base64-encoded `.p12` file | Export from Keychain, then `base64 -i DeveloperID.p12` |
+| `APPLE_CERTIFICATE_PASSWORD` | Passphrase for the `.p12` file | Set when exporting the `.p12` |
+| `APPLE_SIGNING_IDENTITY` | Full identity string: `Developer ID Application: Outright Mental (TEAMID)` | `security find-identity -v -p codesigning` |
+| `APPLE_ID` | Apple ID email used for notarisation | Outright Mental Apple Developer account |
+| `APPLE_PASSWORD` | App-specific password for notarytool | appleid.apple.com → Security → App-Specific Passwords |
+| `APPLE_TEAM_ID` | Ten-character Outright Mental team ID | Apple Developer portal |
+
+**To set or rotate** (values supplied interactively, never committed):
+
+```bash
+gh secret set APPLE_CERTIFICATE \
+  --org outrightmental \
+  --visibility selected \
+  --repos ConversationSimulator,FeverTilt
+# repeat for each secret in the table above
+```
+
+Or use the org Settings UI: GitHub → outrightmental org **Settings → Secrets
+and variables → Actions → Secrets → New organisation secret**, then set
+**Repository access** to *Selected repositories: ConversationSimulator, FeverTilt*.
+
+**Rotation:** Rotating any secret at org level updates it for all scoped
+repositories simultaneously. Run `gh secret list --org outrightmental` to
+confirm the inventory after any change.
 
 Tauri's bundler reads these environment variables from the CI environment
 automatically. The release workflow (`release.yml`) passes them through
@@ -288,9 +307,11 @@ approaches expiry:
 1. Generate a new Developer ID Application certificate in the Apple Developer
    portal.
 2. Export as `.p12` and base64-encode as described above.
-3. Update the `APPLE_CERTIFICATE` and `APPLE_CERTIFICATE_PASSWORD` GitHub
-   Actions secrets.
-4. Update the `APPLE_SIGNING_IDENTITY` secret if the team ID or name changed.
+3. Update the org-level `APPLE_CERTIFICATE` and `APPLE_CERTIFICATE_PASSWORD`
+   secrets (see [CI setup](#ci-setup-github-actions-secrets) for the `gh secret
+   set` command). All scoped repositories pick up the new certificate automatically.
+4. Update the org-level `APPLE_SIGNING_IDENTITY` secret if the team ID or name
+   changed.
 5. Rebuild and re-notarise the latest release to confirm the new certificate
    works end to end.
 6. Existing installed copies signed with the old certificate continue to work —

--- a/publishing/STEAM_APP_REGISTRATION.md
+++ b/publishing/STEAM_APP_REGISTRATION.md
@@ -11,8 +11,8 @@
 >
 > **Sensitive data:** No secret credentials appear in this document. App IDs and
 > depot IDs are non-secret identifiers assigned by Valve. Steam partner
-> credentials are stored as GitHub Actions secrets — see
-> [CI credentials](#ci-credentials).
+> credentials are stored as **outrightmental org-level GitHub Actions secrets**,
+> scoped to selected repositories — see [CI credentials](#ci-credentials).
 
 ---
 
@@ -347,11 +347,16 @@ to Steam using a **dedicated build account**, not the main Outright Mental
 partner account. A separate account limits the blast radius of a compromised CI
 credential.
 
-### Required GitHub Actions secrets
+### Org-level GitHub Actions secrets
+
+These secrets are stored at the **outrightmental organisation level**, scoped
+to `ConversationSimulator` and `FeverTilt`. Entering them once at org level
+means all scoped repositories pick them up automatically — no duplicate secrets
+in each repo.
 
 | Secret name | Description | How to obtain |
 |------------|-------------|---------------|
-| `STEAM_USERNAME` | Steam username of the dedicated CI build account | Create a new Steam account for CI use; grant it Developer access in the Steamworks partner portal under Users & Permissions |
+| `STEAM_USERNAME` | Steam username of the dedicated CI build account | Create a new Steam account for CI use; grant it Developer access in the Steamworks partner portal under Users & Permissions → verify it has App 4963030 permissions |
 | `STEAM_CONFIG_VDF` | Base64-encoded `config.vdf` from an authenticated Steam session on the build account | Log in as the build account on a machine with Steam installed; complete the SteamGuard prompt; copy `~/.steam/steam/config/config.vdf`; encode it: `base64 -w0 ~/.steam/steam/config/config.vdf` |
 
 **Why `STEAM_CONFIG_VDF` instead of a password:** Steam requires two-factor
@@ -360,8 +365,28 @@ session bypasses the interactive 2FA prompt in headless CI environments. Treat
 this file with the same confidentiality as a password — rotate it if the build
 account is ever compromised.
 
-**To set a GitHub Actions secret:** GitHub → repository Settings → Secrets and
-variables → Actions → Secrets tab → New repository secret.
+**To set an org-level secret** (via CLI — values are supplied interactively, never
+committed):
+
+```bash
+gh secret set STEAM_USERNAME \
+  --org outrightmental \
+  --visibility selected \
+  --repos ConversationSimulator,FeverTilt
+
+gh secret set STEAM_CONFIG_VDF \
+  --org outrightmental \
+  --visibility selected \
+  --repos ConversationSimulator,FeverTilt
+```
+
+Or use the org Settings UI: GitHub → outrightmental org **Settings → Secrets
+and variables → Actions → Secrets → New organisation secret**, then set
+**Repository access** to *Selected repositories: ConversationSimulator, FeverTilt*.
+
+**Rotation:** Because the secrets are org-level, rotating a credential once
+updates it for all scoped repositories simultaneously. Run
+`gh secret list --org outrightmental` to confirm the inventory after any change.
 
 ### Refreshing `STEAM_CONFIG_VDF`
 
@@ -372,7 +397,14 @@ error:
 1. Log in as the build account on a local machine with Steam installed.
 2. Complete the SteamGuard prompt.
 3. Copy and re-encode the updated `config.vdf`.
-4. Update the `STEAM_CONFIG_VDF` secret in GitHub.
+4. Update the org-level `STEAM_CONFIG_VDF` secret:
+   ```bash
+   gh secret set STEAM_CONFIG_VDF \
+     --org outrightmental \
+     --visibility selected \
+     --repos ConversationSimulator,FeverTilt
+   ```
+   All scoped repositories pick up the refreshed config automatically.
 
 ---
 

--- a/publishing/WINDOWS_CODE_SIGNING.md
+++ b/publishing/WINDOWS_CODE_SIGNING.md
@@ -71,8 +71,54 @@ chain and private key.
 
 ## CI setup (GitHub Actions secrets)
 
-For OV certificates (`.pfx` file), store the following as **GitHub Actions
-secrets** (Settings → Secrets and variables → Actions → Secrets):
+### Org-level secret inventory
+
+The following Windows signing and scanning secrets are stored at the
+**outrightmental organisation level**, scoped to `ConversationSimulator` and
+`FeverTilt`. They are entered once and rotated in one place.
+
+| Secret name | Contents | Used by |
+|-------------|----------|---------|
+| `WINDOWS_CODESIGN_CERT` | Base64-encoded PEM chain (leaf first) matching the Cloud KMS key | Future KMS/jsign signing step (see note below) |
+| `GCP_SA_KEY_JSON` | GCP service-account key JSON for Cloud KMS access | Future KMS/jsign signing step |
+| `GCP_KMS_KEY` | Fully-qualified Cloud KMS key resource path | Future KMS/jsign signing step |
+| `AZURE_CLIENT_ID` | Azure service-principal client ID for Defender storage | Future Defender upload step |
+| `AZURE_CLIENT_SECRET` | Azure service-principal secret | Future Defender upload step |
+| `AZURE_TENANT_ID` | Azure tenant ID | Future Defender upload step |
+| `AZURE_SUBSCRIPTION_ID` | Azure subscription ID | Future Defender upload step |
+| `AZURE_SCAN_STORAGE_ACCOUNT` | Storage account name for Defender-monitored upload | Future Defender upload step |
+| `AZURE_SCAN_CONTAINER` | Blob container name for Defender-monitored upload | Future Defender upload step |
+
+> **Note:** The KMS/jsign signing migration and the Azure Defender upload job
+> are tracked as separate issues. Until those land, `release.yml` uses the
+> PFX-based approach described below, with `WINDOWS_SIGN_CERT_PFX` and
+> `WINDOWS_SIGN_CERT_PASSWORD` set as repo-level secrets.
+
+**To set or rotate org-level secrets** (values supplied interactively, never
+committed):
+
+```bash
+gh secret set WINDOWS_CODESIGN_CERT \
+  --org outrightmental \
+  --visibility selected \
+  --repos ConversationSimulator,FeverTilt
+# repeat for each secret in the table above
+```
+
+Or use the org Settings UI: GitHub → outrightmental org **Settings → Secrets
+and variables → Actions → Secrets → New organisation secret**, then set
+**Repository access** to *Selected repositories: ConversationSimulator, FeverTilt*.
+
+**Rotation:** Rotating a secret at org level updates it for all scoped
+repositories simultaneously. Run `gh secret list --org outrightmental` to
+confirm the inventory after any change.
+
+### Current approach: PFX-based signing (repo-level secrets)
+
+Until the KMS migration lands, the release workflow uses `.pfx`-based
+Authenticode signing via `signtool.exe`. Store the following as
+**repository-level** GitHub Actions secrets (Settings → Secrets and variables
+→ Actions → Secrets):
 
 | Secret name | Contents |
 |-------------|----------|
@@ -223,8 +269,16 @@ When the code-signing certificate approaches expiry:
 
 1. Purchase a new certificate from the same or another trusted CA.
 2. Export as `.pfx` and base64-encode as described above.
-3. Update `WINDOWS_SIGN_CERT_PFX` and `WINDOWS_SIGN_CERT_PASSWORD` in GitHub
-   Actions secrets.
+3. Update `WINDOWS_SIGN_CERT_PFX` and `WINDOWS_SIGN_CERT_PASSWORD` as
+   repository-level GitHub Actions secrets.
+   Once the KMS migration lands, update the org-level `WINDOWS_CODESIGN_CERT`
+   secret instead (see [Org-level secret inventory](#ci-setup-github-actions-secrets)):
+   ```bash
+   gh secret set WINDOWS_CODESIGN_CERT \
+     --org outrightmental \
+     --visibility selected \
+     --repos ConversationSimulator,FeverTilt
+   ```
 4. Rebuild and sign the current release to confirm the new certificate works.
 5. Files signed with the old certificate remain valid because of the trusted
    timestamp embedded at signing time (`/tr`).


### PR DESCRIPTION
## Summary

This PR documents the org-level GitHub Actions secrets for signing, scanning, and Steam credentials in the outrightmental organization. All secrets are scoped to `ConversationSimulator` and `FeverTilt` repositories, entered once at the org level, and rotated centrally.

### Changes

- **`publishing/STEAM_APP_REGISTRATION.md`**
  - Rewrote CI credentials section to describe org-level secret storage
  - `STEAM_USERNAME` and `STEAM_CONFIG_VDF` documented as outrightmental org-level secrets
  - Added `gh secret set --org outrightmental --visibility selected` CLI commands
  - Added org Settings UI path and rotation procedure
  - Updated `STEAM_CONFIG_VDF` refresh runbook to use `gh secret set --org`

- **`publishing/MACOS_SIGNING_AND_NOTARIZATION.md`**
  - Rewrote CI setup section with org-level secret storage
  - All six Apple secrets (`APPLE_CERTIFICATE`, `APPLE_CERTIFICATE_PASSWORD`, `APPLE_SIGNING_IDENTITY`, `APPLE_ID`, `APPLE_PASSWORD`, `APPLE_TEAM_ID`) documented as org-level
  - Added source column and `gh secret set --org` invocation
  - Added rotation note: changing any secret at org level updates all scoped repos simultaneously
  - Updated certificate rotation runbook to reference org-level rotation

- **`publishing/WINDOWS_CODE_SIGNING.md`**
  - Added org-level secret inventory table covering `WINDOWS_CODESIGN_CERT`, `GCP_SA_KEY_JSON`, `GCP_KMS_KEY`, and five Azure Defender-upload secrets
  - Clarified that current PFX-based secrets (`WINDOWS_SIGN_CERT_PFX`, `WINDOWS_SIGN_CERT_PASSWORD`) remain repo-level pending the KMS migration
  - Added section headers for current approach vs. future KMS migration
  - Updated certificate rotation runbook with forward reference to org-level rotation post-migration

### What was not changed

`release.yml` required no edits: all Apple signing secrets, Tauri updater secrets, and Steam credentials already use the canonical org-level names. The Windows KMS/jsign migration and Azure Defender upload job are tracked as separate issues.

### How it was tested

Doc-only change. Verified `release.yml` secret references against the org secret inventory — every Apple and Tauri secret name matches 1:1. Confirmed no secret values appear in any file.

Closes #403