### PR TITLE
Fix the new-user experience: scenario contract, live runtime activation, engine autostart

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -539,6 +539,18 @@ fn launch_or_verify_core(
             }
         }
 
+        // convsim-core.exe is a console-subsystem binary; spawned from this GUI
+        // app without CREATE_NO_WINDOW it allocates a visible console window
+        // that pops over the UI for the whole session. Suppress it — core's
+        // output still lands in its own log files (and our inherited stdio when
+        // launched from a terminal on other platforms).
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::CommandExt;
+            const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+            cmd.creation_flags(CREATE_NO_WINDOW);
+        }
+
         let child = match cmd.spawn() {
             Ok(c) => c,
             Err(e) => {

--- a/apps/web/src/pages/ScenarioSetup.tsx
+++ b/apps/web/src/pages/ScenarioSetup.tsx
@@ -127,9 +127,9 @@ export function ScenarioSetupPage({ scenarioId, onSessionCreated, onBack }: Prop
             : voiceList[0]?.voice_id ?? null
         return {
           ...prev,
-          difficulty: scenarioData.difficulty.default,
-          player_role_name: scenarioData.player_role.label,
-          language: scenarioData.supported_languages[0] ?? 'en',
+          difficulty: scenarioData.difficulty?.default ?? 'standard',
+          player_role_name: scenarioData.player_role?.label ?? '',
+          language: scenarioData.supported_languages?.[0] ?? 'en',
           tts_enabled: rt.tts_ready && (scenarioData.voice_supported !== false),
           voice_id: prev.voice_id && voiceList.some((v) => v.voice_id === prev.voice_id)
             ? prev.voice_id
@@ -214,7 +214,7 @@ export function ScenarioSetupPage({ scenarioId, onSessionCreated, onBack }: Prop
   }
 
   const availableDifficulties = Object.keys(
-    scenario.difficulty.options,
+    scenario.difficulty?.options ?? {},
   ) as ScenarioDifficulty[];
 
   const validationErrorMap = Object.fromEntries(
@@ -260,7 +260,7 @@ export function ScenarioSetupPage({ scenarioId, onSessionCreated, onBack }: Prop
             </h2>
             <div className="setup-radio-group" role="radiogroup" aria-label="Difficulty">
               {availableDifficulties.map((level) => {
-                const option = scenario.difficulty.options[level];
+                const option = scenario.difficulty?.options?.[level];
                 return (
                   <label key={level} className="setup-radio-label">
                     <input
@@ -273,7 +273,7 @@ export function ScenarioSetupPage({ scenarioId, onSessionCreated, onBack }: Prop
                     <span className="setup-radio-text">
                       <span className="setup-difficulty-name">
                         {difficultyLabel(level, option)}
-                        {level === scenario.difficulty.default && (
+                        {level === scenario.difficulty?.default && (
                           <span className="setup-difficulty-recommended"> (recommended)</span>
                         )}
                       </span>
@@ -291,7 +291,7 @@ export function ScenarioSetupPage({ scenarioId, onSessionCreated, onBack }: Prop
             <h2 id="player-heading" className="setup-section-title">
               Your role
             </h2>
-            <p className="setup-role-brief">{scenario.player_role.brief}</p>
+            <p className="setup-role-brief">{scenario.player_role?.brief ?? ''}</p>
             <label className="setup-field">
               <span className="setup-label">Name to use in this session</span>
               <input
@@ -326,7 +326,7 @@ export function ScenarioSetupPage({ scenarioId, onSessionCreated, onBack }: Prop
                 value={form.language}
                 onChange={(e) => setField('language', e.target.value)}
               >
-                {scenario.supported_languages.map((code) => (
+                {(scenario.supported_languages ?? ['en']).map((code) => (
                   <option key={code} value={code}>
                     {languageLabel(code)}
                   </option>

--- a/apps/web/src/screens/ScenarioLibrary.tsx
+++ b/apps/web/src/screens/ScenarioLibrary.tsx
@@ -191,8 +191,8 @@ export default function ScenarioLibrary() {
     const models = new Set<string>()
     for (const s of scenarios) {
       ratings.add(s.content_rating)
-      for (const l of s.supported_languages) languages.add(l)
-      for (const d of Object.keys(s.difficulty.options)) difficulties.add(d)
+      for (const l of s.supported_languages ?? []) languages.add(l)
+      for (const d of Object.keys(s.difficulty?.options ?? {})) difficulties.add(d)
       for (const t of s.tags ?? []) tags.add(t)
       for (const m of s.recommended_model ?? []) models.add(m)
     }
@@ -210,13 +210,13 @@ export default function ScenarioLibrary() {
     const q = search.trim().toLowerCase()
     const filtered = scenarios.filter((s) => {
       if (filterRating && s.content_rating !== filterRating) return false
-      if (filterLanguage && !s.supported_languages.includes(filterLanguage)) return false
-      if (filterDifficulty && !Object.keys(s.difficulty.options).includes(filterDifficulty)) return false
+      if (filterLanguage && !(s.supported_languages ?? []).includes(filterLanguage)) return false
+      if (filterDifficulty && !Object.keys(s.difficulty?.options ?? {}).includes(filterDifficulty)) return false
       if (filterTag && !(s.tags ?? []).includes(filterTag)) return false
       if (filterModel && !(s.recommended_model ?? []).includes(filterModel)) return false
       if (voiceOnly && !s.voice_supported) return false
       if (q) {
-        const hay = `${s.title} ${s.summary} ${s.pack_name} ${s.player_role.label}`.toLowerCase()
+        const hay = `${s.title} ${s.summary} ${s.pack_name} ${s.player_role?.label ?? ''}`.toLowerCase()
         if (!hay.includes(q)) return false
       }
       return true
@@ -928,15 +928,15 @@ export default function ScenarioLibrary() {
                           aria-label="Scenario details"
                         >
                           <Chip label={scenario.content_rating} />
-                          <Chip label={`Role: ${scenario.player_role.label}`} />
+                          <Chip label={`Role: ${scenario.player_role?.label ?? '—'}`} />
                           <Chip label={scenario.estimated_length_label} />
                           {scenario.voice_supported && (
                             <Chip label="Voice supported" accent="green" />
                           )}
-                          {scenario.supported_languages.map((l) => (
+                          {(scenario.supported_languages ?? []).map((l) => (
                             <Chip key={l} label={l.toUpperCase()} />
                           ))}
-                          {Object.keys(scenario.difficulty.options).map((d) => (
+                          {Object.keys(scenario.difficulty?.options ?? {}).map((d) => (
                             <Chip key={d} label={d.charAt(0).toUpperCase() + d.slice(1)} />
                           ))}
                           {(scenario.tags ?? []).map((t) => (

--- a/apps/web/src/setup/useSetupFlow.ts
+++ b/apps/web/src/setup/useSetupFlow.ts
@@ -341,7 +341,16 @@ export function useSetupFlow(
     // Real model is now active — clear scripted/fake session hint.
     try { localStorage.removeItem(SETUP_KEYS.activeRuntimeHint) } catch { /* ignore */ }
     try { localStorage.removeItem(SETUP_KEYS.tutorialInstallId) } catch { /* ignore */ }
-    void api.startSidecar(trimmed)
+    // AWAIT the engine start (it returns once the model is loaded) so the
+    // benchmark step never races a half-started engine. "Already running"
+    // (409) is success for our purposes; any other failure is surfaced here
+    // instead of as a confusing benchmark error one screen later.
+    const sidecar = await api.startSidecar(trimmed)
+    if (!sidecar.ok && sidecar.error.status !== 409) {
+      setActionError(sidecar.error)
+      setActionLoading(false)
+      return
+    }
     benchmarkStartedRef.current = false
     setStep('benchmark')
     setActionLoading(false)

--- a/services/convsim-core/convsim_core/app.py
+++ b/services/convsim-core/convsim_core/app.py
@@ -93,7 +93,18 @@ def create_app(config: ServiceConfig | None = None) -> FastAPI:
         app.state.cancel_events = {}                 # install_id → asyncio.Event (model downloads)
         app.state.setup_install_cancel_events = {}   # job_id → asyncio.Event (pipeline jobs)
         app.state.app_settings = load_settings(db.connection(), config.data_dir, config.log_dir)
-        app.state.runtime = build_runtime(config.runtime_id)
+        # Boot with the user's persisted runtime selection (written by
+        # /api/models/use and the setup pipeline) rather than the static config
+        # default, so a restart keeps the chosen model instead of silently
+        # falling back to the fake runtime.
+        from convsim_core.runtime.active import (
+            resolve_startup_runtime_id,
+            schedule_startup_autostart,
+        )
+
+        app.state.runtime = build_runtime(
+            resolve_startup_runtime_id(db.connection(), config.runtime_id)
+        )
         app.state.stt_worker = build_stt_worker(config.stt_worker_id)
         app.state.tts_worker = build_tts_worker(config.tts_worker_id)
         app.state.vad_worker = build_vad_worker(config.vad_worker_id)
@@ -109,6 +120,10 @@ def create_app(config: ServiceConfig | None = None) -> FastAPI:
         # Re-drive any one-click install pipeline that a crash/kill left mid-flight
         # so the download resumes from its .part offset instead of freezing.
         setup_install_router.resume_orphaned_jobs(app)
+        # If the persisted runtime is llama_cpp, bring its engine up in the
+        # background so the first conversation after a restart works without
+        # a manual step. Failures are logged; health endpoints stay truthful.
+        schedule_startup_autostart(app)
         yield
         await supervisor.stop_all()
         db.close()

--- a/services/convsim-core/convsim_core/packs/models.py
+++ b/services/convsim-core/convsim_core/packs/models.py
@@ -96,16 +96,57 @@ class PlayerRoleInfo(BaseModel):
     brief: Optional[str] = None
 
 
+class DifficultyConfigInfo(BaseModel):
+    """Difficulty block in the shape the frontend's ScenarioInfo expects."""
+
+    default: str = "standard"
+    options: dict = {}
+
+
+class DurationInfo(BaseModel):
+    """Duration block in the shape the frontend's ScenarioInfo expects."""
+
+    max_turns: Optional[int] = None
+    soft_time_limit_minutes: Optional[int] = None
+
+
 class ScenarioCard(BaseModel):
-    """Summary of a scenario suitable for a library card view."""
+    """Summary of a scenario suitable for a library card view.
+
+    The field set is a superset of the frontend's canonical ``ScenarioInfo``
+    contract (packages/shared/src/types/scenario.ts). The frontend iterates
+    ``supported_languages``, ``difficulty.options``, and reads
+    ``player_role.label`` unconditionally — omitting any of them blank-screens
+    the scenario library (the v0.2.5 "supported_languages is not iterable"
+    startup-adjacent crash), so every canonical field is always present here
+    with a safe default. Legacy flat fields (``difficulty_default``,
+    ``voice_support``, ``model_recommendation``) are kept for compatibility
+    with existing consumers of this API.
+    """
 
     scenario_id: str
     pack_id: str
     pack_name: str
     title: str
-    summary: Optional[str] = None
+    summary: str = ""
     tags: list[str] = []
     content_rating: Optional[str] = None
+
+    # ── Canonical ScenarioInfo contract fields ────────────────────────────────
+    player_role: PlayerRoleInfo = PlayerRoleInfo(label="")
+    difficulty: DifficultyConfigInfo = DifficultyConfigInfo()
+    supported_languages: list[str] = ["en"]
+    duration: DurationInfo = DurationInfo()
+    state_meters_permitted: bool = False
+    voice_supported: bool = False
+    safety_summary: str = ""
+    estimated_length_label: str = ""
+    recommended_model: list[str] = []
+    ladder_position: Optional[str] = None
+    taught_dimensions: list[str] = []
+    tested_dimensions: list[str] = []
+
+    # ── Legacy flat fields (kept for API compatibility) ───────────────────────
     difficulty_default: Optional[str] = None
     max_turns: Optional[int] = None
     estimated_length_minutes: Optional[int] = None
@@ -113,23 +154,15 @@ class ScenarioCard(BaseModel):
     model_recommendation: Optional[str] = None
 
 
-class ScenarioDetail(BaseModel):
-    """Full scenario metadata without hidden agenda."""
+class ScenarioDetail(ScenarioCard):
+    """Full scenario metadata without hidden agenda.
 
-    scenario_id: str
-    pack_id: str
-    pack_name: str
-    title: str
-    summary: Optional[str] = None
-    tags: list[str] = []
-    content_rating: Optional[str] = None
-    difficulty_default: Optional[str] = None
+    Extends the card (which already carries the full canonical ScenarioInfo
+    contract) with detail-only fields used by the setup and conversation
+    screens.
+    """
+
     difficulty_options: dict = {}
-    max_turns: Optional[int] = None
-    estimated_length_minutes: Optional[int] = None
-    voice_support: bool = False
-    model_recommendation: Optional[str] = None
-    player_role: Optional[PlayerRoleInfo] = None
     opening_npc_says: Optional[str] = None
     player_visible_goals: list[str] = []
     hidden_goals: Optional[list[str]] = None

--- a/services/convsim-core/convsim_core/routers/models.py
+++ b/services/convsim-core/convsim_core/routers/models.py
@@ -312,6 +312,24 @@ async def use_model(request: Request, body: UseModelRequest) -> UseModelResponse
         test_runtime = build_runtime(body.runtime_id)
         health = await test_runtime.health()
 
+        # The managed local engine is not a user-run service: when it is not
+        # reachable, start it ourselves (bundled executable + newest ready
+        # model) instead of telling the user to run a server by hand. This is
+        # what makes "Use model" work in packaged builds where nothing else
+        # has started llama-server yet.
+        if body.runtime_id == "llama_cpp" and health.status in (
+            RuntimeStatus.UNAVAILABLE,
+            RuntimeStatus.ERROR,
+            RuntimeStatus.STARTING,
+        ):
+            from convsim_core.runtime.active import ensure_llama_sidecar_running
+
+            started = await ensure_llama_sidecar_running(
+                request.app, model_path=body.model_id
+            )
+            if started is not None:
+                health = await test_runtime.health()
+
         # When an Ollama model is explicitly selected, verify it is installed locally.
         # list_models() returns [] silently on connection failure, so this only fires
         # when Ollama is reachable but the model tag is missing.
@@ -342,6 +360,35 @@ async def use_model(request: Request, body: UseModelRequest) -> UseModelResponse
             await _client.aclose()
 
     if health.status in (RuntimeStatus.UNAVAILABLE, RuntimeStatus.ERROR):
+        if body.runtime_id == "llama_cpp":
+            from convsim_core.runtime.active import find_ready_model_path
+            from convsim_core.runtime.sidecar import find_executable
+
+            # Plain-language failure reasons — never CLI instructions.
+            if find_executable() is None:
+                friendly = (
+                    "The AI engine isn't installed yet. "
+                    "Use “Set me up” on the Welcome screen to install it."
+                )
+            elif (
+                find_ready_model_path(db.connection()) is None and not body.model_id
+            ):
+                friendly = (
+                    "No AI model is installed yet. "
+                    "Use “Set me up” on the Welcome screen, or install a model "
+                    "from the model manager."
+                )
+            else:
+                friendly = (
+                    "The AI engine couldn't start. "
+                    "Restart the app and try again; if it keeps happening, "
+                    "open the logs folder from the Support screen."
+                )
+            raise ConvsimError(
+                code="RUNTIME_UNAVAILABLE",
+                message=friendly,
+                status_code=503,
+            )
         raise ConvsimError(
             code="RUNTIME_UNAVAILABLE",
             message=health.message or f"Runtime '{body.runtime_id}' is not available.",
@@ -352,6 +399,14 @@ async def use_model(request: Request, body: UseModelRequest) -> UseModelResponse
         raise _ollama_model_error
 
     set_active_config(db.connection(), runtime_id=body.runtime_id, model_id=body.model_id)
+
+    # Swap the LIVE runtime so sessions immediately use the new selection.
+    # Persisting the config alone is not enough: app.state.runtime is what the
+    # session endpoints call, and before this swap existed it stayed on the
+    # startup default (the fake runtime in packaged builds) forever.
+    from convsim_core.runtime.active import activate_runtime
+
+    await activate_runtime(request.app, body.runtime_id)
 
     return UseModelResponse(
         runtime_id=body.runtime_id,
@@ -573,10 +628,25 @@ async def benchmark_model(request: Request, body: BenchmarkRequest) -> Benchmark
     model_id = body.model_id or active_cfg.get("model_id")
 
     health = await runtime.health()
+    if (
+        getattr(runtime, "id", None) == "llama_cpp"
+        and health.status in (RuntimeStatus.UNAVAILABLE, RuntimeStatus.ERROR, RuntimeStatus.STARTING)
+    ):
+        # Benchmark runs right after model selection; make sure the managed
+        # engine is actually up rather than failing on a race with its startup.
+        from convsim_core.runtime.active import ensure_llama_sidecar_running
+
+        if await ensure_llama_sidecar_running(request.app, model_path=model_id) is not None:
+            health = await runtime.health()
     if health.status in (RuntimeStatus.UNAVAILABLE, RuntimeStatus.ERROR):
         raise ConvsimError(
             code="RUNTIME_UNAVAILABLE",
-            message=health.message or "Runtime is not available for benchmarking.",
+            message=(
+                "The AI engine isn't running yet, so the speed check couldn't start. "
+                "Try again in a moment."
+                if getattr(runtime, "id", None) == "llama_cpp"
+                else health.message or "Runtime is not available for benchmarking."
+            ),
             status_code=503,
         )
 

--- a/services/convsim-core/convsim_core/routers/setup_install.py
+++ b/services/convsim-core/convsim_core/routers/setup_install.py
@@ -112,6 +112,7 @@ async def _run_pipeline(
     sidecar: LlamaCppSidecar,
     model_cancel_events: dict[int, asyncio.Event],
     cancel_event: asyncio.Event,
+    app: Any = None,
 ) -> None:
     """Orchestrate all five setup stages, persisting progress after each change."""
 
@@ -452,6 +453,18 @@ async def _run_pipeline(
     # stage exists to catch before the user's first conversation.
     set_active_config(conn, runtime_id="llama_cpp", model_id=model_file_path)
 
+    # Swap the LIVE runtime too: sessions read app.state.runtime, and without
+    # this swap the process keeps serving conversations on the startup runtime
+    # (the fake one in packaged builds) until the next restart — the install
+    # would "complete" yet the user would never actually talk to their model.
+    if app is not None:
+        try:
+            from convsim_core.runtime.active import activate_runtime
+
+            await activate_runtime(app, "llama_cpp")
+        except Exception as exc:  # pragma: no cover - never fail the pipeline here
+            logger.warning("setup-install(%d): runtime swap failed: %s", job_id, exc)
+
     _save()
 
     if _is_cancelled():
@@ -508,6 +521,7 @@ def _launch_pipeline_task(
                 sidecar=sidecar,
                 model_cancel_events=model_cancel_events,
                 cancel_event=cancel_event,
+                app=app,
             )
         except Exception as exc:
             logger.exception("setup-install(%d): unhandled error", job_id)

--- a/services/convsim-core/convsim_core/runtime/active.py
+++ b/services/convsim-core/convsim_core/runtime/active.py
@@ -1,0 +1,180 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Live runtime activation: keep ``app.state.runtime`` in sync with selection.
+
+Historically ``app.state.runtime`` was built once at startup from
+``config.runtime_id`` (default ``"fake"``) and never touched again, while
+``POST /api/models/use`` and the one-click install pipeline only persisted the
+selection to the DB via ``set_active_config`` — which nothing read back. The
+result: sessions ran on the startup runtime (the fake one, in packaged builds)
+forever, no matter what the user installed or selected.
+
+This module is the single place that swaps the live runtime object, and the
+startup path resolves the persisted selection so a restart keeps the user's
+choice.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import sqlite3
+from pathlib import Path
+from typing import Any, Optional
+
+import httpx
+
+from convsim_core.runtime.registry import build_runtime, list_runtime_ids
+
+logger = logging.getLogger(__name__)
+
+
+async def _close_runtime(runtime: Any) -> None:
+    """Release a replaced runtime's resources (persistent HTTP clients)."""
+    client = getattr(runtime, "_client", None)
+    if isinstance(client, httpx.AsyncClient):
+        try:
+            await client.aclose()
+        except Exception:  # pragma: no cover - best-effort cleanup
+            pass
+
+
+async def activate_runtime(app: Any, runtime_id: str) -> None:
+    """Swap ``app.state.runtime`` to *runtime_id*, releasing the old runtime.
+
+    No-op when the requested runtime is already active. Raises ``KeyError``
+    for unknown runtime ids (same contract as ``build_runtime``).
+    """
+    old = getattr(app.state, "runtime", None)
+    if old is not None and getattr(old, "id", None) == runtime_id:
+        return
+    new = build_runtime(runtime_id)
+    app.state.runtime = new
+    logger.info(
+        "Active runtime switched: %s -> %s",
+        getattr(old, "id", None),
+        runtime_id,
+    )
+    if old is not None:
+        await _close_runtime(old)
+
+
+def resolve_startup_runtime_id(conn: sqlite3.Connection, config_runtime_id: str) -> str:
+    """Return the runtime id the app should boot with.
+
+    The persisted active selection (written by /api/models/use and the setup
+    pipeline) wins over the static config default, so restarting the app keeps
+    the user's model choice. Unknown/corrupt persisted ids fall back to the
+    config default rather than failing startup.
+    """
+    try:
+        from convsim_core.services.model_manager_service import get_active_config
+
+        persisted = (get_active_config(conn) or {}).get("runtime_id")
+    except Exception:  # pragma: no cover - a fresh DB has no config yet
+        persisted = None
+    if persisted and persisted in list_runtime_ids():
+        return str(persisted)
+    return config_runtime_id
+
+
+def find_ready_model_path(conn: sqlite3.Connection) -> Optional[str]:
+    """Return the newest installed-and-ready GGUF path, or the active model id
+    when it points at an existing file. None when no usable model exists."""
+    try:
+        from convsim_core.services.model_manager_service import get_active_config
+
+        active = (get_active_config(conn) or {}).get("model_id")
+    except Exception:
+        active = None
+    candidates: list[str] = []
+    if active:
+        candidates.append(str(active))
+    try:
+        row = conn.execute(
+            "SELECT file_path FROM installed_models "
+            "WHERE install_status IN ('ready', 'complete') AND file_path != '' "
+            "ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+        if row and row["file_path"]:
+            candidates.append(str(row["file_path"]))
+    except sqlite3.Error:  # pragma: no cover - table missing pre-migration
+        pass
+    for cand in candidates:
+        p = Path(cand).expanduser()
+        if p.is_file() and p.suffix.lower() == ".gguf":
+            return str(p)
+    return None
+
+
+async def ensure_llama_sidecar_running(
+    app: Any,
+    *,
+    model_path: Optional[str] = None,
+    startup_timeout: float = 120.0,
+) -> Optional[str]:
+    """Start the managed llama-server if it is not already reachable.
+
+    Best-effort: returns the model path used on success, None when starting was
+    not possible (no sidecar, no executable, no model, or start failure). Never
+    raises — callers decide how to surface unavailability.
+    """
+    from convsim_core.runtime.sidecar import SidecarState, find_executable
+
+    sidecar = getattr(app.state, "sidecar", None)
+    if sidecar is None:
+        return None
+    if sidecar.state in (SidecarState.RUNNING, SidecarState.STARTING):
+        return None
+
+    conn = app.state.db.connection()
+    path = None
+    if model_path:
+        p = Path(model_path).expanduser()
+        if p.is_file() and p.suffix.lower() == ".gguf":
+            path = str(p)
+    if path is None:
+        path = find_ready_model_path(conn)
+    if path is None:
+        logger.info("llama-server autostart skipped: no ready model file found")
+        return None
+
+    exe = find_executable()
+    if exe is None:
+        logger.info("llama-server autostart skipped: no engine executable found")
+        return None
+
+    try:
+        await sidecar.start(
+            model_path=path,
+            executable=exe,
+            startup_timeout=startup_timeout,
+        )
+        logger.info("llama-server autostarted with model %s", path)
+        return path
+    except Exception as exc:
+        logger.warning("llama-server autostart failed: %s", exc)
+        return None
+
+
+def schedule_startup_autostart(app: Any) -> None:
+    """If the persisted runtime is llama_cpp, start its engine in the background.
+
+    Called from app startup so a restarted app comes back with a working local
+    engine instead of surfacing "runtime unavailable" on the first turn. Runs
+    as a fire-and-forget task; failures are logged and the health endpoints
+    report the true state.
+    """
+    runtime = getattr(app.state, "runtime", None)
+    if getattr(runtime, "id", None) != "llama_cpp":
+        return
+
+    async def _run() -> None:
+        await ensure_llama_sidecar_running(app)
+
+    task = asyncio.create_task(_run())
+    # Keep a strong reference on app.state so the task is not GC'd mid-start.
+    tasks = getattr(app.state, "_autostart_tasks", None)
+    if tasks is None:
+        tasks = set()
+        app.state._autostart_tasks = tasks
+    tasks.add(task)
+    task.add_done_callback(tasks.discard)

--- a/services/convsim-core/convsim_core/runtime/kokoro_sidecar.py
+++ b/services/convsim-core/convsim_core/runtime/kokoro_sidecar.py
@@ -13,6 +13,8 @@ import os
 import shutil
 import socket
 import subprocess
+
+from convsim_core.runtime.procflags import CREATE_NO_WINDOW
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -209,6 +211,7 @@ class KokoroSidecar(SidecarProcess):
                 *cmd,
                 stdout=log_fh,
                 stderr=subprocess.STDOUT,
+                creationflags=CREATE_NO_WINDOW,
             )
         except OSError as exc:
             self._state = SidecarState.CRASHED

--- a/services/convsim-core/convsim_core/runtime/llama_cpp.py
+++ b/services/convsim-core/convsim_core/runtime/llama_cpp.py
@@ -256,8 +256,8 @@ class LlamaCppRuntime(ChatRuntime):
                 runtime_name=self.display_name,
                 status=RuntimeStatus.UNAVAILABLE,
                 message=(
-                    f"Cannot connect to llama-server at {self._base_url}. "
-                    "Start it with: llama-server --port 7356 --model /path/to/model.gguf"
+                    "The local AI engine isn't running. It starts automatically "
+                    "when a model is selected or installed."
                 ),
                 checked_at=checked_at,
             )

--- a/services/convsim-core/convsim_core/runtime/procflags.py
+++ b/services/convsim-core/convsim_core/runtime/procflags.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Platform subprocess helpers.
+
+On Windows, console-subsystem children (llama-server.exe, whisper-cli.exe,
+nvidia-smi, …) allocate a visible console window when spawned from a process
+without one — the packaged app is a GUI app, so every sidecar launch flashed
+a black console over the UI. CREATE_NO_WINDOW suppresses that. No-op on
+other platforms.
+"""
+import subprocess
+import sys
+
+#: Pass as ``creationflags=`` to subprocess.run/Popen/create_subprocess_exec.
+CREATE_NO_WINDOW: int = (
+    subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0  # type: ignore[attr-defined]
+)

--- a/services/convsim-core/convsim_core/runtime/sidecar.py
+++ b/services/convsim-core/convsim_core/runtime/sidecar.py
@@ -18,6 +18,7 @@ from enum import Enum
 from pathlib import Path
 from typing import IO
 
+from convsim_core.runtime.procflags import CREATE_NO_WINDOW
 from convsim_core.runtime.supervisor import SidecarProcess, assert_localhost
 
 
@@ -269,6 +270,7 @@ class LlamaCppSidecar(SidecarProcess):
                 *cmd,
                 stdout=log_fh,
                 stderr=subprocess.STDOUT,
+                creationflags=CREATE_NO_WINDOW,
             )
         except OSError as exc:
             self._state = SidecarState.CRASHED

--- a/services/convsim-core/convsim_core/storage/repositories/scenario_repo.py
+++ b/services/convsim-core/convsim_core/storage/repositories/scenario_repo.py
@@ -1,13 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 """Database queries for the scenario library: listing, filtering, FTS, and detail."""
 import json
+import os
 import sqlite3
 from pathlib import Path
 from typing import Optional
 
 import yaml
 
-from convsim_core.packs.models import PlayerRoleInfo, ScenarioCard, ScenarioDetail
+from convsim_core.packs.models import (
+    DifficultyConfigInfo,
+    DurationInfo,
+    PlayerRoleInfo,
+    ScenarioCard,
+    ScenarioDetail,
+)
 
 _SCENARIO_COLS = """
     s.slug          AS scenario_id,
@@ -16,6 +23,7 @@ _SCENARIO_COLS = """
     COALESCE(s.title, s.name)  AS title,
     s.summary,
     p.tags_json,
+    p.supported_languages_json,
     COALESCE(s.content_rating, p.content_rating) AS content_rating,
     s.difficulty_default,
     s.max_turns,
@@ -123,14 +131,113 @@ def get_scenario_by_id(
     return _row_to_detail(row, include_hidden=include_hidden)
 
 
+def _canonical_fields(row: sqlite3.Row, yaml_data: dict) -> dict:
+    """Build the canonical ScenarioInfo fields the frontend contract requires.
+
+    The web app (packages/shared/src/types/scenario.ts) iterates
+    ``supported_languages`` and ``difficulty.options`` and dereferences
+    ``player_role.label`` without guards, so every field returned here must be
+    present and well-typed even when the scenario YAML is missing, partial, or
+    unparseable — a scenario row must never be able to blank the library.
+    """
+    # player_role — always an object with a string label.
+    pr_raw = yaml_data.get("player_role")
+    if isinstance(pr_raw, dict):
+        player_role = PlayerRoleInfo(
+            label=str(pr_raw.get("label") or ""),
+            brief=pr_raw.get("brief") or "",
+        )
+    else:
+        player_role = PlayerRoleInfo(label="", brief="")
+
+    # difficulty — default + options, YAML first, DB column fallback.
+    difficulty_raw = yaml_data.get("difficulty")
+    difficulty_raw = difficulty_raw if isinstance(difficulty_raw, dict) else {}
+    options = difficulty_raw.get("options")
+    options = options if isinstance(options, dict) else {}
+    default = (
+        difficulty_raw.get("default")
+        or row["difficulty_default"]
+        or (next(iter(options)) if options else "standard")
+    )
+    difficulty = DifficultyConfigInfo(default=str(default), options=options)
+
+    # supported_languages — scenario YAML override → pack manifest → ["en"].
+    langs = yaml_data.get("supported_languages")
+    if not (isinstance(langs, list) and langs):
+        try:
+            langs = json.loads(row["supported_languages_json"] or "[]")
+        except (TypeError, ValueError):
+            langs = []
+    if not (isinstance(langs, list) and langs):
+        langs = ["en"]
+    supported_languages = [str(lang) for lang in langs]
+
+    # duration — YAML block with DB column fallback.
+    duration_raw = yaml_data.get("duration")
+    duration_raw = duration_raw if isinstance(duration_raw, dict) else {}
+    max_turns = duration_raw.get("max_turns") or row["max_turns"]
+    soft_limit = duration_raw.get("soft_time_limit_minutes") or row["soft_time_limit_minutes"]
+    duration = DurationInfo(max_turns=max_turns, soft_time_limit_minutes=soft_limit)
+
+    # state_meters_permitted — true when any state variable is player-visible.
+    state_raw = yaml_data.get("state")
+    variables = (state_raw or {}).get("variables") if isinstance(state_raw, dict) else None
+    state_meters_permitted = False
+    if isinstance(variables, dict):
+        for spec in variables.values():
+            if isinstance(spec, dict) and str(
+                spec.get("visibility", spec.get("visible", ""))
+            ).lower() in ("visible", "true"):
+                state_meters_permitted = True
+                break
+    if isinstance(state_raw, dict) and state_raw.get("visible_to_player"):
+        state_meters_permitted = True
+
+    # estimated_length_label — human label derived from duration.
+    if soft_limit:
+        estimated_length_label = f"~{soft_limit} min"
+    elif max_turns:
+        estimated_length_label = f"~{max_turns} turns"
+    else:
+        estimated_length_label = "Varies"
+
+    # safety_summary — content-rating line; scenario YAML may refine it later.
+    rating = row["content_rating"] or "G"
+    safety_summary = f"Rated {rating}. Conversations stay on this device."
+
+    recommended = row["model_recommendation"]
+    recommended_model = [recommended] if recommended else []
+
+    taught = yaml_data.get("taught_dimensions")
+    tested = yaml_data.get("tested_dimensions")
+    ladder = yaml_data.get("ladder_position")
+
+    return {
+        "player_role": player_role,
+        "difficulty": difficulty,
+        "supported_languages": supported_languages,
+        "duration": duration,
+        "state_meters_permitted": state_meters_permitted,
+        "voice_supported": bool(row["voice_support"]),
+        "safety_summary": safety_summary,
+        "estimated_length_label": estimated_length_label,
+        "recommended_model": recommended_model,
+        "ladder_position": str(ladder) if ladder else None,
+        "taught_dimensions": taught if isinstance(taught, list) else [],
+        "tested_dimensions": tested if isinstance(tested, list) else [],
+    }
+
+
 def _row_to_card(row: sqlite3.Row) -> ScenarioCard:
     tags = json.loads(row["tags_json"] or "[]")
+    yaml_data = _load_scenario_yaml(row["pack_source_path"], row["rel_path"])
     return ScenarioCard(
         scenario_id=row["scenario_id"],
         pack_id=row["pack_id"],
         pack_name=row["pack_name"],
         title=row["title"] or row["scenario_id"],
-        summary=row["summary"],
+        summary=row["summary"] or "",
         tags=tags,
         content_rating=row["content_rating"],
         difficulty_default=row["difficulty_default"],
@@ -138,20 +245,13 @@ def _row_to_card(row: sqlite3.Row) -> ScenarioCard:
         estimated_length_minutes=row["soft_time_limit_minutes"],
         voice_support=bool(row["voice_support"]),
         model_recommendation=row["model_recommendation"],
+        **_canonical_fields(row, yaml_data),
     )
 
 
 def _row_to_detail(row: sqlite3.Row, *, include_hidden: bool) -> ScenarioDetail:
     tags = json.loads(row["tags_json"] or "[]")
     yaml_data = _load_scenario_yaml(row["pack_source_path"], row["rel_path"])
-
-    player_role: Optional[PlayerRoleInfo] = None
-    pr_raw = yaml_data.get("player_role")
-    if isinstance(pr_raw, dict):
-        player_role = PlayerRoleInfo(
-            label=pr_raw.get("label", ""),
-            brief=pr_raw.get("brief"),
-        )
 
     opening_npc_says: Optional[str] = None
     opening = yaml_data.get("opening")
@@ -170,7 +270,7 @@ def _row_to_detail(row: sqlite3.Row, *, include_hidden: bool) -> ScenarioDetail:
         pack_id=row["pack_id"],
         pack_name=row["pack_name"],
         title=row["title"] or row["scenario_id"],
-        summary=row["summary"],
+        summary=row["summary"] or "",
         tags=tags,
         content_rating=row["content_rating"],
         difficulty_default=row["difficulty_default"],
@@ -179,11 +279,17 @@ def _row_to_detail(row: sqlite3.Row, *, include_hidden: bool) -> ScenarioDetail:
         estimated_length_minutes=row["soft_time_limit_minutes"],
         voice_support=bool(row["voice_support"]),
         model_recommendation=row["model_recommendation"],
-        player_role=player_role,
         opening_npc_says=opening_npc_says,
         player_visible_goals=player_visible_goals,
         hidden_goals=hidden_goals,
+        **_canonical_fields(row, yaml_data),
     )
+
+
+# mtime-keyed cache so the list endpoint (which now loads YAML per scenario to
+# build the canonical contract fields) stays O(stat) per request instead of
+# O(read+parse). Bounded by the number of installed scenarios.
+_YAML_CACHE: dict[str, tuple[float, dict]] = {}
 
 
 def _load_scenario_yaml(pack_source_path: Optional[str], rel_path: Optional[str]) -> dict:
@@ -194,7 +300,14 @@ def _load_scenario_yaml(pack_source_path: Optional[str], rel_path: Optional[str]
         base = Path(pack_source_path).resolve()
         path = (base / rel_path).resolve()
         path.relative_to(base)  # raises ValueError if outside pack directory
+        key = str(path)
+        mtime = os.path.getmtime(path)
+        cached = _YAML_CACHE.get(key)
+        if cached is not None and cached[0] == mtime:
+            return cached[1]
         raw = yaml.safe_load(path.read_text(encoding="utf-8"))
-        return raw if isinstance(raw, dict) else {}
+        data = raw if isinstance(raw, dict) else {}
+        _YAML_CACHE[key] = (mtime, data)
+        return data
     except Exception:
         return {}

--- a/services/convsim-core/convsim_core/stt/whisper_cpp.py
+++ b/services/convsim-core/convsim_core/stt/whisper_cpp.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import asyncio
+
+from convsim_core.runtime.procflags import CREATE_NO_WINDOW
 import json
 import logging
 import os
@@ -154,6 +156,7 @@ class WhisperCppWorker(SttWorker):
                     *cmd,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
+                    creationflags=CREATE_NO_WINDOW,
                 )
             except OSError as exc:
                 raise SttError(

--- a/services/convsim-core/convsim_core/vad/silero.py
+++ b/services/convsim-core/convsim_core/vad/silero.py
@@ -7,6 +7,8 @@ import logging
 import os
 import struct
 import subprocess
+
+from convsim_core.runtime.procflags import CREATE_NO_WINDOW
 import tempfile
 import wave
 from datetime import datetime, timezone
@@ -71,6 +73,7 @@ def _try_ffmpeg_to_pcm(audio: bytes, audio_format: str) -> list[float] | None:
             ],
             capture_output=True,
             timeout=30.0,
+            creationflags=CREATE_NO_WINDOW,
         )
     except (OSError, subprocess.TimeoutExpired):
         return None

--- a/services/convsim-core/tests/test_llama_cpp_runtime.py
+++ b/services/convsim-core/tests/test_llama_cpp_runtime.py
@@ -507,7 +507,9 @@ async def test_health_unavailable_on_connect_error(runtime):
 
     assert h.status == RuntimeStatus.UNAVAILABLE
     assert h.message is not None
-    assert "llama-server" in h.message
+    # Plain-language copy (no CLI/binary jargon reaches users): the engine
+    # is managed by the app, not run by hand.
+    assert "AI engine" in h.message
 
 
 @pytest.mark.asyncio

--- a/services/convsim-core/tests/test_runtime_activation.py
+++ b/services/convsim-core/tests/test_runtime_activation.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for live runtime activation (the fake-runtime-forever bug).
+
+``POST /api/models/use`` and the setup pipeline used to persist the selection
+with ``set_active_config`` only — but sessions read ``app.state.runtime``,
+which was built once at startup from ``config.runtime_id`` (default: fake) and
+never swapped. Result: in packaged builds every conversation ran on the fake
+runtime no matter what the user installed or selected, and a restart reverted
+any selection. These tests pin the three guarantees that fix it:
+
+1. a successful /api/models/use swaps the LIVE runtime object;
+2. the persisted selection survives a restart (startup reads the DB);
+3. an unknown persisted runtime id falls back to the config default.
+"""
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from convsim_core.app import create_app
+from convsim_core.config import ServiceConfig
+from convsim_core.runtime.active import resolve_startup_runtime_id
+from convsim_core.services.model_manager_service import set_active_config
+
+
+def _config(tmp_path: Path) -> ServiceConfig:
+    return ServiceConfig(
+        host="127.0.0.1",
+        port=7355,
+        data_dir=str(tmp_path / "data"),
+        log_dir=str(tmp_path / "logs"),
+        db_dir=str(tmp_path / "db"),
+        packs_dir=str(tmp_path / "packs"),
+    )
+
+
+def test_use_model_swaps_live_runtime(tmp_path):
+    config = _config(tmp_path)
+    app = create_app(config)
+    with TestClient(app) as client:
+        assert app.state.runtime.id == "fake"  # config default
+
+        resp = client.post(
+            "/api/models/use", json={"runtime_id": "scripted", "model_id": None}
+        )
+        assert resp.status_code == 200, resp.text
+
+        # The LIVE runtime object sessions use must have been swapped —
+        # persisting the config alone is the exact historical bug.
+        assert app.state.runtime.id == "scripted"
+
+
+def test_selection_survives_restart(tmp_path):
+    config = _config(tmp_path)
+    app = create_app(config)
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/models/use", json={"runtime_id": "scripted", "model_id": None}
+        )
+        assert resp.status_code == 200, resp.text
+
+    # Simulate an app restart on the same profile: the persisted selection —
+    # not the config default — must win.
+    app2 = create_app(config)
+    with TestClient(app2):
+        assert app2.state.runtime.id == "scripted"
+
+
+def test_unknown_persisted_runtime_falls_back_to_config(tmp_path):
+    config = _config(tmp_path)
+    app = create_app(config)
+    with TestClient(app):
+        conn = app.state.db.connection()
+        set_active_config(conn, runtime_id="does-not-exist", model_id=None)
+        assert resolve_startup_runtime_id(conn, "fake") == "fake"

--- a/services/convsim-core/tests/test_scenario_contract.py
+++ b/services/convsim-core/tests/test_scenario_contract.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Frontend contract test for the scenario endpoints.
+
+The web app's canonical ``ScenarioInfo`` type
+(packages/shared/src/types/scenario.ts) is consumed WITHOUT guards in several
+screens: ScenarioLibrary iterates ``supported_languages`` and
+``difficulty.options`` with ``for..of``/``Object.keys`` and reads
+``player_role.label``; ScenarioSetup indexes ``supported_languages[0]`` and
+reads ``difficulty.default`` and ``state_meters_permitted``. A response
+missing any of these fields does not degrade — it blank-screens the app
+behind the "Something went wrong" boundary (observed in the v0.2.5 Steam
+build as ``Y.supported_languages is not iterable``).
+
+This test seeds the real official packs and asserts every scenario returned
+by the list and detail endpoints carries the full canonical contract with
+correct types, so backend model changes can never silently reintroduce the
+mismatch.
+"""
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from convsim_core.app import create_app
+from convsim_core.config import ServiceConfig
+from convsim_core.packs.seeder import seed_official_packs
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_OFFICIAL_PACKS = _REPO_ROOT / "packs" / "official"
+
+# Every key the frontend dereferences without a guard, with its expected type.
+_CANONICAL_CONTRACT: dict[str, type | tuple[type, ...]] = {
+    "scenario_id": str,
+    "pack_id": str,
+    "pack_name": str,
+    "title": str,
+    "summary": str,
+    "supported_languages": list,
+    "state_meters_permitted": bool,
+    "voice_supported": bool,
+    "safety_summary": str,
+    "estimated_length_label": str,
+    "recommended_model": list,
+    "taught_dimensions": list,
+    "tested_dimensions": list,
+}
+
+
+@pytest.fixture()
+def seeded_client(tmp_path, monkeypatch):
+    config = ServiceConfig(
+        host="127.0.0.1",
+        port=7355,
+        data_dir=str(tmp_path / "data"),
+        log_dir=str(tmp_path / "logs"),
+        db_dir=str(tmp_path / "db"),
+        packs_dir=str(tmp_path / "packs"),
+        official_packs_dir=str(_OFFICIAL_PACKS),
+    )
+    app = create_app(config)
+    with TestClient(app) as c:
+        # App startup seeds official packs itself; run the seeder again only as
+        # a safety net for app versions that defer it (idempotent warm start).
+        seed_official_packs(config, app.state.db.connection())
+        yield c
+
+
+def _assert_canonical(s: dict) -> None:
+    for key, typ in _CANONICAL_CONTRACT.items():
+        assert key in s, f"scenario {s.get('scenario_id')!r} missing '{key}'"
+        assert isinstance(s[key], typ), (
+            f"scenario {s.get('scenario_id')!r} field '{key}' has type "
+            f"{type(s[key]).__name__}, expected {typ}"
+        )
+
+    # supported_languages must be a NON-EMPTY list of strings — the setup page
+    # indexes [0] and the library iterates it for the language filter.
+    assert s["supported_languages"], (
+        f"scenario {s.get('scenario_id')!r} has empty supported_languages"
+    )
+    assert all(isinstance(lang, str) for lang in s["supported_languages"])
+
+    # difficulty must be an object with a string default and a dict options.
+    difficulty = s.get("difficulty")
+    assert isinstance(difficulty, dict), "difficulty must be an object"
+    assert isinstance(difficulty.get("default"), str) and difficulty["default"]
+    assert isinstance(difficulty.get("options"), dict)
+
+    # player_role must be an object with a string label.
+    player_role = s.get("player_role")
+    assert isinstance(player_role, dict), "player_role must be an object"
+    assert isinstance(player_role.get("label"), str)
+
+    # duration must be an object with the two canonical keys present.
+    duration = s.get("duration")
+    assert isinstance(duration, dict), "duration must be an object"
+    assert "max_turns" in duration
+    assert "soft_time_limit_minutes" in duration
+
+
+def test_scenario_list_meets_frontend_contract(seeded_client):
+    resp = seeded_client.get("/api/scenarios")
+    assert resp.status_code == 200
+    scenarios = resp.json()
+    assert len(scenarios) >= 5, "official packs should seed multiple scenarios"
+    for s in scenarios:
+        _assert_canonical(s)
+
+
+def test_scenario_detail_meets_frontend_contract(seeded_client):
+    listing = seeded_client.get("/api/scenarios").json()
+    for s in listing:
+        detail = seeded_client.get(f"/api/scenarios/{s['scenario_id']}")
+        assert detail.status_code == 200
+        _assert_canonical(detail.json())
+
+
+def test_tutorial_scenario_canonical_fields(seeded_client):
+    """The tutorial is the first scenario every new user opens — pin its shape."""
+    resp = seeded_client.get("/api/scenarios/first_words_tutorial")
+    assert resp.status_code == 200
+    s = resp.json()
+    _assert_canonical(s)
+    assert s["difficulty"]["default"]
+    assert s["duration"]["max_turns"] == 8
+    assert s["taught_dimensions"], "tutorial declares taught_dimensions"
+    assert s["opening_npc_says"], "tutorial must carry its scripted opening"
+
+
+def test_language_cafe_languages_come_from_pack_manifest(seeded_client):
+    """Language Café's manifest declares en/es/fr/ja — cards must surface them."""
+    resp = seeded_client.get("/api/scenarios", params={"pack": "official.language_cafe"})
+    assert resp.status_code == 200
+    scenarios = resp.json()
+    assert scenarios, "language cafe scenarios must be seeded"
+    for s in scenarios:
+        assert set(s["supported_languages"]) == {"en", "es", "fr", "ja"}

--- a/services/convsim-core/tests/test_whisper_cpp_worker.py
+++ b/services/convsim-core/tests/test_whisper_cpp_worker.py
@@ -311,7 +311,7 @@ class _FakeProcess:
 def _make_mock_subprocess(json_output: dict, returncode: int = 0):
     """Return a mock for asyncio.create_subprocess_exec that writes a JSON sidecar."""
 
-    async def _fake_exec(*args, stdout=None, stderr=None):
+    async def _fake_exec(*args, stdout=None, stderr=None, **kwargs):
         # The worker writes audio to a temp file and passes it as --file arg.
         # Find the --file argument in the command to know where to write the JSON.
         file_idx = list(args).index("--file") + 1
@@ -394,7 +394,7 @@ async def test_transcribe_raises_stt_error_on_nonzero_returncode(tmp_path):
 
     worker = _make_worker(binary=_FAKE_BINARY, model=str(model_file))
 
-    async def _failing_exec(*args, stdout=None, stderr=None):
+    async def _failing_exec(*args, stdout=None, stderr=None, **kwargs):
         return _FakeProcess(b"", b"error: bad input", 1)
 
     with patch("os.path.isfile", return_value=True), \
@@ -413,7 +413,7 @@ async def test_transcribe_falls_back_to_stdout_when_json_sidecar_absent(tmp_path
 
     worker = _make_worker(binary=_FAKE_BINARY, model=str(model_file))
 
-    async def _no_sidecar_exec(*args, stdout=None, stderr=None):
+    async def _no_sidecar_exec(*args, stdout=None, stderr=None, **kwargs):
         # Deliberately do NOT write a JSON sidecar — simulates older binary.
         return _FakeProcess(b"hello world", b"", 0)
 


### PR DESCRIPTION
Three defects together made a first real conversation impossible in packaged builds. See the commit message for the full write-up; in short: (1) the scenario endpoints now serve the canonical ScenarioInfo contract the frontend dereferences unguarded (this was the 'supported_languages is not iterable' blank-screen on every onboarding exit path), with contract tests pinned against the real official packs and defensive frontend guards; (2) /api/models/use and the install pipeline now swap the LIVE runtime and startup restores the persisted selection — previously sessions ran on the fake runtime forever; (3) the managed llama-server autostarts from use/benchmark/startup instead of failing with CLI instructions, and all Windows child processes spawn with CREATE_NO_WINDOW. Full core suite, web tests, and the P1–P8 onboarding e2e matrix pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4GogqwrcPc5M5VkM6wMWT