### PR TITLE
Grant actions:read to release.yml so the Steam job can read build artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,12 @@ on:
 # Write permission needed to create GitHub releases and upload assets.
 permissions:
   contents: write
+  # Required by the called steam-deploy.yml, which downloads this run's desktop-*
+  # build artifacts to assemble the Steam depot. A reusable workflow's permissions
+  # must be a SUBSET of its caller's: granting `actions: read` there but not here
+  # fails the whole run at startup ("workflow file issue") before a single job
+  # starts — and actionlint does not check cross-workflow permission subsets.
+  actions: read
 
 jobs:
   # ── Smoke check ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
The v0.2.3 tag run failed at **startup** — "this run likely failed because of a workflow file issue" — before a single job started.

`steam-deploy.yml` now needs `actions: read` to download the release run's `desktop-*` build artifacts (since GitHub releases no longer carry binaries). But **a reusable workflow's permissions must be a subset of its caller's**, and `release.yml` granted only `contents: write`. Requesting a permission the caller does not hold invalidates the entire workflow.

actionlint does not check cross-workflow permission subsets, so this passed every static gate and only surfaced on a real tag — the same tag-only blind spot as everything else in this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)