### PR TITLE
Retarget issue templates at the new label system; document it in CONTRIBUTING

### DIFF
--- a/.github/ISSUE_TEMPLATE/beta-report.yml
+++ b/.github/ISSUE_TEMPLATE/beta-report.yml
@@ -1,6 +1,6 @@
 name: Beta feedback / bug report
 description: Report a bug or give feedback during the beta. Use the one-click bundle from Support → Report a problem for fastest turnaround.
-labels: ["beta-feedback"]
+labels: ["bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,6 @@
 name: Bug report
 description: Something is broken or behaving unexpectedly.
+labels: ["bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/feature_proposal.yml
@@ -1,5 +1,6 @@
 name: Feature proposal
 description: Suggest a new feature or improvement to the simulator.
+labels: ["enhancement"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/marketplace_creator_survey.yml
+++ b/.github/ISSUE_TEMPLATE/marketplace_creator_survey.yml
@@ -4,9 +4,7 @@ description: >
   marketplace demand spike documented in docs/marketplace-demand-spike.md.
   Responses are anonymised before use; please do not include personally
   identifying information.
-labels:
-  - marketplace
-  - creator-survey
+labels: ["area:packs"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/model_compatibility.yml
+++ b/.github/ISSUE_TEMPLATE/model_compatibility.yml
@@ -1,7 +1,6 @@
 name: Model compatibility report
 description: Report a model that works well, has issues, or is not yet listed in the model registry.
-labels:
-  - ai-runtime
+labels: ["area:models"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/safety_issue.yml
+++ b/.github/ISSUE_TEMPLATE/safety_issue.yml
@@ -1,7 +1,6 @@
 name: Safety issue
 description: Report a safety concern about content, NPC behaviour, or policy enforcement.
-labels:
-  - safety
+labels: ["area:safety"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/scenario_pack_idea.yml
+++ b/.github/ISSUE_TEMPLATE/scenario_pack_idea.yml
@@ -1,7 +1,6 @@
 name: Scenario pack idea
 description: Propose a new scenario pack concept before building it.
-labels:
-  - scenario-packs
+labels: ["enhancement", "area:packs"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/scenario_pack_submission.yml
+++ b/.github/ISSUE_TEMPLATE/scenario_pack_submission.yml
@@ -1,7 +1,6 @@
 name: Scenario pack submission
 description: Submit a completed scenario pack for inclusion in the official repository.
-labels:
-  - scenario-packs
+labels: ["area:packs"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/steam_creator_workbench.yml
+++ b/.github/ISSUE_TEMPLATE/steam_creator_workbench.yml
@@ -3,9 +3,7 @@ description: >
   Report a bug in the Creator Workbench when running under the Steam edition:
   pack authoring, scenario editing, asset management, schema validation, or
   workbench-specific UI issues.
-labels:
-  - steam
-  - creator-workbench
+labels: ["bug", "area:steam", "area:packs"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/steam_model_install.yml
+++ b/.github/ISSUE_TEMPLATE/steam_model_install.yml
@@ -2,9 +2,7 @@ name: Steam — local model install failure
 description: >
   Report a failure to download, verify, or load a local AI model through the
   Steam edition Model Manager.
-labels:
-  - steam
-  - model-install
+labels: ["bug", "area:steam", "area:models"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/steam_pack_bug.yml
+++ b/.github/ISSUE_TEMPLATE/steam_pack_bug.yml
@@ -3,9 +3,7 @@ description: >
   Report a bug in a scenario pack: validation failure, schema error, broken
   scenario, incorrect scoring, or content that does not match the pack's
   declared rating or safety policy.
-labels:
-  - steam
-  - pack-bug
+labels: ["bug", "area:steam", "area:packs"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/steam_performance.yml
+++ b/.github/ISSUE_TEMPLATE/steam_performance.yml
@@ -2,9 +2,7 @@ name: Steam — performance or frame-rate issue
 description: >
   Report a performance problem in the Steam edition: slow inference, high CPU/GPU
   usage, long load times, audio stuttering, or frame-rate problems in the UI.
-labels:
-  - steam
-  - performance
+labels: ["bug", "area:steam"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/steam_platform_bug.yml
+++ b/.github/ISSUE_TEMPLATE/steam_platform_bug.yml
@@ -2,9 +2,7 @@ name: Steam — platform bug
 description: >
   Report a bug specific to the Steam edition: launcher, overlay, controller
   input, Steam Deck, code signing, or platform-specific crash.
-labels:
-  - steam
-  - platform-bug
+labels: ["bug", "area:steam"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/steam_privacy_safety.yml
+++ b/.github/ISSUE_TEMPLATE/steam_privacy_safety.yml
@@ -2,10 +2,7 @@ name: Steam — privacy or safety report
 description: >
   Report a concern about local data handling, unexpected network activity, or
   content safety in the Steam edition.
-labels:
-  - steam
-  - privacy
-  - safety
+labels: ["area:safety", "area:steam"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/stt_issue.yml
+++ b/.github/ISSUE_TEMPLATE/stt_issue.yml
@@ -1,7 +1,6 @@
 name: Speech / STT issue
 description: Report a problem with speech input or the speech-to-text pipeline.
-labels:
-  - speech
+labels: ["bug", "area:models"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/tts_issue.yml
+++ b/.github/ISSUE_TEMPLATE/tts_issue.yml
@@ -1,7 +1,6 @@
 name: TTS issue
 description: Report a problem with speech output or the text-to-speech pipeline.
-labels:
-  - speech
+labels: ["bug", "area:models"]
 body:
   - type: markdown
     attributes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,28 @@ existing packs.
 
 ---
 
+## Labels
+
+The tracker runs on a deliberately small labeling system — four axes, one question each:
+
+| Axis | Labels | Question it answers |
+| ---- | ------ | ------------------- |
+| Type | `bug` · `enhancement` · `docs` · `chore` · `epic` | What kind of change is this? |
+| Priority | `priority:P0` · `priority:P1` · `priority:P2` | P0 blocks the next release; P1 is next up; P2 is opportunistic |
+| Area | `area:engine` · `area:ui` · `area:models` · `area:packs` · `area:steam` · `area:safety` | Which product surface does it touch? |
+| Workflow | `manual` · `review` · `good first issue` · `help wanted` | Who picks it up, and how |
+
+Conventions:
+
+- Every issue gets **one type** label. Add **one or two** `area:*` labels when the surface is clear; epics that span areas carry none.
+- `manual` and `review` are contracts with the [vibrator](https://github.com/outrightmental/vibrator) orchestrator: `manual` keeps an issue or PR out of automated work entirely; `review` lets vibrator implement but leaves the final PR to a human.
+- `good first issue` and `help wanted` mark the community on-ramps — scenario packs are the friendliest entry point.
+- Milestones track *when*; the [delivery board](https://github.com/orgs/outrightmental/projects/12) tracks *status*. Labels only say what, where, and how urgent.
+
+Please do not invent new labels ad hoc — propose additions in an issue first.
+
+---
+
 ## Development setup
 
 ```sh


### PR DESCRIPTION
## What

Retargets every issue template at the new 18-label system and documents the system in CONTRIBUTING.md.

## Why

The tracker previously carried 68 labels across three overlapping generations, and 8 labels referenced by issue templates (`beta-feedback`, `pack-bug`, `performance`, `platform-bug`, `privacy`, `marketplace`, `creator-survey`, `creator-workbench`) did not exist at all — template intake was silently mislabeled. The label overhaul (68 → 18) landed today; this makes intake match it.

## Changes

- 16 issue-form templates: `labels:` now reference only live labels; `bug_report` and `feature_proposal` gain the type labels they were missing
- CONTRIBUTING.md: new **Labels** section — the four axes, conventions, and the vibrator `manual`/`review` contract
- Steam intake templates also carry `area:steam`; STT/TTS intake carries `bug` + `area:models`

Delivery board: https://github.com/orgs/outrightmental/projects/12