### PR TITLE
Docs: landscape, governance, and a fully wired delivery record

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,23 @@ State:  credibility +12  ·  pressure_level +1  ·  composure 65
 
 ---
 
+## Why this exists
+
+Every AI conversation coach on the market — interview prep, sales roleplay, speaking
+coaches, VR soft-skills training — runs in the cloud. But the conversations people most
+need to rehearse (firing someone, the salary ask, the breakup, the visa interview) are
+exactly the ones they least want on somebody else's server. Conversation Simulator is the
+missing intersection: a **structured practice game** (live scenario state, events, scoring,
+debrief) with **100% local inference** (no account, no cloud, no telemetry), in the
+**open** (Apache-2.0) — heir to a sixty-year lineage that runs from ELIZA through Monkey
+Island's insult sword-fighting to Façade, finally buildable because local LLMs dissolved
+the authoring wall those earlier systems hit.
+
+> The full analysis — lineage, competitive field, and the business-model precedents from
+> Dwarf Fortress to Shattered Pixel Dungeon: **[docs/landscape.md](docs/landscape.md)**
+
+---
+
 ## Screenshots
 
 | Screen | What you see |
@@ -279,6 +296,7 @@ Every session runs through a layered safety system before and after the model is
 **[ROADMAP.md](ROADMAP.md)** — MVP acceptance criteria, build order, what is
 deliberately out of scope, and links to the acceptance criteria and docs.
 
+> [Delivery board](https://github.com/orgs/outrightmental/projects/12) — every issue ever shipped, in phases &nbsp;·&nbsp;
 > [GitHub Milestones](https://github.com/outrightmental/ConversationSimulator/milestones) &nbsp;·&nbsp;
 > [Full specification](docs/SPEC.md) &nbsp;·&nbsp;
 > [Post-alpha issues](docs/post-alpha-issues.md)
@@ -300,6 +318,10 @@ Conversation Simulator is **free and open source, and fairly priced**:
   and sold as paid Steam DLC. Their content is never in this public repository.
   See [docs/DLC_MODEL.md](docs/DLC_MODEL.md) for the private-repo → Steam-DLC
   contract. The open core never shrinks: nothing that ships free is relocked as DLC.
+
+This free-on-GitHub, fairly-priced-on-Steam pattern has a strong track record — Dwarf
+Fortress, Shattered Pixel Dungeon, Mindustry, Aseprite — and the reasoning behind it is
+laid out in [docs/landscape.md](docs/landscape.md#business-model-precedents).
 
 The Steam release documents:
 
@@ -328,7 +350,14 @@ in under a minute, nothing uploaded automatically.
 ## Contributing
 
 All contributions are welcome — new scenario packs, bug fixes, documentation
-improvements, or new runtime adapters.
+improvements, or new runtime adapters. Scenario packs are the friendliest entry point —
+you can ship one without touching engine code.
+
+**Start here:**
+[`good first issue`](https://github.com/outrightmental/ConversationSimulator/issues?q=is%3Aissue+state%3Aopen+label%3A%22good+first+issue%22) &nbsp;·&nbsp;
+[`help wanted`](https://github.com/outrightmental/ConversationSimulator/issues?q=is%3Aissue+state%3Aopen+label%3A%22help+wanted%22) &nbsp;·&nbsp;
+[Delivery board](https://github.com/orgs/outrightmental/projects/12) &nbsp;·&nbsp;
+[How the project is run](docs/governance.md)
 
 > [CONTRIBUTING.md](CONTRIBUTING.md) &nbsp;·&nbsp;
 > [CODE\_OF\_CONDUCT.md](CODE_OF_CONDUCT.md) &nbsp;·&nbsp;

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,6 +45,10 @@ criteria.
 
 ## Status
 
+> Live status lives on the **[delivery board](https://github.com/orgs/outrightmental/projects/12)** — every issue this project has ever
+> shipped, organized into phases, with the open backlog extending from there. The
+> snapshot below is narrative; the board is the record.
+
 ### Done — shipped in v0.3.0
 
 - [x] Onboarding overhaul — first conversation in 60 seconds, zero error walls (#388)
@@ -85,9 +89,9 @@ criteria.
 
 ### Remaining polish — before Milestone 1 tag
 
-- [ ] Real UI screenshots (replace SVG placeholders in README)
-- [ ] Desktop app with bundled backend (Tauri sidecar for `convsim-core`)
-- [ ] Automated real-model CI smoke test
+- [ ] Real UI screenshots (replace SVG placeholders in README) — [#455](https://github.com/outrightmental/ConversationSimulator/issues/455)
+- [ ] Desktop app with bundled backend (Tauri sidecar for `convsim-core`) — [#456](https://github.com/outrightmental/ConversationSimulator/issues/456)
+- [ ] Automated real-model CI smoke test — [#457](https://github.com/outrightmental/ConversationSimulator/issues/457)
 
 ### Post-alpha — Milestone 2+
 
@@ -119,9 +123,9 @@ work in these areas needs its own proposal, design, and acceptance criteria.
 
 ### UGC ecosystem
 
-- In-app pack browser / discovery feed
+- In-app pack browser / discovery feed — [#465](https://github.com/outrightmental/ConversationSimulator/issues/465)
 - Community ratings and reviews
-- Pack signing and trust tiers
+- Pack signing and trust tiers — [#466](https://github.com/outrightmental/ConversationSimulator/issues/466)
 - Hosted pack registry (CDN or P2P distribution)
 
 See [`docs/marketplace-architecture.md`](docs/marketplace-architecture.md) for the post-launch community marketplace design baseline — entry gate criteria, distribution path comparison, and scope of schema, signing, moderation, payment, and reporting changes required before any community-authored paid content ships. First-party premium scenario-pack DLC does not wait on this marketplace: it ships separately via Steam's DLC storefront (see [`docs/DLC_MODEL.md`](docs/DLC_MODEL.md)), while the open core stays free.

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1,0 +1,134 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+
+# Governance: how this project is run
+
+Conversation Simulator is maintained by [Outright Mental](https://outrightmental.com) with
+an unusual crew: one human maintainer, an autonomous issue-to-PR factory
+([vibrator](https://github.com/outrightmental/vibrator)), and a community of contributors.
+This document is the operating manual — where decisions are made, how work flows, and the
+rules that keep the record trustworthy. The tracker and board were consolidated into this
+shape on 2026-08-21.
+
+For *why* the project is shaped this way — lineage, competitive landscape, and the
+economics — see [landscape.md](landscape.md).
+
+---
+
+## Decision rights
+
+- **Final call:** the Outright Mental maintainer ([@charneykaye](https://github.com/charneykaye)).
+  Benevolent-dictator model; scope discipline per [ROADMAP.md](../ROADMAP.md) ("Not now"
+  is a real list, and it is enforced).
+- **Proposals:** open an issue. Feature proposals use the issue forms; anything in
+  ROADMAP's "Future work" needs its own proposal, design, and acceptance criteria before
+  implementation.
+- **Conduct:** [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md).
+  **Security:** [SECURITY.md](../SECURITY.md) — private reporting, no public zero-days.
+
+---
+
+## The delivery board
+
+**[github.com/orgs/outrightmental/projects/12](https://github.com/orgs/outrightmental/projects/12)**
+is the single pane of glass: every issue ever shipped and everything still to come — one
+record, in phases.
+
+| View | What it shows |
+| ---- | ------------- |
+| **Board** | Open work by Status (Todo → In Progress → Done) |
+| **Priorities** | Open work grouped P0 → P2; untriaged items surface with no priority |
+| **Timeline** | The entire history as a roadmap — every item with real start/finish dates |
+| **History** | Every phase and everything shipped in it |
+
+Work is organized into **phases** — append-only eras of the project's life:
+
+| Phase | Span | Items | What happened |
+| ----- | ---- | ----- | ------------- |
+| 01 · Alpha build | Jun 30 – Jul 8, 2026 | 85 | Empty repo → complete local MVP (engine, packs, voice, safety, workbench) — `v0.1.0-alpha.1` |
+| 02 · Steam release | Jul 9 – 11 | 62 | Store, depots, signing, platform QA (the closed *Steam Release Roadmap* milestone) |
+| 03 · Beta & signature | Jul 10 – 11 | 23 | Public-beta readiness ([#315](https://github.com/outrightmental/ConversationSimulator/issues/315)) and signature-experience ([#316](https://github.com/outrightmental/ConversationSimulator/issues/316)) programs |
+| 04 · Pivot & onboarding | Jul 11 – 13 | 24 | FOSS/$9.99 business-model pivot ([#366](https://github.com/outrightmental/ConversationSimulator/issues/366)) and the v0.3 onboarding overhaul ([#388](https://github.com/outrightmental/ConversationSimulator/issues/388)) |
+| 05 · Hardening | Jul 13 – Aug 5 | 13 | Signing chains, release dress rehearsals, post-v0.3 fixes |
+| 06 · Release polish | now | — | What remains before the Milestone-1 tag |
+| 07 · Future | — | — | Groomed post-launch backlog (see [post-alpha-issues.md](post-alpha-issues.md)) |
+
+Board automations: new issues add themselves; closing an issue moves it to **Done**;
+reopening returns it to **Todo**; a linked PR moves it to **In Progress**. The Priority
+field mirrors the `priority:*` labels.
+
+---
+
+## Labels, types, and milestones
+
+Three orthogonal systems, each answering one question:
+
+- **Labels** — what/where/how urgent. Four axes, 18 labels total, documented in
+  [CONTRIBUTING.md → Labels](../CONTRIBUTING.md#labels). Do not invent labels ad hoc.
+- **Native issue types** (Bug / Feature / Task) — what kind of work, machine-readable.
+  The factory prioritizes `Bug` first.
+- **Milestones** — release trains (*when*). The board's Phase field records *eras*, not
+  deadlines; milestones carry deadlines.
+
+---
+
+## The factory
+
+[vibrator](https://github.com/outrightmental/vibrator) turns the issue queue into a
+self-driving implementation pipeline:
+
+1. An issue is filed and triaged (type, labels, priority — see above).
+2. Unless it carries the **`manual`** label, vibrator may pick it up — ordered by
+   Type = Bug first, then earlier milestone, then age — respecting `blocked by #N` /
+   sub-issue dependencies.
+3. It implements on a `vibrator/issue-N-…` branch and opens a PR; CI gates it; a human
+   squash-merges.
+
+The two contract labels:
+
+- **`manual`** — humans only; the factory never touches it. Applied to anything requiring
+  real-world action (Steamworks registration, hardware capture), business judgment, or
+  deliberate sequencing.
+- **`review`** — the factory implements, but the final PR review is explicitly human.
+
+**The throttle:** items in *07 · Future* are filed with `manual` on. Releasing one to the
+factory is a single act — remove `manual`. That keeps the backlog groomed and deep without
+the factory building post-launch features prematurely.
+
+---
+
+## Keeping the record honest
+
+- **Every deferral has an issue.** [post-alpha-issues.md](post-alpha-issues.md) items each
+  link a tracking issue; when something ships, its entry is updated or removed. No silent
+  scope changes.
+- **Phases are append-only.** Closed eras on the board are history — do not relabel or
+  rewrite them.
+- **Docs describe shipped reality.** Setup docs must match the shipped UI (CI-enforced
+  since v0.3). Aspirational docs live in proposals, not in `docs/`.
+- **The board stays public.** Visible momentum — 219 items and counting, seven weeks from
+  empty repo to signed Steam-ready build — is both accountability and marketing.
+
+---
+
+## The commercial engine
+
+The money model, in one breath (details:
+[README → How it's distributed](../README.md#how-its-distributed) ·
+[DLC_MODEL.md](DLC_MODEL.md) · precedents: [landscape.md](landscape.md#business-model-precedents)):
+
+**Free engine on GitHub** (Apache-2.0, four official packs CC BY 4.0) → **$9.99 Steam
+edition** selling packaging — signed, notarized, auto-updating, Deck-verified — →
+**first-party premium pack DLC** from a private repo. Revenue funds development. Two
+invariants protect the compact: the open core never shrinks, and every edition keeps the
+same local-first guarantee — no account, no cloud, no telemetry.
+
+---
+
+## Cadence
+
+- **Release trains** follow [STEAM_ROADMAP.md](STEAM_ROADMAP.md) stages, with the
+  [release checklist](release-checklist.md) and dress-rehearsal workflow.
+- **Nightly** real-model smoke ([#457](https://github.com/outrightmental/ConversationSimulator/issues/457))
+  guards inference quality once landed.
+- **Each release:** sweep this document, [landscape.md](landscape.md), and
+  [post-alpha-issues.md](post-alpha-issues.md) for drift.

--- a/docs/landscape.md
+++ b/docs/landscape.md
@@ -1,0 +1,150 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+
+# Landscape: where Conversation Simulator sits
+
+This document orients contributors and future maintainers: the sixty-year lineage this
+project belongs to, the field it competes in today, and the commercial precedents its
+business model is built on. Pair it with [governance.md](governance.md) (how the project
+is run) and [ROADMAP.md](../ROADMAP.md) (what is being built).
+
+> **Keep this honest:** revisit at each release train. If a competitor ships something
+> that changes the analysis, or a precedent stops being true, update it here.
+
+---
+
+## Sixty years of practicing conversation with machines
+
+People have been rehearsing real feelings on artificial interlocutors since before the
+term "chatbot" existed. Conversation Simulator is a deliberate fusion of three older
+traditions:
+
+- **1966 — ELIZA** (Joseph Weizenbaum, MIT). A few hundred lines of pattern matching
+  playing a Rogerian therapist — and people confided in it anyway. The "ELIZA effect" is
+  the founding observation of this entire category: humans readily practice real emotional
+  material with a machine, *especially* when no other human is watching.
+- **1990 — The Secret of Monkey Island.** Insult sword-fighting made verbal sparring a
+  *game mechanic* — exchanges you could win, lose, and get better at. Ritualized verbal
+  duels are far older (flyting goes back to Norse and Scots tradition), but this was the
+  proof that scored dialogue is genuinely fun. (See the flyting proposal in
+  [#454](https://github.com/outrightmental/ConversationSimulator/issues/454).)
+- **2005 — Façade** (Michael Mateas & Andrew Stern). The first natural-language
+  interactive drama: free-text input steering a live social situation with reactive
+  characters and social state. It proved the experience could be compelling — and that
+  authoring it by hand was brutally hard. LLMs dissolve exactly the authoring wall Façade
+  hit.
+- **2010s — the coaching industry moves on-screen.** VR soft-skills trainers and
+  chatbot-based coaching brought "practice the hard conversation before you have it" to
+  enterprise L&D — cloud-hosted, per-seat, subscription-priced.
+- **2022–2026 — the LLM era, split in two.** Cloud AI coaches multiplied (interview
+  prep, sales roleplay, speaking coaches). In parallel, the local-model movement —
+  llama.cpp, Ollama, LM Studio, Jan, SillyTavern — proved that consumer hardware runs
+  capable models with total privacy, and that a large audience will do real setup work to
+  get it.
+
+Conversation Simulator's bet is that these strands belong together: **the game structure**
+(scenario state, events, scoring, debrief), **the coaching value** (rubrics, progression,
+replay), and **the local-first guarantee** (no account, no cloud, no telemetry) — all in
+the open, where the community can extend it.
+
+---
+
+## The field today
+
+| Category | Representatives | Delivery | Typical model |
+| -------- | --------------- | -------- | ------------- |
+| AI communication coaches | Yoodli, Vocal Image, Poised | Cloud SaaS | Subscription; recordings and transcripts processed server-side |
+| Enterprise roleplay & VR training | VirtualSpeech, Retorio, Coachello, Bodyswaps | Cloud / VR, B2B | Per-seat licenses; sold to L&D departments, not individuals |
+| Interview prep | Google Interview Warmup, Big Interview, assorted "AI interview coach" apps | Cloud | Free-with-account or subscription; single-domain |
+| Sales roleplay | Second Nature, Hyperbound | Cloud, B2B | Per-seat; single-domain |
+| Language speaking practice | ELSA, BoldVoice, TalkPal, Duolingo roleplay | Cloud, mobile | Subscription; single-domain |
+| General chatbots pressed into service | ChatGPT Voice, Pi | Cloud | Freemium; no scenario structure, state, scoring, or packs |
+| Local-LLM roleplay frontends | SillyTavern and kin | **Local** | Free/open; entertainment RP — no rubrics, debrief, or curriculum; setup-heavy |
+
+Three observations fall out of that table:
+
+1. **Every direct competitor is cloud-based.** The things people most need to rehearse —
+   firing someone, the salary ask, the breakup, the visa interview, the diagnosis
+   conversation — are exactly the things they least want on someone else's server.
+   Privacy is not a feature checkbox in this category; it is a purchase driver.
+2. **The cloud products cannot follow us here.** Local-first is not a feature a SaaS
+   coach can patch in; it is the negation of their business model (subscriptions,
+   usage-metered inference, data-network effects). The moat is structural.
+3. **The local products are not games, and the games are not local.** SillyTavern proves
+   local roleplay demand but offers no practice structure; the coaches offer structure but
+   no privacy and no play. **No shipping product combines all three: a structured practice
+   game, 100% local inference, and open source.** That intersection is this project.
+
+---
+
+## Business-model precedents
+
+"Free and open source on GitHub, fairly priced on Steam, first-party DLC on top" is not an
+experiment — it is a pattern with a track record:
+
+- **Dwarf Fortress** — freeware for twenty years (sustained by roughly $15k/month in
+  donations), then a paid, packaged Steam edition in December 2022: ~600,000 copies and
+  ~$7M in its first two months, past a million copies since. The free version never went
+  away — it *built* the audience the paid edition converted. The lesson: packaging,
+  onboarding, and platform polish are what people pay for, and the free build does not
+  cannibalize the paid one; it is the funnel.
+- **Shattered Pixel Dungeon** — GPL-3, source and free builds on GitHub and itch.io, ~$10
+  on Steam and mobile stores; that convenience price sustains a full-time maintainer. The
+  lesson: even when compiling is trivial, "installed, updated, and supporting the author"
+  is a product.
+- **Mindustry** — GPL-3, free from source and itch.io, $9.99 on Steam with Workshop
+  integration. The lesson: platform integration (Workshop, cloud saves, achievements) is
+  legitimate paid value on top of an open core.
+- **Aseprite** — source-available; compile it yourself for free or pay ~$20. The lesson:
+  a fair price on an open codebase functions as a tip jar with a barcode — buyers are
+  funding the roadmap and they know it.
+
+What Conversation Simulator borrows, per
+[README → How it's distributed](../README.md#how-its-distributed) and
+[DLC_MODEL.md](DLC_MODEL.md): the engine and four official packs are free forever
+(Apache-2.0 / CC BY 4.0); the $9.99 Steam edition sells *packaging* — signed, notarized,
+auto-updating, Steam Deck–verified — never gated features; premium scenario packs are
+additive first-party DLC from a private repo; **nothing that ships free is ever relocked.**
+
+What it refuses: open-core feature hostage-taking, telemetry-funded free tiers, and any
+cloud dependency for core play.
+
+---
+
+## What this means for stewardship
+
+1. **The free build is the top of the funnel.** Every minute of friction between
+   `git clone` and a first conversation is a revenue problem, not just a DX problem —
+   which is why the v0.3 onboarding overhaul
+   ([#388](https://github.com/outrightmental/ConversationSimulator/issues/388)) was
+   treated as release-gating work.
+2. **The Steam page is the cash register.** Deck verification, achievements, store
+   assets, and review-response hygiene are product work, not chores
+   ([STEAM_ROADMAP.md](STEAM_ROADMAP.md)).
+3. **Packs are the content engine.** Creator tooling compounds: community packs grow the
+   audience that buys first-party DLC, and the eventual marketplace
+   ([marketplace-architecture.md](marketplace-architecture.md),
+   [#465](https://github.com/outrightmental/ConversationSimulator/issues/465),
+   [#466](https://github.com/outrightmental/ConversationSimulator/issues/466)) turns
+   creators into stakeholders.
+4. **Trust is the brand.** The local-first promise must remain *auditable* — offline
+   smoke tests in CI, no-egress guarantees, reproducible builds where possible. One
+   violated promise erases the structural moat.
+5. **The public record is the marketing.** The
+   [delivery board](https://github.com/orgs/outrightmental/projects/12) shows every issue
+   ever shipped, phase by phase — seven weeks from empty repository to signed,
+   Steam-ready build. For skeptical buyers and prospective contributors alike, visible
+   momentum is the strongest argument this project has. Keep it public, keep it honest
+   ([governance.md](governance.md)).
+
+---
+
+## Sources
+
+- [Dwarf Fortress has topped 1 million sales on Steam — Game Developer](https://www.gamedeveloper.com/business/dwarf-fortress-has-topped-1-million-sales-on-steam)
+- [Dwarf Fortress sales figures since Steam release — PC Gamer](https://www.pcgamer.com/dwarf-fortress-releases-sales-figures-since-steam-release-showing-46000-increase-in-earnings/)
+- [Shattered Pixel Dungeon — GitHub](https://github.com/00-Evan/shattered-pixel-dungeon) · [Steam](https://store.steampowered.com/app/1769170/Shattered_Pixel_Dungeon/)
+- [Best apps to practice difficult conversations with AI (2026) — Vocal Image](https://www.vocalimage.app/en/articles/37-practice-difficult-conversations-ai-apps/)
+- [AI roleplays for interview preparation — Yoodli](https://yoodli.ai/use-cases/interview-preparation)
+- [Running local LLMs in 2026: Ollama, LM Studio, and Jan compared — DEV](https://dev.to/synsun/running-local-llms-in-2026-ollama-lm-studio-and-jan-compared-5dii)
+- [Façade (video game) — Wikipedia](https://en.wikipedia.org/wiki/Fa%C3%A7ade_(video_game))
+- [ELIZA, Part 1 — The Digital Antiquarian](https://www.filfre.net/2011/06/eliza-part-1/)

--- a/docs/post-alpha-issues.md
+++ b/docs/post-alpha-issues.md
@@ -12,6 +12,15 @@ by design. If you want to work on one, open or claim the linked issue.
 > GitHub issue and a milestone assignment. The purpose of this document is
 > to make the deferred set visible, not to expand it silently.
 
+> **Status (2026-08-21):** every open item below now has a tracking issue on the
+> [delivery board](https://github.com/orgs/outrightmental/projects/12). The near-term
+> items ([#455](https://github.com/outrightmental/ConversationSimulator/issues/455),
+> [#456](https://github.com/outrightmental/ConversationSimulator/issues/456),
+> [#457](https://github.com/outrightmental/ConversationSimulator/issues/457)) sit in the
+> *06 · Release polish* phase and are open to the implementation factory; the rest sit in
+> *07 · Future* with the `manual` label until deliberately released — see
+> [governance.md](governance.md) for how that throttle works.
+
 ---
 
 ## Deferred from alpha: high priority (Milestone 1 polish)
@@ -27,7 +36,7 @@ playthrough, which in turn requires coordinated hardware access. This is a
 polish step, not a functional blocker.
 
 **Milestone:** 1 (polish)  
-**Tracking:** See `docs/screenshots.md` for the replacement checklist.
+**Tracking:** [#455](https://github.com/outrightmental/ConversationSimulator/issues/455) · see `docs/screenshots.md` for the replacement checklist.
 
 ---
 
@@ -43,8 +52,8 @@ keep the initial surface area small. The source install path is fully
 functional.
 
 **Milestone:** 1 (desktop packaging)  
-**Tracking:** `apps/desktop/` contains the Tauri skeleton; sidecar config
-is the remaining work.
+**Tracking:** [#456](https://github.com/outrightmental/ConversationSimulator/issues/456) · `apps/desktop/` contains the Tauri skeleton; sidecar
+config is the remaining work.
 
 ---
 
@@ -57,7 +66,8 @@ Gatekeeper and SmartScreen do not warn users.
 and a Windows EV certificate. Both have a cost and setup process that is
 not worth completing before the alpha has proven its audience.
 
-**Milestone:** 2 (distribution)
+**Milestone:** 2 (distribution)  
+**Status:** ✅ **Shipped** during the Hardening phase — Windows Authenticode ([#404](https://github.com/outrightmental/ConversationSimulator/issues/404)) and Apple Developer ID signing + notarization ([#406](https://github.com/outrightmental/ConversationSimulator/issues/406)); see `publishing/` for the runbooks. Auto-update (item 4) is now unblocked.
 
 ---
 
@@ -70,7 +80,8 @@ when a new release is available.
 a signed update manifest hosted at a stable URL. Blocked on code signing
 (item 3 above) and a hosting decision.
 
-**Milestone:** 2 (distribution)
+**Milestone:** 2 (distribution)  
+**Tracking:** [#461](https://github.com/outrightmental/ConversationSimulator/issues/461) — unblocked now that code signing (item 3) has shipped.
 
 ---
 
@@ -85,7 +96,8 @@ and install packs published by other creators without leaving the app.
 moderation tooling, which are significant infrastructure additions that
 would compromise the MVP's "no server" principle.
 
-**Milestone:** 3 (community)
+**Milestone:** 3 (community)  
+**Tracking:** [#465](https://github.com/outrightmental/ConversationSimulator/issues/465) · design baseline: `docs/marketplace-architecture.md`
 
 ---
 
@@ -99,7 +111,8 @@ latency and output quality signals.
 cache-unfriendly in most CI environments. The fake runtime provides full
 structural coverage; real-model CI is a quality-of-life improvement.
 
-**Milestone:** 2 (CI hardening)
+**Milestone:** 2 (CI hardening)  
+**Tracking:** [#457](https://github.com/outrightmental/ConversationSimulator/issues/457)
 
 ---
 
@@ -114,7 +127,7 @@ accessibility specialist. The automated `accessibility.test.tsx` covers
 obvious violations; manual audit is needed for full compliance.
 
 **Milestone:** 1 (polish) / 2 (hardening)  
-**Tracking:** `apps/web/src/__tests__/accessibility.test.tsx`
+**Tracking:** [#462](https://github.com/outrightmental/ConversationSimulator/issues/462) · `apps/web/src/__tests__/accessibility.test.tsx`
 
 ---
 
@@ -128,7 +141,8 @@ any regressions against those targets.
 infrastructure. The fake runtime cannot measure inference latency. See
 `docs/performance.md` for guidance in the meantime.
 
-**Milestone:** 2 (hardening)
+**Milestone:** 2 (hardening)  
+**Tracking:** [#463](https://github.com/outrightmental/ConversationSimulator/issues/463) — sequenced after #457 provides real-model infrastructure in CI.
 
 ---
 
@@ -143,7 +157,7 @@ first-run download and configuration flow requires UX work. The text-only
 path is the recommended alpha experience.
 
 **Milestone:** 2 (voice polish)  
-**Tracking:** `runtimes/whisper_cpp/`, `runtimes/kokoro/`
+**Tracking:** [#464](https://github.com/outrightmental/ConversationSimulator/issues/464) · `runtimes/whisper_cpp/`, `runtimes/kokoro/`
 
 ---
 
@@ -156,7 +170,8 @@ from unverified community submissions and enforce appropriate trust levels.
 **Why deferred:** Signing infrastructure is only meaningful once the
 community pack distribution path (item 5) exists.
 
-**Milestone:** 3 (community)
+**Milestone:** 3 (community)  
+**Tracking:** [#466](https://github.com/outrightmental/ConversationSimulator/issues/466) — sequenced after the community pack browser (item 5).
 
 ---
 


### PR DESCRIPTION
## What

A final zoom-out pass on this week's tracker/board overhaul, folded into the documentation — plus the research that grounds the project's positioning and business model.

**Two new documents**

- **`docs/landscape.md`** — the sixty-year lineage (ELIZA → Monkey Island insult sword-fighting → Façade → cloud coaches → local-LLM era), a survey of the current field (every direct competitor is cloud-based; no shipping product combines *structured practice game* + *100% local* + *open source*), and the business-model precedents with receipts (Dwarf Fortress: ~600k copies/~$7M in two months after twenty years of freeware; Shattered Pixel Dungeon; Mindustry; Aseprite). Ends with five stewardship implications tying docs, Steam ops, packs, trust, and the public record to revenue.
- **`docs/governance.md`** — the operating manual encoding this week's reorganization: the delivery board and its four views, the seven phases as append-only history, the label/type/milestone division of labor, the vibrator factory contract (`manual`/`review`, and the *07 · Future* → remove-`manual` release throttle), record-honesty rules, the commercial engine, and cadence.

**Wired into existing docs**

- **README** — new *Why this exists* section (positioning + lineage, links landscape); delivery-board link in Roadmap; contributor on-ramps (`good first issue`, `help wanted`, board, governance) in Contributing; precedent line in *How it's distributed*.
- **ROADMAP.md** — Status now points at the board as the live record; the three Milestone-1 polish items link #455/#456/#457; UGC items link #465/#466.
- **docs/post-alpha-issues.md** — per its own scope rule, every item now links its tracking issue (#455–#457, #461–#466); item 3 (code signing) marked **shipped** (#404, #406), which unblocks auto-update.

## Why

The tracker went from 68 labels/invisible history to 18 labels and a 219-item phased board this week — but none of that structure was written down where a stranger (or a future maintainer, or the factory) could learn it. And the README asserted *what* the project is without ever arguing *why it wins* — the structural moat and the proven revenue pattern were undocumented. Long-term shepherding means the reasoning survives outside anyone's head.

## Verification

- Docs-only change (5 markdown files); no code paths touched
- All relative links checked against files present in this repo; anchors verified (`#labels`, `#how-its-distributed`, `#business-model-precedents`)
- Board/phase figures match a fresh API audit (219 items; 85/62/23/24/13 across closed phases; 18 labels; milestone closed)
- External claims cited to sources in `docs/landscape.md → Sources`

Delivery board: https://github.com/orgs/outrightmental/projects/12