### PR TITLE
Pin the bundled llama.cpp version instead of resolving "latest" at build time

### DIFF
--- a/runtimes/llama_cpp/download-runtime.ps1
+++ b/runtimes/llama_cpp/download-runtime.ps1
@@ -39,6 +39,17 @@ $ErrorActionPreference = "Stop"
 
 $REPO  = "ggml-org/llama.cpp"
 
+# Pinned llama.cpp release. Keep this in sync with download-runtime.sh.
+#
+# Pinned, not "latest", so that two releases built a day apart cannot ship
+# different inference engines, and so the build never depends on an
+# unauthenticated api.github.com call that GitHub rate-limits per IP (the macOS
+# leg of the release failed with a 403 doing exactly that).
+#
+# Pass -Version latest to resolve the newest release instead of the pin.
+$LLAMA_CPP_PINNED_VERSION = "b9996"
+if (-not $Version) { $Version = $LLAMA_CPP_PINNED_VERSION }
+
 # ── Platform detection ────────────────────────────────────────────────────────
 
 $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
@@ -54,7 +65,7 @@ switch ($arch) {
 
 # ── Resolve latest tag if not specified ───────────────────────────────────────
 
-if (-not $Version) {
+if ($Version -eq "latest") {
     Write-Host "Fetching latest llama.cpp release tag..."
     try {
         $apiUrl = "https://api.github.com/repos/$REPO/releases/latest"

--- a/runtimes/llama_cpp/download-runtime.sh
+++ b/runtimes/llama_cpp/download-runtime.sh
@@ -32,7 +32,23 @@ for _arg in "$@"; do
   fi
 done
 
-RELEASE_TAG="${LLAMA_CPP_VERSION:-}"  # empty = auto-detect latest
+# Pinned llama.cpp release. Keep this in sync with download-runtime.ps1.
+#
+# Pinned, not "latest", for two reasons:
+#   1. Reproducibility — "latest" meant two releases built a day apart shipped
+#      DIFFERENT inference engines, with nothing in the tag recording which.
+#   2. Resolving "latest" hits api.github.com unauthenticated, which GitHub
+#      rate-limits per IP. macOS runners share heavily-used IPs, so the release
+#      build failed with `curl: (56) ... 403` while Linux got through.
+#
+# To upgrade: bump this, re-run the script on each platform, and confirm
+# llama-server starts (`llama-server --version`) — that is what catches a
+# renamed asset or a changed archive layout.
+LLAMA_CPP_PINNED_VERSION="b9996"
+
+# Pass --version latest (or LLAMA_CPP_VERSION=latest) to resolve the newest
+# release instead of the pin.
+RELEASE_TAG="${LLAMA_CPP_VERSION:-$LLAMA_CPP_PINNED_VERSION}"
 DEST_DIR="${LLAMA_CPP_DEST:-$HOME/.convsim/bin}"
 BINARY_NAME="llama-server"
 REPO="ggml-org/llama.cpp"
@@ -92,18 +108,31 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# ── Resolve latest tag if not specified ───────────────────────────────────────
+# ── Resolve "latest" only when explicitly requested ───────────────────────────
+# Send the token when one is available: this endpoint is rate-limited per IP for
+# unauthenticated callers, and shared CI IPs hit that limit (403) routinely.
 
-if [[ -z "$RELEASE_TAG" ]]; then
+if [[ -z "$RELEASE_TAG" || "$RELEASE_TAG" == "latest" ]]; then
   echo "Fetching latest llama.cpp release tag..."
+  _API_URL="https://api.github.com/repos/${REPO}/releases/latest"
+  _TOKEN="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
   if command -v curl &>/dev/null; then
-    RELEASE_TAG="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
-      | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')"
+    if [[ -n "$_TOKEN" ]]; then
+      _RESP="$(curl -fsSL -H "Authorization: Bearer ${_TOKEN}" "$_API_URL")"
+    else
+      _RESP="$(curl -fsSL "$_API_URL")"
+    fi
   elif command -v wget &>/dev/null; then
-    RELEASE_TAG="$(wget -qO- "https://api.github.com/repos/${REPO}/releases/latest" \
-      | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')"
+    _RESP="$(wget -qO- "$_API_URL")"
   else
     echo "curl or wget is required to fetch the latest release." >&2
+    exit 1
+  fi
+  RELEASE_TAG="$(printf '%s' "$_RESP" | grep '"tag_name"' | head -1 |
+                 sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')"
+  if [[ -z "$RELEASE_TAG" ]]; then
+    echo "Could not resolve the latest llama.cpp release (rate-limited?)." >&2
+    echo "Pass --version <tag> to pin one explicitly." >&2
     exit 1
   fi
   echo "Latest release: ${RELEASE_TAG}"


### PR DESCRIPTION
The macOS leg of the release failed with `curl: (56) The requested URL returned error: 403`.

Both runtime download scripts resolved the llama.cpp version by calling `api.github.com/releases/latest` **unauthenticated**, and GitHub rate-limits that per IP. macOS runners share heavily-used IPs, so macOS 403'd while Linux got through — the build's success depended on which runner IP the job landed on.

Pinning removes the API call entirely, and fixes a second, quieter problem: with `latest`, **two releases built a day apart shipped different inference engines**, with nothing in the tag recording which one a user got. A release should build the same artifact tomorrow as it does today.

Both scripts now pin **b9996** and state that they must stay in sync. `latest` remains available (`--version latest` / `-Version latest`), now sends `GITHUB_TOKEN` when present so the opt-in path isn't rate-limited either, and fails with an actionable message rather than an empty tag when it is.

## Verification

Ran the pinned path on macOS: **no api.github.com call**, correct asset (`llama-b9996-bin-macos-arm64.tar.gz`), and **every `@rpath` dependency of llama-server resolved** in the install dir. shellcheck and PSScriptAnalyzer clean; both pins confirmed identical.

## Still open

The macOS-minimum question from #434 stands: upstream's b9996 macOS binary calls Metal APIs that don't exist before macOS 26 (`_OBJC_CLASS_$_MTLResidencySetDescriptor`), while the docs promise macOS 13+. Pinning is what makes that *decidable* — the engine version is now a value we choose, rather than whatever happened to ship that morning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)