### PR TITLE
Steam is the only prebuilt channel: stop publishing binaries to GitHub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,12 +84,18 @@ jobs:
       # checklist item into a hard CI enforcement.  Contributor forks and PR
       # builds are unaffected because they never carry a v* tag.
       REQUIRE_SIGNED_MACOS: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.tag, 'v')) }}
-      # Steam depot builds bundle llama-server so players get zero-setup
-      # inference; GitHub release installers stay lean and download it on first
-      # run (see docs/model-download-policy.md §8). This one workflow feeds both
-      # channels, so bundling is an explicit opt-in: set the BUNDLE_LLAMA_SERVER
-      # repository variable to 'true' only for Steam-depot builds.
-      BUNDLE_LLAMA_SERVER: ${{ vars.BUNDLE_LLAMA_SERVER == 'true' }}
+      # Steam is the ONLY channel that ships prebuilt binaries. The other supported
+      # path is building from source at a release tag; no installer is published to
+      # GitHub or the website. Every release build is therefore a Steam depot build:
+      # it bundles llama-server so players get zero-setup inference, and it disables
+      # the in-app updater (Steam owns updates via SteamPipe).
+      #
+      # This used to be an opt-in repository variable, defaulting to false. Nobody
+      # ever set it, so every release built the non-Steam variant, published
+      # installers to GitHub that were not supposed to exist, and produced no depot
+      # payload — which made the Steam publish chained to each tag fail on a depot
+      # audit every single time.
+      BUNDLE_LLAMA_SERVER: true
     strategy:
       fail-fast: false
       matrix:
@@ -1394,157 +1400,53 @@ jobs:
 
   # ── Publish GitHub release ────────────────────────────────────────────────────
   release:
-    name: Publish release
+    name: Publish release notes
     needs: build-desktop
     runs-on: ubuntu-latest
-    env:
-      HAS_UPDATER_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY != '' }}
     steps:
       - uses: actions/checkout@v5
 
-      - name: Download all desktop artifacts
-        uses: actions/download-artifact@v7
-        with:
-          path: release-artifacts
-          pattern: desktop-*
-          merge-multiple: true
-
-      - name: List collected artifacts
-        run: find release-artifacts -type f | sort
-
-      - name: Generate SHA-256 checksums
-        # Record bare filenames (not the release-artifacts/... paths) so the
-        # manifest matches the flattened asset names on the release page and
-        # `sha256sum -c checksums-sha256.txt` works next to the downloads.
-        run: |
-          find release-artifacts -type f | sort | while IFS= read -r f; do
-            ( cd "$(dirname "$f")" && sha256sum "$(basename "$f")" )
-          done > checksums-sha256.txt
-          cat checksums-sha256.txt
-
-      # ── Generate Tauri updater manifest (latest.json) ─────────────────────────
-      # latest.json is the endpoint the app's tauri-plugin-updater polls on
-      # launch.  It lists the new version, per-platform download URLs, and the
-      # Ed25519 updater signatures produced by the "Sign updater artifacts" step.
+      # NO binaries are attached to GitHub releases. Conversation Simulator ships
+      # prebuilt binaries through Steam ONLY; the other supported path is building
+      # from source at a release tag. A GitHub release is therefore a changelog and
+      # a tag — there is nothing to download.
       #
-      # This step is skipped when TAURI_SIGNING_PRIVATE_KEY is absent; in that
-      # case the in-app update check fails silently (offline guard) and no banner
-      # is shown — acceptable until signing infrastructure lands in #235.
-      - name: Generate Tauri updater manifest (latest.json)
-        if: env.HAS_UPDATER_KEY == 'true'
-        run: |
-          set -euo pipefail
-
-          TAG="${{ github.event.inputs.tag || github.ref_name }}"
-          VERSION="${TAG#v}"
-          REPO="outrightmental/ConversationSimulator"
-          BASE_URL="https://github.com/${REPO}/releases/download/${TAG}"
-          PUB_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-
-          # Helper: read .sig content or emit empty string.
-          sig_content() {
-            local FILE="$1"
-            [ -f "$FILE" ] && cat "$FILE" || echo ""
-          }
-
-          # Locate each platform's updater artifact and its signature.
-          MACOS_ARCHIVE="$(find release-artifacts -name '*.app.tar.gz' | head -n1)"
-          MACOS_SIG_FILE="${MACOS_ARCHIVE}.sig"
-          MACOS_SIG="$(sig_content "$MACOS_SIG_FILE")"
-          MACOS_FILENAME="$(basename "$MACOS_ARCHIVE")"
-
-          LINUX_APPIMAGE="$(find release-artifacts -name '*.AppImage' | head -n1)"
-          LINUX_SIG_FILE="${LINUX_APPIMAGE}.sig"
-          LINUX_SIG="$(sig_content "$LINUX_SIG_FILE")"
-          LINUX_FILENAME="$(basename "$LINUX_APPIMAGE")"
-
-          WINDOWS_EXE="$(find release-artifacts -name '*-setup.exe' | head -n1)"
-          WINDOWS_SIG_FILE="${WINDOWS_EXE}.sig"
-          WINDOWS_SIG="$(sig_content "$WINDOWS_SIG_FILE")"
-          WINDOWS_FILENAME="$(basename "$WINDOWS_EXE")"
-
-          # Emit the manifest only when at least one sig file is present.
-          if [ -z "$MACOS_SIG" ] && [ -z "$LINUX_SIG" ] && [ -z "$WINDOWS_SIG" ]; then
-            echo "  WARN  No .sig files found — skipping latest.json generation."
-            echo "        Set TAURI_SIGNING_PRIVATE_KEY to enable updater manifests."
-            exit 0
-          fi
-
-          python3 - <<PYEOF > latest.json
-          import json, sys
-
-          platforms = {}
-          for key, sig, filename in [
-            ("darwin-aarch64", """$MACOS_SIG""", "$MACOS_FILENAME"),
-            ("linux-x86_64",   """$LINUX_SIG""",   "$LINUX_FILENAME"),
-            ("windows-x86_64", """$WINDOWS_SIG""", "$WINDOWS_FILENAME"),
-          ]:
-            sig = sig.strip()
-            if sig and filename:
-              platforms[key] = {
-                "signature": sig,
-                "url": "$BASE_URL/" + filename,
-              }
-
-          manifest = {
-            "version": "$VERSION",
-            "notes":   "See https://github.com/$REPO/releases/tag/$TAG for the full release notes.",
-            "pub_date": "$PUB_DATE",
-            "platforms": platforms,
-          }
-          print(json.dumps(manifest, indent=2))
-          PYEOF
-
-          echo "=== Generated latest.json ==="
-          cat latest.json
-
-      # Derive all release metadata before touching the release so we can:
-      #   - detect a pre-existing (hand-authored) release and preserve its title/body
-      #   - set prerelease from the tag semver suffix rather than hardcoding true
-      #   - set make_latest only for stable tags that will be published immediately
+      # This job used to upload installers for all three platforms, a SHA-256
+      # checksums manifest, and a Tauri updater manifest (latest.json + a
+      # beta-channel release). None of those were supposed to exist. They have been
+      # deleted from every published release, and the steps that produced them are
+      # gone from here so a future tag cannot recreate them.
+      #
+      # The in-app updater is gone with them: its endpoint was a GitHub release
+      # asset that will never exist again, and Steam owns updates via SteamPipe.
       - name: Resolve release metadata
         id: relmeta
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HAS_UPDATER_KEY: ${{ env.HAS_UPDATER_KEY }}
           # Pass the tag through the environment rather than interpolating the
           # ${{ }} expression straight into the script: a tag name can legally
-          # contain shell metacharacters (`$`, backticks, ...) that would
-          # otherwise be evaluated here (command injection). Quoting "$TAG"
-          # below keeps it inert.
+          # contain shell metacharacters that would otherwise be evaluated here.
           TAG: ${{ github.event.inputs.tag || github.ref_name }}
         run: |
           set -euo pipefail
 
-          # Pre-release iff the tag carries a semver pre-release suffix (a hyphen):
-          # v0.1.0 -> stable/Latest, v0.1.0-beta.1 -> pre-release. Mirrors the updater's
-          # version ordering (beta < release) used to build latest.json.
+          # Pre-release iff the tag carries a semver pre-release suffix (a hyphen).
           if [[ "$TAG" == *-* ]]; then PRERELEASE=true; else PRERELEASE=false; fi
 
-          # Does a release for this tag already exist? Creating a release in the GitHub
-          # UI pushes the tag (triggering this workflow) once the release row already
-          # exists, so a hand-authored title/body/"Latest" flag is already live.
+          # Creating a release in the GitHub UI pushes the tag (triggering this
+          # workflow) once the release row already exists, so a hand-authored
+          # title/body is already live. Preserve it by passing empty name/body.
           if gh release view "$TAG" >/dev/null 2>&1; then EXISTS=true; else EXISTS=false; fi
 
-          # Mark as "Latest" only for a stable tag that will actually be published
-          # (a draft release can never be Latest).
-          if [[ "$PRERELEASE" == false && ( "$HAS_UPDATER_KEY" == true || "$EXISTS" == true ) ]]; then
-            MAKE_LATEST=true
-          else
-            MAKE_LATEST=false
-          fi
+          if [[ "$PRERELEASE" == false ]]; then MAKE_LATEST=true; else MAKE_LATEST=false; fi
 
-          # Preserve an existing release's human-authored title and notes by passing
-          # empty name/body. For a brand-new release, seed the default title + template.
           if [[ "$EXISTS" == true ]]; then
             NAME=""
             BODY_PATH=""
-            DRAFT=false            # never demote an already-published release to draft
           else
             NAME="Conversation Simulator $TAG"
             BODY_PATH="docs/release-notes-template.md"
-            if [[ "$HAS_UPDATER_KEY" == true ]]; then DRAFT=false; else DRAFT=true; fi
           fi
 
           {
@@ -1553,58 +1455,20 @@ jobs:
             echo "make_latest=$MAKE_LATEST"
             echo "name=$NAME"
             echo "body_path=$BODY_PATH"
-            echo "draft=$DRAFT"
           } >> "$GITHUB_OUTPUT"
 
-          echo "Resolved: tag=$TAG prerelease=$PRERELEASE make_latest=$MAKE_LATEST exists=$EXISTS draft=$DRAFT"
+          echo "Resolved: tag=$TAG prerelease=$PRERELEASE make_latest=$MAKE_LATEST exists=$EXISTS"
 
-      # When the updater manifest is being produced (HAS_UPDATER_KEY), the
-      # versioned release MUST be published immediately rather than left as a
-      # draft: the beta-channel `latest.json` uploaded in the next step points at
-      # this release's assets and tag page, and draft assets 404 for the public.
-      # When signing is off and no pre-existing release exists, we keep the
-      # previous draft/manual-review behaviour (relmeta sets draft=true).
-      - name: Create versioned GitHub release
-        id: versioned_release
+      # No `files:` key — this publishes notes, never artifacts.
+      - name: Publish release notes (no binaries)
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.relmeta.outputs.tag }}
           name: ${{ steps.relmeta.outputs.name }}
           body_path: ${{ steps.relmeta.outputs.body_path }}
-          draft: ${{ steps.relmeta.outputs.draft }}
+          draft: false
           prerelease: ${{ steps.relmeta.outputs.prerelease }}
           make_latest: ${{ steps.relmeta.outputs.make_latest }}
-          files: |
-            release-artifacts/**
-            checksums-sha256.txt
-            ${{ env.HAS_UPDATER_KEY == 'true' && 'latest.json' || '' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # ── Update beta-channel release ───────────────────────────────────────────
-      # The app's updater plugin checks a fixed URL:
-      #   .../releases/download/beta-channel/latest.json
-      # Uploading latest.json here means every new beta release is discovered
-      # automatically on next app launch without any URL change in the binary.
-      # Previous versioned releases (e.g. v0.1.0-beta.1) remain downloadable.
-      - name: Update beta-channel release with latest updater manifest
-        if: env.HAS_UPDATER_KEY == 'true'
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: beta-channel
-          name: Beta channel — latest updater manifest
-          body: |
-            This release holds the Tauri updater manifest (`latest.json`) for the
-            beta channel.  The app's built-in update checker polls this asset on
-            launch to detect new beta builds.
-
-            **Do not install from this release directly** — download from the
-            corresponding versioned pre-release instead.
-
-            Latest beta: ${{ github.event.inputs.tag || github.ref_name }}
-          prerelease: true
-          draft: false
-          files: latest.json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -1627,6 +1491,11 @@ jobs:
     with:
       release_tag: ${{ github.event.inputs.tag || github.ref_name }}
       set_live_branch: beta
+      # Steam takes its depot payload from THIS run's build artifacts. It used to
+      # `gh release download` the published installers, but GitHub releases no
+      # longer carry binaries — Steam is the only prebuilt channel, so the depot
+      # content has to come from the build that just ran.
+      run_id: ${{ github.run_id }}
     secrets: inherit
 
   # ── Microsoft Defender for Storage malware scan (Windows) ──────────────────

--- a/.github/workflows/steam-deploy.yml
+++ b/.github/workflows/steam-deploy.yml
@@ -88,6 +88,14 @@ on:
         required: false
         default: 'beta'
         type: string
+      run_id:
+        description: >
+          Run ID of the release workflow whose desktop-* build artifacts hold the
+          depot payload (Actions → the Release run → the number in its URL).
+          Required: GitHub releases carry no binaries, so there is nothing to
+          download from the release itself.
+        required: true
+        type: string
 
   # Reusable workflow target: called from release.yml after a successful
   # GitHub release.  The steam-release environment gate (below) still applies
@@ -110,9 +118,20 @@ on:
         required: false
         default: 'beta'
         type: string
+      run_id:
+        description: >
+          Workflow run whose desktop-* build artifacts supply the depot payload.
+          release.yml passes its own github.run_id. Depot content comes from build
+          artifacts, NOT from GitHub release assets — releases no longer carry
+          binaries, because Steam is the only prebuilt channel.
+        required: false
+        default: ''
+        type: string
 
 permissions:
   contents: read
+  # Required to download build artifacts from the run identified by `run_id`.
+  actions: read
 
 jobs:
   steam-upload:
@@ -182,20 +201,21 @@ jobs:
           fi
 
       # ── Download GitHub release assets ─────────────────────────────────────
-      - name: Download release artifacts
+      # Depot payload comes from the BUILD ARTIFACTS of the release run, not from
+      # GitHub release assets. GitHub releases carry no binaries at all: Steam is the
+      # only prebuilt channel, the other supported path is building from source at a
+      # release tag. (This step used to `gh release download` the published
+      # installers — with a --skip-errors flag that does not exist in gh, so it had
+      # never once succeeded.)
+      - name: Download desktop build artifacts
         if: env.HAS_STEAM_CREDS == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ inputs.release_tag }}
-        run: |
-          # --clobber (not --skip-errors, which is not a gh flag and made this step
-          # fail instantly on every release) so a re-run overwrites a partial download
-          # instead of erroring on existing files. Downloading every asset is
-          # deliberate: if the release has none, this SHOULD fail rather than quietly
-          # push an empty depot to Steam.
-          gh release download "$RELEASE_TAG" \
-            --dir release-artifacts \
-            --clobber
+        uses: actions/download-artifact@v7
+        with:
+          path: release-artifacts
+          pattern: desktop-*
+          merge-multiple: true
+          run-id: ${{ inputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: List downloaded artifacts
         if: env.HAS_STEAM_CREDS == 'true'
@@ -230,18 +250,19 @@ jobs:
                 tar -xzf "$f" --strip-components=1 -C steam-content/windows/
               done
           else
-            # Fallback: warn loudly and stage the installer files.  This path is
-            # DEPRECATED and exists only to allow deploys of artifacts built before
-            # issue #408 was implemented.  A depot containing installer packages
-            # WILL FAIL Valve review — do not promote to default with this layout.
-            echo "DEPRECATION WARNING: steam-depot-windows.tar.gz not found." >&2
-            echo "  Falling back to staging NSIS/.msi installers — THIS WILL" >&2
-            echo "  FAIL VALVE REVIEW.  Rebuild from a release tagged after" >&2
-            echo "  issue #408 to get the correct portable depot layout." >&2
-            find release-artifacts -name "*-setup.exe" \
-              -exec cp -v {} steam-content/windows/ \;
-            find release-artifacts -name "*.msi" \
-              -exec cp -v {} steam-content/windows/ \;
+            # Fail rather than stage installers. A depot containing NSIS/MSI
+            # installer packages fails Valve review outright, so the old fallback
+            # could only ever produce a rejected build — it just did so slowly, via
+            # the depot audit, after burning a full upload. Every release build now
+            # sets BUNDLE_LLAMA_SERVER=true, so this tarball is always produced; if
+            # it is missing, the Windows build leg did not do its job and there is
+            # nothing valid to publish.
+            echo "ERROR: steam-depot-windows.tar.gz not found in the build artifacts." >&2
+            echo "       The Windows leg of release.yml must produce the portable depot" >&2
+            echo "       tree (see 'Package Windows portable depot layout for Steam depot')." >&2
+            echo "       Refusing to stage NSIS/MSI installers: a depot containing" >&2
+            echo "       installer packages fails Valve review." >&2
+            exit 1
           fi
 
           # macOS: extract the .app bundle from the .app.tar.gz published by

--- a/docs-site/src/content/docs/start/install.md
+++ b/docs-site/src/content/docs/start/install.md
@@ -1,6 +1,6 @@
 ---
 title: "Installation"
-description: "Download, verify, and install Conversation Simulator on Windows, macOS, or Linux, and set up your first local model."
+description: "Install Conversation Simulator on Windows, macOS, or Linux — from Steam, or by building the open-source code yourself."
 sidebar:
   order: 1
 verified_against: v0.2.3
@@ -10,10 +10,22 @@ Conversation Simulator runs entirely on your computer — no cloud inference,
 no account, no telemetry. You need a local model before any conversation can
 start; the app downloads one on first run after you accept its license.
 
-:::note
-This guide covers installing the **pre-built application** — the right path
-for almost everyone. Contributors who want to run the platform from source
-should follow the [developer install](/dev/developer-install/) instead.
+There are exactly **two ways to get it**:
+
+| | [Steam](#1-steam--the-ready-to-run-build) | [Build from source](#2-build-from-source--free) |
+|---|---|---|
+| **Cost** | $9.99 | Free |
+| **You get** | A ready-to-run app: code-signed, notarized, auto-updating via Steam, Steam Deck–verified. The AI engine is bundled, so there is nothing to install separately. | The same software, built by you from the Apache-2.0 source. |
+| **Best for** | Almost everyone. | Developers, and anyone who wants to inspect or modify the code. |
+
+:::caution[There are no installers to download]
+Conversation Simulator does **not** publish `.dmg`, `.exe`, `.msi`, `.deb`, or
+`AppImage` downloads — not on GitHub, not on our website. Steam is the only
+channel that ships prebuilt binaries. If you find an installer for this app
+anywhere else, it did not come from us.
+
+The GitHub releases page carries release notes and source tags only. To run the
+free version, build it from source at a release tag (below).
 :::
 
 ---
@@ -30,55 +42,51 @@ should follow the [developer install](/dev/developer-install/) instead.
 
 ---
 
-## 1. Download and verify
+## 1. Steam — the ready-to-run build
 
-Download the installer for your platform from the
-[releases page](https://github.com/outrightmental/ConversationSimulator/releases):
+Install **Conversation Simulator** from Steam on Windows, macOS, Linux, or Steam
+Deck. Steam handles installation and updates; there is nothing else to download
+and nothing to verify by hand.
 
-| Platform | File |
-|---|---|
-| macOS (Apple Silicon) | `ConversationSimulator_<version>_aarch64.dmg` |
-| macOS (Intel) | `ConversationSimulator_<version>_x64.dmg` |
-| Linux (x86_64) | `conversation-simulator_<version>_amd64.AppImage` |
-| Windows (x86_64) | `ConversationSimulator_<version>_x64-setup.exe` |
+The Steam build is code-signed on Windows, signed and notarized on macOS, and
+ships with the AI engine bundled — so your first conversation can start while the
+model is still downloading.
 
-Verify the download against the `checksums-sha256.txt` file on the release page:
-
-```bash
-# macOS / Linux
-shasum -a 256 ConversationSimulator_<version>_aarch64.dmg
-```
-
-```powershell
-# Windows PowerShell
-Get-FileHash "ConversationSimulator_<version>_x64-setup.exe" -Algorithm SHA256
-```
+That is the whole procedure. Skip to [First launch](#3-first-launch).
 
 ---
 
-## 2. Install and launch
+## 2. Build from source — free
 
-- **macOS:** open the `.dmg` and drag the app to `/Applications`. On first
-  launch, Gatekeeper may warn about an unidentified developer (pre-release
-  builds are unsigned). Right-click the app → **Open** → **Open** to proceed.
-- **Windows:** run the `.exe` installer. Windows 10/11 release builds are
-  Authenticode-signed, so no SmartScreen warning appears. If you see one on
-  a pre-release build, click **More info → Run anyway**.
-- **Linux:** make the AppImage executable and run it directly — no
-  installation needed:
+The engine is Apache-2.0 and the four official scenario packs are CC BY 4.0, so
+you can always build and run the app yourself at no cost. It is the same
+software; you are supplying the build instead of paying for one.
 
-  ```bash
-  chmod +x conversation-simulator_<version>_amd64.AppImage
-  ./conversation-simulator_<version>_amd64.AppImage
-  ```
+Check out a **release tag** rather than `main` — tags are the versions we test
+and ship:
 
-The app starts its local conversation engine automatically. If the home
-screen reports that the engine did not start, see
-[Troubleshooting](/start/troubleshooting/#engine-startup-failure).
+```bash
+git clone https://github.com/outrightmental/ConversationSimulator.git
+cd ConversationSimulator
+git checkout v0.2.3        # latest release tag
+```
+
+Then follow the [developer install](/dev/developer-install/), which covers
+prerequisites (Node, pnpm, Python, Rust) and building the desktop app.
+
+Note that a source build is not code-signed. macOS Gatekeeper will warn about an
+unidentified developer on first launch: right-click the app → **Open** → **Open**.
+On Windows, SmartScreen may show *"Windows protected your PC"* — click
+**More info → Run anyway**. This is expected for software you built yourself; the
+signed builds are the ones distributed through Steam.
 
 ---
 
 ## 3. Set up your AI (first launch)
+
+However you got the app, the first launch is the same. The app starts its local
+conversation engine automatically; if the home screen reports that the engine did
+not start, see [Troubleshooting](/start/troubleshooting/#engine-startup-failure).
 
 On first launch the app shows the **welcome screen**. The **Set me up** card
 names the recommended model for your hardware and shows its download size and
@@ -91,38 +99,28 @@ license. Click **Set me up** to begin — the download starts right away.
   responses.
 - When all stages complete, click **Continue to Home** to start playing.
 
-No model weights are bundled with the installer. The one-time download is
-the only step that requires an internet connection — after it completes,
-everything works offline.
+No model weights are bundled with the app. The one-time download is the only
+step that requires an internet connection — after it completes, everything works
+offline.
 
 Want to use Ollama or a custom model file instead? See
 [Choosing how to run the AI](/play/ai-engine/).
 
 ---
 
-## Beta builds — direct-download channel
+## Updates and rollback
 
-Beta builds are published to GitHub Releases as versioned pre-releases
-(e.g. `v0.1.0-beta.1`). They are distinct from the Steam beta branch.
+**On Steam,** Steam handles updates. Beta builds are published to the Steam
+**beta branch** — opt in from the app's Properties → Betas in your Steam library.
+To roll back, pick an earlier build from that same menu.
 
-### In-app update notice
+There is no in-app updater and no direct-download beta channel: the app never
+polls GitHub for a new version, because no binaries are published there.
 
-The app checks for a new beta on launch and shows a non-intrusive banner on
-the home screen when one is found. The banner never appears during an active
-conversation session. Click **View notes** to open the release page, or
-**Install** to open it and download the new build. The check is skipped
-silently when you are offline.
-
-### Rollback
-
-Every beta release remains permanently downloadable from its versioned
-release page (e.g., `releases/tag/v0.1.0-beta.1`). To roll back:
-
-1. Download the installer from the previous versioned release page.
-2. Install over the current version — the Windows installer and macOS DMG
-   both support in-place downgrades.
-3. Data created in a newer beta is forward-compatible with older betas at
-   the same schema version (see [Schema versioning](/reference/schema-versioning/)).
+**From source,** update by checking out a newer release tag and rebuilding; roll
+back by checking out an earlier one. Data created in a newer version is
+forward-compatible with older versions at the same schema version (see
+[Schema versioning](/reference/schema-versioning/)).
 
 ---
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -5,8 +5,12 @@ Conversation Simulator runs entirely on your computer — no cloud inference, no
 
 Two install paths are available:
 
-- **Path A — developer install:** clone the source and run the dev services locally. Suitable for contributors and users who want full control.
-- **Path B — alpha app install:** download and run the pre-built desktop application (see below). Note that the alpha build wraps the web UI in a native window; the backend must still be started separately until the sidecar is bundled.
+- **Path A — build from source (free):** clone the repository at a release tag and build it yourself. This is the free path, and the only one served from GitHub.
+- **Path B — Steam ($9.99):** the same software, packaged and ready to run — code-signed, notarized, auto-updating, with the AI engine bundled.
+
+> **There are no installers to download from GitHub.** Steam is the only channel
+> that ships prebuilt binaries. The GitHub releases page carries release notes and
+> source tags only — no `.dmg`, `.exe`, `.msi`, `.deb`, or `AppImage`.
 
 ---
 
@@ -210,62 +214,28 @@ page (e.g., `releases/tag/v0.1.0-beta.1`).  To roll back:
 
 ---
 
-## Path B — alpha app install
+## Path B — Steam
 
-When a release is published on the [GitHub releases page](https://github.com/outrightmental/ConversationSimulator/releases):
+Install **Conversation Simulator** from Steam on Windows, macOS, Linux, or Steam
+Deck. Steam handles installation and updates; there is nothing to download by hand
+and no checksum to verify.
 
-### 1. Pre-flight check
+The Steam build is Authenticode-signed on Windows, signed and notarised on macOS,
+and bundles the llama.cpp AI engine, so the app is standalone — your first
+conversation can start while the model is still downloading.
 
-Run the first-run check before downloading anything:
+### Why there is no GitHub installer
 
-```bash
-./scripts/first-run-check.sh        # macOS / Linux
-.\scripts\first-run-check.ps1       # Windows PowerShell
-```
+Publishing prebuilt binaries on GitHub would mean shipping a second, unsigned
+distribution channel that nobody pays for and nobody can auto-update. The project
+serves the free path as *source you build* and the paid path as *binaries we sign
+and support*. So:
 
-### 2. Download and verify
+- GitHub releases → release notes and a source tag. Nothing to download.
+- Steam → the prebuilt, signed, standalone binaries.
 
-Download the installer for your platform:
-
-| Platform | File |
-|---|---|
-| macOS (Apple Silicon) | `ConversationSimulator_<version>_aarch64.dmg` |
-| macOS (Intel) | `ConversationSimulator_<version>_x64.dmg` |
-| Linux (x86_64) | `conversation-simulator_<version>_amd64.AppImage` |
-| Windows (x86_64) | `ConversationSimulator_<version>_x64-setup.exe` |
-
-Verify the download against the `checksums-sha256.txt` file on the release page:
-
-```bash
-# macOS / Linux
-shasum -a 256 ConversationSimulator_<version>_aarch64.dmg
-```
-
-```powershell
-# Windows PowerShell
-Get-FileHash "ConversationSimulator_<version>_x64-setup.exe" -Algorithm SHA256
-```
-
-### 3. Install and launch
-
-- **macOS:** open the `.dmg` and drag the app to `/Applications`. On first
-  launch, Gatekeeper may warn about an unidentified developer (alpha builds are
-  unsigned). Right-click the app → **Open** → **Open** to proceed.
-- **Windows:** run the `.exe` installer. SmartScreen may warn about an unrecognised
-  publisher — click **More info → Run anyway**.
-- **Linux:** `chmod +x *.AppImage` then run it directly. No installation needed.
-
-### 4. Launch the app
-
-Open the installed application. The backend sidecar (`convsim-core`) starts
-automatically — no separate terminal is required.
-
-### 5. Set up a local model
-
-On first launch the app shows the **welcome screen**. Click **Set me up** to
-download and configure the recommended model automatically. Expand **Advanced
-options** to use Ollama or a custom GGUF file instead. No model weights are
-bundled with the installer.
+The release workflow enforces this: it publishes no binary assets, and its build
+output goes to the Steam depot.
 
 ---
 


### PR DESCRIPTION
## Summary

Conversation Simulator has exactly **two** supported paths: buy the packaged build on **Steam**, or **build from source** at a release tag. No prebuilt binary distribution is served from GitHub or the website.

The README and the marketing site have always said this. **The release pipeline did not.** Every release published installers for all three platforms to GitHub.

Those **34 assets (v0.1.0 → v0.2.3) have been deleted.** This PR stops the pipeline from recreating them on the next tag.

## Root cause: an opt-in nobody ever opted into

`BUNDLE_LLAMA_SERVER` was a repository *variable* defaulting to `false`, and it was never set. So every release built the **non-Steam** variant, which:

1. published installers to GitHub that were not supposed to exist, and
2. produced **no Steam depot payload** — which is exactly why the Steam publish chained to every tag failed its depot audit *every single time* (it fell back to stuffing the NSIS/MSI installers into the depot, which fails Valve review).

It is now unconditionally `true`. **Release builds are Steam builds:** llama-server bundled (standalone, zero-setup inference), in-app updater disabled (Steam owns updates via SteamPipe).

## What changed

**No binaries on GitHub.** The publish job uploads nothing. Gone with the installers: the SHA-256 checksums manifest, the Tauri updater manifest (`latest.json`), and the `beta-channel` release that hosted it — the updater's endpoint was a GitHub release asset that will never exist again. A GitHub release is now a changelog and a tag.

**Steam takes its payload from build artifacts.** It can no longer read release assets, because there are none. It now downloads the `desktop-*` artifacts from the release run (new `run_id` input, passed as `github.run_id`).

**macOS depot is unaffected** — `release.yml` already tars the signed and notarised `.app` itself rather than relying on the updater's `.app.tar.gz`, which a Steam build does not produce. (Worth stating explicitly: flipping to Steam builds would otherwise have silently broken the macOS depot.)

**The Windows depot fallback is now a hard failure.** It used to stage NSIS/MSI installers when the portable tarball was missing. A depot containing installer packages fails Valve review, so that path could only ever produce a *rejected* build — it just did so slowly, after burning a full upload.

**Docs.** The install guides told users to download an installer from the releases page and verify it against `checksums-sha256.txt`. Both files are gone; the instructions were false. Rewritten around the two real paths (Steam / build from source), including *why* there is no GitHub installer. The "beta direct-download channel" and "in-app update notice" sections are replaced with Steam's beta branch.

## Verification

- `actionlint` clean; all three workflows parse.
- Docs-freshness gate passes for `v0.2.3`.
- No `files:`, `checksums-sha256`, `latest.json`, or `beta-channel` publishing paths remain in `release.yml`.
- Confirmed all 5 releases now carry **0 assets**, with tags and changelogs intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
