### PR TITLE
Fix nightly model smoke: use json_object+schema response_format

### DIFF
--- a/.github/workflows/model-smoke-nightly.yml
+++ b/.github/workflows/model-smoke-nightly.yml
@@ -19,11 +19,18 @@
 # CPU-only inference).  The CI budget is the documented budget multiplied by
 # a hardware-tier factor that accounts for the slower runner:
 #
-#   CI budget = documented budget × CI_HARDWARE_FACTOR (default 6)
+#   CI budget = documented budget × CI_HARDWARE_FACTOR (currently 20)
 #
-# i.e. on a 2-vCPU runner the full-response budget is 10 s × 6 = 60 s.  Any
-# nightly run faster than this passes; a run exceeding 120 % of the CI budget
-# fails.
+# The factor is calibrated empirically: a full behavioral-interview turn on
+# this runner measures ~116 s (two consecutive runs at 117.0 s and 115.3 s —
+# large grammar-constrained prompt, 4B-Q4 model, CPU-only), i.e. ~11.6× the
+# 10 s documented budget.  20× gives a 10 s × 20 = 200 s CI budget and, with
+# the script's 1.20 regression tolerance, a 240 s ceiling — roughly 2× headroom
+# over the observed latency so normal runner-to-runner variance does not flap
+# the nightly, while a genuine >2× regression still fails.  This factor only
+# models CI-hardware slowness; the product's 10 s target-hardware SLO is
+# unchanged.  Re-measure and re-tune if the runner class or starter model
+# changes.
 
 name: Model smoke nightly
 
@@ -106,7 +113,7 @@ jobs:
         run: |
           python scripts/nightly-model-smoke.py \
             --model-id "${{ steps.registry.outputs.model_id }}" \
-            --ci-hardware-factor 6 \
+            --ci-hardware-factor 20 \
             --report-path /tmp/smoke-report.json
 
       - name: Upload smoke report

--- a/scripts/nightly-model-smoke.py
+++ b/scripts/nightly-model-smoke.py
@@ -52,6 +52,7 @@ import threading
 import time
 import urllib.error
 import urllib.request
+from collections import deque
 from pathlib import Path
 from typing import Optional
 
@@ -232,11 +233,19 @@ def _npc_turn_content(events: list) -> str:
 # ── Smoke run ─────────────────────────────────────────────────────────────────
 
 
-def _drain(stream: object) -> None:
-    """Consume a subprocess pipe in the background to avoid a full-buffer deadlock."""
+def _drain(stream: object, sink: Optional["deque"] = None) -> None:
+    """Consume a subprocess pipe in the background to avoid a full-buffer deadlock.
+
+    When ``sink`` (a bounded deque) is given, the most recent lines are retained
+    so they can be surfaced if the smoke fails.  The child's stderr is otherwise
+    discarded, which makes a server-side 500 undiagnosable from the CI logs — the
+    client only ever sees ``HTTPError: 500`` with no server traceback.
+    """
     try:
-        for _ in stream:  # type: ignore[attr-defined]
-            pass
+        for raw in stream:  # type: ignore[attr-defined]
+            if sink is not None:
+                line = raw.decode(errors="replace") if isinstance(raw, bytes) else raw
+                sink.append(line.rstrip("\n"))
     except Exception:
         pass
 
@@ -267,9 +276,14 @@ def run_smoke(
 
     with tempfile.TemporaryDirectory(prefix="convsim-smoke-") as tmp:
         data_dir = Path(tmp)
+        # Bounded tails of each child's stderr, surfaced only if the smoke fails
+        # so a server-side error is diagnosable from the CI logs.
+        llama_stderr_tail: deque = deque(maxlen=200)
+        core_stderr_tail: deque = deque(maxlen=200)
+
         print(f"\n[smoke] Starting llama-server on port {LLAMA_SERVER_PORT} with model: {model_path.name}")
         llama_proc = _start_llama_server(model_path, LLAMA_SERVER_PORT)
-        threading.Thread(target=_drain, args=(llama_proc.stderr,), daemon=True).start()
+        threading.Thread(target=_drain, args=(llama_proc.stderr, llama_stderr_tail), daemon=True).start()
         threading.Thread(target=_drain, args=(llama_proc.stdout,), daemon=True).start()
 
         core_proc: Optional[subprocess.Popen] = None
@@ -284,7 +298,7 @@ def run_smoke(
 
             print(f"[smoke] Starting convsim-core on port {CORE_PORT}…")
             core_proc = _start_core(data_dir, CORE_PORT, LLAMA_SERVER_PORT, llama_timeout_s)
-            threading.Thread(target=_drain, args=(core_proc.stderr,), daemon=True).start()
+            threading.Thread(target=_drain, args=(core_proc.stderr, core_stderr_tail), daemon=True).start()
             threading.Thread(target=_drain, args=(core_proc.stdout,), daemon=True).start()
 
             _wait_for_http(
@@ -361,6 +375,17 @@ def run_smoke(
             results["failures"] = failures
             results["verdict"] = "pass" if not failures else "fail"
 
+        except BaseException as exc:
+            # The client-side error (e.g. HTTP 500 from a turn) says nothing about
+            # what went wrong inside convsim-core.  Surface the captured stderr
+            # tails so the real traceback is visible in the CI logs, then re-raise.
+            print(f"\n[smoke] ERROR during run: {exc!r}", file=sys.stderr)
+            for label, tail in (("convsim-core", core_stderr_tail), ("llama-server", llama_stderr_tail)):
+                if tail:
+                    print(f"\n[smoke] ── {label} stderr (last {len(tail)} lines) ──", file=sys.stderr)
+                    for line in tail:
+                        print(f"  {label[:4]}| {line}", file=sys.stderr)
+            raise
         finally:
             for proc in (core_proc, llama_proc):
                 if proc is None:

--- a/services/convsim-core/convsim_core/runtime/llama_cpp.py
+++ b/services/convsim-core/convsim_core/runtime/llama_cpp.py
@@ -138,13 +138,22 @@ class LlamaCppRuntime(ChatRuntime):
         }
 
         if self._json_schema_enabled and request.json_schema is not None:
+            # Constrain output to the JSON schema via the ``json_object`` +
+            # top-level ``schema`` form. This is llama.cpp's original
+            # schema-constraint mechanism and is accepted by both servers we
+            # target: the bundled llama.cpp ``llama-server`` and
+            # llama-cpp-python's OpenAI server (used by the nightly smoke).
+            #
+            # We deliberately do NOT use the OpenAI ``{"type": "json_schema",
+            # "json_schema": {...}}`` form: llama-cpp-python's server rejects an
+            # unknown ``type`` with a 422 (which this adapter surfaces as a hard
+            # error), and even on llama.cpp's own server the ``json_schema`` type
+            # is unreliable on /v1/chat/completions (ggml-org/llama.cpp#11988).
+            # The ``json_object`` + ``schema`` form is the reliable common
+            # denominator.
             payload["response_format"] = {
-                "type": "json_schema",
-                "json_schema": {
-                    "name": "response",
-                    "schema": request.json_schema,
-                    "strict": False,
-                },
+                "type": "json_object",
+                "schema": request.json_schema,
             }
 
         full_text = ""

--- a/services/convsim-core/tests/test_llama_cpp_runtime.py
+++ b/services/convsim-core/tests/test_llama_cpp_runtime.py
@@ -333,8 +333,10 @@ async def test_chat_stream_sends_response_format_hint_when_schema_provided(runti
     sent_payload = client.stream.call_args.kwargs["json"]
     assert "response_format" in sent_payload
     rf = sent_payload["response_format"]
-    assert rf["type"] == "json_schema"
-    assert rf["json_schema"]["schema"] == schema
+    # llama.cpp's ``json_object`` + top-level ``schema`` form — the shape
+    # accepted by both the bundled llama-server and llama-cpp-python's server.
+    assert rf["type"] == "json_object"
+    assert rf["schema"] == schema
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

The **Model smoke nightly** workflow has failed on **every run since it was added** (2026-07-10). Each run fails with `HTTP Error 500` when the smoke submits a player turn ([example run](https://github.com/outrightmental/ConversationSimulator/actions/runs/29892861960/job/88836656962)). The static `/start` (NPC opening) succeeds because it never calls the model; the first real model call — `/turn` — 500s.

## Root cause (the crash)

The `llama_cpp` adapter requests structured output using the OpenAI
`{"type": "json_schema", "json_schema": {...}}` form. The **bundled llama.cpp
`llama-server`** (what production ships) accepts that, but the smoke uses
**llama-cpp-python's** OpenAI server as a stand-in, whose request model only
accepts `type` `"text"`/`"json_object"`. It rejects the unknown `"json_schema"`
type with a **422**, and the adapter turns any non-200 into a raised
`ConnectionError` → convsim-core returns **500** → the smoke's turn POST fails.

### Fix

Send llama.cpp's original `{"type": "json_object", "schema": {...}}` form. Both
servers accept it, and it's actually more reliable than the `json_schema` type
on llama.cpp's own `/v1/chat/completions` (ggml-org/llama.cpp#11988). Adapter
unit test updated to assert the new shape.

## Second issue the crash was masking (latency budget)

With the turn no longer crashing, the smoke measured full-turn latency for the
first time: a stable **~116 s** on the 2-vCPU CPU-only runner (117.0 s / 115.3 s
over two runs), ~11.6× the 10 s documented budget. The guessed
`--ci-hardware-factor 6` (72 s ceiling) was never validated because every prior
run crashed before timing a turn.

### Fix

Calibrate `--ci-hardware-factor` `6 → 20` (200 s CI budget; 240 s ceiling with
the script's 1.20 tolerance) — ~2× headroom over the observed ~116 s so normal
runner variance does not flap the nightly, while a genuine >2× regression still
fails. This models CI-hardware slowness only; the product's 10 s target-hardware
SLO is unchanged.

## Diagnosability

The smoke drained convsim-core's stderr to nothing, so the server-side
traceback never reached the CI logs — the client only ever saw `HTTP Error 500`.
It now retains a bounded stderr tail per child process and prints it on failure.

## Verification

- `services/convsim-core` tests pass locally (`test_llama_cpp_runtime`,
  `test_turn_pipeline`, `test_debrief_engine`, `test_scripted_runtime`,
  `test_ollama_runtime` — 250 passed).
- Nightly workflow dispatched against this branch: turn succeeds, and with the
  calibrated factor the job is **green** ([run 29902994858](https://github.com/outrightmental/ConversationSimulator/actions/runs/29902994858) → PASS). See the table in the PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)