### PR TITLE
Fix docs-freshness gate rejecting docs verified ahead of the release

### DIFF
--- a/docs-site/src/content/docs/dev/developer-install.md
+++ b/docs-site/src/content/docs/dev/developer-install.md
@@ -3,7 +3,7 @@ title: "Developer install (run from source)"
 description: "Clone the repository and run the full Conversation Simulator platform locally — for contributors and anyone who wants full control."
 sidebar:
   order: 9
-verified_against: v0.3.0
+verified_against: v0.2.3
 ---
 
 This is the contributor path: clone the source and run the dev services

--- a/docs-site/src/content/docs/play/ai-engine.md
+++ b/docs-site/src/content/docs/play/ai-engine.md
@@ -3,7 +3,7 @@ title: "Choosing how to run the AI"
 description: "Compare the three ways to run local AI in Conversation Simulator — built-in engine, Ollama, and custom GGUF — and choose the right setup for your machine."
 sidebar:
   order: 1
-verified_against: v0.3.0
+verified_against: v0.2.3
 ---
 <!-- SPDX-License-Identifier: CC-BY-4.0 -->
 

--- a/docs-site/src/content/docs/play/local-models.md
+++ b/docs-site/src/content/docs/play/local-models.md
@@ -3,7 +3,7 @@ title: "Local models"
 description: "This page has moved. See Choosing how to run the AI."
 sidebar:
   hidden: true
-verified_against: v0.3.0
+verified_against: v0.2.3
 ---
 <!-- SPDX-License-Identifier: CC-BY-4.0 -->
 

--- a/docs-site/src/content/docs/start/install.md
+++ b/docs-site/src/content/docs/start/install.md
@@ -3,7 +3,7 @@ title: "Installation"
 description: "Download, verify, and install Conversation Simulator on Windows, macOS, or Linux, and set up your first local model."
 sidebar:
   order: 1
-verified_against: v0.3.0
+verified_against: v0.2.3
 ---
 
 Conversation Simulator runs entirely on your computer — no cloud inference,

--- a/docs-site/src/content/docs/start/quickstart.md
+++ b/docs-site/src/content/docs/start/quickstart.md
@@ -3,7 +3,7 @@ title: "Quickstart"
 description: "Walk through your first conversation: complete first-run setup, choose a scenario, play, and review the debrief."
 sidebar:
   order: 2
-verified_against: v0.3.0
+verified_against: v0.2.3
 ---
 
 This guide walks through your first conversation. Complete the

--- a/docs-site/src/content/docs/start/troubleshooting.md
+++ b/docs-site/src/content/docs/start/troubleshooting.md
@@ -3,7 +3,7 @@ title: "Troubleshooting"
 description: "Solutions for common Conversation Simulator problems, including engine startup failures, model load errors, slow inference, port conflicts, and offline mode."
 sidebar:
   order: 3
-verified_against: v0.3.0
+verified_against: v0.2.3
 ---
 <!-- SPDX-License-Identifier: CC-BY-4.0 -->
 

--- a/docs-site/src/content/docs/trust/model-download-policy.md
+++ b/docs-site/src/content/docs/trust/model-download-policy.md
@@ -3,7 +3,7 @@ title: "Model download policy"
 description: "Rules governing how LLM model weights are downloaded, verified with SHA-256 checksums, and disclosed to players — no silent downloads, no bundled weights."
 sidebar:
   order: 4
-verified_against: v0.3.0
+verified_against: v0.2.3
 ---
 
 > **Purpose:** Define the rules that govern how LLM model weights are

--- a/scripts/check-docs-freshness.sh
+++ b/scripts/check-docs-freshness.sh
@@ -30,37 +30,97 @@ if [[ -z "$VERSION" ]]; then
   exit 1
 fi
 
-# Reduce a version string to its major.minor key, stripping any pre-release
-# suffix: v0.2.2 -> v0.2, v0.3.0-beta.1 -> v0.3.
+# Reduce a version string to its major.minor key, stripping any leading "v" and
+# any pre-release suffix: v0.2.2 -> 0.2, v0.3.0-beta.1 -> 0.3. The "v" is dropped
+# so a page stamped "0.2.2" and a release tagged "v0.2.2" compare equal.
 minor_key() {
-  local v="${1%%-*}"
+  local v="${1#v}"
+  v="${v%%-*}"
   awk -F. '{print $1"."$2}' <<< "$v"
 }
 
+# True when major.minor key $1 is strictly older than key $2.
+#
+# The comparison is numeric and directional, and both properties matter:
+#   - numeric, because a string compare puts 0.10 before 0.9;
+#   - directional, because only a page that LAGS the release is stale. A page
+#     verified against a newer minor than the one being released (an epic that
+#     stamps docs for the upcoming minor, then ships a patch off the same main)
+#     has been verified against this UI or a later one — it is not drift.
+minor_is_older() {
+  local a_major="${1%%.*}" a_minor="${1#*.}"
+  local b_major="${2%%.*}" b_minor="${2#*.}"
+  (( a_major < b_major || ( a_major == b_major && a_minor < b_minor ) ))
+}
+
+# A stamp we cannot parse must fail loudly rather than silently pass the gate.
+is_valid_key() {
+  [[ "$1" =~ ^[0-9]+\.[0-9]+$ ]]
+}
+
 RELEASE_MINOR="$(minor_key "$VERSION")"
+if ! is_valid_key "$RELEASE_MINOR"; then
+  echo "ERROR: cannot parse a major.minor version out of release '$VERSION'." >&2
+  exit 1
+fi
+
 DOCS_DIR="$(dirname "$0")/../docs-site/src/content/docs"
 STALE=()
+AHEAD=()
+MALFORMED=()
 
 while IFS= read -r -d '' file; do
   # Extract verified_against value from YAML front-matter (between first --- pair)
   value="$(awk '/^---/{count++} count==1 && /^verified_against:/{print $2; exit}' "$file")"
-  if [[ -n "$value" && "$(minor_key "$value")" != "$RELEASE_MINOR" ]]; then
+  [[ -n "$value" ]] || continue
+
+  key="$(minor_key "$value")"
+  if ! is_valid_key "$key"; then
+    MALFORMED+=("$file (verified_against: $value)")
+  elif minor_is_older "$key" "$RELEASE_MINOR"; then
     STALE+=("$file (verified_against: $value)")
+  elif minor_is_older "$RELEASE_MINOR" "$key"; then
+    AHEAD+=("$file (verified_against: $value)")
   fi
 done < <(find "$DOCS_DIR" -name "*.md" -print0)
 
-if [[ ${#STALE[@]} -eq 0 ]]; then
-  echo "All docs pages with verified_against are current for $RELEASE_MINOR (release $VERSION)."
-  exit 0
+if [[ ${#MALFORMED[@]} -gt 0 ]]; then
+  echo "ERROR: The following docs pages have a verified_against value that is not a"
+  echo "version number. Set it to the app version the page was verified against:"
+  echo ""
+  for entry in "${MALFORMED[@]}"; do
+    echo "  $entry"
+  done
+  exit 1
 fi
 
-echo "ERROR: The following docs pages have a verified_against version that lags"
-echo "the released minor version ($RELEASE_MINOR, from release $VERSION). Re-verify"
-echo "each page against the current UI and update its verified_against field:"
-echo ""
-for entry in "${STALE[@]}"; do
-  echo "  $entry"
-done
-echo ""
-echo "If the page content is still accurate, just bump verified_against to $VERSION."
-exit 1
+if [[ ${#STALE[@]} -gt 0 ]]; then
+  echo "ERROR: The following docs pages have a verified_against version older than"
+  echo "the released minor version (v$RELEASE_MINOR, from release $VERSION). Re-verify"
+  echo "each page against the current UI and update its verified_against field:"
+  echo ""
+  for entry in "${STALE[@]}"; do
+    echo "  $entry"
+  done
+  echo ""
+  echo "If the page content is still accurate, just bump verified_against to $VERSION."
+  exit 1
+fi
+
+# Ahead-of-release stamps do not block: the page was verified against this UI or a
+# later one. Surface them anyway — a page claiming verification against a minor
+# that has not shipped is usually a stamp written in anticipation of a release
+# that was then cut under a different number.
+if [[ ${#AHEAD[@]} -gt 0 ]]; then
+  echo "NOTE: The following docs pages are stamped ahead of release $VERSION."
+  echo "They do not block the release, but the stamp should name the version whose"
+  echo "UI the page was actually verified against:"
+  echo ""
+  for entry in "${AHEAD[@]}"; do
+    echo "  $entry"
+  done
+  echo ""
+fi
+
+echo "All docs pages with verified_against are current for v$RELEASE_MINOR (release $VERSION)."
+exit 0


### PR DESCRIPTION
## Summary

The `v0.2.3` release tag [failed validation](https://github.com/outrightmental/ConversationSimulator/actions/runs/29296044012/job/86969670404) with every UI-referencing docs page reported as *lagging* v0.2.3 — while each was stamped `verified_against: v0.3.0`, a version **ahead** of the release. Two defects combined to produce that contradiction.

### 1. The comparison was non-directional (`scripts/check-docs-freshness.sh`)

The gate compared minor keys with `!=`, so any stamp that did not *exactly* equal the released minor was reported stale — in either direction. But the drift contract is directional: a page is stale only when it **lags** the release, i.e. has not been re-verified for the new minor. A page verified against a *newer* minor has been verified against this UI or a later one, and is not drift.

- Compare numerically and fail only on strictly-older stamps. (A string compare also orders `0.10` before `0.9`.)
- Report ahead-of-release stamps as a **non-blocking note** rather than an error.
- Unparseable stamps now fail loudly instead of slipping through the old equality check.
- Normalize a leading `v`, so a bare `0.2.3` stamp matches tag `v0.2.3`.

### 2. The stamps themselves were wrong (7 docs pages)

The onboarding epic stamped all seven pages `v0.3.0` in anticipation of shipping as a minor bump, but the work shipped as the **v0.2.3 patch** off the same `main`. The pages were verified against the UI that v0.2.3 ships, so that is the version they must name.

Left at `v0.3.0` they would have silently satisfied the gate for every `v0.3.x` release — disarming drift detection across the whole next minor.

## Verification

`scripts/check-docs-freshness.sh` exercised against the real docs tree and an isolated fixture tree:

| Case | Expect | Result |
|---|---|---|
| Release `v0.2.3`, stamps `v0.2.3` (this release) | pass | ✅ pass |
| Patch `v0.2.9` — patches must not be blocked | pass | ✅ pass |
| Minor bump `v0.3.0` — docs genuinely lag | **fail** | ✅ fail |
| Pre-release `v0.2.4-beta.1` | pass | ✅ pass |
| Page `v0.9` vs release `v0.10.0` (0.9 *is* older) | **fail** | ✅ fail (lexical compare would wrongly pass) |
| Page `v0.10` vs release `v0.9.0` (0.10 is newer) | pass | ✅ pass |
| Malformed stamp (`unreleased`) | **fail** | ✅ fail, no crash |
| Bare `0.2.3` stamp vs tag `v0.2.3` | pass | ✅ pass (old code failed this) |

`shellcheck` clean; `scripts/smoke-check.sh` (the preceding step in the same Validate job) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)