### PR TITLE
Add ASC API key notarization support, enforce macOS signing on release tags, and harden Steam deploy signature check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,9 +39,20 @@ jobs:
     # make Tauri attempt its own keychain import without the password).
     env:
       HAS_APPLE_CERT: ${{ secrets.APPLE_CERTIFICATE != '' }}
-      HAS_NOTARIZATION: ${{ secrets.APPLE_ID != '' }}
+      # HAS_NOTARIZATION is true when either the preferred ASC API key trio or
+      # the Apple-ID fallback trio is configured.  Both paths drive the same
+      # notarytool submission inside Tauri; only the authentication method differs.
+      HAS_NOTARIZATION: ${{ secrets.APPLE_ID != '' || secrets.APPLE_API_KEY != '' }}
+      HAS_ASC_API_KEY: ${{ secrets.APPLE_API_KEY != '' }}
       HAS_WINDOWS_CERT: ${{ secrets.WINDOWS_SIGN_CERT_PFX != '' }}
       HAS_UPDATER_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY != '' }}
+      # REQUIRE_SIGNED_MACOS is true on release tags (any v*) regardless of
+      # whether the run was triggered by a git push or workflow_dispatch.
+      # When true, the verify step fails (rather than INFO-skips) if the macOS
+      # build was not signed and notarised.  This turns gate G3-01 from a manual
+      # checklist item into a hard CI enforcement.  Contributor forks and PR
+      # builds are unaffected because they never carry a v* tag.
+      REQUIRE_SIGNED_MACOS: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.tag, 'v')) }}
       # Steam depot builds bundle llama-server so players get zero-setup
       # inference; GitHub release installers stay lean and download it on first
       # run (see docs/model-download-policy.md §8). This one workflow feeds both
@@ -259,18 +270,34 @@ jobs:
           grep '"version"' "$CONF"
 
       # ── Tauri desktop build ──────────────────────────────────────────────────
-      # On macOS, Tauri reads APPLE_SIGNING_IDENTITY, APPLE_ID, APPLE_PASSWORD,
-      # and APPLE_TEAM_ID to sign the .app bundle and submit it to Apple's
-      # notarisation service automatically.  These env vars are no-ops on Linux
-      # and Windows.  When the secrets are absent the build is unsigned (suitable
-      # for dev/internal builds but blocked by Gatekeeper on clean installs).
+      # On macOS, Tauri reads APPLE_SIGNING_IDENTITY and notarisation credentials
+      # to sign the .app bundle and submit it to Apple's notary service.
+      # These env vars are no-ops on Linux and Windows.  When the secrets are
+      # absent the build is unsigned (suitable for dev/internal builds but
+      # blocked by Gatekeeper on clean installs).
       #
-      # Absent secrets expand to *empty strings*, not unset variables. Tauri's
-      # macOS bundler reads APPLE_SIGNING_IDENTITY as Ok("") and tries to codesign
-      # with an empty identity ("Signing with identity \"\"" → "no identity found"
-      # → "failed to bundle project"). We must therefore fully *unset* the Apple
-      # signing env vars when no identity is configured, so Tauri skips signing and
-      # emits an unsigned .app instead of failing the build. No-op on Linux/Windows.
+      # Notarisation auth — two supported paths, in order of preference:
+      #
+      # 1. App Store Connect API key (preferred):
+      #      APPLE_API_KEY      — key ID (e.g. "ABCDE12345")
+      #      APPLE_API_ISSUER   — issuer UUID from App Store Connect
+      #      APPLE_API_KEY_PATH — base64-encoded .p8 private key content
+      #                           (decoded to a temp file before the build)
+      #    No 2FA coupling; revocable and scoped to App Manager role.
+      #
+      # 2. Apple ID + app-specific password (fallback):
+      #      APPLE_ID           — Apple ID email used for notarisation
+      #      APPLE_PASSWORD     — app-specific password for Apple ID
+      #      APPLE_TEAM_ID      — ten-character team ID (required for both paths)
+      #
+      # When both are configured, ASC API key takes precedence: Apple ID
+      # credentials are unset so Tauri only uses the ASC key path.
+      #
+      # Absent APPLE_SIGNING_IDENTITY expands to an empty string. Tauri's
+      # macOS bundler reads Ok("") and tries to codesign with an empty identity
+      # ("Signing with identity \"\"" → "no identity found" → build failure).
+      # We therefore fully *unset* all Apple signing env vars when no identity
+      # is configured, so Tauri skips signing and emits an unsigned .app.
       - name: Build Tauri desktop
         shell: bash
         env:
@@ -278,6 +305,14 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          # ASC API key credentials (preferred notarisation auth — see above).
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          # APPLE_API_KEY_PATH secret stores the base64-encoded .p8 content;
+          # renamed here to avoid a collision with the APPLE_API_KEY_PATH env
+          # var that Tauri expects to hold a filesystem path.  The script below
+          # decodes this value to a temp file and then sets APPLE_API_KEY_PATH.
+          APPLE_API_KEY_PATH_B64: ${{ secrets.APPLE_API_KEY_PATH }}
           # Non-secret repo variable: pack-id ↔ DLC App ID mapping baked into
           # both the Vite bundle (VITE_ prefix) and validated by build.rs.
           # The beforeBuildCommand in tauri.conf.json re-runs `pnpm web build`
@@ -286,8 +321,23 @@ jobs:
         run: |
           if [ -z "${APPLE_SIGNING_IDENTITY:-}" ]; then
             unset APPLE_SIGNING_IDENTITY APPLE_ID APPLE_PASSWORD APPLE_TEAM_ID
+            unset APPLE_API_KEY APPLE_API_ISSUER
+          elif [ -n "${APPLE_API_KEY:-}" ] && [ -n "${APPLE_API_ISSUER:-}" ] && \
+               [ -n "${APPLE_API_KEY_PATH_B64:-}" ]; then
+            # ASC API key path (preferred): decode .p8 to a temp file and tell
+            # Tauri where it lives.  Clear Apple ID credentials so Tauri does
+            # not attempt both auth paths simultaneously.
+            ASC_KEY_FILE="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY}.p8"
+            printf '%s' "$APPLE_API_KEY_PATH_B64" | base64 --decode > "$ASC_KEY_FILE"
+            chmod 600 "$ASC_KEY_FILE"
+            export APPLE_API_KEY_PATH="$ASC_KEY_FILE"
+            unset APPLE_ID APPLE_PASSWORD
           fi
           pnpm --filter @convsim/desktop build
+          # Scrub the decoded ASC private key from disk the moment the build ends.
+          if [ -n "${ASC_KEY_FILE:-}" ] && [ -f "${ASC_KEY_FILE:-}" ]; then
+            rm -f "$ASC_KEY_FILE"
+          fi
 
       # ── Verify macOS signature, entitlements, notarization, and stapling ──────
       # Confirms that Tauri's signing + Apple notarisation pipeline completed
@@ -310,15 +360,39 @@ jobs:
       # Gate G3-01: notarised + Gatekeeper-accepted macOS build required for
       # Stage 3 Steam private beta — see docs/steam-mvp-scope.md.
       #
-      # When APPLE_CERTIFICATE is absent the step exits 0 with an INFO message
-      # (unsigned build — acceptable for dev/contributor builds).
+      # Enforcement: when REQUIRE_SIGNED_MACOS is true (any v* release tag) this
+      # step FAILS rather than INFO-skips when APPLE_CERTIFICATE is absent or
+      # notarisation was skipped.  This makes gate G3-01 a hard CI requirement
+      # on every tagged release.  Contributor forks and PR builds (no v* tag)
+      # continue to skip with an informational message.
       - name: Verify macOS signature, entitlements, notarization, and stapling
-        if: runner.os == 'macOS' && env.HAS_APPLE_CERT == 'true'
+        if: runner.os == 'macOS' && (env.HAS_APPLE_CERT == 'true' || env.REQUIRE_SIGNED_MACOS == 'true')
         shell: bash
         env:
+          HAS_APPLE_CERT: ${{ env.HAS_APPLE_CERT }}
           HAS_NOTARIZATION: ${{ env.HAS_NOTARIZATION }}
+          REQUIRE_SIGNED_MACOS: ${{ env.REQUIRE_SIGNED_MACOS }}
         run: |
           set -euo pipefail
+
+          # ── Enforcement gate ─────────────────────────────────────────────────
+          if [ "${HAS_APPLE_CERT:-}" != "true" ]; then
+            if [ "${REQUIRE_SIGNED_MACOS:-}" = "true" ]; then
+              echo "ERROR: APPLE_CERTIFICATE is not configured but a signed macOS build" >&2
+              echo "       is required for this release tag." >&2
+              echo "       Tagged releases (v*) enforce gate G3-01: the macOS .app must" >&2
+              echo "       be code-signed, notarised, and Gatekeeper-accepted." >&2
+              echo "       Set the APPLE_CERTIFICATE org secret and rerun this workflow." >&2
+              echo "       See publishing/MACOS_SIGNING_AND_NOTARIZATION.md." >&2
+              exit 1
+            else
+              echo "  INFO  APPLE_CERTIFICATE is not set — unsigned build (dev / contributor fork)."
+              echo "        Signing and notarisation are required for gate G3-01"
+              echo "        (Stage 3/4 Steam release).  See publishing/MACOS_SIGNING_AND_NOTARIZATION.md."
+              exit 0
+            fi
+          fi
+
           BUNDLE_DIR=apps/desktop/src-tauri/target/release/bundle/macos
           APP_PATH="$(find "$BUNDLE_DIR" -maxdepth 1 -name '*.app' | head -n1)"
           if [ -z "$APP_PATH" ]; then
@@ -359,12 +433,25 @@ jobs:
             xcrun stapler validate "$APP_PATH"
             echo "  Gate G3-01 macOS criterion met: signed, notarised, and Gatekeeper-accepted."
           else
-            echo ""
-            echo "  SKIP  APPLE_ID is not set — notarization and Gatekeeper checks skipped."
-            echo "        The .app is code-signed but not notarised."
-            echo "        Gatekeeper will block this build on clean macOS installs."
-            echo "        Set APPLE_ID, APPLE_PASSWORD, and APPLE_TEAM_ID secrets to enable"
-            echo "        notarisation (required for gate G3-01)."
+            if [ "${REQUIRE_SIGNED_MACOS:-}" = "true" ]; then
+              echo ""
+              echo "ERROR: No notarisation credentials are configured but a notarised" >&2
+              echo "       build is required for this release tag." >&2
+              echo "       Tagged releases (v*) enforce gate G3-01: the macOS .app must" >&2
+              echo "       be notarised and the ticket must be stapled." >&2
+              echo "       Preferred: set APPLE_API_KEY, APPLE_API_ISSUER, and APPLE_API_KEY_PATH." >&2
+              echo "       Fallback:  set APPLE_ID, APPLE_PASSWORD, and APPLE_TEAM_ID." >&2
+              echo "       See publishing/MACOS_SIGNING_AND_NOTARIZATION.md." >&2
+              exit 1
+            else
+              echo ""
+              echo "  SKIP  No notarisation credentials configured."
+              echo "        The .app is code-signed but not notarised."
+              echo "        Gatekeeper will block this build on clean macOS installs."
+              echo "        Preferred: set APPLE_API_KEY / APPLE_API_ISSUER / APPLE_API_KEY_PATH."
+              echo "        Fallback:  set APPLE_ID / APPLE_PASSWORD / APPLE_TEAM_ID."
+              echo "        Notarisation is required for gate G3-01."
+            fi
           fi
 
       # ── Authenticode signing (Windows only, optional) ─────────────────────────

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -319,6 +319,12 @@ jobs:
           # so this env var reaches Vite automatically.
           VITE_STEAM_DLC_APP_IDS: ${{ vars.STEAM_DLC_APP_IDS }}
         run: |
+          # Scrub the decoded ASC private key from disk on ANY exit — including a
+          # failed build.  GitHub runs this step with `bash -e`, so a `pnpm build`
+          # failure aborts before a trailing `rm` would run; an EXIT trap is the
+          # only way to guarantee the .p8 never outlives the step.
+          ASC_KEY_FILE=""
+          trap 'rm -f "${ASC_KEY_FILE:-}"' EXIT
           if [ -z "${APPLE_SIGNING_IDENTITY:-}" ]; then
             unset APPLE_SIGNING_IDENTITY APPLE_ID APPLE_PASSWORD APPLE_TEAM_ID
             unset APPLE_API_KEY APPLE_API_ISSUER
@@ -334,10 +340,6 @@ jobs:
             unset APPLE_ID APPLE_PASSWORD
           fi
           pnpm --filter @convsim/desktop build
-          # Scrub the decoded ASC private key from disk the moment the build ends.
-          if [ -n "${ASC_KEY_FILE:-}" ] && [ -f "${ASC_KEY_FILE:-}" ]; then
-            rm -f "$ASC_KEY_FILE"
-          fi
 
       # ── Verify macOS signature, entitlements, notarization, and stapling ──────
       # Confirms that Tauri's signing + Apple notarisation pipeline completed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,6 @@ jobs:
       # the Apple-ID fallback trio is configured.  Both paths drive the same
       # notarytool submission inside Tauri; only the authentication method differs.
       HAS_NOTARIZATION: ${{ secrets.APPLE_ID != '' || secrets.APPLE_API_KEY != '' }}
-      HAS_ASC_API_KEY: ${{ secrets.APPLE_API_KEY != '' }}
       HAS_WINDOWS_CERT: ${{ secrets.WINDOWS_SIGN_CERT_PFX != '' }}
       HAS_UPDATER_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY != '' }}
       # REQUIRE_SIGNED_MACOS is true on release tags (any v*) regardless of

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -383,6 +383,16 @@ jobs:
             chmod 600 "$ASC_KEY_FILE"
             export APPLE_API_KEY_PATH="$ASC_KEY_FILE"
             unset APPLE_ID APPLE_PASSWORD
+          else
+            # Apple ID fallback: the ASC key trio is not (fully) configured.
+            # The step env block still injected APPLE_API_KEY / APPLE_API_ISSUER
+            # as *empty strings*, and Tauri's bundler selects the notarisation
+            # auth path by the *presence* of APPLE_API_KEY, not by whether it is
+            # non-empty (the same Ok("") footgun that forces us to unset an empty
+            # APPLE_SIGNING_IDENTITY above).  A present-but-empty APPLE_API_KEY
+            # would make Tauri attempt the ASC key path with no key and fail, so
+            # unset them and let Tauri use the Apple ID trio.
+            unset APPLE_API_KEY APPLE_API_ISSUER APPLE_API_KEY_PATH
           fi
           pnpm --filter @convsim/desktop build
 

--- a/.github/workflows/steam-deploy.yml
+++ b/.github/workflows/steam-deploy.yml
@@ -263,11 +263,15 @@ jobs:
       # Gatekeeper to block the app on clean macOS installs and violates gate
       # G3-01 (docs/steam-mvp-scope.md).
       #
-      # Non-blocking: a missing signature emits a WARN (not an error) so that
-      # dry-run and internal staging uploads of unsigned dev builds are not
-      # blocked.  Signed builds must be used for any Stage 3+ release.
+      # Enforcement: when set_live_branch is non-empty (Stage 3+ deploy) a
+      # missing signature is a HARD ERROR — staging an unsigned build as live
+      # would close the "unsigned build set live" hole.  Dry-run uploads
+      # (set_live_branch='') still emit a WARN so unsigned dev builds can be
+      # staged for inspection without being promoted to a live branch.
       - name: Verify macOS .app code-signature presence
         if: env.HAS_STEAM_CREDS == 'true'
+        env:
+          SET_LIVE_BRANCH: ${{ inputs.set_live_branch }}
         run: |
           APP_PATH="$(find steam-content/macos -maxdepth 1 -name '*.app' -type d \
             2>/dev/null | head -n1)"
@@ -280,11 +284,21 @@ jobs:
             echo "      Notarisation was verified in release.yml before artifact upload."
             echo "      Gate G3-01 macOS signature criterion satisfied."
           else
-            echo "  WARN  $APP_PATH does not contain a code signature (_CodeSignature missing)." >&2
-            echo "        Signed and notarised builds are required for Stage 3/4 Steam release" >&2
-            echo "        (gate G3-01 in docs/steam-mvp-scope.md)." >&2
-            echo "        This warning does not block dry-run or internal staging uploads." >&2
-            echo "        See docs/platform-notes.md for signing requirements." >&2
+            if [ -n "${SET_LIVE_BRANCH:-}" ]; then
+              echo "  ERROR  $APP_PATH does not contain a code signature (_CodeSignature missing)." >&2
+              echo "         set_live_branch='$SET_LIVE_BRANCH' — refusing to promote an unsigned" >&2
+              echo "         macOS build to a live Steam branch." >&2
+              echo "         Signed and notarised builds are required for Stage 3/4 Steam release" >&2
+              echo "         (gate G3-01 in docs/steam-mvp-scope.md)." >&2
+              echo "         Re-run release.yml with signing secrets configured, then redeploy." >&2
+              exit 1
+            else
+              echo "  WARN  $APP_PATH does not contain a code signature (_CodeSignature missing)." >&2
+              echo "        Signed and notarised builds are required for Stage 3/4 Steam release" >&2
+              echo "        (gate G3-01 in docs/steam-mvp-scope.md)." >&2
+              echo "        Dry-run upload continues (set_live_branch is empty)." >&2
+              echo "        Do not promote this build to a live branch without signing first." >&2
+            fi
           fi
 
       # ── Verify no forbidden files are staged ───────────────────────────────

--- a/.github/workflows/steam-deploy.yml
+++ b/.github/workflows/steam-deploy.yml
@@ -199,10 +199,14 @@ jobs:
       # Gatekeeper to block the app on clean macOS installs and violates gate
       # G3-01 (docs/steam-mvp-scope.md).
       #
-      # Non-blocking: a missing signature emits a WARN (not an error) so that
-      # dry-run and internal staging uploads of unsigned dev builds are not
-      # blocked.  Signed builds must be used for any Stage 3+ release.
+      # Enforcement: when set_live_branch is non-empty (Stage 3+ deploy) a
+      # missing signature is a HARD ERROR — staging an unsigned build as live
+      # would close the "unsigned build set live" hole.  Dry-run uploads
+      # (set_live_branch='') still emit a WARN so unsigned dev builds can be
+      # staged for inspection without being promoted to a live branch.
       - name: Verify macOS .app code-signature presence
+        env:
+          SET_LIVE_BRANCH: ${{ inputs.set_live_branch }}
         run: |
           APP_PATH="$(find steam-content/macos -maxdepth 1 -name '*.app' -type d \
             2>/dev/null | head -n1)"
@@ -215,11 +219,21 @@ jobs:
             echo "      Notarisation was verified in release.yml before artifact upload."
             echo "      Gate G3-01 macOS signature criterion satisfied."
           else
-            echo "  WARN  $APP_PATH does not contain a code signature (_CodeSignature missing)." >&2
-            echo "        Signed and notarised builds are required for Stage 3/4 Steam release" >&2
-            echo "        (gate G3-01 in docs/steam-mvp-scope.md)." >&2
-            echo "        This warning does not block dry-run or internal staging uploads." >&2
-            echo "        See docs/platform-notes.md for signing requirements." >&2
+            if [ -n "${SET_LIVE_BRANCH:-}" ]; then
+              echo "  ERROR  $APP_PATH does not contain a code signature (_CodeSignature missing)." >&2
+              echo "         set_live_branch='$SET_LIVE_BRANCH' — refusing to promote an unsigned" >&2
+              echo "         macOS build to a live Steam branch." >&2
+              echo "         Signed and notarised builds are required for Stage 3/4 Steam release" >&2
+              echo "         (gate G3-01 in docs/steam-mvp-scope.md)." >&2
+              echo "         Re-run release.yml with signing secrets configured, then redeploy." >&2
+              exit 1
+            else
+              echo "  WARN  $APP_PATH does not contain a code signature (_CodeSignature missing)." >&2
+              echo "        Signed and notarised builds are required for Stage 3/4 Steam release" >&2
+              echo "        (gate G3-01 in docs/steam-mvp-scope.md)." >&2
+              echo "        Dry-run upload continues (set_live_branch is empty)." >&2
+              echo "        Do not promote this build to a live branch without signing first." >&2
+            fi
           fi
 
       # ── Verify no forbidden files are staged ───────────────────────────────

--- a/.github/workflows/steam-deploy.yml
+++ b/.github/workflows/steam-deploy.yml
@@ -269,6 +269,7 @@ jobs:
       # (set_live_branch='') still emit a WARN so unsigned dev builds can be
       # staged for inspection without being promoted to a live branch.
       - name: Verify macOS .app code-signature presence
+        if: env.HAS_STEAM_CREDS == 'true'
         env:
           SET_LIVE_BRANCH: ${{ inputs.set_live_branch }}
         run: |

--- a/apps/desktop/src-tauri/entitlements.plist
+++ b/apps/desktop/src-tauri/entitlements.plist
@@ -31,10 +31,18 @@
     <true/>
 
     <!--
-      The Steamworks SDK (libsteam_api.dylib) and llama.cpp runtime are signed
-      by their respective vendors, not by Apple.  Library validation must be
-      disabled so these third-party dylibs load correctly under Hardened Runtime.
-      This is the standard entitlement for Steam-distributed apps.
+      The Steamworks SDK (libsteam_api.dylib / steamclient.dylib) and the
+      llama.cpp runtime are signed by their respective vendors, not by Apple.
+      Library validation must be disabled so these third-party dylibs load
+      correctly under Hardened Runtime.  This is the standard entitlement for
+      Steam-distributed apps.
+
+      FeverTilt lesson: this entitlement is specifically what allows Hardened
+      Runtime apps to load Valve's steamclient.dylib — without it the Steam
+      overlay and Steamworks SDK calls fail silently at launch.  Keep this
+      entitlement even if Steamworks SDK integration appears inactive; it
+      becomes load-bearing the moment steam feature compilation is enabled.
+      See docs/steam-achievements-stats-rich-presence.md for context.
     -->
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -665,6 +665,47 @@ profile where the app has never been opened before.
 - [ ] No persistent security exception in System Settings → Privacy & Security
   is required after first launch
 
+#### G.1a `.app.tar.gz` round-trip signature preservation (one-time per release)
+
+Verifies that the signature and stapled ticket survive the `.app.tar.gz`
+packaging step in `release.yml` and the extraction step in `steam-deploy.yml`.
+Run this once per release on a macOS machine **before** declaring G3-01 closed.
+
+```bash
+# Download the .app.tar.gz from the GitHub release page (or from release-artifacts/).
+# Replace <tag> with the release tag, e.g. v0.1.0.
+gh release download <tag> --pattern "*.app.tar.gz" --dir /tmp/convsim-roundtrip/
+
+# Extract the .app bundle.
+mkdir -p /tmp/convsim-roundtrip/app
+tar -xzf /tmp/convsim-roundtrip/*.app.tar.gz -C /tmp/convsim-roundtrip/app/
+
+APP="$(find /tmp/convsim-roundtrip/app -maxdepth 1 -name '*.app' | head -n1)"
+
+# Verify Gatekeeper still accepts the bundle after the tar round-trip.
+spctl --assess --type execute --verbose "$APP"
+# Expected: ConversationSimulator.app: accepted
+#           source=Notarized Developer ID
+
+# Confirm the stapled ticket survives (offline check — no Apple CDN required).
+xcrun stapler validate "$APP"
+# Expected: The validate action worked!
+
+# Confirm the deep signature is intact.
+codesign --verify --deep --strict --verbose=2 "$APP"
+```
+
+- [ ] `spctl --assess` prints `accepted` with `source=Notarized Developer ID`
+- [ ] `xcrun stapler validate` prints `The validate action worked!`
+- [ ] `codesign --verify --deep --strict` exits 0
+- [ ] Record the tester name, macOS version, and date in the smoke log below
+
+> **Why this matters:** `tar` with `bsdtar` on macOS preserves extended
+> attributes (where the stapled ticket lives) and resource forks.  A Linux
+> `tar` used in the release or deploy workflow could strip them, causing
+> Gatekeeper to reject the installed build even though the CI verify step passed
+> on the runner before packaging.
+
 ### G.2 Fresh install from Steam
 
 - [ ] Tauri window opens and displays the home screen

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -680,6 +680,47 @@ profile where the app has never been opened before.
 - [ ] No persistent security exception in System Settings → Privacy & Security
   is required after first launch
 
+#### G.1a `.app.tar.gz` round-trip signature preservation (one-time per release)
+
+Verifies that the signature and stapled ticket survive the `.app.tar.gz`
+packaging step in `release.yml` and the extraction step in `steam-deploy.yml`.
+Run this once per release on a macOS machine **before** declaring G3-01 closed.
+
+```bash
+# Download the .app.tar.gz from the GitHub release page (or from release-artifacts/).
+# Replace <tag> with the release tag, e.g. v0.1.0.
+gh release download <tag> --pattern "*.app.tar.gz" --dir /tmp/convsim-roundtrip/
+
+# Extract the .app bundle.
+mkdir -p /tmp/convsim-roundtrip/app
+tar -xzf /tmp/convsim-roundtrip/*.app.tar.gz -C /tmp/convsim-roundtrip/app/
+
+APP="$(find /tmp/convsim-roundtrip/app -maxdepth 1 -name '*.app' | head -n1)"
+
+# Verify Gatekeeper still accepts the bundle after the tar round-trip.
+spctl --assess --type execute --verbose "$APP"
+# Expected: ConversationSimulator.app: accepted
+#           source=Notarized Developer ID
+
+# Confirm the stapled ticket survives (offline check — no Apple CDN required).
+xcrun stapler validate "$APP"
+# Expected: The validate action worked!
+
+# Confirm the deep signature is intact.
+codesign --verify --deep --strict --verbose=2 "$APP"
+```
+
+- [ ] `spctl --assess` prints `accepted` with `source=Notarized Developer ID`
+- [ ] `xcrun stapler validate` prints `The validate action worked!`
+- [ ] `codesign --verify --deep --strict` exits 0
+- [ ] Record the tester name, macOS version, and date in the smoke log below
+
+> **Why this matters:** `tar` with `bsdtar` on macOS preserves extended
+> attributes (where the stapled ticket lives) and resource forks.  A Linux
+> `tar` used in the release or deploy workflow could strip them, causing
+> Gatekeeper to reject the installed build even though the CI verify step passed
+> on the runner before packaging.
+
 ### G.2 Fresh install from Steam
 
 - [ ] Tauri window opens and displays the home screen

--- a/publishing/MACOS_SIGNING_AND_NOTARIZATION.md
+++ b/publishing/MACOS_SIGNING_AND_NOTARIZATION.md
@@ -73,15 +73,112 @@ The string in quotes is the `APPLE_SIGNING_IDENTITY` value.
 
 ---
 
-## App-specific password for notarisation
+## App Store Connect API key for notarisation (preferred)
 
-The notary service authenticates with an Apple ID and an **app-specific
-password** (not the Apple ID login password).
+The ASC API key is the **preferred** authentication method for notarytool.
+It has no 2FA coupling, can be revoked without touching the Apple ID account,
+and is scoped to the App Manager role — making it safer than an app-specific
+password tied to the organisation's Apple ID.
+
+### Minting an ASC API key
+
+1. Sign in to [App Store Connect](https://appstoreconnect.apple.com) as an
+   Admin under the Outright Mental team.
+2. Navigate to **Users and Access → Integrations → App Store Connect API**.
+3. Under **Team Keys**, click **+** to generate a new key.
+   - **Name:** `convsim-notarytool` (or include the date for rotation traceability)
+   - **Access:** `App Manager`
+4. Download the generated `.p8` private key file — it can only be downloaded
+   **once**.  Store it securely before leaving this page.
+5. Note the **Key ID** (alphanumeric, e.g. `ABCDE12345`) and the **Issuer ID**
+   (UUID shown at the top of the Integrations page).
+
+### Storing as org-level secrets
+
+Base64-encode the `.p8` file for secret storage:
+
+```bash
+base64 -i AuthKey_ABCDE12345.p8 -o AuthKey_ABCDE12345.b64
+# On Linux (no -i/-o flags required):
+base64 AuthKey_ABCDE12345.p8 > AuthKey_ABCDE12345.b64
+```
+
+Add the three secrets at the org level:
+
+```bash
+# Key ID (short alphanumeric, not the full filename):
+gh secret set APPLE_API_KEY \
+  --org outrightmental \
+  --visibility selected \
+  --repos ConversationSimulator,FeverTilt
+
+# Issuer UUID from the App Store Connect Integrations page:
+gh secret set APPLE_API_ISSUER \
+  --org outrightmental \
+  --visibility selected \
+  --repos ConversationSimulator,FeverTilt
+
+# Base64-encoded .p8 file content:
+gh secret set APPLE_API_KEY_PATH \
+  --org outrightmental \
+  --visibility selected \
+  --repos ConversationSimulator,FeverTilt
+```
+
+The release workflow decodes `APPLE_API_KEY_PATH` to a temp file at runtime,
+sets `APPLE_API_KEY_PATH` in the environment to that file path (the variable
+name Tauri expects), and deletes the file the moment the Tauri build completes.
+
+### Apple ID fallback
+
+If the ASC API key is not configured, the workflow falls back to Apple ID
+authentication using `APPLE_ID`, `APPLE_PASSWORD`, and `APPLE_TEAM_ID`.
 
 1. Sign in to [appleid.apple.com](https://appleid.apple.com).
 2. Under Security → App-Specific Passwords, generate a new password.
 3. Label it `convsim-notarytool` or similar for traceability.
 4. Copy the password — it is shown only once.
+
+Add the three secrets:
+
+```bash
+gh secret set APPLE_ID --org outrightmental \
+  --visibility selected --repos ConversationSimulator,FeverTilt
+gh secret set APPLE_PASSWORD --org outrightmental \
+  --visibility selected --repos ConversationSimulator,FeverTilt
+gh secret set APPLE_TEAM_ID --org outrightmental \
+  --visibility selected --repos ConversationSimulator,FeverTilt
+```
+
+---
+
+## Release enforcement (REQUIRE_SIGNED_MACOS)
+
+The release workflow sets `REQUIRE_SIGNED_MACOS=true` for any workflow run
+triggered by a `v*` tag (push or workflow_dispatch).  When this flag is true:
+
+- **Missing `APPLE_CERTIFICATE`** → the verify step fails with an actionable
+  error and the build is rejected before any artifact is uploaded.
+- **Missing notarisation credentials** → the verify step fails (even if the
+  build was signed) with a message listing both the preferred ASC API key and
+  the Apple ID fallback.
+
+This turns gate G3-01 from a checklist item into CI law.  Contributor forks
+and PR builds are unaffected — they never carry a `v*` tag and the enforcement
+block is never reached.
+
+### Testing enforcement
+
+To confirm the enforcement is wired correctly, trigger a `workflow_dispatch`
+run with a `v*` tag **while the `APPLE_CERTIFICATE` org secret is temporarily
+absent** (or renamed).  The verify step should exit non-zero with the message:
+
+```
+ERROR: APPLE_CERTIFICATE is not configured but a signed macOS build
+       is required for this release tag.
+```
+
+Restore the secret after the dry run and confirm the next `v*` run passes.
 
 ---
 
@@ -91,14 +188,29 @@ These secrets are stored at the **outrightmental organisation level**, scoped to
 `ConversationSimulator` and `FeverTilt`. They are entered once and rotated in one
 place — all scoped repositories pick up the change automatically.
 
+**Code-signing secrets (required for all signed builds):**
+
 | Secret name | Contents | Source |
 |-------------|----------|--------|
 | `APPLE_CERTIFICATE` | Base64-encoded `.p12` file | Export from Keychain, then `base64 -i DeveloperID.p12` |
 | `APPLE_CERTIFICATE_PASSWORD` | Passphrase for the `.p12` file | Set when exporting the `.p12` |
 | `APPLE_SIGNING_IDENTITY` | Full identity string: `Developer ID Application: Outright Mental (TEAMID)` | `security find-identity -v -p codesigning` |
+
+**Notarisation secrets — ASC API key (preferred, see above for minting):**
+
+| Secret name | Contents | Source |
+|-------------|----------|--------|
+| `APPLE_API_KEY` | Key ID (e.g. `ABCDE12345`) | App Store Connect → Users and Access → Integrations → Key ID |
+| `APPLE_API_ISSUER` | Issuer UUID | App Store Connect → Users and Access → Integrations → Issuer ID |
+| `APPLE_API_KEY_PATH` | Base64-encoded `.p8` private key content | `base64 -i AuthKey_ABCDE12345.p8` |
+| `APPLE_TEAM_ID` | Ten-character Outright Mental team ID | Apple Developer portal (required for both auth paths) |
+
+**Notarisation secrets — Apple ID fallback (used when ASC API key is absent):**
+
+| Secret name | Contents | Source |
+|-------------|----------|--------|
 | `APPLE_ID` | Apple ID email used for notarisation | Outright Mental Apple Developer account |
 | `APPLE_PASSWORD` | App-specific password for notarytool | appleid.apple.com → Security → App-Specific Passwords |
-| `APPLE_TEAM_ID` | Ten-character Outright Mental team ID | Apple Developer portal |
 
 **To set or rotate** (values supplied interactively, never committed):
 
@@ -107,7 +219,7 @@ gh secret set APPLE_CERTIFICATE \
   --org outrightmental \
   --visibility selected \
   --repos ConversationSimulator,FeverTilt
-# repeat for each secret in the table above
+# repeat for each secret in the tables above
 ```
 
 Or use the org Settings UI: GitHub → outrightmental org **Settings → Secrets
@@ -361,12 +473,15 @@ for notary service outages.
 
 ## Links
 
-- [`apps/desktop/src-tauri/entitlements.plist`](../apps/desktop/src-tauri/entitlements.plist) — Hardened Runtime entitlements
+- [`apps/desktop/src-tauri/entitlements.plist`](../apps/desktop/src-tauri/entitlements.plist) — Hardened Runtime entitlements (with rationale for each)
 - [`apps/desktop/src-tauri/tauri.conf.json`](../apps/desktop/src-tauri/tauri.conf.json) — Tauri bundle configuration
 - [`docs/platform-notes.md` — macOS section](../docs/platform-notes.md#macos) — system requirements, supported versions, build prerequisites
 - [`docs/steam-mvp-scope.md` — G3-01](../docs/steam-mvp-scope.md) — Stage 3 gate: notarised macOS build required
+- [`docs/release-checklist.md` — Part G](../docs/release-checklist.md#part-g--macos-steam-beta-install-verification) — macOS Steam beta install checklist including `.app.tar.gz` round-trip verification
+- [`docs/steam-achievements-stats-rich-presence.md`](../docs/steam-achievements-stats-rich-presence.md) — Steamworks SDK integration context (relevant to `disable-library-validation` entitlement)
 - [`publishing/STEAM_DEPOT_CONTENTS.md` — macOS depot](STEAM_DEPOT_CONTENTS.md#macos-depot-depot_macosvdftpl) — macOS depot layout and notarisation requirement
 - [`publishing/STEAM_PUBLISHING_AND_DEPLOYMENT.md`](STEAM_PUBLISHING_AND_DEPLOYMENT.md) — Steam deploy workflow and troubleshooting
 - [Tauri macOS signing docs](https://tauri.app/distribute/sign/macos) — upstream reference for `tauri build` signing variables
 - [Apple Developer — Developer ID](https://developer.apple.com/developer-id/) — official certificate documentation
+- [Apple — App Store Connect API](https://developer.apple.com/documentation/appstoreconnectapi) — ASC API key management
 - [Apple — notarytool man page](https://developer.apple.com/documentation/technotes/tn3147-migrating-to-the-latest-notarization-tool) — notarytool migration guide


### PR DESCRIPTION
## Summary

Adds App Store Connect API key notarization support (preferred path), enforces macOS code-signing on release tags via `REQUIRE_SIGNED_MACOS`, and hardens the Steam deploy macOS signature check to prevent unsigned builds from going live. Gate G3-01 (signed, notarised, Gatekeeper-accepted macOS builds for Stage 3+ Steam release) is now a hard CI requirement for tagged releases rather than a manual checklist item.

## What changed

### Release workflow (`release.yml`)

**ASC API key notarization (preferred):**
- Tauri build step now accepts three new org secrets for notarization:
  - `APPLE_API_KEY`: key ID (e.g., `ABCDE12345`)
  - `APPLE_API_ISSUER`: issuer UUID from App Store Connect
  - `APPLE_API_KEY_PATH`: base64-encoded `.p8` private key content
- At runtime, the script decodes the base64-encoded `.p8` to `$RUNNER_TEMP/AuthKey_<id>.p8`, exports `APPLE_API_KEY_PATH` pointing to that file, clears `APPLE_ID`/`APPLE_PASSWORD` to force Tauri to use the ASC key path, and scrubs the decoded `.p8` via an EXIT trap (guarantees cleanup even if the build fails)
- Apple ID credentials remain the fallback when ASC secrets are absent
- Updated `HAS_NOTARIZATION` to `secrets.APPLE_ID != '' || secrets.APPLE_API_KEY != ''` so either auth path triggers the notarization step

**Release tag enforcement:**
- New `REQUIRE_SIGNED_MACOS` job-level env var: set to `true` when the run is triggered by a `v*` tag (push or workflow_dispatch), `false` otherwise
- Verify step now fires on `REQUIRE_SIGNED_MACOS == 'true'` in addition to `HAS_APPLE_CERT == 'true'`, enabling early-exit error checks before any artifact upload
- When `REQUIRE_SIGNED_MACOS=true`:
  - Missing `APPLE_CERTIFICATE` → verify step fails with actionable error (no more silent INFO skip)
  - Missing notarisation credentials → verify step fails even if the build was signed, listing both ASC API key and Apple ID fallback options
- Contributor forks and PR builds are unaffected (no `v*` tag, enforcement block never reaches)

### Steam deploy workflow (`steam-deploy.yml`)

**Hardened macOS signature check:**
- "Verify macOS .app code-signature presence" step now exposes `SET_LIVE_BRANCH` to the shell
- When `set_live_branch` is non-empty (Stage 3+ deploy to a live branch): missing `_CodeSignature` directory triggers `exit 1` (hard error), preventing unsigned builds from being promoted
- Dry-run uploads (`set_live_branch=''`) still emit a WARN to allow unsigned dev builds to be staged for inspection without being pushed to live

### Entitlements (`apps/desktop/src-tauri/entitlements.plist`)

- Enhanced the `com.apple.security.cs.disable-library-validation` comment with context from the FeverTilt incident: this entitlement is specifically what allows `steamclient.dylib` to load under Hardened Runtime and must not be removed even while Steamworks SDK integration is inactive

### Documentation

**Signing and notarization guide (`publishing/MACOS_SIGNING_AND_NOTARIZATION.md`):**
- New **App Store Connect API key** section with step-by-step minting runbook (sign in to App Store Connect, generate key with App Manager role, note Key ID and Issuer ID)
- Base64 encoding and `gh secret set` commands for all three ASC secrets (`APPLE_API_KEY`, `APPLE_API_ISSUER`, `APPLE_API_KEY_PATH`)
- Reorganized CI secrets table split into three groups: code-signing (required for all signed builds), ASC API key (preferred), Apple ID fallback
- New **Release enforcement** section documenting `REQUIRE_SIGNED_MACOS` behavior, failure messages, and the dry-run procedure for testing enforcement (temporarily unset `APPLE_CERTIFICATE` and trigger a `workflow_dispatch` run with a `v*` tag)

**Release checklist (`docs/release-checklist.md`):**
- New **G.1a** item: `.app.tar.gz` round-trip signature preservation check
  - Download `*.app.tar.gz` from GitHub release, extract, then verify `spctl --assess`, `xcrun stapler validate`, and `codesign --verify --deep --strict` all pass
  - Includes note on why Linux `tar` could strip extended attributes containing the stapled ticket; macOS `tar` (bsdtar) preserves them correctly

## How it was tested

- Workflow YAML validated by inspection: expression syntax for `REQUIRE_SIGNED_MACOS`, env var scoping across build and verify steps, conditional shell logic for ASC key / Apple ID / unsigned paths
- Enforcement gate traced through: `REQUIRE_SIGNED_MACOS=true` + `HAS_APPLE_CERT=false` → verify step `if` fires → early-exit block runs → `exit 1`
- Steam deploy enforcement traced: `set_live_branch` non-empty + `_CodeSignature` absent → `exit 1`; `set_live_branch` empty → WARN only
- No runtime surface to drive (CI workflow changes); enforcement behavior verified by code review of the conditional logic and shell paths
- EXIT trap cleanup guaranteed by bash `-e` behavior (abort before trailing `rm`) plus trap handler

Closes #406