### PR TITLE
Fix Steam build startup crash: register updater plugin only when configured

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -38,13 +38,26 @@ struct UpdateInfo {
 /// frontend.
 struct PendingUpdateState(Arc<Mutex<Option<String>>>);
 
+/// Whether the updater plugin was registered at startup.  Steam builds ship
+/// with `plugins.updater` removed from the merged Tauri config (Steam owns
+/// updates via SteamPipe), so the plugin is not registered — see `run()`.
+struct UpdaterEnabledState(bool);
+
 /// Check for a beta update.  Fails silently when offline or when the updater
 /// manifest is unavailable — the frontend shows nothing in that case.
 #[tauri::command]
 async fn check_for_update(
     app: AppHandle,
+    enabled: tauri::State<'_, UpdaterEnabledState>,
     state: tauri::State<'_, PendingUpdateState>,
 ) -> Result<Option<UpdateInfo>, String> {
+    // Steam builds do not register the updater plugin at all; touching
+    // `app.updater()` without the plugin's managed state would panic (and with
+    // `panic = "abort"` take the whole app down). Report "no update" — Steam
+    // delivers updates through SteamPipe.
+    if !enabled.0 {
+        return Ok(None);
+    }
     let updater = match app.updater() {
         Ok(u) => u,
         Err(e) => {
@@ -638,11 +651,37 @@ pub fn run() {
     let steam_status = Arc::new(Mutex::new(steam_status_val));
     let steam_runtime = Arc::new(Mutex::new(steam_runtime_val));
 
-    let app = tauri::Builder::default()
+    // Register the updater plugin ONLY when the merged Tauri config actually
+    // carries an updater entry.
+    //
+    // Steam builds pass `--config tauri.steam.conf.json`, whose
+    // `"updater": null` removes the key from the merged config (JSON Merge
+    // Patch, RFC 7396) so the app never polls GitHub for updates — Steam owns
+    // updates via SteamPipe. But `tauri_plugin_updater` REQUIRES its config
+    // (`pubkey` is a mandatory field): registering it while the config key is
+    // absent makes plugin initialisation fail, and with `panic = "abort"` the
+    // app dies before a window ever appears (Windows fail-fast 0xc0000409).
+    // That was exactly the "app doesn't launch" failure in the v0.2.4 Steam
+    // build (BuildID 24354771) — and invisible in non-Steam builds, whose
+    // tauri.conf.json carries a full updater config.
+    let context = tauri::generate_context!();
+    let updater_enabled = context
+        .config()
+        .plugins
+        .0
+        .get("updater")
+        .map(|v| !v.is_null())
+        .unwrap_or(false);
+
+    let mut builder = tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())
-        .plugin(tauri_plugin_fs::init())
-        .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(tauri_plugin_fs::init());
+    if updater_enabled {
+        builder = builder.plugin(tauri_plugin_updater::Builder::new().build());
+    }
+    let app = builder
+        .manage(UpdaterEnabledState(updater_enabled))
         .manage(CoreProcessState(Arc::clone(&process_inner)))
         .manage(CoreStatusState(Arc::clone(&status_inner)))
         .manage(PendingUpdateState(Arc::clone(&pending_update_inner)))
@@ -671,7 +710,7 @@ pub fn run() {
             );
             Ok(())
         })
-        .build(tauri::generate_context!())
+        .build(context)
         .expect("error while building tauri application");
 
     app.run(move |_app_handle, event| {


### PR DESCRIPTION
The Steam build overlay (tauri.steam.conf.json) sets plugins.updater to null, which removes the key from the merged config — but lib.rs registered tauri-plugin-updater unconditionally. The plugin cannot deserialize an absent/null config (pubkey is mandatory), so plugin init fails and with panic=abort the app fail-fasts (0xc0000409) before any window appears. This is the 'app does not launch' failure in the v0.2.4 Steam build (BuildID 24354771) and the remaining cause of the Valve review launch failures after the v0.2.4 crt-static fix.

Fix: register the updater plugin only when the merged config actually carries a non-null plugins.updater entry, and gate check_for_update on the same flag so Steam builds report 'no update' instead of touching unregistered plugin state.

Verification: reproduced the exact production panic by building the previous code against the RFC 7396-merged Steam config; the fixed binary starts cleanly under both the Steam-merged and standard configs. Event-log crash signature from the shipped v0.2.4 depot matches (same fault offset across runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4GogqwrcPc5M5VkM6wMWT