### PR TITLE
Make every library scenario playable; fix conversation, meters, and debrief flow

### DIFF
--- a/apps/web/src/__tests__/Conversation.test.tsx
+++ b/apps/web/src/__tests__/Conversation.test.tsx
@@ -20,6 +20,7 @@ vi.mock('../api/client', () => ({
     connectSession: vi.fn(),
     getScenario: vi.fn(),
     getSetupInstallStatus: vi.fn(),
+    getSessionTranscript: vi.fn(),
   },
   apiClient: {
     health: vi.fn(),
@@ -44,7 +45,10 @@ const startResponse: SessionStartResponse = {
       event_id: 1,
       session_id: SESSION_ID,
       event_type: 'npc_opening',
-      payload: { content: "Thanks for coming in. Tell me about yourself." },
+      payload: {
+        content: "Thanks for coming in. Tell me about yourself.",
+        visible_state: { trust: 50, patience: 75, rapport: 50, openness: 50, objective_progress: 0 },
+      },
       created_at: '2026-07-01T00:00:00Z',
     },
   ],
@@ -173,13 +177,31 @@ describe('Conversation screen', () => {
       )
     })
 
-    it('recovers gracefully when session was already started (409)', async () => {
+    it('recovers silently when session was already started (409): hydrates transcript, no error banner', async () => {
       mockApi.startSession.mockResolvedValue({ ok: false, error: { kind: 'network', message: 'INVALID_TRANSITION' } })
+      mockApi.getSessionTranscript.mockResolvedValue({
+        ok: true,
+        data: {
+          session_id: SESSION_ID,
+          scenario_id: 'behavioral_interview',
+          transcript_saved: true,
+          turns: [
+            { turn_number: 0, role: 'npc_opening', content: 'Thanks for coming in. Tell me about yourself.', flow_state_after: 'PlayerTurnListening' },
+            { turn_number: 1, role: 'player', content: 'Happy to be here.', flow_state_after: 'NpcThinking' },
+            { turn_number: 2, role: 'npc', content: 'Great — walk me through your background.', flow_state_after: 'PlayerTurnListening' },
+          ],
+        },
+      })
       renderConversation()
+      // The prior turns are rehydrated (opening included) …
       await waitFor(() =>
-        expect(screen.getByRole('alert')).toHaveTextContent('Connection failed'),
+        expect(screen.getByText('Thanks for coming in. Tell me about yourself.')).toBeInTheDocument(),
       )
+      expect(screen.getByText('Great — walk me through your background.')).toBeInTheDocument()
+      // … the conversation is interactive …
       expect(screen.getByRole('textbox', { name: /your response/i })).toBeInTheDocument()
+      // … and no scary error banner covers a working conversation.
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
     })
   })
 

--- a/apps/web/src/__tests__/ModelManager.test.tsx
+++ b/apps/web/src/__tests__/ModelManager.test.tsx
@@ -608,8 +608,21 @@ describe('ModelManager — GGUF branch', () => {
     expect(mockApi.startSidecar).toHaveBeenCalledWith('/home/user/models/my-model.gguf')
   })
 
-  it('continues to the benchmark step even when the sidecar fails to start', async () => {
-    mockApi.startSidecar.mockResolvedValue({ ok: false, error: { kind: 'network', message: 'sidecar failed' } })
+  it('surfaces a sidecar start failure on the GGUF step instead of racing into the benchmark', async () => {
+    // The engine start is now awaited: a real failure is shown here, where the
+    // user can act on it — not one screen later as a cryptic benchmark error.
+    mockApi.startSidecar.mockResolvedValue({ ok: false, error: { kind: 'http-error', message: 'The AI engine couldn\'t start.', status: 503 } })
+    await goToGguf()
+    fireEvent.change(screen.getByRole('textbox', { name: /file path/i }), {
+      target: { value: '/home/user/models/my-model.gguf' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /use this file/i }))
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+    expect(screen.queryByRole('heading', { name: /model benchmark/i })).not.toBeInTheDocument()
+  })
+
+  it('treats an already-running engine (409) as success and continues to the benchmark', async () => {
+    mockApi.startSidecar.mockResolvedValue({ ok: false, error: { kind: 'http-error', message: 'SIDECAR_ALREADY_RUNNING', status: 409 } })
     await goToGguf()
     fireEvent.change(screen.getByRole('textbox', { name: /file path/i }), {
       target: { value: '/home/user/models/my-model.gguf' },

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -450,6 +450,27 @@ export const api = {
   createSession(request: SessionCreateRequest): Promise<ApiResult<SessionCreateResponse>> {
     return post<SessionCreateResponse>('/sessions', request)
   },
+  /** Persisted transcript rows for a session (convsim-core response shape).
+   *  Used to rehydrate the conversation view when the session was already
+   *  started (page reload / remount) so the opening and prior turns are not
+   *  lost. */
+  getSessionTranscript(sessionId: string): Promise<ApiResult<{
+    session_id: string
+    scenario_id: string
+    transcript_saved: boolean
+    message?: string
+    turns: Array<{
+      turn_number: number
+      role: 'npc_opening' | 'npc' | 'player'
+      content: string
+      source_mode?: string | null
+      emotion?: string | null
+      flow_state_after?: string | null
+      created_at?: string
+    }>
+  }>> {
+    return get(`/sessions/${sessionId}/transcript`)
+  },
   getDataFolder(): Promise<ApiResult<{ path: string }>> {
     return get<{ path: string }>('/privacy/data-folder')
   },

--- a/apps/web/src/screens/Conversation.tsx
+++ b/apps/web/src/screens/Conversation.tsx
@@ -126,7 +126,8 @@ export default function Conversation() {
   const [sessionState, setSessionState] = useState('NotStarted')
   const [endingType, setEndingType] = useState<string | null>(null)
   const [turns, setTurns] = useState<TurnEntry[]>([])
-  const [stateVars, setStateVars] = useState<Record<string, number>>(BASELINE_STATE_VARS)
+  // Populated from the server's visible_state snapshots (scenario-specific).
+  const [stateVars, setStateVars] = useState<Record<string, number>>({})
   const [allEventFlags, setAllEventFlags] = useState<string[]>([])
   const [error, setError] = useState<ApiError | null>(null)
   const [devMode] = useState(() => isDevModeEnabled())
@@ -318,17 +319,34 @@ export default function Conversation() {
       if (cancelled) return
       if (!startResult.ok) {
         // A 409 / INVALID_TRANSITION means the session was already started
-        // (e.g. a reload). That is recoverable: surface the notice but keep the
-        // conversation interactive rather than dropping into the dead-end error
-        // state, so the player can continue.
+        // (dev-mode double mount, or a page reload). That is fully
+        // recoverable: rehydrate the transcript (opening + any prior turns)
+        // and continue silently. Showing an error card here put a scary red
+        // "Request failed" banner over a perfectly working conversation and
+        // dropped Alex's opening message on the floor.
         const e = startResult.error
         const alreadyStarted =
           e.status === 409 || e.message.includes('INVALID_TRANSITION')
-        setError(e)
         if (alreadyStarted) {
-          setSessionState('PlayerTurnListening')
+          const tr = await api.getSessionTranscript(sessionId)
+          if (cancelled) return
+          if (tr.ok && tr.data.turns.length > 0) {
+            const hydrated = tr.data.turns.map((t) => ({
+              id: ++turnUidRef.current,
+              role: t.role,
+              content: t.content,
+              emotion: t.emotion ?? undefined,
+              turnNum: ++turnNumRef.current,
+            }))
+            setTurns(hydrated)
+          }
+          const lastState = tr.ok
+            ? tr.data.turns[tr.data.turns.length - 1]?.flow_state_after
+            : null
+          setSessionState(lastState ?? 'PlayerTurnListening')
           setPhase('active')
         } else {
+          setError(e)
           setPhase('error')
         }
         return
@@ -359,7 +377,10 @@ export default function Conversation() {
         }
       }
       setSessionState(startData.state)
-      setStateVars({ ...BASELINE_STATE_VARS })
+      const openingVisible = opening?.payload['visible_state']
+      if (openingVisible && typeof openingVisible === 'object') {
+        setStateVars({ ...(openingVisible as Record<string, number>) })
+      }
       setPhase('active')
     })()
 
@@ -379,13 +400,7 @@ export default function Conversation() {
           case 'session.state':
             setSessionState(event.payload.state)
             if (event.payload.state_vars) {
-              setStateVars((prev) => {
-                const next = { ...prev }
-                for (const [k, v] of Object.entries(event.payload.state_vars!)) {
-                  if (k in next) next[k] = v
-                }
-                return next
-              })
+              setStateVars((prev) => ({ ...prev, ...event.payload.state_vars! }))
             }
             break
           case 'npc.token':
@@ -616,7 +631,11 @@ export default function Conversation() {
         ])
       }
 
-      if (Object.keys(delta).length > 0) {
+      const visibleState = payload?.['visible_state']
+      if (visibleState && typeof visibleState === 'object' && Object.keys(visibleState).length > 0) {
+        // Authoritative snapshot of the scenario's visible variables.
+        setStateVars({ ...(visibleState as Record<string, number>) })
+      } else if (Object.keys(delta).length > 0) {
         setStateVars((prev) => {
           const next = { ...prev }
           for (const [k, d] of Object.entries(delta)) {
@@ -1061,8 +1080,8 @@ export default function Conversation() {
         )}
       </div>
 
-      {/* State meters — shown only when enabled in setup */}
-      {showStateMeters && (
+      {/* State meters — shown only when enabled in setup and hydrated */}
+      {showStateMeters && Object.keys(stateVars).length > 0 && (
         <details open>
           <summary
             style={{ cursor: 'pointer', fontSize: '0.8rem', color: '#71717a', userSelect: 'none' }}

--- a/services/convsim-core/convsim_core/app.py
+++ b/services/convsim-core/convsim_core/app.py
@@ -17,7 +17,7 @@ from convsim_core.errors import (
 from convsim_core.logging_setup import configure_logging
 from convsim_core.packs.seeder import seed_official_packs
 from convsim_core.paths import legacy_convsim_dir, platform_data_root
-from convsim_core.routers import cloud_settings as cloud_settings_router, diag as diag_router, health, logbook as logbook_router, models as models_router, packs as packs_router, preflight as preflight_router, privacy as privacy_router, relationship_memory as relationship_memory_router, runtime_settings as runtime_settings_router, scenarios as scenarios_router, sessions as sessions_router, settings as settings_router, setup as setup_router, setup_install as setup_install_router, sidecar as sidecar_router, stt as stt_router, tts as tts_router, vad as vad_router, workbench as workbench_router
+from convsim_core.routers import cloud_settings as cloud_settings_router, diag as diag_router, health, logbook as logbook_router, models as models_router, packs as packs_router, preflight as preflight_router, privacy as privacy_router, relationship_memory as relationship_memory_router, runtime_settings as runtime_settings_router, scenarios as scenarios_router, sessions as sessions_router, settings as settings_router, setup as setup_router, setup_install as setup_install_router, sidecar as sidecar_router, stt as stt_router, tts as tts_router, vad as vad_router, workbench as workbench_router, workshop as workshop_router
 from convsim_core.runtime import build_runtime
 from convsim_core.runtime.sidecar import LlamaCppSidecar
 from convsim_core.runtime.kokoro_sidecar import KokoroSidecar
@@ -161,6 +161,7 @@ def create_app(config: ServiceConfig | None = None) -> FastAPI:
     app.include_router(scenarios_router.router)
     app.include_router(sessions_router.router)
     app.include_router(workbench_router.router)
+    app.include_router(workshop_router.router)
     app.include_router(logbook_router.router)
     app.include_router(relationship_memory_router.router)
     app.include_router(setup_router.router)

--- a/services/convsim-core/convsim_core/routers/sessions.py
+++ b/services/convsim-core/convsim_core/routers/sessions.py
@@ -25,7 +25,7 @@ from fastapi.responses import PlainTextResponse
 from pydantic import BaseModel, field_validator
 
 from convsim_core.scenario_state import build_variable_defs, partition_state_by_visibility
-from convsim_core.scenarios import get_scenario_info
+from convsim_core.scenarios import resolve_scenario_info
 from convsim_core.services.branch_service import fork_session
 from convsim_core.services.debrief_engine import generate_debrief
 from convsim_core.services.relationship_memory import update_relationship_memory
@@ -339,7 +339,7 @@ def _row_to_response(row: Any) -> SessionResponse:
 
 @router.post("", status_code=201, response_model=SessionResponse)
 async def create_session(body: SessionCreateRequest, request: Request) -> SessionResponse:
-    info = get_scenario_info(body.scenario_id)
+    info = resolve_scenario_info(body.scenario_id, request.app.state.db.connection())
     if info is None:
         raise HTTPException(status_code=400, detail=f"Unknown scenario_id: {body.scenario_id!r}")
 
@@ -405,7 +405,7 @@ async def start_session(session_id: str, request: Request) -> SessionStartRespon
             current_state,
         )
 
-    info = get_scenario_info(row["scenario_id"])
+    info = resolve_scenario_info(row["scenario_id"], request.app.state.db.connection())
     opening_text = (
         info.opening_npc_says if info else "Hello! I am ready to begin. Please go ahead."
     )
@@ -431,11 +431,31 @@ async def start_session(session_id: str, request: Request) -> SessionStartRespon
                 (session_id, 0, "npc_opening", opening_text),
             )
 
+    # Include the scenario's initial VISIBLE state variables in the opening
+    # event so the meters render correct scenario-specific values from turn
+    # zero (the frontend previously guessed with a hardcoded baseline that
+    # matched no actual scenario).
+    initial_visible: Dict[str, int] = {}
+    if info is not None:
+        try:
+            from convsim_core.scenario_state import (
+                build_variable_defs,
+                initialize_state,
+                partition_state_by_visibility,
+            )
+
+            defs = build_variable_defs(info.state_variable_overrides)
+            initial_visible, _ = partition_state_by_visibility(
+                initialize_state(defs), defs
+            )
+        except Exception:  # pragma: no cover - meters are best-effort
+            initial_visible = {}
+
     opening_event = SessionEventPayload(
         event_id=cursor.lastrowid,
         session_id=session_id,
         event_type="npc_opening",
-        payload={"content": opening_text},
+        payload={"content": opening_text, "visible_state": initial_visible},
         created_at=now,
     )
 
@@ -480,7 +500,7 @@ async def submit_turn(session_id: str, body: TurnSubmitRequest, request: Request
     setup = json.loads(row["setup_json"])
     scenario_id = row["scenario_id"]
     difficulty = setup.get("difficulty", "standard")
-    info = get_scenario_info(scenario_id)
+    info = resolve_scenario_info(scenario_id, request.app.state.db.connection())
     if info is None:
         raise HTTPException(status_code=500, detail=f"Scenario {scenario_id!r} not found in registry")
 
@@ -722,7 +742,7 @@ async def create_debrief(session_id: str, request: Request) -> DebriefResponse:
     scenario_id = row["scenario_id"]
     setup = json.loads(row["setup_json"])
     difficulty = setup.get("difficulty", "standard")
-    info = get_scenario_info(scenario_id)
+    info = resolve_scenario_info(scenario_id, request.app.state.db.connection())
     if info is None:
         raise HTTPException(status_code=500, detail=f"Scenario {scenario_id!r} not found in registry")
 
@@ -1036,7 +1056,7 @@ async def export_session(session_id: str, request: Request) -> SessionExportResp
     setup = json.loads(row["setup_json"])
     save_transcript = setup.get("save_transcript", True)
     scenario_id = row["scenario_id"]
-    info = get_scenario_info(scenario_id)
+    info = resolve_scenario_info(scenario_id, request.app.state.db.connection())
     scenario_meta: Dict[str, Any] = {
         "id": scenario_id,
         "name": info.scenario_data.title if info else scenario_id,

--- a/services/convsim-core/convsim_core/routers/workshop.py
+++ b/services/convsim-core/convsim_core/routers/workshop.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Steam Workshop item index endpoints.
+
+The full Workshop sync flow (validate → import → quarantine) is driven by the
+desktop shell handing subscribed-item paths to ``POST /api/workshop/sync``.
+The sync implementation has not been ported from the legacy Node API yet; the
+read endpoints below exist so the library and workshop UI can render their
+(empty) Workshop sections without console-noise 404s in every session.
+
+When sync lands, these endpoints read from the same tables it writes.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+from pydantic import BaseModel
+
+router = APIRouter(prefix="/api/workshop", tags=["workshop"])
+
+
+class WorkshopItemEntry(BaseModel):
+    item_id: str
+    pack_id: str
+    author_name: str
+    install_path: str
+    workshop_updated_at: int
+    synced_at: int
+
+
+class WorkshopQuarantineEntry(BaseModel):
+    item_id: str
+    install_path: str
+    reason: str
+    quarantined_at: int
+
+
+class WorkshopItemsResponse(BaseModel):
+    items: list[WorkshopItemEntry] = []
+
+
+class WorkshopQuarantineResponse(BaseModel):
+    items: list[WorkshopQuarantineEntry] = []
+
+
+def _table_exists(conn, name: str) -> bool:
+    row = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?", (name,)
+    ).fetchone()
+    return row is not None
+
+
+@router.get("/items", response_model=WorkshopItemsResponse)
+async def list_workshop_items(request: Request) -> WorkshopItemsResponse:
+    """List successfully synced Workshop items. Empty until sync has run."""
+    conn = request.app.state.db.connection()
+    if not _table_exists(conn, "workshop_items"):
+        return WorkshopItemsResponse(items=[])
+    rows = conn.execute(
+        "SELECT item_id, pack_id, author_name, install_path, "
+        "workshop_updated_at, synced_at FROM workshop_items ORDER BY synced_at DESC"
+    ).fetchall()
+    return WorkshopItemsResponse(
+        items=[WorkshopItemEntry(**dict(r)) for r in rows]
+    )
+
+
+@router.get("/quarantine", response_model=WorkshopQuarantineResponse)
+async def list_workshop_quarantine(request: Request) -> WorkshopQuarantineResponse:
+    """List Workshop items quarantined by validation. Empty until sync has run."""
+    conn = request.app.state.db.connection()
+    if not _table_exists(conn, "workshop_quarantine"):
+        return WorkshopQuarantineResponse(items=[])
+    rows = conn.execute(
+        "SELECT item_id, install_path, reason, quarantined_at "
+        "FROM workshop_quarantine ORDER BY quarantined_at DESC"
+    ).fetchall()
+    return WorkshopQuarantineResponse(
+        items=[WorkshopQuarantineEntry(**dict(r)) for r in rows]
+    )

--- a/services/convsim-core/convsim_core/scenarios.py
+++ b/services/convsim-core/convsim_core/scenarios.py
@@ -470,12 +470,77 @@ def _npc_data_from_dict(raw: Dict[str, Any]) -> NpcData:
     )
 
 
-def load_scenario_info_from_pack(pack_dir: Path, scenario_rel_path: str) -> ScenarioInfo:
+def _difficulty_options_from_yaml(raw: Dict[str, Any]) -> Dict[str, DifficultySettings]:
+    """Parse a scenario YAML ``difficulty.options`` block into engine presets.
+
+    Unknown/missing knobs fall back to the neutral 50 baseline. Always returns
+    at least a ``standard`` preset so session creation can validate against it.
+    """
+    difficulty_section = raw.get("difficulty") or {}
+    options_raw = difficulty_section.get("options") if isinstance(difficulty_section, dict) else None
+    options: Dict[str, DifficultySettings] = {}
+    if isinstance(options_raw, dict):
+        for name, knobs in options_raw.items():
+            knobs = knobs if isinstance(knobs, dict) else {}
+
+            def _knob(key: str) -> int:
+                value = knobs.get(key, 50)
+                try:
+                    return max(0, min(100, int(value)))
+                except (TypeError, ValueError):
+                    return 50
+
+            options[str(name)] = DifficultySettings(
+                patience=_knob("patience"),
+                volatility=_knob("volatility"),
+                disclosure=_knob("disclosure"),
+                time_pressure=_knob("time_pressure"),
+            )
+    if not options:
+        options["standard"] = DifficultySettings()
+    return options
+
+
+def _events_from_yaml(raw: Dict[str, Any]) -> Optional[List[ScenarioEvent]]:
+    """Parse a scenario YAML ``events`` list into engine ScenarioEvent objects."""
+    events_raw = raw.get("events")
+    if not isinstance(events_raw, list):
+        return None
+    events: List[ScenarioEvent] = []
+    for entry in events_raw:
+        if not isinstance(entry, dict):
+            continue
+        when = entry.get("when")
+        instruction = entry.get("npc_instruction")
+        event_id = entry.get("id")
+        if not (event_id and isinstance(when, dict) and instruction):
+            continue
+        events.append(
+            ScenarioEvent(
+                id=str(event_id),
+                when=when,
+                npc_instruction=str(instruction),
+                repeat=bool(entry.get("repeat", False)),
+            )
+        )
+    return events or None
+
+
+def load_scenario_info_from_pack(
+    pack_dir: Path,
+    scenario_rel_path: str,
+    *,
+    supported_languages: Optional[List[str]] = None,
+) -> ScenarioInfo:
     """Load a ScenarioInfo by reading scenario (and NPC) YAML files from a pack directory.
 
-    Raises ``ValueError`` or ``OSError`` if the files cannot be read or parsed.
+    Parses the full engine surface — difficulty presets, scenario events,
+    ending conditions, and state-variable overrides — so pack scenarios play
+    with the same mechanics as built-in ones (not just a neutral "standard"
+    preset). Raises ``ValueError`` or ``OSError`` if the files cannot be read
+    or parsed.
     """
-    import yaml  # local import — only needed for workbench test sessions
+    import yaml  # local import — only needed off the hot path
 
     scenario_file = (pack_dir / scenario_rel_path).resolve()
     raw: Dict[str, Any] = yaml.safe_load(scenario_file.read_text(encoding="utf-8")) or {}
@@ -508,6 +573,19 @@ def load_scenario_info_from_pack(pack_dir: Path, scenario_rel_path: str) -> Scen
     state_section = raw.get("state") or {}
     state_variable_overrides: Optional[Dict[str, Any]] = state_section.get("variables") or None
 
+    ending_raw = raw.get("ending_conditions")
+    ending_conditions: Optional[Dict[str, Any]] = (
+        ending_raw if isinstance(ending_raw, dict) and ending_raw else None
+    )
+
+    langs_raw = raw.get("supported_languages")
+    if isinstance(langs_raw, list) and langs_raw:
+        langs = [str(lang) for lang in langs_raw]
+    elif supported_languages:
+        langs = list(supported_languages)
+    else:
+        langs = ["en"]
+
     scenario_data = ScenarioData(
         scenario_id=raw.get("scenario_id") or "workbench_test",
         title=raw.get("title") or "Workbench Test",
@@ -520,8 +598,61 @@ def load_scenario_info_from_pack(pack_dir: Path, scenario_rel_path: str) -> Scen
     return ScenarioInfo(
         scenario_data=scenario_data,
         max_turns=max_turns,
-        supported_languages=["en"],
-        difficulty_options={"standard": DifficultySettings()},
+        supported_languages=langs,
+        difficulty_options=_difficulty_options_from_yaml(raw),
         opening_npc_says=opening_npc_says,
         state_variable_overrides=state_variable_overrides,
+        events=_events_from_yaml(raw),
+        ending_conditions=ending_conditions,
     )
+
+
+def resolve_scenario_info(scenario_id: str, conn: Any = None) -> ScenarioInfo | None:
+    """Resolve a scenario for the session engine, falling back to installed packs.
+
+    Resolution order: built-in catalog → dynamic registry → installed pack
+    lookup via the DB (slug → pack source path + scenario file). A pack hit is
+    registered in the dynamic registry so subsequent calls (start/turn/debrief
+    on the same session) resolve without touching the DB again.
+
+    Before this fallback existed only the handful of hardcoded catalog
+    scenarios were playable: every other seeded library scenario failed
+    session creation with "Unknown scenario_id" — the library advertised 21
+    scenarios and could start 6.
+    """
+    info = get_scenario_info(scenario_id)
+    if info is not None or conn is None:
+        return info
+
+    try:
+        row = conn.execute(
+            "SELECT s.rel_path, s.slug, p.source_path, p.supported_languages_json "
+            "FROM scenarios s JOIN packs p ON s.pack_id = p.id "
+            "WHERE s.slug = ? LIMIT 1",
+            (scenario_id,),
+        ).fetchone()
+    except Exception:
+        return None
+    if row is None or not row["source_path"] or not row["rel_path"]:
+        return None
+
+    try:
+        import json as _json
+
+        langs_json = row["supported_languages_json"]
+        langs = _json.loads(langs_json) if langs_json else []
+        langs = [str(lang) for lang in langs] if isinstance(langs, list) else []
+    except Exception:
+        langs = []
+
+    try:
+        info = load_scenario_info_from_pack(
+            Path(row["source_path"]),
+            row["rel_path"],
+            supported_languages=langs or None,
+        )
+    except Exception:
+        return None
+
+    register_dynamic_scenario(scenario_id, info)
+    return info

--- a/services/convsim-core/convsim_core/services/debrief_engine.py
+++ b/services/convsim-core/convsim_core/services/debrief_engine.py
@@ -22,7 +22,7 @@ import json
 import logging
 import re
 import sqlite3
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields as dataclass_fields
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
@@ -445,6 +445,39 @@ async def generate_debrief(
     total_turns: int = int(session_row["turn_count"])
     now = datetime.now(timezone.utc).isoformat()
 
+    # Idempotent: a debrief already exists (double-click, remount, retry after a
+    # dropped response) → return it instead of violating the UNIQUE constraint
+    # with a 500. Generation is expensive and the content is deterministic per
+    # session end, so "generate" is naturally "generate-or-get".
+    existing = conn.execute(
+        "SELECT content_json FROM session_debriefs WHERE session_id = ?",
+        (session_id,),
+    ).fetchone()
+    if existing is not None:
+        try:
+            cached = json.loads(existing["content_json"])
+            # content_json is a superset of DebriefResult (schema_version,
+            # difficulty_preset, …) and may omit optional fields — filter and
+            # default rather than trusting an exact match.
+            allowed = {f.name for f in dataclass_fields(DebriefResult)}
+            data = {k: v for k, v in cached.items() if k in allowed}
+            data.setdefault("pack_id", None)
+            data.setdefault("used_fallback", False)
+            data.setdefault("metrics", {})
+            result = DebriefResult(**data)
+            conn.execute(
+                "UPDATE turn_sessions SET flow_state = 'DebriefReady' WHERE session_id = ?",
+                (session_id,),
+            )
+            conn.commit()
+            return result
+        except (TypeError, ValueError, KeyError):
+            # Corrupt cached row — fall through and regenerate over it.
+            conn.execute(
+                "DELETE FROM session_debriefs WHERE session_id = ?", (session_id,)
+            )
+            conn.commit()
+
     # Transition to DebriefGenerating.
     conn.execute(
         "UPDATE turn_sessions SET flow_state = 'DebriefGenerating' WHERE session_id = ?",
@@ -579,11 +612,16 @@ async def generate_debrief(
         if difficulty_preset:
             debrief_doc["difficulty_preset"] = difficulty_preset
 
-        # Persist and transition to DebriefReady.
+        # Persist and transition to DebriefReady. ON CONFLICT DO NOTHING makes
+        # concurrent generation attempts race-safe: the pre-generation
+        # existence check above covers sequential retries, but two overlapping
+        # requests (double-click, remount) both pass it and both generate —
+        # the second INSERT must not blow up the request with a 500.
         with conn:
             conn.execute(
                 "INSERT INTO session_debriefs (session_id, content_json, metrics_json, generated_at) "
-                "VALUES (?, ?, ?, ?)",
+                "VALUES (?, ?, ?, ?) "
+                "ON CONFLICT(session_id) DO NOTHING",
                 (session_id, json.dumps(debrief_doc), json.dumps(metrics), now),
             )
             # Backfill ended_at for sessions that reached a terminal state

--- a/services/convsim-core/tests/test_pack_scenario_sessions.py
+++ b/services/convsim-core/tests/test_pack_scenario_sessions.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Sessions must be playable for every installed pack scenario.
+
+The session engine used to resolve scenarios only from the hardcoded catalog
+in ``convsim_core/scenarios.py`` (6 entries), while the library seeds 20+
+scenarios from the official packs — every non-catalog scenario failed session
+creation with "Unknown scenario_id". ``resolve_scenario_info`` now falls back
+to the installed pack's YAML (difficulty presets, events, ending conditions,
+languages included). These tests pin that behaviour end-to-end through the
+HTTP surface: create → start (opening + initial visible state) → turn.
+"""
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from convsim_core.app import create_app
+from convsim_core.config import ServiceConfig
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_OFFICIAL_PACKS = _REPO_ROOT / "packs" / "official"
+
+
+@pytest.fixture()
+def seeded_client(tmp_path):
+    config = ServiceConfig(
+        host="127.0.0.1",
+        port=7355,
+        data_dir=str(tmp_path / "data"),
+        log_dir=str(tmp_path / "logs"),
+        db_dir=str(tmp_path / "db"),
+        packs_dir=str(tmp_path / "packs"),
+        official_packs_dir=str(_OFFICIAL_PACKS),
+    )
+    app = create_app(config)
+    with TestClient(app) as c:
+        yield c
+
+
+def _create(client: TestClient, scenario_id: str, language: str = "en") -> str:
+    resp = client.post(
+        "/api/sessions",
+        json={
+            "scenario_id": scenario_id,
+            "difficulty": "standard",
+            "language": language,
+            "player_role_name": "Test Player",
+            "save_transcript": True,
+        },
+    )
+    assert resp.status_code == 201, f"{scenario_id}: {resp.text}"
+    return resp.json()["session_id"]
+
+
+def test_non_catalog_pack_scenario_full_session(seeded_client):
+    """japanese_convenience_store is NOT in the static catalog — must play."""
+    session_id = _create(seeded_client, "japanese_convenience_store", language="ja")
+
+    start = seeded_client.post(f"/api/sessions/{session_id}/start")
+    assert start.status_code == 200, start.text
+    events = start.json()["events"]
+    opening = next(e for e in events if e["event_type"] == "npc_opening")
+    # Opening must come from the pack YAML, not the generic fallback line.
+    assert "いらっしゃいませ" in opening["payload"]["content"]
+    # Initial visible state includes the scenario's custom variables.
+    visible = opening["payload"].get("visible_state") or {}
+    assert "comprehension" in visible and "confidence" in visible
+
+    turn = seeded_client.post(
+        f"/api/sessions/{session_id}/turn",
+        json={"content": "こんにちは！おにぎりはありますか？"},
+    )
+    assert turn.status_code == 200, turn.text
+
+
+def test_every_seeded_scenario_can_create_a_session(seeded_client):
+    """No library card may dead-end at session creation."""
+    scenarios = seeded_client.get("/api/scenarios").json()
+    assert len(scenarios) >= 15
+    failures = []
+    for s in scenarios:
+        difficulty = s["difficulty"]["default"]
+        language = s["supported_languages"][0]
+        resp = seeded_client.post(
+            "/api/sessions",
+            json={
+                "scenario_id": s["scenario_id"],
+                "difficulty": difficulty,
+                "language": language,
+                "player_role_name": "Test Player",
+                "save_transcript": True,
+            },
+        )
+        if resp.status_code != 201:
+            failures.append(f"{s['scenario_id']}: {resp.status_code} {resp.text[:120]}")
+    assert not failures, "unplayable library scenarios:\n" + "\n".join(failures)
+
+
+def test_pack_scenario_difficulty_presets_come_from_yaml(seeded_client):
+    """A YAML 'warm' preset must be accepted for a non-catalog scenario."""
+    resp = seeded_client.post(
+        "/api/sessions",
+        json={
+            "scenario_id": "japanese_convenience_store",
+            "difficulty": "warm",
+            "language": "ja",
+            "player_role_name": "Test Player",
+            "save_transcript": True,
+        },
+    )
+    assert resp.status_code == 201, resp.text


### PR DESCRIPTION
Second batch of the new-user-experience overhaul. Pack scenarios now resolve into the session engine from installed pack YAML (previously only 6 hardcoded scenarios were playable of 21 in the library); conversation 409-recovery hydrates the transcript silently instead of showing an error card and losing the NPC opening; state meters are driven by server visible_state snapshots (scenario-specific variables, initial values included in the opening event); debrief generation is idempotent and race-safe; workshop read endpoints replace per-visit 404s. Full core suite (2067), web suite (1291), onboarding e2e (56), and a scripted fresh-profile browser journey pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4GogqwrcPc5M5VkM6wMWT