### PR TITLE
Fix the Steam publish download flag, and lint workflows in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,32 @@ jobs:
           echo "Local: shellcheck scripts/*.sh"
           shellcheck scripts/*.sh
 
+  # ── Workflow linting ────────────────────────────────────────────────────────
+  # The release workflow is the least-tested code in the repo: most of it runs
+  # only on a v* tag, so a typo'd expression, a bad `needs:`, or a shell error in
+  # a run: block is discovered during a release. actionlint type-checks every
+  # workflow expression and shellchecks every run: block without executing them.
+  #
+  # It does NOT catch everything — an invalid CLI flag in an otherwise valid
+  # command (`gh release download --skip-errors`, which broke the Steam publish)
+  # still requires actually running the step. It does catch the whole class of
+  # errors that are statically visible.
+  #
+  # SC2016 is excluded: the workflows intentionally single-quote strings
+  # containing `$` that must reach a downstream shell or Python heredoc unexpanded.
+  actionlint:
+    name: Workflow lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Lint GitHub Actions workflows
+        env:
+          SHELLCHECK_OPTS: -e SC2016
+        run: |
+          echo "Local: brew install actionlint && SHELLCHECK_OPTS='-e SC2016' actionlint"
+          bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          ./actionlint -color
+
   # ── PowerShell lint and unit tests ──────────────────────────────────────────
   # The .sh scripts have had shellcheck since day one; the .ps1 scripts had no CI
   # coverage of any kind. That gap is why the v0.2.3 release broke: the Windows

--- a/.github/workflows/steam-deploy.yml
+++ b/.github/workflows/steam-deploy.yml
@@ -188,9 +188,14 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
+          # --clobber (not --skip-errors, which is not a gh flag and made this step
+          # fail instantly on every release) so a re-run overwrites a partial download
+          # instead of erroring on existing files. Downloading every asset is
+          # deliberate: if the release has none, this SHOULD fail rather than quietly
+          # push an empty depot to Steam.
           gh release download "$RELEASE_TAG" \
             --dir release-artifacts \
-            --skip-errors
+            --clobber
 
       - name: List downloaded artifacts
         if: env.HAS_STEAM_CREDS == 'true'


### PR DESCRIPTION
## Summary

v0.2.3 now builds, signs, notarises, and **publishes** on all three platforms. The last chained job failed instantly:

```
gh release download "$RELEASE_TAG" --dir release-artifacts --skip-errors
unknown flag: --skip-errors
```

There is no `--skip-errors` flag in `gh` (the real one is `--skip-existing`). As with every other failure in this release, the Steam job only runs when chained from a `v*` tag — so the invalid flag had never once been executed.

Switched to `--clobber`, so a re-run overwrites a partial download instead of erroring on existing files. Downloading every asset stays deliberate: if the release has no assets this **should** fail, rather than quietly push an empty depot to Steam.

## Prevention: actionlint in CI

The release workflow is the least-tested code in the repo. actionlint type-checks every workflow expression and shellchecks every `run:` block **without executing them** — catching bad `needs:`, typo'd contexts, and shell errors on the PR that introduces them. Verified it catches both classes on a synthetic broken workflow, and it is already clean on this repo.

**Being honest about its limits:** actionlint would *not* have caught `--skip-errors` — a valid shell command with an invalid flag. Nothing static catches that; only running the step does. It covers the statically visible class, which is worth having.

🤖 Generated with [Claude Code](https://claude.com/claude-code)