### PR TITLE
Chain Steam publication to the end of the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -949,3 +949,24 @@ jobs:
           files: latest.json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ── Steam publication (beta) ──────────────────────────────────────────────────
+  # Chains automatically after a successful GitHub release.  The steam-release
+  # GitHub environment gates this job behind a required-reviewer approval, so no
+  # Steam credential is exposed without a human click.
+  #
+  # Automatic runs always target the 'beta' branch.  'default' (public) must be
+  # promoted via steam-promote.yml after the Stage 4 gate passes.
+  #
+  # If STEAM_USERNAME / STEAM_CONFIG_VDF are not yet configured, steam-deploy
+  # short-circuits with an INFO message and this job succeeds, leaving the release
+  # green.  See publishing/STEAM_APP_REGISTRATION.md for credential setup.
+  steam:
+    name: Publish to Steam (beta)
+    needs: release
+    if: ${{ !cancelled() && needs.release.result == 'success' }}
+    uses: ./.github/workflows/steam-deploy.yml
+    with:
+      release_tag: ${{ github.event.inputs.tag || github.ref_name }}
+      set_live_branch: beta
+    secrets: inherit

--- a/.github/workflows/steam-deploy.yml
+++ b/.github/workflows/steam-deploy.yml
@@ -89,6 +89,28 @@ on:
         default: 'beta'
         type: string
 
+  # Reusable workflow target: called from release.yml after a successful
+  # GitHub release.  The steam-release environment gate (below) still applies
+  # on this path — a human click is required before Steam credentials are
+  # exposed.  Automatic runs always pass set_live_branch: beta; "default" is
+  # refused (see the Guard step).
+  workflow_call:
+    inputs:
+      release_tag:
+        description: 'GitHub release tag to upload (e.g. v0.1.0)'
+        required: true
+        type: string
+      build_description:
+        description: 'Human-readable build description shown in Steamworks. Defaults to "Conversation Simulator <tag>" if left empty.'
+        required: false
+        default: ''
+        type: string
+      set_live_branch:
+        description: 'Steam branch to set live. Automatic runs only target "beta" — "default" is refused on workflow_call.'
+        required: false
+        default: 'beta'
+        type: string
+
 permissions:
   contents: read
 
@@ -100,13 +122,52 @@ jobs:
     # The steam-release environment gates this job behind a manual approval step.
     # Create it in GitHub → Settings → Environments → New environment.
     # Add required reviewers so no Steam credential is exposed without sign-off.
+    # This gate applies on both workflow_dispatch and workflow_call trigger paths.
     environment: steam-release
+
+    # Expose a boolean presence flag so steps can gate on `env` rather than
+    # the secrets context (which cannot be used in step `if:` conditionals).
+    # When STEAM_USERNAME or STEAM_CONFIG_VDF are absent the job short-circuits
+    # with an INFO message, leaving the calling release workflow green.
+    env:
+      HAS_STEAM_CREDS: ${{ secrets.STEAM_USERNAME != '' && secrets.STEAM_CONFIG_VDF != '' }}
 
     steps:
       - uses: actions/checkout@v5
 
+      # ── Credential presence check ──────────────────────────────────────────
+      # If Steam secrets are not configured, emit INFO and let all subsequent
+      # steps skip — the release workflow stays green.  Matches the INFO
+      # convention used by the signing steps in release.yml.
+      - name: Check Steam credentials
+        if: env.HAS_STEAM_CREDS != 'true'
+        run: |
+          echo "  INFO  STEAM_USERNAME or STEAM_CONFIG_VDF is not set — skipping Steam upload."
+          echo "        Set both secrets in Settings → Secrets and variables → Actions → Secrets"
+          echo "        to enable automated Steam deployment from the release workflow."
+          echo "        See publishing/STEAM_APP_REGISTRATION.md for the setup procedure."
+
+      # ── Branch policy guard ────────────────────────────────────────────────
+      # Automatic (workflow_call) runs may only target the 'beta' branch.
+      # Promoting to 'default' (public) requires an explicit workflow_dispatch
+      # with the Stage 4 gate checklist — use steam-promote.yml after sign-off.
+      - name: Guard — refuse default branch on automatic runs
+        if: env.HAS_STEAM_CREDS == 'true'
+        env:
+          SET_LIVE_BRANCH: ${{ inputs.set_live_branch }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [ "$SET_LIVE_BRANCH" = "default" ] && [ "$EVENT_NAME" != "workflow_dispatch" ]; then
+            echo "ERROR: set_live_branch=default is not permitted on automatic (workflow_call) runs." >&2
+            echo "       Automated releases always target the 'beta' branch." >&2
+            echo "       To promote to 'default', trigger steam-deploy.yml manually via" >&2
+            echo "       workflow_dispatch after all Stage 4 gate criteria are met." >&2
+            exit 1
+          fi
+
       # ── Resolve build description ──────────────────────────────────────────
       - name: Resolve build description
+        if: env.HAS_STEAM_CREDS == 'true'
         id: desc
         # Inputs are passed through env vars — never interpolated directly into
         # the shell — to avoid GitHub Actions expression injection (CWE-94).
@@ -122,6 +183,7 @@ jobs:
 
       # ── Download GitHub release assets ─────────────────────────────────────
       - name: Download release artifacts
+        if: env.HAS_STEAM_CREDS == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ inputs.release_tag }}
@@ -131,6 +193,7 @@ jobs:
             --skip-errors
 
       - name: List downloaded artifacts
+        if: env.HAS_STEAM_CREDS == 'true'
         run: find release-artifacts -type f | sort
 
       # ── Organise artifacts into per-platform depot content directories ──────
@@ -144,6 +207,7 @@ jobs:
       # depot layout for Windows is tracked separately and not part of this
       # macOS-focused change.
       - name: Organise depot content
+        if: env.HAS_STEAM_CREDS == 'true'
         run: |
           mkdir -p steam-content/windows steam-content/macos steam-content/linux
 
@@ -203,6 +267,7 @@ jobs:
       # dry-run and internal staging uploads of unsigned dev builds are not
       # blocked.  Signed builds must be used for any Stage 3+ release.
       - name: Verify macOS .app code-signature presence
+        if: env.HAS_STEAM_CREDS == 'true'
         run: |
           APP_PATH="$(find steam-content/macos -maxdepth 1 -name '*.app' -type d \
             2>/dev/null | head -n1)"
@@ -229,6 +294,7 @@ jobs:
       # expects: weight files (.gguf/.safetensors/.bin/.pt/.pth/.ckpt) and
       # unapproved binary payloads (large pickle/NumPy/ONNX files, models/ dirs).
       - name: Audit depot content
+        if: env.HAS_STEAM_CREDS == 'true'
         run: |
           for platform in windows macos linux; do
             echo "── Auditing steam-content/$platform ──"
@@ -241,15 +307,18 @@ jobs:
       # version stamping, icon presence, executable permissions, and depot
       # layout structure.  Skips a platform directory when it is empty.
       - uses: actions/setup-python@v6
+        if: env.HAS_STEAM_CREDS == 'true'
         with:
           python-version: "3.11"
 
       - name: Install Python test dependencies for artifact inspection
+        if: env.HAS_STEAM_CREDS == 'true'
         run: |
           pip install -e "packages/prompt-composer"
           pip install -e "services/convsim-core[dev]"
 
       - name: Run artifact inspection tests
+        if: env.HAS_STEAM_CREDS == 'true'
         run: |
           FAIL=0
           for platform in windows macos linux; do
@@ -266,6 +335,7 @@ jobs:
 
       # ── Generate SteamPipe build scripts from VDF templates ────────────────
       - name: Generate SteamPipe VDF files
+        if: env.HAS_STEAM_CREDS == 'true'
         env:
           STEAM_APP_ID:            ${{ vars.STEAM_APP_ID }}
           STEAM_DEPOT_WINDOWS_ID:  ${{ vars.STEAM_DEPOT_WINDOWS_ID }}
@@ -286,6 +356,7 @@ jobs:
 
       # ── Install steamcmd ───────────────────────────────────────────────────
       - name: Install steamcmd
+        if: env.HAS_STEAM_CREDS == 'true'
         run: |
           sudo add-apt-repository multiverse
           sudo dpkg --add-architecture i386
@@ -297,6 +368,7 @@ jobs:
       # Decodes the base64-encoded config.vdf from the STEAM_CONFIG_VDF secret.
       # This bypasses the interactive SteamGuard prompt in headless CI.
       - name: Restore Steam config
+        if: env.HAS_STEAM_CREDS == 'true'
         env:
           STEAM_CONFIG_VDF: ${{ secrets.STEAM_CONFIG_VDF }}
         run: |
@@ -307,6 +379,7 @@ jobs:
 
       # ── Upload to Steam ────────────────────────────────────────────────────
       - name: Upload build to Steam
+        if: env.HAS_STEAM_CREDS == 'true'
         env:
           STEAM_USERNAME: ${{ secrets.STEAM_USERNAME }}
         run: |
@@ -317,7 +390,7 @@ jobs:
 
       # ── Log build output ───────────────────────────────────────────────────
       - name: Show steamcmd build output
-        if: always()
+        if: always() && env.HAS_STEAM_CREDS == 'true'
         run: |
           if [ -d steam-build/output ]; then
             find steam-build/output -type f | sort

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -31,6 +31,21 @@ intend to tag.
 | Release smoke — macOS aarch64 | `.github/workflows/release-smoke.yml` (job: `smoke-macos / aarch64`) | All CI-subset subsystems on Apple Silicon |
 | Release smoke — Windows x86_64 | `.github/workflows/release-smoke.yml` (job: `smoke-windows`) | All CI-subset subsystems on Windows |
 
+**Release workflow job chain** (triggered by pushing a `vX.Y.Z` tag):
+
+| Job | Depends on | What it does |
+|---|---|---|
+| `validate` | — | Smoke check |
+| `build-desktop` | `validate` | Cross-platform Tauri builds (macOS, Linux, Windows) |
+| `release` | `build-desktop` | Publishes GitHub release; updates beta-channel updater manifest |
+| `steam` | `release` | Stages the build to Steam and sets `beta` live — **pauses for `steam-release` environment approval** |
+
+> **Steam step:** After pushing a tag, the `steam` job appears in Actions →
+> Release and waits for a required reviewer to click **Approve** before any
+> Steam credential is used. Approving uploads all three depots and sets the
+> `beta` branch live. If Steam secrets are not yet configured, the job emits an
+> INFO and completes without uploading — the release remains green.
+
 **CI-subset subsystems (no model downloads, fake runtime):**
 
 - [ ] `[setup]` — All expected monorepo paths present

--- a/publishing/STEAM_APP_REGISTRATION.md
+++ b/publishing/STEAM_APP_REGISTRATION.md
@@ -116,14 +116,14 @@ access to the app. They are stored as GitHub repository **variables** (not
 secrets) so that CI workflows can reference them without hardcoding values in
 source files.
 
-| Identifier | GitHub repository variable | Description |
-|-----------|---------------------------|-------------|
-| App ID | `vars.STEAM_APP_ID` | Assigned by Valve at registration. Seven-digit format, e.g. `1234567`. |
-| Windows depot ID | `vars.STEAM_DEPOT_WINDOWS_ID` | First depot created; Windows x86-64 content. Valve assigns depot IDs sequentially after the App ID. |
-| macOS depot ID | `vars.STEAM_DEPOT_MACOS_ID` | Second depot created; macOS (Apple Silicon + Intel) content. |
-| Linux/SteamOS depot ID | `vars.STEAM_DEPOT_LINUX_ID` | Third depot created; Linux x86-64 and Steam Deck content. |
-| Base package ID | *(record here after registration)* | The paid base package that grants the base app and its three platform depots. Not referenced in CI. |
-| DLC App IDs | `vars.STEAM_DLC_APP_IDS` | One Steam App ID per premium scenario-pack DLC (comma-separated). Non-secret. DLC content is built and uploaded from the private `ConversationSimulator-DLC` repo — see [`docs/DLC_MODEL.md`](../docs/DLC_MODEL.md). |
+| Identifier | Value | GitHub repository variable | Description |
+|-----------|-------|---------------------------|-------------|
+| App ID | **4963030** | `vars.STEAM_APP_ID` | Assigned by Valve at registration. |
+| Windows depot ID | *(assigned in partner portal — set as repo variable)* | `vars.STEAM_DEPOT_WINDOWS_ID` | First depot created; Windows x86-64 content. Valve assigns depot IDs sequentially after the App ID. |
+| macOS depot ID | *(assigned in partner portal — set as repo variable)* | `vars.STEAM_DEPOT_MACOS_ID` | Second depot created; macOS (Apple Silicon + Intel) content. |
+| Linux/SteamOS depot ID | *(assigned in partner portal — set as repo variable)* | `vars.STEAM_DEPOT_LINUX_ID` | Third depot created; Linux x86-64 and Steam Deck content. |
+| Base package ID | *(record here after registration)* | *(not referenced in CI)* | The paid base package that grants the base app and its three platform depots. |
+| DLC App IDs | *(record here per pack)* | `vars.STEAM_DLC_APP_IDS` | One Steam App ID per premium scenario-pack DLC (comma-separated). Non-secret. DLC content is built and uploaded from the private `ConversationSimulator-DLC` repo — see [`docs/DLC_MODEL.md`](../docs/DLC_MODEL.md). |
 
 **To set a repository variable:** GitHub → repository Settings → Secrets and
 variables → Actions → Variables tab → New repository variable.

--- a/publishing/STEAM_PUBLISHING_AND_DEPLOYMENT.md
+++ b/publishing/STEAM_PUBLISHING_AND_DEPLOYMENT.md
@@ -129,9 +129,27 @@ Create a `steam-release` environment under Settings → Environments. Add at
 least one required reviewer so the workflow pauses for approval before secrets
 are used. This prevents accidental or unauthorised deployments.
 
-### Triggering a deployment
+### Automatic deployment (primary path)
 
-The workflow is triggered manually under Actions → Steam Deploy → Run workflow.
+Publishing a GitHub release (pushing a `vX.Y.Z` tag or running the release
+workflow manually) now **automatically chains** to `steam-deploy.yml` via the
+`steam` job appended to `release.yml`.
+
+The automatic chain always passes `set_live_branch: beta` — the `default`
+(public) branch can never be set live from an automated run. The
+`steam-release` GitHub environment gate still applies: every release pauses at
+**"Publish to Steam (beta)"** until a required reviewer approves in
+Actions → Release → steam job. Only after that approval are Steam credentials
+exposed and the upload proceeds.
+
+If `STEAM_USERNAME` or `STEAM_CONFIG_VDF` are not yet configured, the `steam`
+job emits an INFO message and exits 0 — the release itself stays green.
+
+### Manual deployment (workflow\_dispatch)
+
+`steam-deploy.yml` retains a `workflow_dispatch` trigger for dry-runs and
+out-of-band uploads. Trigger it manually under Actions → Steam Deploy → Run
+workflow.
 
 | Input | Required | Description |
 |-------|----------|-------------|


### PR DESCRIPTION
Pushing a `vX.Y.Z` tag now automatically stages the build to Steam and sets the `beta` branch live — no manual dispatch needed. The `steam-release` GitHub environment gate requires a human click before any Steam credential is exposed.

## What changed

### `.github/workflows/steam-deploy.yml`
- Added `workflow_call` trigger alongside `workflow_dispatch`, with the same three inputs (`release_tag`, `build_description`, `set_live_branch`). The `environment: steam-release` gate remains on the job, so the approval requirement applies on both trigger paths.
- Added `HAS_STEAM_CREDS` job-level env flag (`secrets.STEAM_USERNAME != '' && secrets.STEAM_CONFIG_VDF != ''`). When either secret is absent every step after checkout is skipped and a single INFO message is emitted — the calling release workflow stays green.
- Added **Guard step** that exits 1 if `set_live_branch=default` is requested from a non-`workflow_dispatch` run. Automatic releases can only ever target `beta`.

### `.github/workflows/release.yml`
- Appended `steam` job:
  ```yaml
  steam:
    name: Publish to Steam (beta)
    needs: release
    if: ${{ !cancelled() && needs.release.result == 'success' }}
    uses: ./.github/workflows/steam-deploy.yml
    with:
      release_tag: ${{ github.event.inputs.tag || github.ref_name }}
      set_live_branch: beta
    secrets: inherit
  ```

### `publishing/STEAM_APP_REGISTRATION.md`
- Added **Value** column to the Identifiers table and recorded App ID **4963030**.
- Depot IDs remain placeholders pending partner portal assignment.

### `publishing/STEAM_PUBLISHING_AND_DEPLOYMENT.md`
- Added **Automatic deployment** section documenting the release-to-Steam chain, the `steam-release` approval gate, and the graceful-skip behaviour when credentials are absent.
- Renamed the previous trigger section to **Manual deployment (workflow_dispatch)**.

### `docs/release-checklist.md`
- Added release workflow job chain table (`validate → build-desktop → release → steam`) under Part A, with a note explaining the `steam-release` approval gate and the INFO skip when credentials are not yet configured.

## How it was tested

- YAML syntax verified by inspection; the `workflow_call` / `workflow_dispatch` dual-trigger pattern follows GitHub Actions documentation.
- The `HAS_STEAM_CREDS` pattern matches the existing `HAS_APPLE_CERT` / `HAS_WINDOWS_CERT` convention already used in `release.yml`.
- The Guard step is unit-testable: set `set_live_branch=default` with `EVENT_NAME=workflow_call` and the step exits 1.
- No existing `workflow_dispatch` behaviour was changed; all original inputs, defaults, and step logic are preserved.

Closes #407