### PR TITLE
Show actionable error when runtime settings endpoint returns 404

### DIFF
--- a/apps/web/src/__tests__/RuntimeSettingsPanel.test.tsx
+++ b/apps/web/src/__tests__/RuntimeSettingsPanel.test.tsx
@@ -104,6 +104,18 @@ describe('RuntimeSettingsPanel — loading', () => {
       expect(screen.getByRole('alert')).toHaveTextContent(/Connection failed/i),
     )
   })
+
+  it('shows an actionable update message when getRuntimeSettings returns 404', async () => {
+    mockApi.getRuntimeSettings.mockResolvedValue({
+      ok: false,
+      error: { kind: 'http-error', status: 404, message: 'Not Found' },
+    })
+    await renderPanel()
+    await waitFor(() => {
+      const alert = screen.getByRole('alert')
+      expect(alert).toHaveTextContent(/update ConversationSimulator/i)
+    })
+  })
 })
 
 // ── Basic settings — provider and model ──────────────────────────────────────

--- a/apps/web/src/__tests__/RuntimeSettingsPanel.test.tsx
+++ b/apps/web/src/__tests__/RuntimeSettingsPanel.test.tsx
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import RuntimeSettingsPanel from '../components/RuntimeSettingsPanel'
+import { SETUP_DOCS_URL } from '../setup/docsUrls'
 import type { ModelsResponse, RuntimeSettingsResponse } from '@convsim/shared'
 
 vi.mock('../api/client', () => ({
@@ -105,16 +106,57 @@ describe('RuntimeSettingsPanel — loading', () => {
     )
   })
 
-  it('shows an actionable update message when getRuntimeSettings returns 404', async () => {
+  // A 404 from /api/runtime/settings means the bundled runtime predates the
+  // route (issue #429). The rest of the panel is served by /api/models and must
+  // stay usable, with plain-language guidance in place of the advanced section.
+  describe('when getRuntimeSettings returns 404', () => {
+    beforeEach(() => {
+      mockApi.getRuntimeSettings.mockResolvedValue({
+        ok: false,
+        error: { kind: 'http-error', status: 404, message: 'Not Found' },
+      })
+    })
+
+    it('does not block the panel behind an error view', async () => {
+      await renderPanel()
+      await waitFor(() =>
+        expect(screen.getByRole('combobox', { name: /provider/i })).toBeInTheDocument(),
+      )
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /apply provider and model/i })).toBeInTheDocument()
+    })
+
+    it('explains that an update is needed and links to the instructions', async () => {
+      await renderPanel()
+      const notice = await screen.findByRole('status', {
+        name: /runtime advanced settings unavailable/i,
+      })
+      expect(notice).toHaveTextContent(/not available in this version of ConversationSimulator/i)
+      expect(notice).toHaveTextContent(/update to the latest version/i)
+      expect(screen.getByRole('link', { name: /how to update/i })).toHaveAttribute(
+        'href',
+        SETUP_DOCS_URL,
+      )
+    })
+
+    it('hides the advanced settings toggle, which the missing endpoint backs', async () => {
+      await renderPanel()
+      await screen.findByRole('status', { name: /runtime advanced settings unavailable/i })
+      expect(
+        screen.queryByRole('button', { name: /show runtime advanced settings/i }),
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  it('still shows a blocking error when getRuntimeSettings fails for a non-404 reason', async () => {
     mockApi.getRuntimeSettings.mockResolvedValue({
       ok: false,
-      error: { kind: 'http-error', status: 404, message: 'Not Found' },
+      error: { kind: 'http-error', status: 500, message: 'settings store is corrupt' },
     })
     await renderPanel()
-    await waitFor(() => {
-      const alert = screen.getByRole('alert')
-      expect(alert).toHaveTextContent(/update ConversationSimulator/i)
-    })
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/settings store is corrupt/i),
+    )
   })
 })
 

--- a/apps/web/src/__tests__/RuntimeSettingsPanel.test.tsx
+++ b/apps/web/src/__tests__/RuntimeSettingsPanel.test.tsx
@@ -2,7 +2,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import RuntimeSettingsPanel from '../components/RuntimeSettingsPanel'
-import { SETUP_DOCS_URL } from '../setup/docsUrls'
+import { UPDATE_DOCS_URL } from '../setup/docsUrls'
 import type { ModelsResponse, RuntimeSettingsResponse } from '@convsim/shared'
 
 vi.mock('../api/client', () => ({
@@ -133,10 +133,13 @@ describe('RuntimeSettingsPanel — loading', () => {
       })
       expect(notice).toHaveTextContent(/not available in this version of ConversationSimulator/i)
       expect(notice).toHaveTextContent(/update to the latest version/i)
+      // Deep-links to the "Updates and rollback" section, not the top of the long
+      // install page — the user needs the update steps, not a fresh install.
       expect(screen.getByRole('link', { name: /how to update/i })).toHaveAttribute(
         'href',
-        SETUP_DOCS_URL,
+        UPDATE_DOCS_URL,
       )
+      expect(UPDATE_DOCS_URL).toContain('#updates-and-rollback')
     })
 
     it('hides the advanced settings toggle, which the missing endpoint backs', async () => {

--- a/apps/web/src/__tests__/RuntimeSettingsPanel.test.tsx
+++ b/apps/web/src/__tests__/RuntimeSettingsPanel.test.tsx
@@ -161,6 +161,26 @@ describe('RuntimeSettingsPanel — loading', () => {
       expect(screen.getByRole('alert')).toHaveTextContent(/settings store is corrupt/i),
     )
   })
+
+  // A 404 carrying an HTML body means a static server or proxy answered while core
+  // was down — client.ts maps that to runtime-unreachable, not http-error. Only the
+  // latter proves the route is missing, so the leniency above must not extend here:
+  // telling this user to update the app would send them after the wrong problem.
+  it('still shows a blocking error on a 404 that means the runtime is unreachable', async () => {
+    mockApi.getRuntimeSettings.mockResolvedValue({
+      ok: false,
+      error: {
+        kind: 'runtime-unreachable',
+        status: 404,
+        message: 'API returned HTML instead of JSON — the local runtime is not running.',
+      },
+    })
+    await renderPanel()
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    expect(
+      screen.queryByRole('status', { name: /runtime advanced settings unavailable/i }),
+    ).not.toBeInTheDocument()
+  })
 })
 
 // ── Basic settings — provider and model ──────────────────────────────────────

--- a/apps/web/src/api/client.test.ts
+++ b/apps/web/src/api/client.test.ts
@@ -79,6 +79,45 @@ describe('api.createSession — ApiResult return type', () => {
     }
   });
 
+  it('extracts message from a FastAPI { detail } error body', async () => {
+    // FastAPI's standard error shape. Without this, the user saw the raw
+    // `{"detail":"Not Found"}` JSON as the error message (issue #429).
+    mockFetch(404, { detail: 'Not Found' });
+    const result = await api.createSession(BASE_SESSION);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.kind).toBe('http-error');
+      expect(result.error.status).toBe(404);
+      expect(result.error.message).toBe('Not Found');
+      expect(result.error.message).not.toContain('{');
+    }
+  });
+
+  it('extracts messages from a FastAPI 422 validation detail list', async () => {
+    mockFetch(422, {
+      detail: [
+        { type: 'string_too_short', loc: ['body', 'player_role_name'], msg: 'String should have at least 1 character' },
+        { type: 'greater_than_equal', loc: ['body', 'seed'], msg: 'Input should be greater than or equal to 0' },
+      ],
+    });
+    const result = await api.createSession({ ...BASE_SESSION, player_role_name: '' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toBe(
+        'String should have at least 1 character; Input should be greater than or equal to 0',
+      );
+      expect(result.error.message).not.toContain('{');
+      expect(result.error.message).not.toContain('loc');
+    }
+  });
+
+  it('prefers an explicit message over detail when a body carries both', async () => {
+    mockFetch(400, { message: 'player_role_name cannot be blank', detail: 'Bad Request' });
+    const result = await api.createSession({ ...BASE_SESSION, player_role_name: '' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toBe('player_role_name cannot be blank');
+  });
+
   it('falls back to raw text for non-JSON error bodies', async () => {
     mockFetch(500, 'Internal server error (plain text)');
     const result = await api.createSession(BASE_SESSION);

--- a/apps/web/src/api/client.test.ts
+++ b/apps/web/src/api/client.test.ts
@@ -111,6 +111,41 @@ describe('api.createSession — ApiResult return type', () => {
     }
   });
 
+  it('extracts message and code from an object-shaped FastAPI detail', async () => {
+    // convsim-core raises HTTPException(detail={ message, code, … }) for state
+    // conflicts (sessions.py _conflict) and registers no handler to reshape it,
+    // so FastAPI passes the dict straight through as { detail: { … } }.
+    mockFetch(409, {
+      detail: {
+        message: 'Cannot start a session that is already Running',
+        code: 'INVALID_TRANSITION',
+        current_state: 'Running',
+      },
+    });
+    const result = await api.createSession(BASE_SESSION);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toBe(
+        'INVALID_TRANSITION: Cannot start a session that is already Running',
+      );
+      expect(result.error.message).not.toContain('{');
+      expect(result.error.message).not.toContain('current_state');
+    }
+  });
+
+  it('falls back to the status line rather than dumping a JSON body with no message', async () => {
+    // Any structured body we cannot read a sentence out of. Echoing it verbatim is
+    // exactly how `{"detail":"Not Found"}` reached the UI in issue #429.
+    mockFetch(500, { detail: { free_gb: 1.2, required_gb: 10 } });
+    const result = await api.createSession(BASE_SESSION);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toBe('500 Internal Server Error');
+      expect(result.error.message).not.toContain('{');
+      expect(result.error.message).not.toContain('free_gb');
+    }
+  });
+
   it('prefers an explicit message over detail when a body carries both', async () => {
     mockFetch(400, { message: 'player_role_name cannot be blank', detail: 'Bad Request' });
     const result = await api.createSession({ ...BASE_SESSION, player_role_name: '' });

--- a/apps/web/src/api/client.test.ts
+++ b/apps/web/src/api/client.test.ts
@@ -133,6 +133,13 @@ describe('api.createSession — ApiResult return type', () => {
     }
   });
 
+  it('extracts a bare string error field rather than falling back to the status line', async () => {
+    mockFetch(500, { error: 'disk is full' });
+    const result = await api.createSession(BASE_SESSION);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toBe('disk is full');
+  });
+
   it('falls back to the status line rather than dumping a JSON body with no message', async () => {
     // Any structured body we cannot read a sentence out of. Echoing it verbatim is
     // exactly how `{"detail":"Not Found"}` reached the UI in issue #429.

--- a/apps/web/src/api/client.test.ts
+++ b/apps/web/src/api/client.test.ts
@@ -153,6 +153,15 @@ describe('api.createSession — ApiResult return type', () => {
     }
   });
 
+  it('falls back to the status line for a JSON scalar body rather than echoing it', async () => {
+    // `null` parses as valid JSON but carries no sentence; echoing the body would
+    // put the literal "null" in front of the user.
+    mockFetch(500, null);
+    const result = await api.createSession(BASE_SESSION);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toBe('500 Internal Server Error');
+  });
+
   it('prefers an explicit message over detail when a body carries both', async () => {
     mockFetch(400, { message: 'player_role_name cannot be blank', detail: 'Bad Request' });
     const result = await api.createSession({ ...BASE_SESSION, player_role_name: '' });

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -152,7 +152,10 @@ function parseErrorText(text: string, res: Response): string {
     return text || statusLine
   }
   if (typeof json === 'string') return json || statusLine
-  if (json === null || typeof json !== 'object') return text || statusLine
+  // A JSON scalar (null, a number, a bare true) parses fine but carries no
+  // sentence. Echoing `text` here would put the literal "null" in front of the
+  // user — the raw-body leak this function exists to prevent.
+  if (json === null || typeof json !== 'object') return statusLine
 
   // convsim-core (Python) returns { error: { code, message } }; the interim
   // convsim-api (TypeScript) returns { code?, message } at the top level.

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -157,12 +157,7 @@ function parseErrorText(text: string, res: Response): string {
   // convsim-core (Python) returns { error: { code, message } }; the interim
   // convsim-api (TypeScript) returns { code?, message } at the top level.
   // Accept either shape so error text is clean regardless of active backend.
-  const body = json as {
-    message?: unknown
-    code?: unknown
-    detail?: unknown
-    error?: { message?: unknown; code?: unknown } | unknown
-  }
+  const body = json as { message?: unknown; code?: unknown; detail?: unknown; error?: unknown }
   let msg = str(body.message)
   let code = str(body.code)
   if (!msg && body.error && typeof body.error === 'object') {
@@ -170,6 +165,10 @@ function parseErrorText(text: string, res: Response): string {
     msg = str(err.message)
     code = str(err.code)
   }
+  // A bare sentence on `error`, e.g. { error: "disk is full" }. Nothing in-tree
+  // emits this today, but falling through to the status line would drop the only
+  // words in the body — the very failure this function exists to prevent.
+  if (!msg) msg = str(body.error)
 
   // FastAPI serializes an HTTPException as { detail: … } and convsim-core registers
   // no handler to reshape it, so both of its detail shapes reach us: a string for

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -157,9 +157,17 @@ function parseErrorText(text: string, res: Response): string {
       msg = json.error.message
       code = json.error.code
     }
-    // FastAPI uses { detail: string } for standard HTTP errors (404, 500, etc.)
+    // FastAPI uses { detail: string } for standard HTTP errors (404, 500, …) and
+    // { detail: [{ loc, msg, type }] } for request-validation failures (422).
+    // Read the human sentence out of either, so neither reaches the UI as raw JSON.
     if (!msg && typeof json.detail === 'string') {
       msg = json.detail
+    }
+    if (!msg && Array.isArray(json.detail)) {
+      const sentences = json.detail
+        .map((d) => (d && typeof d === 'object' ? (d as { msg?: unknown }).msg : undefined))
+        .filter((m): m is string => typeof m === 'string' && m !== '')
+      if (sentences.length > 0) msg = sentences.join('; ')
     }
     if (msg) return code ? `${code}: ${msg}` : msg
   } catch {

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -142,11 +142,13 @@ function parseErrorText(text: string, res: Response): string {
   const fallback = text || `${res.status} ${res.statusText}`
   try {
     // convsim-core (Python) returns { error: { code, message } }; the interim
-    // convsim-api (TypeScript) returns { code?, message } at the top level.
-    // Accept either shape so error text is clean regardless of active backend.
+    // convsim-api (TypeScript) returns { code?, message } at the top level;
+    // FastAPI standard errors (404, 422, etc.) return { detail: string }.
+    // Accept all shapes so error text is clean regardless of active backend.
     const json = JSON.parse(text) as {
       message?: string
       code?: string
+      detail?: string | unknown[]
       error?: { message?: string; code?: string } | string
     }
     let msg = json.message
@@ -154,6 +156,10 @@ function parseErrorText(text: string, res: Response): string {
     if (!msg && json.error && typeof json.error === 'object') {
       msg = json.error.message
       code = json.error.code
+    }
+    // FastAPI uses { detail: string } for standard HTTP errors (404, 500, etc.)
+    if (!msg && typeof json.detail === 'string') {
+      msg = json.detail
     }
     if (msg) return code ? `${code}: ${msg}` : msg
   } catch {

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -171,11 +171,14 @@ function parseErrorText(text: string, res: Response): string {
     code = str(err.code)
   }
 
-  // FastAPI serializes an uncaught HTTPException as { detail: … }, and convsim-core
-  // registers no handler to reshape it, so all three of its detail shapes reach us:
-  // a string for standard errors (404, 500, …), a [{ loc, msg, type }] list for
-  // request-validation failures (422), and an object whenever a route raises
-  // HTTPException(detail={ message, code, … }) — see sessions.py's INVALID_TRANSITION.
+  // FastAPI serializes an HTTPException as { detail: … } and convsim-core registers
+  // no handler to reshape it, so both of its detail shapes reach us: a string for
+  // routing and simple errors (the 404 of issue #429, "Session not found", …), and
+  // an object whenever a route raises HTTPException(detail={ message, code, … }) —
+  // see sessions.py's INVALID_TRANSITION. A [{ loc, msg, type }] list is FastAPI's
+  // default 422 body; convsim-core's request_validation_error_handler reshapes those
+  // into { error: … } today, but an older bundled runtime need not have, and any
+  // 422 raised before that handler is installed still arrives in the default shape.
   // Read the human sentence out of each, so none reaches the UI as raw JSON.
   const detail = body.detail
   if (!msg && typeof detail === 'string') {

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -135,45 +135,69 @@ const HTML_ERROR: Omit<ApiError, 'status'> = {
   message: 'API returned HTML instead of JSON — the local runtime is not running.',
 }
 
-// Turn an already-read error body into a clean message. Never returns HTML or
-// parser internals — an HTML body is handled upstream in errorFromResponse and
-// never reaches here.
+function str(v: unknown): string | undefined {
+  return typeof v === 'string' && v !== '' ? v : undefined
+}
+
+// Turn an already-read error body into a clean message. Never returns HTML,
+// parser internals, or a raw JSON body — an HTML body is handled upstream in
+// errorFromResponse and never reaches here.
 function parseErrorText(text: string, res: Response): string {
-  const fallback = text || `${res.status} ${res.statusText}`
+  const statusLine = `${res.status} ${res.statusText}`.trim()
+  let json: unknown
   try {
-    // convsim-core (Python) returns { error: { code, message } }; the interim
-    // convsim-api (TypeScript) returns { code?, message } at the top level;
-    // FastAPI standard errors (404, 422, etc.) return { detail: string }.
-    // Accept all shapes so error text is clean regardless of active backend.
-    const json = JSON.parse(text) as {
-      message?: string
-      code?: string
-      detail?: string | unknown[]
-      error?: { message?: string; code?: string } | string
-    }
-    let msg = json.message
-    let code = json.code
-    if (!msg && json.error && typeof json.error === 'object') {
-      msg = json.error.message
-      code = json.error.code
-    }
-    // FastAPI uses { detail: string } for standard HTTP errors (404, 500, …) and
-    // { detail: [{ loc, msg, type }] } for request-validation failures (422).
-    // Read the human sentence out of either, so neither reaches the UI as raw JSON.
-    if (!msg && typeof json.detail === 'string') {
-      msg = json.detail
-    }
-    if (!msg && Array.isArray(json.detail)) {
-      const sentences = json.detail
-        .map((d) => (d && typeof d === 'object' ? (d as { msg?: unknown }).msg : undefined))
-        .filter((m): m is string => typeof m === 'string' && m !== '')
-      if (sentences.length > 0) msg = sentences.join('; ')
-    }
-    if (msg) return code ? `${code}: ${msg}` : msg
+    json = JSON.parse(text)
   } catch {
-    // text is not JSON; use as-is
+    // Not JSON — the body is already plain text.
+    return text || statusLine
   }
-  return fallback
+  if (typeof json === 'string') return json || statusLine
+  if (json === null || typeof json !== 'object') return text || statusLine
+
+  // convsim-core (Python) returns { error: { code, message } }; the interim
+  // convsim-api (TypeScript) returns { code?, message } at the top level.
+  // Accept either shape so error text is clean regardless of active backend.
+  const body = json as {
+    message?: unknown
+    code?: unknown
+    detail?: unknown
+    error?: { message?: unknown; code?: unknown } | unknown
+  }
+  let msg = str(body.message)
+  let code = str(body.code)
+  if (!msg && body.error && typeof body.error === 'object') {
+    const err = body.error as { message?: unknown; code?: unknown }
+    msg = str(err.message)
+    code = str(err.code)
+  }
+
+  // FastAPI serializes an uncaught HTTPException as { detail: … }, and convsim-core
+  // registers no handler to reshape it, so all three of its detail shapes reach us:
+  // a string for standard errors (404, 500, …), a [{ loc, msg, type }] list for
+  // request-validation failures (422), and an object whenever a route raises
+  // HTTPException(detail={ message, code, … }) — see sessions.py's INVALID_TRANSITION.
+  // Read the human sentence out of each, so none reaches the UI as raw JSON.
+  const detail = body.detail
+  if (!msg && typeof detail === 'string') {
+    msg = detail
+  }
+  if (!msg && Array.isArray(detail)) {
+    const sentences = detail
+      .map((d) => (d && typeof d === 'object' ? str((d as { msg?: unknown }).msg) : undefined))
+      .filter((m): m is string => m !== undefined)
+    if (sentences.length > 0) msg = sentences.join('; ')
+  }
+  if (!msg && detail && typeof detail === 'object') {
+    const d = detail as { message?: unknown; msg?: unknown; code?: unknown }
+    msg = str(d.message) ?? str(d.msg)
+    code = code ?? str(d.code)
+  }
+
+  if (msg) return code ? `${code}: ${msg}` : msg
+  // The body was structured but carried no human sentence. Showing it verbatim is
+  // how `{"detail":"Not Found"}` ended up in the UI (issue #429); the status line
+  // says no less, and says it in words.
+  return statusLine
 }
 
 // Build an ApiError for a non-2xx response. Reads the body once and applies the

--- a/apps/web/src/components/RuntimeSettingsPanel.tsx
+++ b/apps/web/src/components/RuntimeSettingsPanel.tsx
@@ -4,7 +4,7 @@ import { api } from '../api/client'
 import type { ModelsResponse, RuntimeSettings } from '@convsim/shared'
 import type { ApiError } from '../api/errors'
 import { ApiErrorView } from './ApiErrorView'
-import { AI_ENGINE_DOCS_URL as DOCS_URL, SETUP_DOCS_URL } from '../setup/docsUrls'
+import { AI_ENGINE_DOCS_URL as DOCS_URL, UPDATE_DOCS_URL } from '../setup/docsUrls'
 
 const PROVIDER_NAMES: Record<string, string> = {
   llama_cpp: 'llama.cpp',
@@ -485,7 +485,7 @@ export default function RuntimeSettingsPanel() {
           Update to the latest version to change context length, GPU layers, CPU threads and
           sampling. The provider and model settings above still work.{' '}
           <a
-            href={SETUP_DOCS_URL}
+            href={UPDATE_DOCS_URL}
             target="_blank"
             rel="noreferrer"
             aria-label="how to update ConversationSimulator"

--- a/apps/web/src/components/RuntimeSettingsPanel.tsx
+++ b/apps/web/src/components/RuntimeSettingsPanel.tsx
@@ -214,7 +214,23 @@ export default function RuntimeSettingsPanel() {
     setLoadError(null)
     const [modelsR, settingsR] = await Promise.all([api.getModels(), api.getRuntimeSettings()])
     if (!modelsR.ok) { setLoadError(modelsR.error); return }
-    if (!settingsR.ok) { setLoadError(settingsR.error); return }
+    if (!settingsR.ok) {
+      // A 404 on this endpoint means the bundled runtime service is an older
+      // build that predates the /api/runtime/settings route. Guide the user
+      // toward the only actionable fix rather than showing a raw HTTP error.
+      const err = settingsR.error
+      if (err.kind === 'http-error' && err.status === 404) {
+        setLoadError({
+          ...err,
+          message:
+            'Runtime settings are not available in this version. ' +
+            'Please update ConversationSimulator to the latest version to access these options.',
+        })
+      } else {
+        setLoadError(err)
+      }
+      return
+    }
     setModelsData(modelsR.data)
     setProvider(modelsR.data.active.runtime_id ?? 'llama_cpp')
     setModelId(modelsR.data.active.model_id ?? '')

--- a/apps/web/src/components/RuntimeSettingsPanel.tsx
+++ b/apps/web/src/components/RuntimeSettingsPanel.tsx
@@ -4,7 +4,7 @@ import { api } from '../api/client'
 import type { ModelsResponse, RuntimeSettings } from '@convsim/shared'
 import type { ApiError } from '../api/errors'
 import { ApiErrorView } from './ApiErrorView'
-import { AI_ENGINE_DOCS_URL as DOCS_URL } from '../setup/docsUrls'
+import { AI_ENGINE_DOCS_URL as DOCS_URL, SETUP_DOCS_URL } from '../setup/docsUrls'
 
 const PROVIDER_NAMES: Record<string, string> = {
   llama_cpp: 'llama.cpp',
@@ -186,6 +186,7 @@ function FieldRow({
 export default function RuntimeSettingsPanel() {
   const [modelsData, setModelsData] = useState<ModelsResponse | null>(null)
   const [loadError, setLoadError] = useState<ApiError | null>(null)
+  const [settingsUnavailable, setSettingsUnavailable] = useState(false)
 
   const [provider, setProvider] = useState<string>('llama_cpp')
   const [modelId, setModelId] = useState<string>('')
@@ -214,27 +215,23 @@ export default function RuntimeSettingsPanel() {
     setLoadError(null)
     const [modelsR, settingsR] = await Promise.all([api.getModels(), api.getRuntimeSettings()])
     if (!modelsR.ok) { setLoadError(modelsR.error); return }
-    if (!settingsR.ok) {
-      // A 404 on this endpoint means the bundled runtime service is an older
-      // build that predates the /api/runtime/settings route. Guide the user
-      // toward the only actionable fix rather than showing a raw HTTP error.
-      const err = settingsR.error
-      if (err.kind === 'http-error' && err.status === 404) {
-        setLoadError({
-          ...err,
-          message:
-            'Runtime settings are not available in this version. ' +
-            'Please update ConversationSimulator to the latest version to access these options.',
-        })
-      } else {
-        setLoadError(err)
-      }
-      return
-    }
+
+    // Neither backend raises 404 from /api/runtime/settings once the route is
+    // registered, so a 404 means the bundled runtime is an older build that
+    // predates the route. Only the advanced fields depend on that endpoint —
+    // provider, model and health all come from /api/models and still work — so
+    // degrade to hiding the advanced section rather than blocking the whole
+    // panel behind an error the user cannot retry their way out of.
+    const settingsMissing =
+      !settingsR.ok && settingsR.error.kind === 'http-error' && settingsR.error.status === 404
+    if (!settingsR.ok && !settingsMissing) { setLoadError(settingsR.error); return }
+
+    setSettingsUnavailable(settingsMissing)
+    if (settingsMissing) setShowAdvanced(false)
     setModelsData(modelsR.data)
     setProvider(modelsR.data.active.runtime_id ?? 'llama_cpp')
     setModelId(modelsR.data.active.model_id ?? '')
-    setForm(settingsToForm(settingsR.data.settings))
+    if (settingsR.ok) setForm(settingsToForm(settingsR.data.settings))
     setRequiresRestart(false)
   }, [])
 
@@ -467,23 +464,57 @@ export default function RuntimeSettingsPanel() {
         </div>
       )}
 
+      {/* Advanced settings are served by /api/runtime/settings. When the bundled
+          runtime predates that route, say so in plain language and point at the
+          one step that fixes it — updating the app. */}
+      {settingsUnavailable && (
+        <div
+          role="status"
+          aria-label="runtime advanced settings unavailable"
+          style={{
+            padding: '0.6rem 0.75rem',
+            borderRadius: '6px',
+            background: 'rgba(251,191,36,0.08)',
+            border: '1px solid rgba(251,191,36,0.3)',
+            fontSize: '0.85rem',
+            color: '#fcd34d',
+            marginBottom: '1rem',
+          }}
+        >
+          Advanced runtime settings are not available in this version of ConversationSimulator.
+          Update to the latest version to change context length, GPU layers, CPU threads and
+          sampling. The provider and model settings above still work.{' '}
+          <a
+            href={SETUP_DOCS_URL}
+            target="_blank"
+            rel="noreferrer"
+            aria-label="how to update ConversationSimulator"
+            style={{ color: '#fcd34d', textDecoration: 'underline' }}
+          >
+            How to update ↗
+          </a>
+        </div>
+      )}
+
       {/* Advanced toggle */}
-      <button
-        onClick={() => setShowAdvanced((v) => !v)}
-        aria-expanded={showAdvanced}
-        aria-label={showAdvanced ? 'hide runtime advanced settings' : 'show runtime advanced settings'}
-        style={{
-          background: 'none',
-          border: 'none',
-          cursor: 'pointer',
-          color: '#71717a',
-          fontSize: '0.85rem',
-          padding: 0,
-          marginBottom: '0.75rem',
-        }}
-      >
-        {showAdvanced ? '▾ Hide runtime advanced settings' : '▸ Show runtime advanced settings'}
-      </button>
+      {!settingsUnavailable && (
+        <button
+          onClick={() => setShowAdvanced((v) => !v)}
+          aria-expanded={showAdvanced}
+          aria-label={showAdvanced ? 'hide runtime advanced settings' : 'show runtime advanced settings'}
+          style={{
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+            color: '#71717a',
+            fontSize: '0.85rem',
+            padding: 0,
+            marginBottom: '0.75rem',
+          }}
+        >
+          {showAdvanced ? '▾ Hide runtime advanced settings' : '▸ Show runtime advanced settings'}
+        </button>
+      )}
 
       {showAdvanced && (
         <div

--- a/apps/web/src/setup/docsUrls.ts
+++ b/apps/web/src/setup/docsUrls.ts
@@ -4,5 +4,8 @@
 // to confirm the corresponding redirect or page exists.
 
 export const SETUP_DOCS_URL = 'https://docs.conversationsimulator.com/start/install/'
+// The "Updates and rollback" section of the install page — Steam beta branch, or
+// checking out a newer tag from source.
+export const UPDATE_DOCS_URL = 'https://docs.conversationsimulator.com/start/install/#updates-and-rollback'
 export const TROUBLESHOOTING_DOCS_URL = 'https://docs.conversationsimulator.com/start/troubleshooting/'
 export const AI_ENGINE_DOCS_URL = 'https://docs.conversationsimulator.com/play/ai-engine/'


### PR DESCRIPTION
## What changed

On first run against a runtime build that predates the `/api/runtime/settings` route, the Settings → Runtime panel was replaced entirely by:

> **Request failed**
> `{"detail":"Not Found"}`

Two things were wrong: the error text was raw JSON, and a 404 from one optional endpoint took down the whole panel with no way for the user to act on it.

## Fixes

**`apps/web/src/api/client.ts`** — `parseErrorText` now understands FastAPI's error shapes in addition to the convsim-core (`{ error: { code, message } }`) and convsim-api (`{ code?, message }`) shapes it already handled:

- `{ detail: string }` for standard HTTP errors (404, 500, …)
- `{ detail: { message, code, … } }` for state-conflict errors where convsim-core raises `HTTPException(detail={…})` without further reshaping
- `{ detail: [{ loc, msg, type }] }` for 422 request-validation failures, whose `msg` sentences are joined
- `{ error: string }` for bare error strings (not emitted in-tree today, but prevents dropping the only message in a body)

This is a general fix — no FastAPI error reaches the UI as raw JSON now, not just this one. The function also never echoes JSON scalars (null, numbers) that parse fine but carry no sentence.

**`apps/web/src/components/RuntimeSettingsPanel.tsx`** — a 404 from `getRuntimeSettings()` no longer blocks the panel. Only the advanced fields (context length, GPU layers, CPU threads, sampling) come from that endpoint; provider, model and runtime health come from `/api/models` and still work. So the panel now degrades instead of failing: it keeps the working controls, hides the advanced toggle, and shows a status notice explaining that advanced settings need a newer version, with a link to the update instructions. Any non-404 failure still surfaces as a blocking error, since that is a real fault worth retrying. A 404 that indicates the runtime is unreachable (HTML body instead of JSON) is also still blocking, since it's a different problem than "your app is out of date."

**`apps/web/src/setup/docsUrls.ts`** — added `UPDATE_DOCS_URL` pointing to the "Updates and rollback" section of the install docs (not the top of the page), so the user can find the specific update steps they need.

## Testing

- `RuntimeSettingsPanel.test.tsx`: on a 404 the panel stays usable, the notice explains the update and links to the docs, and the advanced toggle is gone; a 500 still blocks; a 404 that means the runtime is unreachable (via `runtime-unreachable` error kind) still blocks.
- `client.test.ts`: FastAPI 404 `detail` string, 422 `detail` list, object-shaped `detail` with `message`/`code`, bare `error` string, JSON scalar fallback, and precedence of `message` over `detail`.
- Full web suite passes (1265 tests) and `pnpm typecheck` is clean.

Closes #429