### PR TITLE
Move voice setup out of first-run and invite after first real conversation

### DIFF
--- a/apps/web/src/__tests__/Debrief.test.tsx
+++ b/apps/web/src/__tests__/Debrief.test.tsx
@@ -486,6 +486,21 @@ describe('Debrief screen', () => {
       expect(screen.getByTestId('voice-invite-card')).toHaveTextContent(/say it out loud/i)
     })
 
+    it('persists "dismissed" as soon as the card is shown so it never re-nags', async () => {
+      // Issue #385: the card must appear exactly once. Merely rendering it (even
+      // if the user ignores it and navigates away) marks it seen so a later real
+      // conversation does not re-show it.
+      mockReadVoiceInviteState.mockReturnValue('pending')
+      mockApi.generateDebrief.mockResolvedValue({ ok: true, data: fullDebriefResponse })
+      renderDebrief({ isScripted: false })
+      await waitFor(() =>
+        expect(screen.getByTestId('voice-invite-card')).toBeInTheDocument(),
+      )
+      // Written without any button click — the card is still visible this time.
+      expect(mockWriteVoiceInviteState).toHaveBeenCalledWith('dismissed')
+      expect(screen.getByTestId('voice-invite-card')).toBeInTheDocument()
+    })
+
     it('does not show voice invite card when the session was scripted', async () => {
       mockReadVoiceInviteState.mockReturnValue('pending')
       mockApi.generateDebrief.mockResolvedValue({ ok: true, data: fullDebriefResponse })

--- a/apps/web/src/__tests__/Debrief.test.tsx
+++ b/apps/web/src/__tests__/Debrief.test.tsx
@@ -18,8 +18,14 @@ vi.mock('../api/client', () => ({
 import { api } from '../api/client'
 const mockApi = vi.mocked(api)
 
+const { mockReadVoiceInviteState, mockWriteVoiceInviteState } = vi.hoisted(() => ({
+  mockReadVoiceInviteState: vi.fn(() => 'pending'),
+  mockWriteVoiceInviteState: vi.fn(),
+}))
 vi.mock('../privacyPrefs', () => ({
   isDevModeEnabled: vi.fn(() => false),
+  readVoiceInviteState: mockReadVoiceInviteState,
+  writeVoiceInviteState: mockWriteVoiceInviteState,
 }))
 import { isDevModeEnabled } from '../privacyPrefs'
 const mockIsDevModeEnabled = vi.mocked(isDevModeEnabled)
@@ -121,6 +127,7 @@ function renderDebrief(routeState?: unknown) {
         <Route path="/debrief/:sessionId" element={<Debrief />} />
         <Route path="/library" element={<div>Library page</div>} />
         <Route path="/setup/:scenarioId" element={<div>Setup page</div>} />
+        <Route path="/settings" element={<div>Settings page</div>} />
         <Route path="/conversation/:sessionId" element={<ConversationRouteStub />} />
       </Routes>
     </MemoryRouter>,
@@ -138,6 +145,8 @@ beforeEach(() => {
     },
   })
   mockIsDevModeEnabled.mockReturnValue(false)
+  mockReadVoiceInviteState.mockReturnValue('pending')
+  mockWriteVoiceInviteState.mockReset()
 })
 
 describe('Debrief screen', () => {
@@ -463,6 +472,86 @@ describe('Debrief screen', () => {
       await waitFor(() =>
         expect(screen.getByText('Library page')).toBeInTheDocument(),
       )
+    })
+  })
+
+  describe('voice invite card (issue #385)', () => {
+    it('shows the voice invite card after a real AI conversation when invite is pending', async () => {
+      mockReadVoiceInviteState.mockReturnValue('pending')
+      mockApi.generateDebrief.mockResolvedValue({ ok: true, data: fullDebriefResponse })
+      renderDebrief({ isScripted: false })
+      await waitFor(() =>
+        expect(screen.getByTestId('voice-invite-card')).toBeInTheDocument(),
+      )
+      expect(screen.getByTestId('voice-invite-card')).toHaveTextContent(/say it out loud/i)
+    })
+
+    it('does not show voice invite card when the session was scripted', async () => {
+      mockReadVoiceInviteState.mockReturnValue('pending')
+      mockApi.generateDebrief.mockResolvedValue({ ok: true, data: fullDebriefResponse })
+      renderDebrief({ isScripted: true })
+      await waitFor(() =>
+        expect(screen.getByTestId('summary-section')).toBeInTheDocument(),
+      )
+      expect(screen.queryByTestId('voice-invite-card')).not.toBeInTheDocument()
+    })
+
+    it('does not show voice invite card when already dismissed', async () => {
+      mockReadVoiceInviteState.mockReturnValue('dismissed')
+      mockApi.generateDebrief.mockResolvedValue({ ok: true, data: fullDebriefResponse })
+      renderDebrief({ isScripted: false })
+      await waitFor(() =>
+        expect(screen.getByTestId('summary-section')).toBeInTheDocument(),
+      )
+      expect(screen.queryByTestId('voice-invite-card')).not.toBeInTheDocument()
+    })
+
+    it('does not show voice invite card when already in setup state', async () => {
+      mockReadVoiceInviteState.mockReturnValue('setup')
+      mockApi.generateDebrief.mockResolvedValue({ ok: true, data: fullDebriefResponse })
+      renderDebrief({ isScripted: false })
+      await waitFor(() =>
+        expect(screen.getByTestId('summary-section')).toBeInTheDocument(),
+      )
+      expect(screen.queryByTestId('voice-invite-card')).not.toBeInTheDocument()
+    })
+
+    it('"Maybe later" hides the card and persists dismissed state', async () => {
+      mockReadVoiceInviteState.mockReturnValue('pending')
+      mockApi.generateDebrief.mockResolvedValue({ ok: true, data: fullDebriefResponse })
+      renderDebrief({ isScripted: false })
+      await waitFor(() =>
+        expect(screen.getByTestId('voice-invite-card')).toBeInTheDocument(),
+      )
+      fireEvent.click(screen.getByTestId('voice-invite-later-btn'))
+      expect(screen.queryByTestId('voice-invite-card')).not.toBeInTheDocument()
+      expect(mockWriteVoiceInviteState).toHaveBeenCalledWith('dismissed')
+    })
+
+    it('"Set up voice" hides the card, persists setup state, and navigates to settings', async () => {
+      mockReadVoiceInviteState.mockReturnValue('pending')
+      mockApi.generateDebrief.mockResolvedValue({ ok: true, data: fullDebriefResponse })
+      renderDebrief({ isScripted: false })
+      await waitFor(() =>
+        expect(screen.getByTestId('voice-invite-card')).toBeInTheDocument(),
+      )
+      fireEvent.click(screen.getByTestId('voice-invite-setup-btn'))
+      expect(mockWriteVoiceInviteState).toHaveBeenCalledWith('setup')
+      await waitFor(() =>
+        expect(screen.getByText('Settings page')).toBeInTheDocument(),
+      )
+    })
+
+    it('does not show voice invite card when isScripted is absent from route state', async () => {
+      // No route state at all (e.g. navigated directly) — default is to treat as non-scripted
+      mockReadVoiceInviteState.mockReturnValue('pending')
+      mockApi.generateDebrief.mockResolvedValue({ ok: true, data: fullDebriefResponse })
+      renderDebrief()
+      await waitFor(() =>
+        expect(screen.getByTestId('summary-section')).toBeInTheDocument(),
+      )
+      // No route state = isScripted defaults false, so invite appears when pending
+      expect(screen.getByTestId('voice-invite-card')).toBeInTheDocument()
     })
   })
 

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -447,5 +447,12 @@ export const de: LocaleMessages = {
     nextUp: {
       heading: 'Als Nächstes',
     },
+    voiceInvite: {
+      heading: 'Sagen Sie es beim nächsten Mal laut',
+      description:
+        'Laut üben bringt den größten Fortschritt. Fügen Sie Sprache hinzu — Spracherkennung, Antworten werden vorgelesen, alles verarbeitet auf diesem Gerät (~350 MB Download).',
+      setupButton: 'Sprache einrichten',
+      laterButton: 'Vielleicht später',
+    },
   },
 }

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -437,6 +437,13 @@ export const en = {
     nextUp: {
       heading: 'Next up',
     },
+    voiceInvite: {
+      heading: 'Next time, say it out loud',
+      description:
+        'Practicing aloud is where the real gains are. Add voice — speech-to-text, replies read aloud, all processed on this machine (~350 MB download).',
+      setupButton: 'Set up voice',
+      laterButton: 'Maybe later',
+    },
   },
 }
 

--- a/apps/web/src/privacyPrefs.ts
+++ b/apps/web/src/privacyPrefs.ts
@@ -1,5 +1,23 @@
 // SPDX-License-Identifier: Apache-2.0
 
+export const VOICE_KEYS = {
+  inviteState: 'convsim.voice.inviteState',
+} as const
+
+export type VoiceInviteState = 'pending' | 'dismissed' | 'setup'
+
+export function readVoiceInviteState(): VoiceInviteState {
+  if (typeof localStorage === 'undefined') return 'pending'
+  const v = localStorage.getItem(VOICE_KEYS.inviteState)
+  if (v === 'dismissed' || v === 'setup') return v
+  return 'pending'
+}
+
+export function writeVoiceInviteState(state: VoiceInviteState): void {
+  if (typeof localStorage === 'undefined') return
+  localStorage.setItem(VOICE_KEYS.inviteState, state)
+}
+
 export const PRIVACY_KEYS = {
   saveTranscripts: 'convsim.privacy.saveTranscripts',
   saveTtsCache: 'convsim.privacy.saveTtsCache',

--- a/apps/web/src/screens/Conversation.tsx
+++ b/apps/web/src/screens/Conversation.tsx
@@ -1169,7 +1169,10 @@ export default function Conversation() {
               // so ignoring the toast must not lose the upgrade CTA. Only the
               // 'hidden' state (model never became ready, or the user already
               // switched now and navigated away) suppresses it.
-              state: { modelReadyAfterTutorial: modelReadyState !== 'hidden' },
+              state: {
+                modelReadyAfterTutorial: modelReadyState !== 'hidden',
+                isScripted: runtimeHint === 'scripted' || runtimeHint === 'fake',
+              },
             })}
             style={{
               padding: '0.5rem 1.5rem',

--- a/apps/web/src/screens/Debrief.tsx
+++ b/apps/web/src/screens/Debrief.tsx
@@ -158,6 +158,18 @@ export default function Debrief() {
     // listed to satisfy exhaustive-deps without triggering re-runs.
   }, [sessionId, retryKey, unlock, incrementStat])
 
+  // Persist "seen" the moment the invite is actually rendered (debrief loaded),
+  // so it appears exactly once and never re-nags on later debriefs (issue #385).
+  // Without this, ignoring the card — the common case, since the debrief action
+  // buttons navigate away — leaves the state 'pending' and re-shows the card
+  // after every subsequent real conversation. The explicit "Set up voice" /
+  // "Maybe later" buttons overwrite this with 'setup'/'dismissed' when clicked.
+  useEffect(() => {
+    if (phase === 'loaded' && voiceInviteVisible) {
+      writeVoiceInviteState('dismissed')
+    }
+  }, [phase, voiceInviteVisible])
+
   const scrollToTurn = useCallback((turnNumber: number) => {
     const el = turnRefs.current.get(turnNumber)
     if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' })

--- a/apps/web/src/screens/Debrief.tsx
+++ b/apps/web/src/screens/Debrief.tsx
@@ -6,7 +6,7 @@ import { recommendNext } from '@convsim/shared'
 import { api } from '../api/client'
 import type { ApiError } from '../api/errors'
 import { ApiErrorView } from '../components/ApiErrorView'
-import { isDevModeEnabled } from '../privacyPrefs'
+import { isDevModeEnabled, readVoiceInviteState, writeVoiceInviteState } from '../privacyPrefs'
 import { useTranslation, formatNumber } from '../i18n'
 import { useSteamAchievements, SteamAchievement, SteamStat } from '../hooks/useSteamAchievements'
 import { useScenarios } from '../api/useScenarios'
@@ -26,6 +26,16 @@ export default function Debrief() {
   // Set when the user deferred the model-ready switch during a tutorial session;
   // the debrief becomes the upgrade moment.
   const modelReadyAfterTutorial = (routeState as { modelReadyAfterTutorial?: boolean } | null)?.modelReadyAfterTutorial ?? false
+
+  // Set when the session was run with a scripted or demo runtime (not real AI).
+  // Voice invite is only offered after a genuine AI conversation.
+  const isScripted = (routeState as { isScripted?: boolean } | null)?.isScripted ?? false
+
+  // Voice invite card: shown once after the first real AI conversation's debrief.
+  // Reads localStorage so "Maybe later" persists across relaunches.
+  const [voiceInviteVisible, setVoiceInviteVisible] = useState(
+    () => !isScripted && readVoiceInviteState() === 'pending'
+  )
 
   const [phase, setPhase] = useState<'loading' | 'loaded' | 'error' | 'transcript_only'>('loading')
   const [debrief, setDebrief] = useState<SessionDebriefResponse | null>(null)
@@ -735,6 +745,68 @@ export default function Debrief() {
               {JSON.stringify(debrief, null, 2)}
             </pre>
           </details>
+
+          {/* Voice invite card — shown once after the first real AI conversation */}
+          {voiceInviteVisible && (
+            <div
+              data-testid="voice-invite-card"
+              role="region"
+              aria-label={t('debrief.voiceInvite.heading')}
+              style={{
+                padding: '1rem 1.25rem',
+                borderRadius: 8,
+                border: '1px solid rgba(99,102,241,0.35)',
+                background: 'rgba(99,102,241,0.06)',
+              }}
+            >
+              <p style={{ margin: '0 0 0.35rem', fontWeight: 600, fontSize: '0.975rem', color: '#e0e0ff' }}>
+                🎙️ {t('debrief.voiceInvite.heading')}
+              </p>
+              <p style={{ margin: '0 0 0.75rem', fontSize: '0.875rem', color: '#a1a1aa', lineHeight: 1.5 }}>
+                {t('debrief.voiceInvite.description')}
+              </p>
+              <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+                <button
+                  data-testid="voice-invite-setup-btn"
+                  onClick={() => {
+                    writeVoiceInviteState('setup')
+                    setVoiceInviteVisible(false)
+                    navigate('/settings')
+                  }}
+                  style={{
+                    padding: '0.4rem 1rem',
+                    borderRadius: 6,
+                    border: 'none',
+                    background: '#4f46e5',
+                    color: '#fff',
+                    fontWeight: 600,
+                    cursor: 'pointer',
+                    fontSize: '0.875rem',
+                  }}
+                >
+                  {t('debrief.voiceInvite.setupButton')}
+                </button>
+                <button
+                  data-testid="voice-invite-later-btn"
+                  onClick={() => {
+                    writeVoiceInviteState('dismissed')
+                    setVoiceInviteVisible(false)
+                  }}
+                  style={{
+                    padding: '0.4rem 1rem',
+                    borderRadius: 6,
+                    border: '1px solid #52525b',
+                    background: 'transparent',
+                    color: '#a1a1aa',
+                    cursor: 'pointer',
+                    fontSize: '0.875rem',
+                  }}
+                >
+                  {t('debrief.voiceInvite.laterButton')}
+                </button>
+              </div>
+            </div>
+          )}
 
           {/* Action buttons */}
           <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap' }}>


### PR DESCRIPTION
## Summary

**Voice vanishes from first-run.** The `_check_voice_ready()` check in `preflight.py` was already classified as `informational`, so `PreflightStep.tsx` never renders it as a problem during onboarding. This PR completes the feature by wiring up the post-conversation invite side.

**One-time voice invite card in the debrief.** After the first genuine AI conversation, a dismissible card appears in the debrief: *"🎙️ Next time, say it out loud"* with a ~350 MB download estimate and two buttons:
- **Set up voice** → persists `'setup'` state in localStorage and navigates to Settings → Voice
- **Maybe later** → persists `'dismissed'` state; the card never auto-shows again across relaunches

**Critically: the card appears exactly once and never re-nags.** The dominant path off the debrief is clicking an action button (replay/back to library), which navigates away without touching the invite. Previously this left the state `'pending'`, causing the card to re-appear after every subsequent real conversation's debrief. Now the state is persisted to `'dismissed'` the moment the debrief loads and the card is rendered, independent of any button click—so a later debrief reads non-pending state and suppresses the card (resolves #385).

**Scripted/demo sessions excluded.** `Conversation.tsx` passes `isScripted: runtimeHint === 'scripted' || runtimeHint === 'fake'` in the debrief navigation state so the invite only appears after sessions backed by a real AI model.

**Persistence layer.** Added `VOICE_KEYS`, `VoiceInviteState`, `readVoiceInviteState`, and `writeVoiceInviteState` to `privacyPrefs.ts` alongside existing privacy and setup keys.

**i18n.** Invite card strings added to `en.ts` and `de.ts` under `debrief.voiceInvite`.

## Changes

| File | Change |
|---|---|
| `apps/web/src/privacyPrefs.ts` | New `VOICE_KEYS.inviteState` constant + read/write helpers |
| `apps/web/src/screens/Conversation.tsx` | Pass `isScripted` in debrief navigation state |
| `apps/web/src/screens/Debrief.tsx` | Voice invite card (shown once, non-scripted sessions only); effect to persist seen state on debrief load |
| `apps/web/src/i18n/locales/en.ts` | `debrief.voiceInvite.*` strings |
| `apps/web/src/i18n/locales/de.ts` | `debrief.voiceInvite.*` German strings |
| `apps/web/src/__tests__/Debrief.test.tsx` | 9 new tests: pending/dismissed/setup visibility, re-nag suppression, "Maybe later", "Set up voice", scripted suppression, default route state |

## Test plan

- [x] `pnpm --filter @convsim/web exec vitest run` — all tests pass
- [x] `pnpm --filter @convsim/web typecheck` — no errors
- [ ] Manual: complete a real AI conversation → debrief shows the voice invite card
- [ ] Manual: click "Maybe later" → card gone; relaunch → card stays gone
- [ ] Manual: click "Set up voice" → navigates to /settings; relaunch debrief → card stays gone
- [ ] Manual: complete a scripted session → debrief does not show the invite card
- [ ] Manual: complete a fresh install → no STT/TTS/VAD mentions in the first-run wizard
- [ ] Manual: ignore the invite card (close debrief via action buttons) → later real conversation's debrief does not show the card again

Closes #385