### PR TITLE
Stage Steam builds instead of setting a branch live from CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1545,7 +1545,13 @@ jobs:
     uses: ./.github/workflows/steam-deploy.yml
     with:
       release_tag: ${{ github.event.inputs.tag || github.ref_name }}
-      set_live_branch: beta
+      # Empty: stage the build, do not move a Steam branch. The build lands in
+      # Steamworks → Builds and a human sets it live. A git tag must not be able to
+      # put a build in front of players by itself, and CI cannot verify that the
+      # target branch exists or that the build account may set builds live — a
+      # SetLive against a branch that does not exist fails the commit AFTER every
+      # depot has uploaded, which is how the first v0.2.3 upload failed.
+      set_live_branch: ''
       # Steam takes its depot payload from THIS run's build artifacts. It used to
       # `gh release download` the published installers, but GitHub releases no
       # longer carry binaries — Steam is the only prebuilt channel, so the depot

--- a/.github/workflows/steam-deploy.yml
+++ b/.github/workflows/steam-deploy.yml
@@ -21,7 +21,19 @@
 #
 # ── Release gate reminder ────────────────────────────────────────────────────
 #
-# Stage 3 (private beta): set_live_branch = "beta"  ← workflow default
+# Automatic runs (chained from release.yml) STAGE the build: it is committed and
+# appears in Steamworks → Builds, but no branch is moved live. A human sets it live
+# from the partner portal. That is deliberate — a git tag should not be able to put
+# a build in front of players on its own — and it also sidesteps two things CI
+# cannot see: whether the target branch exists, and whether the build account holds
+# the separate Steamworks permission to set builds live.
+#
+# Setting a branch live is therefore a manual workflow_dispatch:
+#
+# Stage 3 (private beta): set_live_branch = "beta"
+#   The "beta" branch must already exist (Steamworks → App Admin → Builds →
+#   Branches). SetLive against a branch that does not exist fails the COMMIT, after
+#   the depots have uploaded — which is exactly how the first v0.2.3 upload failed.
 #   All Stage 3 gate criteria in docs/steam-mvp-scope.md must pass first,
 #   including G3-01 (code signing and notarisation) and G3-02 (depot audit).
 #
@@ -29,8 +41,7 @@
 #   All Stage 4 gate criteria must pass first, including G4-01 (Valve review
 #   approval) and G4-02 (Steam Deck Verified tier).
 #
-# Leave set_live_branch empty to stage the build without making any branch
-# live — use this for dry runs or when manual sign-off is required.
+# Leave set_live_branch empty to stage the build without making any branch live.
 #
 # ── Private beta verification procedure ──────────────────────────────────────
 #
@@ -114,9 +125,12 @@ on:
         default: ''
         type: string
       set_live_branch:
-        description: 'Steam branch to set live. Automatic runs only target "beta" — "default" is refused on workflow_call.'
+        description: >
+          Steam branch to set live after upload. EMPTY on automatic runs: the build
+          is committed and appears in Steamworks, but no branch is moved without a
+          human. "default" is refused on workflow_call.
         required: false
-        default: 'beta'
+        default: ''
         type: string
       run_id:
         description: >
@@ -445,11 +459,57 @@ jobs:
         if: env.HAS_STEAM_CREDS == 'true'
         env:
           STEAM_USERNAME: ${{ secrets.STEAM_USERNAME }}
+          SET_LIVE_BRANCH: ${{ inputs.set_live_branch }}
         run: |
+          set -o pipefail
+          rc=0
           steamcmd \
             +login "$STEAM_USERNAME" \
             +run_app_build "$(pwd)/steam-build/app_build.vdf" \
-            +quit
+            +quit || rc=$?
+
+          if [ "$rc" -eq 0 ]; then
+            if [ -z "${SET_LIVE_BRANCH:-}" ]; then
+              echo ""
+              echo "  OK  Build committed and STAGED — no Steam branch was moved."
+              echo ""
+              echo "  To put it in front of testers:"
+              echo "    Steamworks → App Admin → Builds → find this build → Set Build Live"
+              echo "    on the 'beta' branch, then Publish."
+            else
+              echo ""
+              echo "  OK  Build committed and set live on branch: $SET_LIVE_BRANCH"
+            fi
+            exit 0
+          fi
+
+          # steamcmd's own message for a failed commit is just "Failure", so spell out
+          # what actually causes it. The depots upload BEFORE the commit, so reaching
+          # here with all depots uploaded means the content was fine and only the
+          # commit was refused.
+          echo "" >&2
+          echo "ERROR: steamcmd exited $rc." >&2
+          if grep -qs "Failed to commit build" steam-build/output/*.log; then
+            echo "" >&2
+            echo "The depots uploaded, but Steam refused to COMMIT the build." >&2
+            echo "That is a Steamworks-side configuration problem, not a content problem." >&2
+            echo "" >&2
+            if [ -n "${SET_LIVE_BRANCH:-}" ]; then
+              echo "  SetLive was '$SET_LIVE_BRANCH'. The two usual causes:" >&2
+              echo "    1. That branch does not exist. Create it first:" >&2
+              echo "       Steamworks → App Admin → Builds → Branches." >&2
+              echo "       (A new app has only 'default'.)" >&2
+              echo "    2. The build account can upload builds but lacks the separate" >&2
+              echo "       permission to set them live." >&2
+              echo "" >&2
+              echo "  Re-run with set_live_branch empty to stage the build instead, then" >&2
+              echo "  set it live by hand in Steamworks." >&2
+            else
+              echo "  Check that all three depots are assigned to this App ID and that the" >&2
+              echo "  app configuration has been published in Steamworks." >&2
+            fi
+          fi
+          exit "$rc"
 
       # ── Log build output ───────────────────────────────────────────────────
       - name: Show steamcmd build output


### PR DESCRIPTION
## What happened

The v0.2.3 Steam upload **worked**. It logged in, scanned content, signed the install script, and uploaded all three depots:

| Depot | Result |
|---|---|
| 4963031 (Windows) | Success — manifest created |
| 4963032 (macOS) | Success — 64 chunks uploaded |
| 4963033 (Linux) | Success — 180 chunks uploaded |

Then it failed on the very last step:

```
ERROR! Failed to commit build for AppID 4963030 : Failure
```

The content and credentials were fine — only the **commit** was refused.

## Why

The generated `app_build.vdf` carried `SetLive "beta"`, and all three depots reported **"no baseline manifest"** — this is the app's **first build ever**. A new Steamworks app has only the `default` branch; `beta` must be created by hand in the partner portal, and `SetLive` against a branch that doesn't exist fails the commit *after* every depot has already uploaded.

(The other candidate: the build account may *upload* builds but lack the separate Steamworks permission to *set them live*. CI can see neither, and steamcmd reports both as bare "Failure".)

## Fix

**Automatic runs now stage the build.** It is committed and appears in Steamworks → Builds; a human sets it live from the portal.

This is the right default independently of the bug — a git tag should not be able to put a build in front of players on its own, which is the same reason this job already sits behind the `steam-release` approval gate, and it is what the workflow's own header always recommended for sign-off runs. Setting a branch live is now an explicit `workflow_dispatch`.

steamcmd renders a failed commit as bare "Failure" and exit 6, so the step now **explains itself**: which of the two causes applies, how to create the branch, and that staging is the way around it. On success it prints the exact Steamworks path to set a staged build live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)