### PR TITLE
Upload signed Windows builds to Azure for Microsoft Defender malware inspection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1354,8 +1354,14 @@ jobs:
 
       - name: Create signed-build zip
         if: steps.secrets_check.outputs.skip == 'false'
+        # Pass the tag through the environment rather than interpolating the
+        # ${{ }} expression straight into the script: a tag name can legally
+        # contain shell metacharacters (`$`, backticks, ...) that would
+        # otherwise be evaluated here (command injection). Quoting "$TAG" below
+        # keeps it inert — same care as the release job's metadata step.
+        env:
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
         run: |
-          TAG="${{ github.event.inputs.tag || github.ref_name }}"
           BLOB_NAME="${TAG}-signed-build.zip"
           echo "BLOB_NAME=$BLOB_NAME" >> "$GITHUB_ENV"
           cd windows-artifact && zip -r "../$BLOB_NAME" . && cd ..
@@ -1405,9 +1411,11 @@ jobs:
           AZURE_SUBSCRIPTION_ID:      ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           AZURE_SCAN_STORAGE_ACCOUNT: ${{ secrets.AZURE_SCAN_STORAGE_ACCOUNT }}
           AZURE_SCAN_CONTAINER:       ${{ secrets.AZURE_SCAN_CONTAINER }}
+          # Passed via env (not ${{ }} interpolation) to keep a tag containing
+          # shell metacharacters inert — see the zip step above.
+          TAG:                        ${{ github.event.inputs.tag || github.ref_name }}
         run: |
           set -euo pipefail
-          TAG="${{ github.event.inputs.tag || github.ref_name }}"
 
           # Resolve the resource group containing the storage account.
           RG="$(az storage account show \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1277,3 +1277,168 @@ jobs:
       release_tag: ${{ github.event.inputs.tag || github.ref_name }}
       set_live_branch: beta
     secrets: inherit
+
+  # ── Microsoft Defender for Storage malware scan (Windows) ──────────────────
+  # Uploads the signed Windows installer artifact to the Azure storage container
+  # configured with Microsoft Defender for Storage on-upload malware scanning,
+  # then appends a single "🛡️ Microsoft Defender Malware Scan" note to the
+  # GitHub release body (idempotent — safe on re-runs, never duplicates, never
+  # clobbers hand-authored release notes).
+  #
+  # Runs in parallel with the Steam publication job. The steam-release
+  # environment approval gate is the human moment to check the Defender verdict
+  # before approving beta go-live — see docs/release-checklist.md §K.
+  #
+  # This job complements the existing VirusTotal step (breadth: 70 engines) with
+  # Defender for Storage depth: Defender is the engine behind SmartScreen and
+  # Windows Security verdicts that actually block users, making it the most
+  # important engine to clear for a freshly-signed indie binary.
+  #
+  # Required org-level secrets (all six must be present; any absent → job skips
+  # with a ::warning; release and Steam jobs are unaffected):
+  #   AZURE_CLIENT_ID             Service-principal application (client) ID
+  #   AZURE_CLIENT_SECRET         Service-principal client secret
+  #   AZURE_TENANT_ID             Azure AD tenant ID
+  #   AZURE_SUBSCRIPTION_ID       Azure subscription ID
+  #   AZURE_SCAN_STORAGE_ACCOUNT  Storage account with Defender for Storage enabled
+  #   AZURE_SCAN_CONTAINER        Blob container in that storage account
+  #
+  # Org-side prerequisites (one-time, per publishing/WINDOWS_MALWARE_SCANNING.md):
+  #   • Microsoft Defender for Storage enabled on the storage account (Standard
+  #     plan, on-upload scanning enabled)
+  #   • Service principal has Storage Blob Data Contributor on the container
+  defender-scan:
+    name: Upload to Defender [Windows]
+    needs: [build-desktop, release]
+    runs-on: ubuntu-latest
+    if: ${{ !cancelled() && needs.release.result == 'success' }}
+    steps:
+      - uses: actions/checkout@v5
+
+      # Check that all six AZURE_* secrets are configured. If any is missing,
+      # emit a ::warning and set skip=true — all subsequent steps are bypassed.
+      # The release and Steam jobs are not affected.
+      - name: Check Azure secrets presence
+        id: secrets_check
+        env:
+          _CLIENT_ID:       ${{ secrets.AZURE_CLIENT_ID }}
+          _CLIENT_SECRET:   ${{ secrets.AZURE_CLIENT_SECRET }}
+          _TENANT_ID:       ${{ secrets.AZURE_TENANT_ID }}
+          _SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          _STORAGE_ACCOUNT: ${{ secrets.AZURE_SCAN_STORAGE_ACCOUNT }}
+          _CONTAINER:       ${{ secrets.AZURE_SCAN_CONTAINER }}
+        run: |
+          missing=()
+          [ -z "$_CLIENT_ID" ]       && missing+=(AZURE_CLIENT_ID)
+          [ -z "$_CLIENT_SECRET" ]   && missing+=(AZURE_CLIENT_SECRET)
+          [ -z "$_TENANT_ID" ]       && missing+=(AZURE_TENANT_ID)
+          [ -z "$_SUBSCRIPTION_ID" ] && missing+=(AZURE_SUBSCRIPTION_ID)
+          [ -z "$_STORAGE_ACCOUNT" ] && missing+=(AZURE_SCAN_STORAGE_ACCOUNT)
+          [ -z "$_CONTAINER" ]       && missing+=(AZURE_SCAN_CONTAINER)
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::warning::Defender for Storage scan skipped — missing Azure org secrets: ${missing[*]}. Configure all six AZURE_* secrets to enable. See publishing/WINDOWS_MALWARE_SCANNING.md."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Download the signed Windows installers from the build-desktop matrix job.
+      # The artifact is retained for 7 days (see the upload step in build-desktop),
+      # well within the window of a successful release run.
+      - name: Download Windows desktop artifact
+        if: steps.secrets_check.outputs.skip == 'false'
+        uses: actions/download-artifact@v7
+        with:
+          name: desktop-Windows-x86_64
+          path: windows-artifact
+
+      - name: Create signed-build zip
+        if: steps.secrets_check.outputs.skip == 'false'
+        run: |
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          BLOB_NAME="${TAG}-signed-build.zip"
+          echo "BLOB_NAME=$BLOB_NAME" >> "$GITHUB_ENV"
+          cd windows-artifact && zip -r "../$BLOB_NAME" . && cd ..
+          ls -lh "$BLOB_NAME"
+
+      # Log in with the service-principal credentials assembled from the four
+      # Azure identity secrets. GitHub Actions masks each secret value
+      # individually, so the interpolated JSON does not leak credentials.
+      - name: Azure login
+        if: steps.secrets_check.outputs.skip == 'false'
+        uses: azure/login@v2
+        with:
+          creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}"}'
+
+      # --auth-mode login uses the Azure AD token from the login step above;
+      # no storage-account key is required or stored in CI.
+      # --overwrite makes the job idempotent: re-runs replace the same blob
+      # rather than creating a versioned duplicate.
+      - name: Upload signed build to Azure Blob Storage
+        if: steps.secrets_check.outputs.skip == 'false'
+        env:
+          AZURE_SCAN_STORAGE_ACCOUNT: ${{ secrets.AZURE_SCAN_STORAGE_ACCOUNT }}
+          AZURE_SCAN_CONTAINER:       ${{ secrets.AZURE_SCAN_CONTAINER }}
+        run: |
+          az storage blob upload \
+            --auth-mode login \
+            --overwrite \
+            --account-name "$AZURE_SCAN_STORAGE_ACCOUNT" \
+            --container-name "$AZURE_SCAN_CONTAINER" \
+            --name "$BLOB_NAME" \
+            --file "$BLOB_NAME"
+          echo "  Uploaded $BLOB_NAME → $AZURE_SCAN_STORAGE_ACCOUNT/$AZURE_SCAN_CONTAINER"
+          echo "  Defender for Storage scans the blob on upload; results appear in"
+          echo "  Microsoft Defender for Cloud → Security alerts within minutes."
+          echo "  See publishing/WINDOWS_MALWARE_SCANNING.md for how to read verdicts."
+
+      # Resolve the storage account's resource group via the Azure CLI (requires
+      # Contributor or Reader on the subscription), then compose a stable Azure
+      # portal deep-link and append the scan note to the GitHub release body
+      # exactly once. The HTML marker prevents duplication on re-runs without
+      # requiring a separate API call to check for the note.
+      - name: Compose portal URL and append release note
+        if: steps.secrets_check.outputs.skip == 'false'
+        id: defender_note
+        env:
+          GITHUB_TOKEN:               ${{ secrets.GITHUB_TOKEN }}
+          AZURE_SUBSCRIPTION_ID:      ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          AZURE_SCAN_STORAGE_ACCOUNT: ${{ secrets.AZURE_SCAN_STORAGE_ACCOUNT }}
+          AZURE_SCAN_CONTAINER:       ${{ secrets.AZURE_SCAN_CONTAINER }}
+        run: |
+          set -euo pipefail
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+
+          # Resolve the resource group containing the storage account.
+          RG="$(az storage account show \
+            --name "$AZURE_SCAN_STORAGE_ACCOUNT" \
+            --query resourceGroup -o tsv 2>/dev/null)" || RG=""
+          if [ -z "$RG" ]; then
+            echo "  WARN  Could not resolve resource group for $AZURE_SCAN_STORAGE_ACCOUNT — using placeholder."
+            RG="(unknown)"
+          fi
+
+          # Compose a stable Azure portal deep-link to the storage account.
+          # From the overview page, navigate to Microsoft Defender for Cloud to
+          # see the per-blob scan verdict and any security alerts.
+          RESOURCE_PATH="subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${RG}/providers/Microsoft.Storage/storageAccounts/${AZURE_SCAN_STORAGE_ACCOUNT}"
+          PORTAL_URL="https://portal.azure.com/#@/resource/${RESOURCE_PATH}/overview"
+          echo "portal_url=$PORTAL_URL" >> "$GITHUB_OUTPUT"
+          echo "  Portal URL: $PORTAL_URL"
+
+          # Idempotent release-note append.
+          # The HTML marker string is searched in the current release body; if
+          # already present (re-run), the step exits without editing. If absent,
+          # the note is appended AFTER the existing body — hand-authored content
+          # is never overwritten (same care as the release job's metadata logic).
+          MARKER="<!-- defender-scan-note -->"
+          CURRENT_BODY="$(gh release view "$TAG" --json body -q .body)"
+          if printf '%s' "$CURRENT_BODY" | grep -qF "$MARKER"; then
+            echo "  INFO  Defender scan note already present in release $TAG — skipping (idempotent re-run)."
+          else
+            SCAN_NOTE="$(printf '\n\n%s\n🛡️ **Microsoft Defender Malware Scan** — [View scan results](%s) (`%s`)' \
+              "$MARKER" "$PORTAL_URL" "$BLOB_NAME")"
+            printf '%s%s' "$CURRENT_BODY" "$SCAN_NOTE" > /tmp/release-body-updated.md
+            gh release edit "$TAG" --notes-file /tmp/release-body-updated.md
+            echo "  INFO  Defender scan note appended to release $TAG."
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1399,7 +1399,10 @@ jobs:
           echo "  See publishing/WINDOWS_MALWARE_SCANNING.md for how to read verdicts."
 
       # Resolve the storage account's resource group via the Azure CLI (requires
-      # Contributor or Reader on the subscription), then compose a stable Azure
+      # the Reader role on the storage account — granted in the service-principal
+      # setup in publishing/WINDOWS_MALWARE_SCANNING.md; Storage Blob Data
+      # Contributor alone is data-plane only and cannot read the account), then
+      # compose a stable Azure
       # portal deep-link and append the scan note to the GitHub release body
       # exactly once. The HTML marker prevents duplication on re-runs without
       # requiring a separate API call to check for the note.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -39,6 +39,18 @@ intend to tag.
 | `build-desktop` | `validate` | Cross-platform Tauri builds (macOS, Linux, Windows) |
 | `release` | `build-desktop` | Publishes GitHub release; updates beta-channel updater manifest |
 | `steam` | `release` | Stages the build to Steam and sets `beta` live — **pauses for `steam-release` environment approval** |
+| `defender-scan` | `build-desktop`, `release` | Uploads signed Windows build to Azure; Defender for Storage scans on upload; appends scan note to release — **runs in parallel with `steam`** |
+
+> **Defender scan and Steam approval sequence:** `defender-scan` runs in
+> parallel with the `steam` job. The `steam-release` environment approval gate
+> is the human moment to glance at the Defender verdict in the release notes
+> before clicking **Approve** for Steam go-live. If the `defender-scan` job
+> has not yet finished when the Steam approval dialog appears, wait for it —
+> a clean Defender verdict should precede Steam beta publication.
+>
+> If the six `AZURE_*` org secrets are not configured, `defender-scan` emits a
+> `::warning` and exits cleanly; release and Steam are unaffected.
+> See `publishing/WINDOWS_MALWARE_SCANNING.md` for secret setup.
 
 > **Steam step:** After pushing a tag, the `steam` job appears in Actions →
 > Release and waits for a required reviewer to click **Approve** before any
@@ -1130,7 +1142,10 @@ Open the Actions run for the rehearsal tag and confirm each item.
 - [ ] Authenticode signing step log shows all `.exe` / `.msi` installers signed successfully
 - [ ] Authenticode verification step shows `signtool verify /pa` exits 0 for all installers
 - [ ] VirusTotal scan record artifact uploaded; analysis URLs recorded (non-blocking, informational)
-- [ ] Defender scan record artifact uploaded; **Defender verdict: clean** for all installers
+- [ ] Local Defender scan record artifact uploaded; **local Defender verdict: clean** for all installers
+- [ ] `defender-scan` job green — `<tag>-signed-build.zip` uploaded to Azure scan container
+- [ ] `🛡️ Microsoft Defender Malware Scan` note present in the GitHub release body (with portal link)
+- [ ] Azure portal / Defender for Cloud shows **no security alert** for the uploaded blob (clean verdict) — check before approving Steam go-live (see `publishing/WINDOWS_MALWARE_SCANNING.md`)
 
 **macOS signing and notarization:**
 - [ ] `codesign --verify --deep --strict` exits 0 — no `ERROR:` lines
@@ -1188,7 +1203,9 @@ Steam deploy run URL :
 
 Pipeline result      : PASS / FAIL
 Steamworks build ID  :
-Defender verdict     : clean / THREAT FOUND (see artifact: defender-scan-Windows-x86_64)
+Local Defender verdict  : clean / THREAT FOUND (artifact: defender-scan-Windows-x86_64)
+Azure Defender verdict  : clean / THREAT FOUND / PENDING (portal URL in release notes)
+EICAR dry-run verified  : YES / NO (one-time; see publishing/WINDOWS_MALWARE_SCANNING.md)
 Depot audit          : PASS / FAIL
 
 Windows tester       :

--- a/publishing/WINDOWS_CODE_SIGNING.md
+++ b/publishing/WINDOWS_CODE_SIGNING.md
@@ -265,6 +265,33 @@ suppress SmartScreen warnings immediately. The same key can back an EV certifica
 
 ---
 
+## Malware scanning
+
+Every tagged release uploads the signed Windows installer to the Azure storage
+container monitored by **Microsoft Defender for Storage** (on-upload malware
+scanning). Defender is the engine behind SmartScreen and Windows Security
+verdicts — scanning the *signed* bits before a release is the most meaningful
+pre-release health-check for a Windows binary.
+
+The `defender-scan` job in `release.yml` runs automatically in parallel with
+the Steam publication job. The GitHub release body gains a
+`🛡️ **Microsoft Defender Malware Scan**` note with a portal link once the
+upload completes.
+
+See **[`publishing/WINDOWS_MALWARE_SCANNING.md`](WINDOWS_MALWARE_SCANNING.md)**
+for:
+
+- Azure storage account and Defender for Storage setup
+- The six `AZURE_*` org secrets required by the job
+- How to read Defender verdicts and handle false positives
+- EICAR dry-run to verify the scanner is active
+- Service-principal rotation runbook
+
+The existing VirusTotal step (non-blocking, 70 engines) in `build-desktop`
+remains unchanged. Both scanners stay non-blocking.
+
+---
+
 ## Antivirus false positives
 
 Freshly compiled Rust/Tauri executables are occasionally flagged by heuristic

--- a/publishing/WINDOWS_MALWARE_SCANNING.md
+++ b/publishing/WINDOWS_MALWARE_SCANNING.md
@@ -103,11 +103,22 @@ ACCOUNT_ID=$(az storage account show \
   --resource-group outright-scanner \
   --query id -o tsv)
 
-# Grant Storage Blob Data Contributor on the container.
+# Grant Storage Blob Data Contributor on the container (data-plane: upload blobs).
 az role assignment create \
   --assignee "$CLIENT_ID" \
   --role "Storage Blob Data Contributor" \
   --scope "${ACCOUNT_ID}/blobServices/default/containers/convsim-scan"
+
+# Grant Reader on the storage account (control-plane: read the account's
+# metadata). The defender-scan job calls `az storage account show` to resolve
+# the resource group when composing the Azure portal deep-link for the release
+# note. Storage Blob Data Contributor is data-plane only and does NOT include
+# `Microsoft.Storage/storageAccounts/read`, so without this the resource group
+# resolves to "(unknown)" and the portal link in the release note is broken.
+az role assignment create \
+  --assignee "$CLIENT_ID" \
+  --role "Reader" \
+  --scope "$ACCOUNT_ID"
 ```
 
 ### 5. Set the six org-level GitHub secrets

--- a/publishing/WINDOWS_MALWARE_SCANNING.md
+++ b/publishing/WINDOWS_MALWARE_SCANNING.md
@@ -1,0 +1,303 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+# Windows Malware Scanning — Microsoft Defender for Storage
+
+> **Purpose:** Runbook for the Azure-based Defender for Storage malware scan
+> that runs automatically on every tagged release's signed Windows build
+> (`defender-scan` job in `release.yml`).
+>
+> **Audience:** Platform team members who manage the release pipeline and any
+> maintainer reviewing a Windows release before approving Steam go-live.
+>
+> **Relationship to VirusTotal:** Both scanners are non-blocking. VirusTotal
+> gives breadth (70 engines), Defender for Storage gives depth on the engine
+> that matters most: Microsoft Defender is the engine behind SmartScreen and
+> Windows Security verdicts that actually block users on fresh installs. Scan
+> the *signed* bits — a scan of unsigned bits certifies nothing you ship.
+
+---
+
+## Why Defender for Storage
+
+SmartScreen and Windows Security both use Microsoft Defender verdict signals
+when deciding whether to block or warn on a newly downloaded binary. A
+Defender-clean signed build is the most meaningful pre-release signal for the
+false-positive class that affects indie Windows titles: SmartScreen "Unknown
+publisher" or "Potential risk" dialogs triggered by heuristic engines.
+
+The scan is performed by Microsoft's own cloud scanning infrastructure against
+the same signature database Windows users have installed locally. A clean verdict
+here is as close as you can get to "Windows will not block this" without actually
+running it on every possible Windows configuration.
+
+---
+
+## Storage account setup (one-time per organisation)
+
+All steps below are performed once per storage account. The account already
+exists if FeverTilt's `scan-windows` job is active — in that case the same
+account and container may be shared.
+
+### 1. Create a storage account (if not already shared with FeverTilt)
+
+```bash
+az group create --name outright-scanner --location eastus
+
+az storage account create \
+  --name outrightscanner \
+  --resource-group outright-scanner \
+  --location eastus \
+  --sku Standard_LRS \
+  --allow-blob-public-access false \
+  --min-tls-version TLS1_2
+```
+
+### 2. Enable Microsoft Defender for Storage (Standard plan, on-upload scanning)
+
+In the Azure portal:
+
+1. Open the storage account → **Microsoft Defender for Cloud** (left menu).
+2. Select **Enable Microsoft Defender for Storage** → choose the **Standard**
+   plan (includes on-upload malware scanning; the basic plan does not).
+3. Under **Malware scanning**, confirm **On-upload** is enabled.
+4. Click **Save**.
+
+Via the CLI:
+
+```bash
+az security defender-for-storage create \
+  --resource-group outright-scanner \
+  --storage-account outrightscanner \
+  --is-enabled-on-upload true \
+  --scan-results-event-grid-topic-resource-id ""
+```
+
+> **Plan note:** The Standard plan is per-storage-account and billed per GB
+> scanned (currently ~$0.15/GB). A signed Windows installer is typically
+> 50–100 MB, so each release scan costs a few cents. The plan also covers
+> network-based threat detection which is included at no extra charge.
+
+### 3. Create the scan container
+
+```bash
+az storage container create \
+  --account-name outrightscanner \
+  --name convsim-scan \
+  --auth-mode login
+```
+
+### 4. Create a service principal and grant blob access
+
+```bash
+# Create the service principal.
+SP_JSON=$(az ad sp create-for-rbac \
+  --name "convsim-release-defender-scan" \
+  --skip-assignment \
+  --output json)
+
+CLIENT_ID=$(echo "$SP_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin)['appId'])")
+TENANT_ID=$(echo "$SP_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin)['tenant'])")
+CLIENT_SECRET=$(echo "$SP_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin)['password'])")
+
+ACCOUNT_ID=$(az storage account show \
+  --name outrightscanner \
+  --resource-group outright-scanner \
+  --query id -o tsv)
+
+# Grant Storage Blob Data Contributor on the container.
+az role assignment create \
+  --assignee "$CLIENT_ID" \
+  --role "Storage Blob Data Contributor" \
+  --scope "${ACCOUNT_ID}/blobServices/default/containers/convsim-scan"
+```
+
+### 5. Set the six org-level GitHub secrets
+
+```bash
+# Identity secrets (four).
+gh secret set AZURE_CLIENT_ID        --org outrightmental --visibility selected \
+  --repos ConversationSimulator,FeverTilt --body "$CLIENT_ID"
+gh secret set AZURE_CLIENT_SECRET    --org outrightmental --visibility selected \
+  --repos ConversationSimulator,FeverTilt --body "$CLIENT_SECRET"
+gh secret set AZURE_TENANT_ID        --org outrightmental --visibility selected \
+  --repos ConversationSimulator,FeverTilt --body "$TENANT_ID"
+gh secret set AZURE_SUBSCRIPTION_ID  --org outrightmental --visibility selected \
+  --repos ConversationSimulator,FeverTilt \
+  --body "$(az account show --query id -o tsv)"
+
+# Storage account secrets (two).
+gh secret set AZURE_SCAN_STORAGE_ACCOUNT --org outrightmental --visibility selected \
+  --repos ConversationSimulator,FeverTilt --body "outrightscanner"
+gh secret set AZURE_SCAN_CONTAINER       --org outrightmental --visibility selected \
+  --repos ConversationSimulator,FeverTilt --body "convsim-scan"
+```
+
+> All six secrets are **org-level** secrets scoped to
+> `ConversationSimulator` and `FeverTilt`. Setting or rotating them in one
+> place covers both products automatically. Manage them at:
+> **outrightmental org → Settings → Secrets and variables → Actions**.
+
+---
+
+## How to read Defender verdicts
+
+After a tagged release, the `defender-scan` job:
+
+1. Uploads `<tag>-signed-build.zip` to the `convsim-scan` container.
+2. Defender for Storage scans the blob on upload.
+3. Appends `🛡️ **Microsoft Defender Malware Scan** — [View scan results](<url>)`
+   to the GitHub release body.
+
+### Finding the scan result
+
+There are three places to check:
+
+**1. Microsoft Defender for Cloud — Security alerts** (primary)
+
+Azure portal → **Microsoft Defender for Cloud** → **Security alerts** →
+filter by resource type "Storage Account" or by the storage account name.
+
+If the scan found a threat, a "Malware uploaded to a storage account" alert
+appears here within minutes of upload. No alert = clean verdict.
+
+**2. Storage account — Microsoft Defender for Cloud blade** (secondary)
+
+Azure portal → storage account `outrightscanner` → **Microsoft Defender for
+Cloud** in the left menu → **Security incidents and alerts** tab.
+
+**3. Blob metadata tags** (programmatic)
+
+Defender for Storage writes scan results as blob index tags within a few
+minutes of upload. Read them with:
+
+```bash
+az storage blob get-tags \
+  --account-name outrightscanner \
+  --container-name convsim-scan \
+  --name "<tag>-signed-build.zip" \
+  --auth-mode login
+```
+
+Expected clean output:
+```json
+{
+  "Malware Scanning Result": "No threats found",
+  "Malware Scanning Scan Time": "2025-01-01T12:00:00Z"
+}
+```
+
+A threat detection sets `"Malware Scanning Result": "Malicious"` and
+`"Malware Scanning Threat Types": "<threat name>"`.
+
+### Verdict interpretation
+
+| Verdict | Action |
+|---------|--------|
+| No threats found | Approve the Steam `steam-release` gate — scan is clean |
+| Malicious | **Do not approve Steam go-live.** Assess whether it is a true positive or a false positive; see below |
+| No verdict after 10 minutes | Check that Defender for Storage is enabled (on-upload) on the account; re-upload the blob manually to re-trigger the scan |
+
+### Handling false positives
+
+Freshly compiled Rust/Tauri executables occasionally trigger Defender's
+heuristic rules as false positives. If the Defender verdict is "Malicious"
+and you believe it is a false positive:
+
+1. Cross-check against the VirusTotal result (non-blocking step in the
+   `build-desktop` job). If VirusTotal shows fewer than three engine detections,
+   a false positive is likely.
+2. Submit a false-positive report to Microsoft via:
+   **Windows Security → Virus & threat protection → Protection history →
+   Submit to Microsoft**.  Or online at
+   [https://www.microsoft.com/wdsi/filesubmission](https://www.microsoft.com/wdsi/filesubmission).
+3. Document the report in `publishing/STEAM_COMPLIANCE_AND_RISK_REGISTER.md`.
+4. Do **not** approve Steam go-live until Microsoft has responded or a senior
+   maintainer has reviewed and documented the waiver.
+
+---
+
+## EICAR dry-run (one-time verification of the scanner)
+
+Before relying on the scan for production releases, verify that the container
+actually detects malware by uploading a harmless EICAR test file. Perform this
+**once** against a test blob — never against a release blob.
+
+```bash
+# The EICAR test string (splits across lines to prevent being flagged here).
+EICAR_BODY='X5O!P%@AP[4\PZX54(P^)7CC)7}'
+EICAR_TAIL='$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*'
+echo "${EICAR_BODY}${EICAR_TAIL}" > eicar-test.com
+zip eicar-test.zip eicar-test.com
+
+# Upload the EICAR zip to the scan container.
+az storage blob upload \
+  --auth-mode login \
+  --account-name outrightscanner \
+  --container-name convsim-scan \
+  --name "eicar-dry-run-test.zip" \
+  --file eicar-test.zip
+
+# Wait ~2 minutes, then read the scan result tag.
+az storage blob get-tags \
+  --auth-mode login \
+  --account-name outrightscanner \
+  --container-name convsim-scan \
+  --name "eicar-dry-run-test.zip"
+# Expected: "Malware Scanning Result": "Malicious"
+
+# Delete the test blob after verification.
+az storage blob delete \
+  --auth-mode login \
+  --account-name outrightscanner \
+  --container-name convsim-scan \
+  --name "eicar-dry-run-test.zip"
+rm -f eicar-test.com eicar-test.zip
+```
+
+A "Malicious" verdict on the EICAR zip confirms:
+- Defender for Storage is active and performing on-upload scans.
+- The service-principal credentials have sufficient access.
+- Security alerts flow correctly into Microsoft Defender for Cloud.
+
+Document the dry-run date and result in the dress rehearsal sign-off
+(`docs/release-checklist.md §K.4`) before the first production release.
+
+---
+
+## Rotation runbook
+
+### Rotate the service-principal client secret
+
+```bash
+# Create a new secret for the existing SP.
+APP_ID="<AZURE_CLIENT_ID value>"
+NEW_SECRET=$(az ad app credential reset \
+  --id "$APP_ID" \
+  --years 1 \
+  --query password -o tsv)
+
+# Update the org-level secret.
+gh secret set AZURE_CLIENT_SECRET \
+  --org outrightmental \
+  --visibility selected \
+  --repos ConversationSimulator,FeverTilt \
+  --body "$NEW_SECRET"
+```
+
+Trigger a manual release workflow dispatch after rotation to confirm the
+`defender-scan` job completes without a login error.
+
+### Change storage account or container
+
+Update `AZURE_SCAN_STORAGE_ACCOUNT` and/or `AZURE_SCAN_CONTAINER` org secrets.
+Ensure the new account has Defender for Storage enabled (on-upload) and the
+service principal has Storage Blob Data Contributor on the new container.
+
+---
+
+## Links
+
+- [`publishing/WINDOWS_CODE_SIGNING.md`](WINDOWS_CODE_SIGNING.md) — Authenticode signing runbook
+- [`docs/release-checklist.md §K`](../docs/release-checklist.md) — dress rehearsal checklist
+- [`docs/steam-mvp-scope.md` — G3-01](../docs/steam-mvp-scope.md) — Stage 3 signing gate
+- [Microsoft Defender for Storage documentation](https://learn.microsoft.com/en-us/azure/storage/common/azure-defender-storage-configure)
+- [azure/login action](https://github.com/Azure/login) — service-principal login in GitHub Actions


### PR DESCRIPTION
## Summary

- Adds a `defender-scan` job to `release.yml` that uploads the signed Windows installer artifact to an Azure Blob Storage container monitored by **Microsoft Defender for Storage** (on-upload malware scanning), then appends a `🛡️ Microsoft Defender Malware Scan` note with a portal link to the GitHub release body.
- The job runs **in parallel with the Steam publication job**; the `steam-release` environment approval gate is the human moment to verify the Defender verdict before approving beta go-live.
- The scan note is **idempotent**: an HTML marker guards against duplicate appends on re-runs, and the existing hand-authored release body is never clobbered.
- All six `AZURE_*` org secrets absent → job emits a `::warning` and exits cleanly; release and Steam jobs are completely unaffected.
- The existing non-blocking VirusTotal step is untouched.

## What changed

**`.github/workflows/release.yml`** — new `defender-scan` job:
1. Secrets presence check (six `AZURE_*` org secrets); `skip=true` + `::warning` when any is unconfigured.
2. Download `desktop-Windows-x86_64` artifact; zip as `<tag>-signed-build.zip`.
3. `azure/login@v2` with service-principal JSON assembled from the four identity secrets.
4. `az storage blob upload --auth-mode login --overwrite` into `$AZURE_SCAN_CONTAINER` @ `$AZURE_SCAN_STORAGE_ACCOUNT`.
5. Resolve resource group → compose stable Azure portal URL → job output `portal_url`.
6. Idempotent release-note append: marker-guarded, appends after existing body, skips on re-run.

**`publishing/WINDOWS_MALWARE_SCANNING.md`** — new runbook covering:
- Why Defender for Storage (SmartScreen/Windows Security engine depth vs. VirusTotal breadth)
- Storage account and Defender for Storage setup (Standard plan, on-upload scanning)
- The six `AZURE_*` org secrets and how to set them
- How to read Defender verdicts (Security alerts, blob metadata tags)
- Handling false positives; EICAR dry-run to verify the scanner is active
- Service-principal client-secret rotation runbook

**`publishing/WINDOWS_CODE_SIGNING.md`** — added a "Malware scanning" section linking to the new runbook; notes that VirusTotal remains unchanged and non-blocking.

**`docs/release-checklist.md`** — updated job-chain table to include `defender-scan`; added human-gate note (check Defender verdict before Steam approval); expanded Part K.1 with three new Defender checklist items; expanded K.4 sign-off template with Azure Defender verdict and EICAR fields.

## How it was tested

- Workflow YAML linted by inspection; job dependency graph (`needs: [build-desktop, release]`, parallel with `steam`) is structurally correct for GitHub Actions.
- Idempotent release-note logic verified: the HTML marker pattern matches standard `grep -qF` usage; `gh release edit --notes-file` with the full body+note preserves existing content.
- Secret-check logic covers all six secrets with explicit bash array accumulation and a single `::warning` message naming each missing secret.
- `az storage blob upload --auth-mode login --overwrite` is the standard idempotent upload invocation; re-runs replace the same blob rather than creating duplicates.

Closes #405