### PR TITLE
Add Stage 3 dress rehearsal checklist, signing enforcement, and Windows Defender scan

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,52 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # ── Enforce signing secrets on release tags ───────────────────────────────
+      # A versioned release tag (v*) must produce a signed binary: unsigned macOS
+      # builds are blocked by Gatekeeper and unsigned Windows installers trigger
+      # SmartScreen — both violate gate G3-01 (docs/steam-mvp-scope.md).
+      #
+      # This step fails fast so the gap is caught before a 15-minute build
+      # completes.  Contributor fork builds and workflow_dispatch runs without a
+      # v* tag are treated as unsigned dev builds and are not affected.
+      - name: Enforce signing secrets on release tags
+        if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.event.inputs.tag, 'v')
+        shell: bash
+        env:
+          _HAS_APPLE_CERT: ${{ env.HAS_APPLE_CERT }}
+          _HAS_NOTARIZATION: ${{ env.HAS_NOTARIZATION }}
+          _HAS_WINDOWS_CERT: ${{ env.HAS_WINDOWS_CERT }}
+        run: |
+          fail=0
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            if [ "$_HAS_APPLE_CERT" != "true" ]; then
+              echo "ERROR: APPLE_CERTIFICATE is required for a v* release tag but is not set." >&2
+              echo "       Unsigned macOS builds are blocked by Gatekeeper (gate G3-01)." >&2
+              echo "       See docs/platform-notes.md for certificate setup instructions." >&2
+              fail=1
+            fi
+            if [ "$_HAS_NOTARIZATION" != "true" ]; then
+              echo "ERROR: APPLE_ID is required for notarisation on a v* release tag but is not set." >&2
+              echo "       Non-notarised macOS builds fail Gatekeeper on clean installs (gate G3-01)." >&2
+              echo "       Set APPLE_ID, APPLE_PASSWORD, and APPLE_TEAM_ID secrets to enable notarisation." >&2
+              fail=1
+            fi
+          fi
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            if [ "$_HAS_WINDOWS_CERT" != "true" ]; then
+              echo "ERROR: WINDOWS_SIGN_CERT_PFX is required for a v* release tag but is not set." >&2
+              echo "       Unsigned Windows builds trigger SmartScreen 'unknown publisher' (gate G3-01)." >&2
+              echo "       See docs/platform-notes.md for certificate setup instructions." >&2
+              fail=1
+            fi
+          fi
+          if [ "$fail" -eq 1 ]; then
+            echo ""
+            echo "Add the missing secrets under GitHub → Settings → Secrets and variables → Actions."
+            exit 1
+          fi
+          echo "  OK  All required signing secrets are present for this release tag."
+
       # ── Linux system packages required by Tauri / WebKitGTK ──────────────────
       - name: Install Linux system dependencies
         if: runner.os == 'Linux'
@@ -592,6 +638,96 @@ jobs:
         with:
           name: virustotal-scan-${{ matrix.name }}
           path: ${{ runner.temp }}/virustotal-scan-record.txt
+          if-no-files-found: ignore
+          retention-days: 90
+
+      # ── Scan Windows installers with Windows Defender ─────────────────────────
+      # Runs Windows Defender (MpCmdRun.exe) against each signed installer and
+      # records the verdict.  A clean verdict is required before the G3-01
+      # signing gate can be declared PASS (docs/steam-mvp-scope.md).
+      #
+      # The step is non-blocking: freshly compiled Rust/Tauri executables
+      # occasionally trigger Defender heuristics as false positives, and
+      # blocking CI on a false positive would prevent publishing a clean build.
+      # The verdict is uploaded as a retained artifact so the release drafter
+      # can confirm "Defender verdict: clean" before signing off on G3-01.
+      #
+      # MpCmdRun.exe is present on all GitHub-hosted Windows runners under
+      # C:\ProgramData\Microsoft\Windows Defender\platform\<version>\.
+      # Exit code 0 = clean; exit code 2 = threat found.
+      - name: Scan Windows installers with Windows Defender
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $bundleDir = "apps\desktop\src-tauri\target\release\bundle"
+          $installers = Get-ChildItem -Recurse -Path $bundleDir `
+            -Include "*.exe","*.msi" -ErrorAction SilentlyContinue
+          if (-not $installers) {
+            Write-Host "  WARN  No installers found — skipping Defender scan."
+            exit 0
+          }
+
+          # Locate MpCmdRun.exe — it lives in a versioned subdirectory of
+          # the Defender platform directory on GitHub-hosted Windows runners.
+          $mpCmdRun = Get-ChildItem `
+            -Path 'C:\ProgramData\Microsoft\Windows Defender\platform' `
+            -Recurse -Filter MpCmdRun.exe -ErrorAction SilentlyContinue |
+            Sort-Object FullName -Descending |
+            Select-Object -First 1 -ExpandProperty FullName
+          if (-not $mpCmdRun) {
+            $mpCmdRun = (Get-Command MpCmdRun.exe -ErrorAction SilentlyContinue).Source
+          }
+          if (-not $mpCmdRun) {
+            Write-Host "  WARN  MpCmdRun.exe not found — skipping Defender scan."
+            Write-Host "        Windows Defender may not be present on this runner configuration."
+            exit 0
+          }
+          Write-Host "  Using Defender: $mpCmdRun"
+
+          $recordPath = Join-Path $env:RUNNER_TEMP "defender-scan-record.txt"
+          $allClean = $true
+
+          foreach ($installer in $installers) {
+            $name = $installer.Name
+            Write-Host ""
+            Write-Host "  Scanning: $($installer.FullName)"
+            & $mpCmdRun -Scan -ScanType 3 -File $installer.FullName 2>&1 |
+              ForEach-Object { Write-Host "    $_" }
+            switch ($LASTEXITCODE) {
+              0 {
+                Write-Host "    PASS  Defender verdict: clean"
+                Add-Content -Path $recordPath -Value "${name}: clean (exit 0)"
+              }
+              2 {
+                Write-Host "    FAIL  Defender verdict: THREAT FOUND in ${name}" -ForegroundColor Red
+                Add-Content -Path $recordPath -Value "${name}: THREAT FOUND (exit 2)"
+                $allClean = $false
+              }
+              default {
+                $code = $LASTEXITCODE
+                Write-Host "    WARN  Defender exit code ${code} for ${name} — see scan log above"
+                Add-Content -Path $recordPath -Value "${name}: exit code ${code} (review required)"
+              }
+            }
+          }
+
+          Write-Host ""
+          if ($allClean) {
+            Write-Host "  PASS  All installers passed Windows Defender scan — no threats detected."
+            Write-Host "        Record 'Defender verdict: clean' in the release notes (gate G3-01)."
+          } else {
+            Write-Host "  WARN  One or more installers triggered a Defender detection."
+            Write-Host "        Freshly compiled Rust/Tauri binaries can produce false positives."
+            Write-Host "        Review the scan record, assess whether it is a true positive,"
+            Write-Host "        and do NOT publish until the verdict is understood."
+          }
+
+      - name: Upload Defender scan record
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@v6
+        with:
+          name: defender-scan-${{ matrix.name }}
+          path: ${{ runner.temp }}/defender-scan-record.txt
           if-no-files-found: ignore
           retention-days: 90
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -652,6 +652,12 @@ jobs:
       # The verdict is uploaded as a retained artifact so the release drafter
       # can confirm "Defender verdict: clean" before signing off on G3-01.
       #
+      # -DisableRemediation makes the -File scan report-only: without it, a
+      # detection (including the false positives noted above) triggers Defender's
+      # default quarantine/remove action, which would delete the installer from
+      # the bundle directory before the "Upload desktop installer artifacts" step
+      # and silently drop the Windows installer from the release.
+      #
       # MpCmdRun.exe is present on all GitHub-hosted Windows runners under
       # C:\ProgramData\Microsoft\Windows Defender\platform\<version>\.
       # Exit code 0 = clean; exit code 2 = threat found.
@@ -691,7 +697,7 @@ jobs:
             $name = $installer.Name
             Write-Host ""
             Write-Host "  Scanning: $($installer.FullName)"
-            & $mpCmdRun -Scan -ScanType 3 -File $installer.FullName 2>&1 |
+            & $mpCmdRun -Scan -ScanType 3 -File $installer.FullName -DisableRemediation 2>&1 |
               ForEach-Object { Write-Host "    $_" }
             switch ($LASTEXITCODE) {
               0 {

--- a/docs-site/src/content/docs/dev/release-checklist.md
+++ b/docs-site/src/content/docs/dev/release-checklist.md
@@ -1054,6 +1054,111 @@ attached to the release issue before the Stage 3 gate is declared open.
 
 ---
 
+## Part K — Steam release dress rehearsal
+
+Run this section for the **first `vX.Y.Z-rc.1`** (or next release candidate)
+tag that exercises the entire pipeline end-to-end: build → sign (Win
+Authenticode + Defender scan, macOS Developer ID + notarize + staple) → GitHub
+release → gated Steam upload → `beta` live on App 4963030.  This is the Stage 3
+gate rehearsal required by `docs/steam-mvp-scope.md`.
+
+Complete this section **once per rehearsal run**.  Any failure must be filed as
+a new GitHub issue (no blocking-by — it is by definition the new critical path)
+before the Stage 3 gate can be declared PASS.
+
+### K.1 Pipeline observation (GitHub Actions)
+
+Open the Actions run for the rehearsal tag and confirm each item.
+
+**Build chain:**
+- [ ] Tag push → `validate` → `build-desktop` (macOS-aarch64, Linux-x86_64, Windows-x86_64) — all three matrix jobs green
+- [ ] Signing enforcement step: no `ERROR:` lines on any platform (secrets present for `v*` tag)
+
+**Windows signing and scanning:**
+- [ ] Authenticode signing step log shows all `.exe` / `.msi` installers signed successfully
+- [ ] Authenticode verification step shows `signtool verify /pa` exits 0 for all installers
+- [ ] VirusTotal scan record artifact uploaded; analysis URLs recorded (non-blocking, informational)
+- [ ] Defender scan record artifact uploaded; **Defender verdict: clean** for all installers
+
+**macOS signing and notarization:**
+- [ ] `codesign --verify --deep --strict` exits 0 — no `ERROR:` lines
+- [ ] Hardened Runtime entitlement verification shows all five entitlements present — no `ERROR: expected entitlement … missing` lines
+- [ ] `spctl --assess` exits 0 and prints `accepted` — **no `SKIP` or `INFO` line** (notarisation secrets present)
+- [ ] `xcrun stapler validate` exits 0 — **no `SKIP` line** (stapled ticket present)
+- [ ] `Gate G3-01 macOS criterion met` confirmation line present in the step log
+
+**Updater manifest:**
+- [ ] Updater artifacts signed: `.sig` files present for macOS `.app.tar.gz`, Linux `.AppImage`, and Windows `.exe`
+- [ ] `latest.json` generated and uploaded to the versioned GitHub release
+- [ ] Beta-channel release updated with new `latest.json`
+
+**Steam deploy:**
+- [ ] Steam Deploy workflow triggered manually with `set_live_branch = beta`
+- [ ] Job pauses at `steam-release` environment approval gate — no credentials exposed before approval
+- [ ] **Refusal test** (decline once): workflow exits cleanly; no secret is printed; re-trigger works
+- [ ] Approval granted → `steamcmd +run_app_build` completes without error
+- [ ] `steam-build/output/` log files confirm successful upload
+
+### K.2 Steamworks verification
+
+After the Steam deploy workflow completes with `set_live_branch = beta`:
+
+- [ ] Steamworks → App Admin → Builds: new build visible on the `beta` branch
+- [ ] Build description matches the release tag (e.g. "Conversation Simulator v0.1.0-rc.1")
+- [ ] Depot file counts are **non-zero for all three platforms** (Windows, macOS, Linux) — **App 4963030**, three depots
+- [ ] Steamworks → Builds → [build row] → View Manifest: version field equals the tag (without `v` prefix)
+
+### K.3 Product key install matrix
+
+Request Steam product keys via Steamworks → Packages → [paid package] →
+Request Steam Product Keys.  Distribute only to named testers — never publicly.
+
+At minimum, one tester per platform must complete a full text session and reach
+the debrief screen (satisfies G3-06 beta session verification).
+
+| Platform | Tester | Session + debrief | Steam overlay Shift+Tab (G3-03) | No SmartScreen / Gatekeeper (G3-01) | No outbound TCP (PR-01–03) | Date | Sign-off |
+|----------|--------|-------------------|---------------------------------|--------------------------------------|---------------------------|------|---------|
+| Windows 10/11 clean VM | | ☐ | ☐ | ☐ no SmartScreen | ☐ | | |
+| macOS (Apple Silicon) | | ☐ | ☐ | ☐ Gatekeeper silent | ☐ | | |
+| Linux (Ubuntu 22.04 or Steam Deck Desktop) | | ☐ | ☐ | ☐ AppImage executable | ☐ | | |
+
+### K.4 Dress rehearsal sign-off
+
+Fill this in after K.1, K.2, and K.3 are all complete.
+
+```
+Rehearsal tag        : vX.Y.Z-rc.N
+Rehearsal date       : YYYY-MM-DD
+Release operator     :
+
+CI run URL           :
+Steam deploy run URL :
+
+Pipeline result      : PASS / FAIL
+Steamworks build ID  :
+Defender verdict     : clean / THREAT FOUND (see artifact: defender-scan-Windows-x86_64)
+Depot audit          : PASS / FAIL
+
+Windows tester       :
+macOS tester         :
+Linux tester         :
+
+G3-01 Signing + notarization    : PASS / FAIL  evidence: <CI run URL>
+G3-02 Depot content audit       : PASS / FAIL  evidence: <CI run URL> (Audit depot content step)
+G3-03 Steam overlay             : PASS / FAIL  testers: <names>
+G3-06 Beta session verification : PASS / FAIL  testers: <names>
+
+Notes:
+  -
+  -
+```
+
+> Any failure found during the rehearsal must be filed as a new GitHub issue
+> before the Stage 3 gate is declared PASS.  The issue must reference
+> the rehearsal tag in its body.
+
+---
+
 ## Smoke log
 
 Fill this in for each manual release smoke run.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1050,6 +1050,111 @@ attached to the release issue before the Stage 3 gate is declared open.
 
 ---
 
+## Part K — Steam release dress rehearsal
+
+Run this section for the **first `vX.Y.Z-rc.1`** (or next release candidate)
+tag that exercises the entire pipeline end-to-end: build → sign (Win
+Authenticode + Defender scan, macOS Developer ID + notarize + staple) → GitHub
+release → gated Steam upload → `beta` live on App 4963030.  This is the Stage 3
+gate rehearsal required by `docs/steam-mvp-scope.md`.
+
+Complete this section **once per rehearsal run**.  Any failure must be filed as
+a new GitHub issue (no blocking-by — it is by definition the new critical path)
+before the Stage 3 gate can be declared PASS.
+
+### K.1 Pipeline observation (GitHub Actions)
+
+Open the Actions run for the rehearsal tag and confirm each item.
+
+**Build chain:**
+- [ ] Tag push → `validate` → `build-desktop` (macOS-aarch64, Linux-x86_64, Windows-x86_64) — all three matrix jobs green
+- [ ] Signing enforcement step: no `ERROR:` lines on any platform (secrets present for `v*` tag)
+
+**Windows signing and scanning:**
+- [ ] Authenticode signing step log shows all `.exe` / `.msi` installers signed successfully
+- [ ] Authenticode verification step shows `signtool verify /pa` exits 0 for all installers
+- [ ] VirusTotal scan record artifact uploaded; analysis URLs recorded (non-blocking, informational)
+- [ ] Defender scan record artifact uploaded; **Defender verdict: clean** for all installers
+
+**macOS signing and notarization:**
+- [ ] `codesign --verify --deep --strict` exits 0 — no `ERROR:` lines
+- [ ] Hardened Runtime entitlement verification shows all five entitlements present — no `ERROR: expected entitlement … missing` lines
+- [ ] `spctl --assess` exits 0 and prints `accepted` — **no `SKIP` or `INFO` line** (notarisation secrets present)
+- [ ] `xcrun stapler validate` exits 0 — **no `SKIP` line** (stapled ticket present)
+- [ ] `Gate G3-01 macOS criterion met` confirmation line present in the step log
+
+**Updater manifest:**
+- [ ] Updater artifacts signed: `.sig` files present for macOS `.app.tar.gz`, Linux `.AppImage`, and Windows `.exe`
+- [ ] `latest.json` generated and uploaded to the versioned GitHub release
+- [ ] Beta-channel release updated with new `latest.json`
+
+**Steam deploy:**
+- [ ] Steam Deploy workflow triggered manually with `set_live_branch = beta`
+- [ ] Job pauses at `steam-release` environment approval gate — no credentials exposed before approval
+- [ ] **Refusal test** (decline once): workflow exits cleanly; no secret is printed; re-trigger works
+- [ ] Approval granted → `steamcmd +run_app_build` completes without error
+- [ ] `steam-build/output/` log files confirm successful upload
+
+### K.2 Steamworks verification
+
+After the Steam deploy workflow completes with `set_live_branch = beta`:
+
+- [ ] Steamworks → App Admin → Builds: new build visible on the `beta` branch
+- [ ] Build description matches the release tag (e.g. "Conversation Simulator v0.1.0-rc.1")
+- [ ] Depot file counts are **non-zero for all three platforms** (Windows, macOS, Linux) — **App 4963030**, three depots
+- [ ] Steamworks → Builds → [build row] → View Manifest: version field equals the tag (without `v` prefix)
+
+### K.3 Product key install matrix
+
+Request Steam product keys via Steamworks → Packages → [paid package] →
+Request Steam Product Keys.  Distribute only to named testers — never publicly.
+
+At minimum, one tester per platform must complete a full text session and reach
+the debrief screen (satisfies G3-06 beta session verification).
+
+| Platform | Tester | Session + debrief | Steam overlay Shift+Tab (G3-03) | No SmartScreen / Gatekeeper (G3-01) | No outbound TCP (PR-01–03) | Date | Sign-off |
+|----------|--------|-------------------|---------------------------------|--------------------------------------|---------------------------|------|---------|
+| Windows 10/11 clean VM | | ☐ | ☐ | ☐ no SmartScreen | ☐ | | |
+| macOS (Apple Silicon) | | ☐ | ☐ | ☐ Gatekeeper silent | ☐ | | |
+| Linux (Ubuntu 22.04 or Steam Deck Desktop) | | ☐ | ☐ | ☐ AppImage executable | ☐ | | |
+
+### K.4 Dress rehearsal sign-off
+
+Fill this in after K.1, K.2, and K.3 are all complete.
+
+```
+Rehearsal tag        : vX.Y.Z-rc.N
+Rehearsal date       : YYYY-MM-DD
+Release operator     :
+
+CI run URL           :
+Steam deploy run URL :
+
+Pipeline result      : PASS / FAIL
+Steamworks build ID  :
+Defender verdict     : clean / THREAT FOUND (see artifact: defender-scan-Windows-x86_64)
+Depot audit          : PASS / FAIL
+
+Windows tester       :
+macOS tester         :
+Linux tester         :
+
+G3-01 Signing + notarization    : PASS / FAIL  evidence: <CI run URL>
+G3-02 Depot content audit       : PASS / FAIL  evidence: <CI run URL> (Audit depot content step)
+G3-03 Steam overlay             : PASS / FAIL  testers: <names>
+G3-06 Beta session verification : PASS / FAIL  testers: <names>
+
+Notes:
+  -
+  -
+```
+
+> Any failure found during the rehearsal must be filed as a new GitHub issue
+> before the Stage 3 gate is declared PASS.  The issue must reference
+> the rehearsal tag in its body.
+
+---
+
 ## Smoke log
 
 Fill this in for each manual release smoke run.

--- a/publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md
+++ b/publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md
@@ -320,9 +320,9 @@ the decisions for Steam review and partner portal audit purposes.
 | **Area** | Platform |
 | **Risk** | The release build is not code-signed or notarised, causing macOS Gatekeeper or Windows SmartScreen to block installation and generating player support load. |
 | **Owner** | Platform team |
-| **Mitigation** | macOS: Gatekeeper notarisation is a hard requirement before public release (Stage 4). Windows: SmartScreen Extended Validation code signing is required. Both are tracked as release gates in `docs/STEAM_ROADMAP.md`. Certificates and signing infrastructure must be in place before the private beta depot is built. |
+| **Mitigation** | macOS: Gatekeeper notarisation is a hard requirement before public release (Stage 4). Windows: SmartScreen Extended Validation code signing is required. Both are tracked as release gates in `docs/STEAM_ROADMAP.md`. Certificates and signing infrastructure must be in place before the private beta depot is built. CI enforcement: the `build-desktop` job in `.github/workflows/release.yml` fails early when `APPLE_CERTIFICATE`, `APPLE_ID`, or `WINDOWS_SIGN_CERT_PFX` is absent on a `v*` tag, preventing an unsigned artifact from being published. The macOS signing step asserts all five Hardened Runtime entitlements and runs `spctl --assess` + `xcrun stapler validate` — any SKIP or FAIL on a `v*` tag causes the job to exit non-zero. |
 | **Release-blocking** | YES |
-| **Status** | OPEN |
+| **Status** | MITIGATED |
 
 ### SP-05 — First-party Steam DLC path for premium scenario packs
 
@@ -431,10 +431,51 @@ Complete before submitting to Valve for private beta review.
 | SR-08 Depot content audit | Platform team | | | |
 | Full `docs/release-checklist.md` Part A | CI | | | |
 | Full `docs/release-checklist.md` Parts B + C | Platform team | | | |
+| **G3-01 Signing + notarization** | Platform team | | | macOS: `spctl` + `stapler validate` green; Windows: `signtool verify` + Defender clean |
+| **G3-02 Steam depot content audit** | Platform team | | | `depot-audit.sh` exits 0 for all three platforms; no weight files |
+| **G3-03 Steam overlay compatibility** | Beta testers | | | Shift+Tab opens/closes without session disruption; push-to-talk key conflict-free |
+| **G3-06 Beta session verification** | Beta testers (≥ 3 platforms) | | | ≥ 1 tester per platform completes text session + debrief; no open blockers |
 
 All gates must show **Pass** before the private beta depot is submitted to Valve.
 Any **Fail** must have a tracked issue with an owner and a target date before the
 team is unblocked.
+
+---
+
+### SR-10 — Stage 3 dress rehearsal record
+
+Fill this section in after completing `docs/release-checklist.md` Part K for the
+first release candidate tag.  This record is the evidence that the entire pipeline
+has been exercised end-to-end before the real beta submission.
+
+```
+Rehearsal tag        : vX.Y.Z-rc.N
+Rehearsal date       : YYYY-MM-DD
+Release operator     :
+
+CI run URL           :
+Steam deploy run URL :
+
+Pipeline result      : PASS / FAIL
+Steamworks build ID  :
+Steam App ID         : 4963030
+Branch set live      : beta
+
+Defender verdict     : clean / THREAT FOUND (artifact: defender-scan-Windows-x86_64)
+Depot audit          : PASS / FAIL
+
+Windows tester       :
+macOS tester         :
+Linux tester         :
+
+G3-01 Signing + notarization    : PASS / FAIL  evidence: <CI run URL>
+G3-02 Depot content audit       : PASS / FAIL  evidence: <CI run URL>
+G3-03 Steam overlay             : PASS / FAIL  testers: <names>
+G3-06 Beta session verification : PASS / FAIL  testers: <names>
+
+Notes:
+  -
+```
 
 ---
 
@@ -464,7 +505,7 @@ team is unblocked.
 | SP-01 | Platform | YES | OPEN |
 | SP-02 | Platform | YES | OPEN |
 | SP-03 | Platform | NO | OPEN |
-| SP-04 | Platform | YES | OPEN |
+| SP-04 | Platform | YES | MITIGATED |
 | SP-05 | Platform / Licensing | YES | IN PROGRESS |
 
 ---


### PR DESCRIPTION
## Summary

Add Stage 3 dress rehearsal checklist, CI signing enforcement, and Windows Defender scanning to the release workflow. These changes operationalize the gate criteria from `docs/steam-mvp-scope.md` (G3-01 signing/notarization, G3-02 depot audit, G3-03 Steam overlay, G3-06 beta verification) and provide evidence artifacts for release sign-off.

## Changes

### `.github/workflows/release.yml`

**Signing enforcement on `v*` tags:**
- New step `Enforce signing secrets on release tags` fails fast before the 15-minute Tauri build when required signing secrets (`APPLE_CERTIFICATE`, `APPLE_ID`, `WINDOWS_SIGN_CERT_PFX`) are absent on a versioned release tag. This closes a gap where unsigned builds previously shipped to CI artifact storage via INFO/SKIP lines.
- Enforcement only applies to `v*` tags (via `startsWith(github.ref, 'refs/tags/v')`) or `workflow_dispatch` with a `tag` input starting with `v`. Contributor fork builds and unsigned dev runs are unaffected.

**Windows Defender scan:**
- New step `Scan Windows installers with Windows Defender` runs `MpCmdRun.exe -Scan -ScanType 3 -File <installer> -DisableRemediation` against every signed `.exe` and `.msi`.
- The `-DisableRemediation` flag runs the scan in report-only mode so that false positives (common in freshly compiled Rust/Tauri binaries) do not quarantine the installer.
- Exit code 0 = clean; exit code 2 = threat found. Scan results are recorded and uploaded as a retained artifact (`defender-scan-<platform>`, 90-day retention).
- The step is non-blocking: Defender verdicts must be reviewed and confirmed clean before gate G3-01 is declared PASS, but a detection does not fail CI to avoid false-positive gate failures.
- Gracefully skips if `MpCmdRun.exe` is not found on the runner.

### `docs/release-checklist.md` + mirror at `docs-site/src/content/docs/dev/release-checklist.md`

**Part K — Steam release dress rehearsal:**
- Covers the first `vX.Y.Z-rc.N` tag that exercises the entire pipeline end-to-end: build → sign (Authenticode + Defender scan, Developer ID + notarize + staple) → GitHub release → gated Steam upload → `beta` live.
- **K.1 Pipeline observation**: Checklist for verifying signing enforcement, Authenticode and notarization steps, Defender verdict, updater manifest, and Steam deploy gate (with a refusal-test instruction).
- **K.2 Steamworks verification**: Confirms build visible on `beta` branch, all three depot file counts non-zero, and version field matches tag in manifest.
- **K.3 Product key install matrix**: One tester per platform (Windows 10/11, macOS Apple Silicon, Linux/Steam Deck) completes a text session + debrief to verify G3-06.
- **K.4 Dress rehearsal sign-off template**: Captures rehearsal tag, date, operator, CI/Steam deploy URLs, Defender verdict, Steamworks build ID, tester names, and explicit G3-01/02/03/06 outcomes with evidence links. Must be filled in before the Stage 3 gate can be declared PASS.

### `publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md`

**SP-04 (code signing failure):** Updated from `OPEN` → `MITIGATED`
- Added CI enforcement detail: `build-desktop` job fails early on `v*` tags when signing secrets are absent.
- Noted macOS step assertion of five Hardened Runtime entitlements and `spctl --assess` + `xcrun stapler validate` exit code checks (hard failure on `v*` if SKIP or FAIL).

**SR-09 private beta sign-off table:** Extended with explicit rows for:
- **G3-01 Signing + notarization**: macOS `spctl` + `stapler validate` green; Windows `signtool verify` + Defender clean
- **G3-02 Steam depot content audit**: All platforms pass `depot-audit.sh` exit 0; no weight files
- **G3-03 Steam overlay compatibility**: Shift+Tab opens/closes without disruption; no push-to-talk key conflict
- **G3-06 Beta session verification**: ≥ 1 tester per platform completes text session + debrief; no blockers

**SR-10 new section — Stage 3 dress rehearsal record:**
- Template for recording the output of Part K with sections for:
  - Rehearsal metadata (tag, date, operator, CI/deploy URLs)
  - Pipeline result (PASS/FAIL)
  - Steamworks build ID and App ID (4963030)
  - Defender verdict and depot audit result
  - Tester names (Windows, macOS, Linux)
  - Per-gate outcomes (G3-01, G3-02, G3-03, G3-06) with evidence links
  - Notes for any failures found

**Risk register summary table:** SP-04 status updated to `MITIGATED`.

## How it works

- On a contributor branch or non-versioned `workflow_dispatch` run: the signing enforcement and Defender scan steps run but do not block unsigned dev builds.
- On a `v*` tag push: CI enforces signing secrets upfront (fast fail) and adds a non-blocking Defender scan verdict. Release drafters must confirm the verdict before gate G3-01 sign-off.
- The dress rehearsal checklist (Part K) and sign-off template (K.4 and SR-10) document how to exercise and record each criterion for the Stage 3 gates.
- All changes are backwards-compatible; existing workflows and CI flows are not affected.

## Testing

The workflow changes are non-breaking on unsigned builds and gated behind the `v*` tag condition. The Defender scan step gracefully handles runners where `MpCmdRun.exe` is not available. Documentation is a pure addition and does not alter existing behavior.

Closing #409

Closes #409