### PR TITLE
convsim-core: emit shared RuntimeReadiness from /api/health, add /api/runtime/settings

### DIFF
--- a/docs-site/src/content/docs/dev/release-checklist.md
+++ b/docs-site/src/content/docs/dev/release-checklist.md
@@ -122,7 +122,7 @@ curl http://127.0.0.1:7355/api/health | python3 -m json.tool
 
 - [ ] `status` is `"ok"`
 - [ ] `database.status` is `"ok"`
-- [ ] `runtime.status` is `"ready"` (fake runtime on source install is expected)
+- [ ] `llm_runtime.status` is `"ready"` (fake runtime on source install is expected)
 - [ ] `stt.status` and `tts.status` fields are present (value may be `"unavailable"` without runtimes installed)
 
 ### B.4 Web launch

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -145,7 +145,7 @@ curl http://127.0.0.1:7355/api/health | python3 -m json.tool
 
 - [ ] `status` is `"ok"`
 - [ ] `database.status` is `"ok"`
-- [ ] `runtime.status` is `"ready"` (fake runtime on source install is expected)
+- [ ] `llm_runtime.status` is `"ready"` (fake runtime on source install is expected)
 - [ ] `stt.status` and `tts.status` fields are present (value may be `"unavailable"` without runtimes installed)
 
 ### B.4 Web launch

--- a/scripts/nightly-model-smoke.py
+++ b/scripts/nightly-model-smoke.py
@@ -296,7 +296,7 @@ def run_smoke(
 
             # Sanity-check that the real runtime is wired (not the fake default).
             health = _get_json(f"{base}/health")
-            runtime_id = health.get("runtime", {}).get("runtime_id")
+            runtime_id = health.get("llm_runtime", {}).get("runtime_id")
             print(f"[smoke] convsim-core ready (runtime_id={runtime_id}).")
             if runtime_id != "llama_cpp":
                 raise RuntimeError(

--- a/scripts/release-smoke.ps1
+++ b/scripts/release-smoke.ps1
@@ -253,7 +253,7 @@ function Invoke-SmokeBackendHealth {
             Write-Fail "health" "/api/health status=$($body.status) (expected ok)"
             return
         }
-        Write-Pass "health" "/api/health status=ok runtime=$($body.runtime.status)"
+        Write-Pass "health" "/api/health status=ok llm=$($body.llm_runtime.status) llm_ready=$($body.runtime.llm_ready)"
     } catch {
         Write-Fail "health" "GET $CoreUrl/api/health failed: $_ — is convsim-core running?"
     }

--- a/services/convsim-core/convsim_core/app.py
+++ b/services/convsim-core/convsim_core/app.py
@@ -17,7 +17,7 @@ from convsim_core.errors import (
 from convsim_core.logging_setup import configure_logging
 from convsim_core.packs.seeder import seed_official_packs
 from convsim_core.paths import legacy_convsim_dir, platform_data_root
-from convsim_core.routers import cloud_settings as cloud_settings_router, diag as diag_router, health, logbook as logbook_router, models as models_router, packs as packs_router, preflight as preflight_router, privacy as privacy_router, relationship_memory as relationship_memory_router, scenarios as scenarios_router, sessions as sessions_router, settings as settings_router, setup as setup_router, setup_install as setup_install_router, sidecar as sidecar_router, stt as stt_router, tts as tts_router, vad as vad_router, workbench as workbench_router
+from convsim_core.routers import cloud_settings as cloud_settings_router, diag as diag_router, health, logbook as logbook_router, models as models_router, packs as packs_router, preflight as preflight_router, privacy as privacy_router, relationship_memory as relationship_memory_router, runtime_settings as runtime_settings_router, scenarios as scenarios_router, sessions as sessions_router, settings as settings_router, setup as setup_router, setup_install as setup_install_router, sidecar as sidecar_router, stt as stt_router, tts as tts_router, vad as vad_router, workbench as workbench_router
 from convsim_core.runtime import build_runtime
 from convsim_core.runtime.sidecar import LlamaCppSidecar
 from convsim_core.runtime.kokoro_sidecar import KokoroSidecar
@@ -138,6 +138,7 @@ def create_app(config: ServiceConfig | None = None) -> FastAPI:
     app.include_router(diag_router.router)
     app.include_router(models_router.router)
     app.include_router(sidecar_router.router)
+    app.include_router(runtime_settings_router.router)
     app.include_router(stt_router.router)
     app.include_router(tts_router.router)
     app.include_router(vad_router.router)

--- a/services/convsim-core/convsim_core/routers/health.py
+++ b/services/convsim-core/convsim_core/routers/health.py
@@ -193,12 +193,20 @@ def _build_readiness(
     """Derive the user-facing readiness summary.
 
     The LLM counts as installed/ready when the user has an active model
-    selection backed by a usable install record (or an existing GGUF file),
-    or — for runtimes without local model files (fake, scripted, ollama) —
-    when the selection was made or the configured runtime reports ready.
-    The live sidecar process state is deliberately NOT required here: it is
-    started on demand, and "installed but not currently loaded" must still
-    read as installed on the Home screen.
+    selection backed by a usable install record (an existing GGUF file, or an
+    Ollama tag validated at selection time). For a selected model the live
+    sidecar process state is deliberately NOT required: it is started on
+    demand, and "installed but not currently loaded" must still read as
+    installed on the Home screen.
+
+    When no local model file is involved — the fake/scripted runtimes or an
+    external server — we fall back to the live runtime health, so a llama.cpp
+    runtime selected without a model loaded does not falsely read as ready.
+
+    ``last_error`` reports only a *blocking* problem: why the LLM (which gates
+    play) is unavailable. Optional voice (STT/TTS) being uninstalled is
+    surfaced through ``stt_ready``/``tts_ready`` and must not populate
+    ``last_error``, or the Home screen shows an error card for a text-ready app.
     """
     runtime_id = active_cfg.get("runtime_id")
     model_id = active_cfg.get("model_id")
@@ -227,26 +235,25 @@ def _build_readiness(
                 "Re-select a model in the model manager."
             )
             llm_model_name = os.path.basename(model_id) or model_id
-    elif runtime_id:
-        # A runtime was actively selected without a model file (e.g. scripted
-        # or an external server). The selection endpoint validated it.
+    elif runtime_health.status in (RuntimeStatus.READY, RuntimeStatus.DEGRADED):
+        # No local model file is involved (fake/scripted runtime, or an
+        # external server), or nothing was explicitly selected and the default
+        # runtime is usable. With nothing to stat, the live runtime health is
+        # the only real signal — a llama.cpp runtime selected without a model
+        # loaded is not ready here and correctly reports so.
         llm_ready = True
-        llm_model_name = runtime_id
-    elif runtime_health.status == RuntimeStatus.READY:
-        # No explicit selection, but the configured default runtime is usable
-        # (e.g. the deterministic fake runtime in dev/test builds).
-        llm_ready = True
-        llm_model_name = runtime_health.model_id or runtime_health.runtime_name
+        llm_model_name = (
+            runtime_health.model_id or runtime_health.runtime_name or runtime_id
+        )
     elif runtime_health.message:
         errors.append(runtime_health.message)
 
+    # Optional voice: readiness is conveyed via the booleans below. Their
+    # "not installed" messages must NOT feed last_error — that field reports
+    # only blocking (LLM) problems, so a text-ready app doesn't surface a
+    # voice-unavailable message as a blocking error card on Home.
     stt_ready = stt_health.status in (RuntimeStatus.READY, RuntimeStatus.DEGRADED)
-    if not stt_ready and stt_health.message:
-        errors.append(stt_health.message)
-
     tts_ready = tts_health.status in (RuntimeStatus.READY, RuntimeStatus.DEGRADED)
-    if not tts_ready and tts_health.message:
-        errors.append(tts_health.message)
 
     return _RuntimeReadiness(
         llm_ready=llm_ready,

--- a/services/convsim-core/convsim_core/routers/health.py
+++ b/services/convsim-core/convsim_core/routers/health.py
@@ -1,12 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 import os
+import sqlite3
 from typing import Any, Optional
 
 from fastapi import APIRouter, Request
 from pydantic import BaseModel
 
 from convsim_core import __version__
-from convsim_core.runtime.types import RuntimeHealth
+from convsim_core.runtime.types import RuntimeHealth, RuntimeStatus
 from convsim_core.services.model_manager_service import get_active_config, get_most_recent_benchmark
 from convsim_core.stt.types import SttHealth
 from convsim_core.tts.types import TtsHealth
@@ -126,19 +127,138 @@ class _BenchmarkSummary(BaseModel):
     benchmarked_at: str
 
 
+class _RuntimeReadiness(BaseModel):
+    """Matches ``RuntimeReadiness`` in packages/shared/src/types/runtime.ts.
+
+    This is the contract the web UI's Home screen, scenario setup, and voice
+    settings read from ``HealthResponse.runtime``. It must stay a superset-
+    compatible shape with the shared TypeScript type.
+    """
+
+    llm_ready: bool
+    llm_model_name: Optional[str] = None
+    stt_ready: bool
+    tts_ready: bool
+    tts_voice_name: Optional[str] = None
+    network_required: bool
+    last_error: Optional[str] = None
+
+
 class HealthResponse(BaseModel):
     status: str
     version: str
     pid: int
     config_path: str
     database: _DatabaseStatus
-    runtime: RuntimeHealth
+    # User-facing readiness summary consumed by the web UI (shared contract).
+    runtime: _RuntimeReadiness
+    # Detailed diagnostic health of the configured chat runtime.
+    llm_runtime: RuntimeHealth
     active_model: _ActiveModelConfig
     privacy: _PrivacyPosture
     stt: SttHealth
     tts: TtsHealth
     sidecar_diagnostics: _SidecarDiagnostics
     last_benchmark: Optional[_BenchmarkSummary] = None
+
+
+def _find_installed_model(
+    conn: sqlite3.Connection, model_id: str
+) -> Optional[dict[str, Any]]:
+    """Look up an installed model by file path or registry id.
+
+    Only rows in a usable terminal state count as installed.
+    """
+    row = conn.execute(
+        """
+        SELECT id, registry_id, filename, file_path, install_status, display_name
+        FROM installed_models
+        WHERE (file_path = ? OR registry_id = ?)
+          AND install_status IN ('complete', 'ready')
+        ORDER BY id DESC
+        LIMIT 1
+        """,
+        (model_id, model_id),
+    ).fetchone()
+    return dict(row) if row is not None else None
+
+
+def _build_readiness(
+    conn: sqlite3.Connection,
+    active_cfg: dict[str, Optional[str]],
+    runtime_health: RuntimeHealth,
+    stt_health: SttHealth,
+    tts_health: TtsHealth,
+) -> _RuntimeReadiness:
+    """Derive the user-facing readiness summary.
+
+    The LLM counts as installed/ready when the user has an active model
+    selection backed by a usable install record (or an existing GGUF file),
+    or — for runtimes without local model files (fake, scripted, ollama) —
+    when the selection was made or the configured runtime reports ready.
+    The live sidecar process state is deliberately NOT required here: it is
+    started on demand, and "installed but not currently loaded" must still
+    read as installed on the Home screen.
+    """
+    runtime_id = active_cfg.get("runtime_id")
+    model_id = active_cfg.get("model_id")
+
+    llm_ready = False
+    llm_model_name: Optional[str] = None
+    errors: list[str] = []
+
+    if model_id:
+        installed = _find_installed_model(conn, model_id)
+        if installed is not None and os.path.isfile(installed["file_path"]):
+            llm_ready = True
+            llm_model_name = installed.get("display_name") or installed.get("filename")
+        elif os.path.isfile(model_id):
+            # A user-supplied GGUF path that exists but has no DB row.
+            llm_ready = True
+            llm_model_name = os.path.basename(model_id)
+        elif runtime_id == "ollama":
+            # Ollama model tags are not files; availability was validated at
+            # selection time by /api/models/use.
+            llm_ready = True
+            llm_model_name = model_id
+        else:
+            errors.append(
+                f"Selected model file not found: {model_id}. "
+                "Re-select a model in the model manager."
+            )
+            llm_model_name = os.path.basename(model_id) or model_id
+    elif runtime_id:
+        # A runtime was actively selected without a model file (e.g. scripted
+        # or an external server). The selection endpoint validated it.
+        llm_ready = True
+        llm_model_name = runtime_id
+    elif runtime_health.status == RuntimeStatus.READY:
+        # No explicit selection, but the configured default runtime is usable
+        # (e.g. the deterministic fake runtime in dev/test builds).
+        llm_ready = True
+        llm_model_name = runtime_health.model_id or runtime_health.runtime_name
+    elif runtime_health.message:
+        errors.append(runtime_health.message)
+
+    stt_ready = stt_health.status in (RuntimeStatus.READY, RuntimeStatus.DEGRADED)
+    if not stt_ready and stt_health.message:
+        errors.append(stt_health.message)
+
+    tts_ready = tts_health.status in (RuntimeStatus.READY, RuntimeStatus.DEGRADED)
+    if not tts_ready and tts_health.message:
+        errors.append(tts_health.message)
+
+    return _RuntimeReadiness(
+        llm_ready=llm_ready,
+        llm_model_name=llm_model_name,
+        stt_ready=stt_ready,
+        tts_ready=tts_ready,
+        tts_voice_name=None,
+        # All supported runtimes (llama.cpp sidecar, Ollama, fake, scripted)
+        # run locally; nothing requires network to play.
+        network_required=False,
+        last_error=errors[0] if errors else None,
+    )
 
 
 @router.get("/api/health", response_model=HealthResponse)
@@ -164,6 +284,10 @@ async def health(request: Request) -> HealthResponse:
 
     supervisor = getattr(request.app.state, "supervisor", None)
 
+    runtime_health = await request.app.state.runtime.health()
+    stt_health = await request.app.state.stt_worker.health()
+    tts_health = await request.app.state.tts_worker.health()
+
     return HealthResponse(
         status="ok",
         version=__version__,
@@ -174,7 +298,8 @@ async def health(request: Request) -> HealthResponse:
             path=db.path,
             migrations_applied=db.migrations_applied,
         ),
-        runtime=await request.app.state.runtime.health(),
+        runtime=_build_readiness(conn, active_cfg, runtime_health, stt_health, tts_health),
+        llm_runtime=runtime_health,
         active_model=_ActiveModelConfig(**active_cfg),
         privacy=_PrivacyPosture(
             telemetry_enabled=app_settings.telemetry_enabled,
@@ -182,8 +307,8 @@ async def health(request: Request) -> HealthResponse:
             save_raw_audio=app_settings.save_raw_audio,
             crash_logging_enabled=app_settings.crash_logging_enabled,
         ),
-        stt=await request.app.state.stt_worker.health(),
-        tts=await request.app.state.tts_worker.health(),
+        stt=stt_health,
+        tts=tts_health,
         sidecar_diagnostics=_build_sidecar_diagnostics(supervisor),
         last_benchmark=last_benchmark,
     )

--- a/services/convsim-core/convsim_core/routers/runtime_settings.py
+++ b/services/convsim-core/convsim_core/routers/runtime_settings.py
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Runtime settings endpoints (/api/runtime/settings).
+
+Implements the shared ``RuntimeSettingsResponse`` contract consumed by the
+web UI (see packages/shared/src/types/models.ts). Settings are persisted in
+the ``user_settings`` table under ``runtime_setting.<name>`` keys so they
+survive restarts and live alongside the active model selection.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from typing import Optional
+
+from fastapi import APIRouter, Request
+from pydantic import BaseModel
+
+from convsim_core.errors import ConvsimError
+
+router = APIRouter()
+
+_KEY_PREFIX = "runtime_setting."
+
+_SETTING_KEYS = (
+    "context_length",
+    "gpu_layers",
+    "threads",
+    "temperature",
+    "top_p",
+    "repeat_penalty",
+)
+
+# Changing these requires restarting the llama-server sidecar to take effect.
+_RESTART_REQUIRED = {"context_length", "gpu_layers"}
+
+_INT_KEYS = {"context_length", "gpu_layers", "threads"}
+
+
+class RuntimeSettings(BaseModel):
+    context_length: Optional[int] = None
+    gpu_layers: Optional[int] = None
+    threads: Optional[int] = None
+    temperature: Optional[float] = None
+    top_p: Optional[float] = None
+    repeat_penalty: Optional[float] = None
+
+
+class RuntimeSettingsResponse(BaseModel):
+    settings: RuntimeSettings
+    recommended: RuntimeSettings
+    requires_restart: bool
+
+
+def load_runtime_settings(conn: sqlite3.Connection) -> RuntimeSettings:
+    """Read persisted runtime settings; missing/invalid values become None."""
+    rows = conn.execute(
+        "SELECT key, value FROM user_settings WHERE key LIKE ?",
+        (_KEY_PREFIX + "%",),
+    ).fetchall()
+    stored = {row["key"][len(_KEY_PREFIX):]: row["value"] for row in rows}
+
+    values: dict[str, int | float | None] = {}
+    for key in _SETTING_KEYS:
+        raw = stored.get(key)
+        if raw is None or raw == "" or raw == "null":
+            values[key] = None
+            continue
+        try:
+            values[key] = int(raw) if key in _INT_KEYS else float(raw)
+        except ValueError:
+            values[key] = None
+    return RuntimeSettings(**values)
+
+
+def _save_runtime_settings(conn: sqlite3.Connection, patch: dict[str, object]) -> None:
+    for key in _SETTING_KEYS:
+        if key not in patch:
+            continue
+        value = patch[key]
+        conn.execute(
+            """
+            INSERT INTO user_settings (key, value, updated_at)
+            VALUES (?, ?, datetime('now'))
+            ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at
+            """,
+            (_KEY_PREFIX + key, "null" if value is None else str(value)),
+        )
+    conn.commit()
+
+
+def _validate(patch: dict[str, object]) -> list[str]:
+    """Return human-readable validation errors; empty list when valid."""
+    errors: list[str] = []
+
+    def _check_int(key: str, lo: int, hi: int, label: str) -> None:
+        v = patch.get(key)
+        if v is None or key not in patch:
+            return
+        if not isinstance(v, int) or isinstance(v, bool) or v < lo or v > hi:
+            errors.append(f"{label} must be an integer between {lo} and {hi}.")
+
+    def _check_float(key: str, lo: float, hi: float, label: str) -> None:
+        v = patch.get(key)
+        if v is None or key not in patch:
+            return
+        if not isinstance(v, (int, float)) or isinstance(v, bool) or v < lo or v > hi:
+            errors.append(f"{label} must be between {lo} and {hi}.")
+
+    _check_int("context_length", 512, 131072, "Context length")
+    _check_int("gpu_layers", -1, 256, "GPU layers")
+    _check_int("threads", 1, 64, "Thread count")
+    _check_float("temperature", 0.0, 2.0, "Temperature")
+    _check_float("top_p", 0.0, 1.0, "Top-P")
+    _check_float("repeat_penalty", 1.0, 2.0, "Repeat penalty")
+    return errors
+
+
+def _recommended() -> RuntimeSettings:
+    """Conservative recommendations; None means 'use the runtime default'."""
+    cpu = os.cpu_count()
+    return RuntimeSettings(threads=max(1, (cpu or 2) // 2) if cpu else None)
+
+
+@router.get("/api/runtime/settings", response_model=RuntimeSettingsResponse)
+async def get_runtime_settings(request: Request) -> RuntimeSettingsResponse:
+    conn = request.app.state.db.connection()
+    return RuntimeSettingsResponse(
+        settings=load_runtime_settings(conn),
+        recommended=_recommended(),
+        requires_restart=False,
+    )
+
+
+@router.put("/api/runtime/settings", response_model=RuntimeSettingsResponse)
+async def update_runtime_settings(request: Request, body: RuntimeSettings) -> RuntimeSettingsResponse:
+    conn = request.app.state.db.connection()
+    patch = body.model_dump(exclude_unset=True)
+
+    errors = _validate(patch)
+    if errors:
+        raise ConvsimError(
+            code="INVALID_RUNTIME_SETTINGS",
+            message=" ".join(errors),
+            status_code=422,
+        )
+
+    current = load_runtime_settings(conn).model_dump()
+    requires_restart = any(
+        key in patch and patch[key] != current[key] for key in _RESTART_REQUIRED
+    )
+    _save_runtime_settings(conn, patch)
+
+    return RuntimeSettingsResponse(
+        settings=load_runtime_settings(conn),
+        recommended=_recommended(),
+        requires_restart=requires_restart,
+    )
+
+
+@router.post("/api/runtime/settings/reset", response_model=RuntimeSettingsResponse)
+async def reset_runtime_settings(request: Request) -> RuntimeSettingsResponse:
+    conn = request.app.state.db.connection()
+    _save_runtime_settings(conn, {key: None for key in _SETTING_KEYS})
+    return RuntimeSettingsResponse(
+        settings=load_runtime_settings(conn),
+        recommended=_recommended(),
+        requires_restart=True,
+    )

--- a/services/convsim-core/tests/test_health.py
+++ b/services/convsim-core/tests/test_health.py
@@ -40,12 +40,61 @@ def test_health_database_migrations_applied(client):
     assert body["database"]["migrations_applied"] >= 1
 
 
-def test_health_runtime_fields_exist(client):
-    rt = client.get("/api/health").json()["runtime"]
+def test_health_llm_runtime_fields_exist(client):
+    rt = client.get("/api/health").json()["llm_runtime"]
     assert rt["runtime_id"] == "fake"
     assert rt["runtime_name"] == "Fake (deterministic)"
     assert rt["status"] == "ready"
     assert "checked_at" in rt
+
+
+# ── runtime readiness (shared RuntimeReadiness contract) ─────────────────────
+
+
+def test_health_runtime_readiness_shape(client):
+    rt = client.get("/api/health").json()["runtime"]
+    for key in (
+        "llm_ready",
+        "llm_model_name",
+        "stt_ready",
+        "tts_ready",
+        "tts_voice_name",
+        "network_required",
+        "last_error",
+    ):
+        assert key in rt
+
+
+def test_health_readiness_defaults(client):
+    rt = client.get("/api/health").json()["runtime"]
+    # Default test config: fake runtime is ready, no whisper binary installed.
+    assert rt["llm_ready"] is True
+    assert rt["stt_ready"] is False
+    assert rt["network_required"] is False
+
+
+def test_health_llm_ready_after_register_gguf(client, tmp_path):
+    model_file = tmp_path / "my-model.gguf"
+    model_file.write_bytes(b"\x00" * 16)
+    resp = client.post("/api/models/register-gguf", json={"path": str(model_file)})
+    assert resp.status_code == 200
+
+    rt = client.get("/api/health").json()["runtime"]
+    assert rt["llm_ready"] is True
+    assert rt["llm_model_name"] == "my-model.gguf"
+
+
+def test_health_llm_not_ready_when_model_file_deleted(client, tmp_path):
+    model_file = tmp_path / "gone-model.gguf"
+    model_file.write_bytes(b"\x00" * 16)
+    resp = client.post("/api/models/register-gguf", json={"path": str(model_file)})
+    assert resp.status_code == 200
+    model_file.unlink()
+
+    rt = client.get("/api/health").json()["runtime"]
+    assert rt["llm_ready"] is False
+    assert rt["last_error"] is not None
+    assert "not found" in rt["last_error"].lower()
 
 
 def test_health_config_path_present(client):

--- a/services/convsim-core/tests/test_health.py
+++ b/services/convsim-core/tests/test_health.py
@@ -71,6 +71,10 @@ def test_health_readiness_defaults(client):
     assert rt["llm_ready"] is True
     assert rt["stt_ready"] is False
     assert rt["network_required"] is False
+    # The LLM is ready, so no blocking error. Optional voice (STT/TTS) being
+    # unavailable must NOT leak into last_error, or Home shows an error card
+    # for a text-ready app.
+    assert rt["last_error"] is None
 
 
 def test_health_llm_ready_after_register_gguf(client, tmp_path):

--- a/services/convsim-core/tests/test_runtime_settings.py
+++ b/services/convsim-core/tests/test_runtime_settings.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for /api/runtime/settings (GET / PUT / reset)."""
+
+_SETTING_KEYS = (
+    "context_length",
+    "gpu_layers",
+    "threads",
+    "temperature",
+    "top_p",
+    "repeat_penalty",
+)
+
+
+def test_get_runtime_settings_returns_200(client):
+    resp = client.get("/api/runtime/settings")
+    assert resp.status_code == 200
+
+
+def test_get_runtime_settings_shape(client):
+    body = client.get("/api/runtime/settings").json()
+    assert "settings" in body
+    assert "recommended" in body
+    assert body["requires_restart"] is False
+    for key in _SETTING_KEYS:
+        assert key in body["settings"]
+        assert key in body["recommended"]
+
+
+def test_get_runtime_settings_defaults_are_null(client):
+    settings = client.get("/api/runtime/settings").json()["settings"]
+    assert all(settings[key] is None for key in _SETTING_KEYS)
+
+
+def test_put_runtime_settings_persists(client):
+    resp = client.put(
+        "/api/runtime/settings",
+        json={"context_length": 4096, "temperature": 0.7},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["settings"]["context_length"] == 4096
+
+    settings = client.get("/api/runtime/settings").json()["settings"]
+    assert settings["context_length"] == 4096
+    assert settings["temperature"] == 0.7
+    assert settings["threads"] is None
+
+
+def test_put_runtime_settings_partial_update_preserves_others(client):
+    client.put("/api/runtime/settings", json={"threads": 8})
+    client.put("/api/runtime/settings", json={"top_p": 0.9})
+    settings = client.get("/api/runtime/settings").json()["settings"]
+    assert settings["threads"] == 8
+    assert settings["top_p"] == 0.9
+
+
+def test_put_runtime_settings_restart_flag_for_context_length(client):
+    resp = client.put("/api/runtime/settings", json={"context_length": 8192})
+    assert resp.json()["requires_restart"] is True
+
+
+def test_put_runtime_settings_no_restart_for_sampling_params(client):
+    resp = client.put("/api/runtime/settings", json={"temperature": 1.0})
+    assert resp.json()["requires_restart"] is False
+
+
+def test_put_runtime_settings_rejects_invalid_context_length(client):
+    resp = client.put("/api/runtime/settings", json={"context_length": 100})
+    assert resp.status_code == 422
+    assert "Context length" in resp.json()["error"]["message"]
+
+
+def test_put_runtime_settings_rejects_invalid_temperature(client):
+    resp = client.put("/api/runtime/settings", json={"temperature": 5.0})
+    assert resp.status_code == 422
+
+
+def test_put_runtime_settings_rejects_invalid_gpu_layers(client):
+    resp = client.put("/api/runtime/settings", json={"gpu_layers": -5})
+    assert resp.status_code == 422
+
+
+def test_put_runtime_settings_accepts_null_to_clear(client):
+    client.put("/api/runtime/settings", json={"threads": 8})
+    client.put("/api/runtime/settings", json={"threads": None})
+    settings = client.get("/api/runtime/settings").json()["settings"]
+    assert settings["threads"] is None
+
+
+def test_reset_runtime_settings(client):
+    client.put("/api/runtime/settings", json={"context_length": 4096, "threads": 8})
+    resp = client.post("/api/runtime/settings/reset")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert all(body["settings"][key] is None for key in _SETTING_KEYS)
+    assert body["requires_restart"] is True
+
+
+def test_runtime_settings_do_not_break_app_settings(client):
+    """runtime_setting.* keys share user_settings; AppSettings must ignore them."""
+    client.put("/api/runtime/settings", json={"temperature": 0.5})
+    resp = client.get("/api/health")
+    assert resp.status_code == 200
+    assert resp.json()["privacy"]["telemetry_enabled"] is False

--- a/tests/acceptance/test_player_text_path.py
+++ b/tests/acceptance/test_player_text_path.py
@@ -461,7 +461,10 @@ class TestNoCloudInference:
         app = create_app(tmp_config)
         with TestClient(app) as c:
             health = c.get("/api/health")
-        runtime_status = health.json().get("runtime", {})
+        # The detailed runtime diagnostics (runtime_id/status) live under
+        # llm_runtime; the top-level `runtime` is the user-facing readiness
+        # summary, which intentionally does not expose runtime_id.
+        runtime_status = health.json().get("llm_runtime", {})
         runtime_id = runtime_status.get("runtime_id", "") or runtime_status.get("id", "")
         # The default runtime must be the fake one — a ready *cloud* runtime would
         # also report "ready", so status alone cannot prove no cloud inference.


### PR DESCRIPTION
## Summary

The desktop app runs the **convsim-core Python backend**, but its `/api/health` response never included the fields the web UI reads for readiness. Two user-visible bugs resulted:

- **Home always showed "Not installed"** for the LLM/STT/TTS, no matter what was actually registered. The frontend reads `llm_ready` / `stt_ready` / `tts_ready` / `llm_model_name` / `network_required` from `HealthResponse.runtime`, but convsim-core emitted the *diagnostic* `RuntimeHealth` shape there instead — every field resolved to `undefined` → `false`.
- **Settings showed "Request failed / Not Found"** — the panel calls `GET /api/runtime/settings`, which simply did not exist in convsim-core.

Importantly, **the registered GGUF selection was never lost.** It persists correctly in SQLite (`user_settings.active_model_id` + an `installed_models` row). Only the health/settings HTTP contract was wrong. After this change, an already-registered GGUF shows up on Home without re-selecting it.

## Changes (all in `services/convsim-core`)

- **`routers/health.py`** — `/api/health.runtime` now emits the shared `RuntimeReadiness` contract (`packages/shared/src/types/runtime.ts`), byte-for-byte compatible with the TypeScript type the UI already consumes:
  - `llm_ready` is derived from the **persisted selection + file existence**, deliberately **not** the live sidecar process — so "installed but not currently loaded" still reads as installed on Home (the sidecar starts on demand).
  - A registered GGUF whose file was since moved/deleted correctly reports `llm_ready: false` with an explanatory `last_error`.
  - Ollama tags (not files) and file-less runtimes (fake/scripted) are handled via their selection/health.
  - `llm_model_name` comes from the registered display name; `stt_ready`/`tts_ready` map from their worker health.
  - The detailed runtime diagnostics move to a **new `llm_runtime`** field on the response.
- **`routers/runtime_settings.py`** (new) — `GET` / `PUT` / reset for `/api/runtime/settings`, matching the shared `RuntimeSettingsResponse` type. Persisted in `user_settings` under `runtime_setting.*` keys, with validation ranges for `context_length`, `gpu_layers`, `threads`, `temperature`, `top_p`, `repeat_penalty`. `PUT` reports `requires_restart` when a restart-only field (context length / GPU layers) actually changes.
- **`app.py`** — register the `runtime_settings` router.
- **`scripts/release-smoke.ps1`** + **release-checklist docs (×2)** — follow the renamed field: the detailed status moved from `runtime.status` to `llm_runtime.status`. The smoke check now also reports `runtime.llm_ready`.

## Contract note

`runtime.ts`'s `RuntimeReadiness` on `main` matches the Python model field-for-field, and `main`'s `health.py` was still emitting the old shape — so this fix conforms to the existing frontend contract rather than inventing a new one.

## Tests

- **5 new health readiness tests**: shape/defaults, register-GGUF → `llm_ready: true`, and deleted-file → not ready with a clear error.
- **13 new runtime-settings tests**: GET/PUT/reset, partial updates, restart-flag semantics, validation rejections, and non-interference with `AppSettings`.
- Local run of `test_health.py` + `test_runtime_settings.py` + `test_model_manager.py`: **112 passed**.

> The pre-existing Windows-only failures in `test_sidecar.py` / `test_preflight.py` / `test_whisper_cpp_worker.py` (Unicode/executable-bit/unwritable-dir) are unrelated to this change — confirmed they fail identically on a clean checkout of `main`.

## Follow-ups (not in this PR)

- `apps/api` (the dev/interim TypeScript backend) hardcodes all readiness to `false` and persists selections to different keys — dev and packaged builds will keep drifting until one contract is enforced, ideally via a shared conformance test.
- Home already has a `showNoModelPrompt` branch; once `llm_ready` is real, that's the natural place to route new users into the model manager instead of a bare "Not installed" link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)