### PR TITLE
Add a copy-diagnostics action with log excerpts to every error surface

### DIFF
--- a/apps/web/src/__tests__/CopyDiagnosticsButton.test.tsx
+++ b/apps/web/src/__tests__/CopyDiagnosticsButton.test.tsx
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { CopyDiagnosticsButton } from '../components/CopyDiagnosticsButton'
+import { fetchLogExcerpt, EXCERPT_UNAVAILABLE_NOTE } from '../api/diag'
+import type { ApiError } from '../api/errors'
+
+const EXCERPT_PAYLOAD = {
+  excerpt: 'ConversationSimulator log excerpt\n── runtime.log ──\nllama-server exited early (code 137)',
+  sources: ['runtime.log'],
+  notice: 'Log excerpt assembled locally. It is never transmitted automatically.',
+}
+
+function mockFetchOk() {
+  const fn = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(EXCERPT_PAYLOAD),
+  })
+  vi.stubGlobal('fetch', fn)
+  return fn
+}
+
+function mockFetchFail() {
+  const fn = vi.fn().mockRejectedValue(new TypeError('fetch failed'))
+  vi.stubGlobal('fetch', fn)
+  return fn
+}
+
+function mockClipboard() {
+  const writeText = vi.fn().mockResolvedValue(undefined)
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText },
+    configurable: true,
+  })
+  return writeText
+}
+
+const SAMPLE_ERROR: ApiError = {
+  kind: 'http-error',
+  message: 'Model downloaded but failed to start: llama-server exited early (code 137).',
+  status: 500,
+}
+
+beforeEach(() => {
+  vi.unstubAllGlobals()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  // Remove the per-test clipboard stub so tests stay independent.
+  delete (navigator as unknown as { clipboard?: unknown }).clipboard
+})
+
+describe('CopyDiagnosticsButton', () => {
+  it('renders the default label', () => {
+    mockFetchOk()
+    render(<CopyDiagnosticsButton error={SAMPLE_ERROR} />)
+    expect(screen.getByRole('button', { name: 'Copy diagnostics' })).toBeInTheDocument()
+  })
+
+  it('copies error header plus fetched log excerpt, then confirms', async () => {
+    const fetchMock = mockFetchOk()
+    const writeText = mockClipboard()
+    render(<CopyDiagnosticsButton error={SAMPLE_ERROR} context="setup-install:warmup" />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy diagnostics' }))
+    expect(await screen.findByText('Copied!')).toBeInTheDocument()
+
+    // Requested the excerpt endpoint with the context tag.
+    const url = String(fetchMock.mock.calls[0][0])
+    expect(url).toContain('/diag/log-excerpt')
+    expect(url).toContain(encodeURIComponent('setup-install:warmup'))
+
+    const copied = String(writeText.mock.calls[0][0])
+    // Client-side error details lead the report…
+    expect(copied).toContain('kind: http-error')
+    expect(copied).toContain('Model downloaded but failed to start')
+    expect(copied).toContain('context: setup-install:warmup')
+    // …followed by the server-assembled log excerpt.
+    expect(copied).toContain('llama-server exited early (code 137)')
+  })
+
+  it('falls back to a logs-folder pointer when the core service is unreachable', async () => {
+    mockFetchFail()
+    const writeText = mockClipboard()
+    render(<CopyDiagnosticsButton error={SAMPLE_ERROR} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy diagnostics' }))
+    expect(await screen.findByText('Copied!')).toBeInTheDocument()
+
+    const copied = String(writeText.mock.calls[0][0])
+    expect(copied).toContain('kind: http-error')
+    expect(copied).toContain('log excerpts unavailable')
+    expect(copied).toContain('Logs folder:')
+  })
+
+  it('prefers an explicit header over the error prop', async () => {
+    mockFetchOk()
+    const writeText = mockClipboard()
+    render(
+      <CopyDiagnosticsButton
+        header={'ConversationSimulator diagnostics\nkind: render-error\nmessage: boom'}
+        error={SAMPLE_ERROR}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy diagnostics' }))
+    expect(await screen.findByText('Copied!')).toBeInTheDocument()
+
+    const copied = String(writeText.mock.calls[0][0])
+    expect(copied).toContain('kind: render-error')
+    expect(copied).not.toContain('kind: http-error')
+  })
+
+  it('shows a failure state when no clipboard mechanism works', async () => {
+    mockFetchOk()
+    // No navigator.clipboard, and execCommand is unavailable in this test.
+    render(<CopyDiagnosticsButton error={SAMPLE_ERROR} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy diagnostics' }))
+    expect(await screen.findByText('Copy failed')).toBeInTheDocument()
+  })
+
+  it('supports a custom label', () => {
+    mockFetchOk()
+    render(<CopyDiagnosticsButton error={SAMPLE_ERROR} label="Copy log excerpt" />)
+    expect(screen.getByRole('button', { name: 'Copy log excerpt' })).toBeInTheDocument()
+  })
+})
+
+describe('fetchLogExcerpt', () => {
+  it('returns the payload on success', async () => {
+    mockFetchOk()
+    const result = await fetchLogExcerpt('test-context')
+    expect(result).not.toBeNull()
+    expect(result!.excerpt).toContain('llama-server exited early')
+    expect(result!.sources).toEqual(['runtime.log'])
+  })
+
+  it('returns null on network failure', async () => {
+    mockFetchFail()
+    expect(await fetchLogExcerpt()).toBeNull()
+  })
+
+  it('returns null on a non-OK response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, json: () => Promise.resolve({}) }))
+    expect(await fetchLogExcerpt()).toBeNull()
+  })
+
+  it('returns null on a malformed payload', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({ nope: true }) }),
+    )
+    expect(await fetchLogExcerpt()).toBeNull()
+  })
+
+  it('exposes a fallback note that names the logs folder per platform', () => {
+    expect(EXCERPT_UNAVAILABLE_NOTE).toContain('macOS')
+    expect(EXCERPT_UNAVAILABLE_NOTE).toContain('Windows')
+    expect(EXCERPT_UNAVAILABLE_NOTE).toContain('Linux')
+  })
+})

--- a/apps/web/src/__tests__/RuntimeRecoveryCard.test.tsx
+++ b/apps/web/src/__tests__/RuntimeRecoveryCard.test.tsx
@@ -157,7 +157,7 @@ describe('RuntimeRecoveryCard — primary action', () => {
       />,
     )
     expect(screen.getByRole('button', { name: /restarting/i })).toBeInTheDocument()
-    expect(screen.getByRole('button')).toBeDisabled()
+    expect(screen.getByRole('button', { name: /restarting/i })).toBeDisabled()
   })
 
   it('renders an external link when href is provided instead of onClick', () => {

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -52,6 +52,32 @@ import type { ApiError, ApiResult } from './errors';
 
 const BASE = _isTauriProduction ? `${CORE_ORIGIN}/api` : '/api'
 
+/**
+ * Fetch the diagnostics log excerpt as raw JSON, bounded by a timeout.
+ *
+ * Lives here because all HTTP must go through api/client.ts (lint-enforced).
+ * Unlike the ApiResult helpers this must never throw and wants a short
+ * deadline: it runs inside error surfaces, possibly while the core service
+ * is down. Payload validation happens in api/diag.ts.
+ */
+export async function getLogExcerptRaw(
+  context: string | undefined,
+  timeoutMs: number,
+): Promise<unknown | null> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const qs = context != null && context !== '' ? `?context=${encodeURIComponent(context)}` : ''
+    const res = await fetch(`${BASE}/diag/log-excerpt${qs}`, { signal: controller.signal })
+    if (!res.ok) return null
+    return (await res.json()) as unknown
+  } catch {
+    return null
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
 export interface CloudSettings {
   /** Last model ID selected by the user. The only field Steam Cloud syncs. */
   last_model_id: string | null

--- a/apps/web/src/api/diag.ts
+++ b/apps/web/src/api/diag.ts
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Diagnostics helpers for the "Copy diagnostics" action on error surfaces.
+//
+// Every error card in the app offers a one-click copy of the client-side
+// error details PLUS the most relevant local log excerpts, so a user can
+// paste a complete, triage-able report into a GitHub issue without hunting
+// for log files. The excerpt comes from GET /api/diag/log-excerpt (assembled
+// and redacted locally by convsim-core; never transmitted anywhere).
+//
+// This module must be safe to call while the system is unhealthy: the fetch
+// is bounded by a short timeout and every failure resolves to a fallback
+// note instead of throwing into the error surface that invoked it.
+import { getLogExcerptRaw } from './client'
+
+export interface LogExcerptResponse {
+  excerpt: string
+  sources: string[]
+  notice: string
+}
+
+const EXCERPT_TIMEOUT_MS = 4000
+
+// Where the logs live per platform (mirrors convsim_core/paths.py). Shown
+// only when the core service cannot be reached, so the copied report still
+// tells the user where to find logs by hand.
+const LOGS_FOLDER_HINTS = [
+  'macOS:   ~/Library/Application Support/com.outrightmental.convsim/logs',
+  'Windows: %LOCALAPPDATA%\\outrightmental\\convsim\\logs',
+  'Linux:   ~/.local/share/convsim/logs',
+]
+
+export const EXCERPT_UNAVAILABLE_NOTE = [
+  '(log excerpts unavailable — the local service could not be reached)',
+  'Logs folder:',
+  ...LOGS_FOLDER_HINTS.map((hint) => `  ${hint}`),
+].join('\n')
+
+/**
+ * Fetch the redacted local log excerpt, or null when the core service is
+ * unreachable, slow, or returns an unexpected payload. Never throws.
+ */
+export async function fetchLogExcerpt(
+  context?: string,
+): Promise<LogExcerptResponse | null> {
+  const data = await getLogExcerptRaw(context, EXCERPT_TIMEOUT_MS)
+  if (
+    typeof data === 'object' &&
+    data !== null &&
+    typeof (data as { excerpt?: unknown }).excerpt === 'string' &&
+    Array.isArray((data as { sources?: unknown }).sources)
+  ) {
+    const payload = data as { excerpt: string; sources: unknown[]; notice?: unknown }
+    return {
+      excerpt: payload.excerpt,
+      sources: payload.sources.filter((s): s is string => typeof s === 'string'),
+      notice: typeof payload.notice === 'string' ? payload.notice : '',
+    }
+  }
+  return null
+}
+
+/**
+ * Build the full diagnostics report placed on the clipboard: the caller's
+ * client-side header followed by the local log excerpt (or a fallback note
+ * pointing at the logs folder when the core service is unreachable).
+ */
+export async function buildDiagnosticsReport(
+  header: string,
+  context?: string,
+): Promise<string> {
+  const excerpt = await fetchLogExcerpt(context)
+  const body = excerpt != null ? excerpt.excerpt : EXCERPT_UNAVAILABLE_NOTE
+  return `${header}\n\n${body}`
+}

--- a/apps/web/src/components/ApiErrorView.tsx
+++ b/apps/web/src/components/ApiErrorView.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-import { useState } from 'react'
 import type { ApiError } from '../api/errors'
-import { ERROR_COPY, buildDiagnosticsText } from '../api/errors'
+import { ERROR_COPY } from '../api/errors'
+import { CopyDiagnosticsButton } from './CopyDiagnosticsButton'
 
 interface ApiErrorViewProps {
   error: ApiError
@@ -11,7 +11,6 @@ interface ApiErrorViewProps {
 }
 
 export function ApiErrorView({ error, onRetry, context, compact = false }: ApiErrorViewProps) {
-  const [copied, setCopied] = useState(false)
   const copy = ERROR_COPY[error.kind]
   // For an http-error the server sent a clean, human-readable business message
   // (e.g. "Unknown scenario_id" or "SHA-256 checksum mismatch"). The content-type
@@ -21,18 +20,6 @@ export function ApiErrorView({ error, onRetry, context, compact = false }: ApiEr
   // text, so we keep the designed plain-language description instead.
   const detail =
     error.kind === 'http-error' && error.message ? error.message : copy.description
-
-  function handleCopyDiagnostics() {
-    void (async () => {
-      try {
-        await navigator.clipboard.writeText(buildDiagnosticsText(error, context))
-        setCopied(true)
-        setTimeout(() => setCopied(false), 2000)
-      } catch {
-        // clipboard unavailable in non-secure contexts
-      }
-    })()
-  }
 
   if (compact) {
     return (
@@ -60,20 +47,7 @@ export function ApiErrorView({ error, onRetry, context, compact = false }: ApiEr
             {copy.action}
           </button>
         )}
-        <button
-          onClick={handleCopyDiagnostics}
-          style={{
-            padding: '0.1rem 0.4rem',
-            borderRadius: '3px',
-            border: '1px solid rgba(255,255,255,0.12)',
-            background: 'transparent',
-            color: '#71717a',
-            fontSize: '0.72rem',
-            cursor: 'pointer',
-          }}
-        >
-          {copied ? 'Copied!' : 'Copy diagnostics'}
-        </button>
+        <CopyDiagnosticsButton error={error} context={context} compact />
       </span>
     )
   }
@@ -111,20 +85,7 @@ export function ApiErrorView({ error, onRetry, context, compact = false }: ApiEr
             {copy.action}
           </button>
         )}
-        <button
-          onClick={handleCopyDiagnostics}
-          style={{
-            padding: '0.3rem 0.75rem',
-            borderRadius: '4px',
-            border: '1px solid rgba(255,255,255,0.12)',
-            background: 'transparent',
-            color: '#71717a',
-            fontSize: '0.8rem',
-            cursor: 'pointer',
-          }}
-        >
-          {copied ? 'Copied!' : 'Copy diagnostics'}
-        </button>
+        <CopyDiagnosticsButton error={error} context={context} />
       </div>
     </div>
   )

--- a/apps/web/src/components/CopyDiagnosticsButton.tsx
+++ b/apps/web/src/components/CopyDiagnosticsButton.tsx
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+// One-click "copy the most relevant log excerpts" affordance for error
+// surfaces. Renders a small button that assembles a diagnostics report —
+// the client-side error details plus a redacted excerpt of the local logs
+// (via GET /api/diag/log-excerpt) — and places it on the clipboard.
+//
+// Design contract: every error the app shows should render one of these
+// (directly, or via ApiErrorView / RuntimeRecoveryCard) so a user never has
+// to hunt for log files to report a problem. The button must keep working
+// when the system is unhealthy: if the core service is unreachable the
+// copied report falls back to the client-side details plus a pointer to the
+// on-disk logs folder.
+import { useEffect, useRef, useState } from 'react'
+import type { ApiError } from '../api/errors'
+import { buildDiagnosticsText } from '../api/errors'
+import { buildDiagnosticsReport } from '../api/diag'
+
+/**
+ * Write text to the clipboard, preferring the async Clipboard API and
+ * falling back to a hidden textarea + execCommand for webviews where
+ * navigator.clipboard is unavailable. Resolves false when neither works.
+ */
+export async function copyTextToClipboard(text: string): Promise<boolean> {
+  try {
+    if (typeof navigator !== 'undefined' && navigator.clipboard != null) {
+      await navigator.clipboard.writeText(text)
+      return true
+    }
+  } catch {
+    // fall through to the legacy path
+  }
+  try {
+    const textarea = document.createElement('textarea')
+    textarea.value = text
+    textarea.setAttribute('readonly', '')
+    textarea.style.position = 'fixed'
+    textarea.style.opacity = '0'
+    document.body.appendChild(textarea)
+    textarea.select()
+    const ok = document.execCommand('copy')
+    document.body.removeChild(textarea)
+    return ok
+  } catch {
+    return false
+  }
+}
+
+export interface CopyDiagnosticsButtonProps {
+  /** Error whose details lead the report (header built via buildDiagnosticsText). */
+  error?: ApiError | null
+  /** Pre-assembled header — wins over `error` when provided (e.g. render crashes). */
+  header?: string
+  /** Short tag naming the surface, embedded in the excerpt (e.g. "setup-install:warmup"). */
+  context?: string
+  label?: string
+  compact?: boolean
+  style?: React.CSSProperties
+}
+
+function defaultHeader(context?: string): string {
+  const lines = ['ConversationSimulator diagnostics']
+  if (context) lines.push(`context: ${context}`)
+  lines.push(`time: ${new Date().toISOString()}`)
+  return lines.join('\n')
+}
+
+export function CopyDiagnosticsButton({
+  error,
+  header,
+  context,
+  label = 'Copy diagnostics',
+  compact = false,
+  style,
+}: CopyDiagnosticsButtonProps) {
+  const [status, setStatus] = useState<'idle' | 'busy' | 'copied' | 'failed'>('idle')
+  const mounted = useRef(true)
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    mounted.current = true
+    return () => {
+      mounted.current = false
+      if (resetTimer.current != null) clearTimeout(resetTimer.current)
+    }
+  }, [])
+
+  function scheduleReset() {
+    if (resetTimer.current != null) clearTimeout(resetTimer.current)
+    resetTimer.current = setTimeout(() => {
+      if (mounted.current) setStatus('idle')
+    }, 2000)
+  }
+
+  function handleCopy() {
+    void (async () => {
+      setStatus('busy')
+      const head =
+        header != null && header !== ''
+          ? header
+          : error != null
+            ? buildDiagnosticsText(error, context)
+            : defaultHeader(context)
+      const report = await buildDiagnosticsReport(head, context)
+      const ok = await copyTextToClipboard(report)
+      if (!mounted.current) return
+      setStatus(ok ? 'copied' : 'failed')
+      scheduleReset()
+    })()
+  }
+
+  const text =
+    status === 'copied' ? 'Copied!' : status === 'failed' ? 'Copy failed' : label
+
+  const baseStyle: React.CSSProperties = compact
+    ? {
+        padding: '0.1rem 0.4rem',
+        borderRadius: '3px',
+        border: '1px solid rgba(255,255,255,0.12)',
+        background: 'transparent',
+        color: '#71717a',
+        fontSize: '0.72rem',
+        cursor: 'pointer',
+      }
+    : {
+        padding: '0.3rem 0.75rem',
+        borderRadius: '4px',
+        border: '1px solid rgba(255,255,255,0.12)',
+        background: 'transparent',
+        color: '#71717a',
+        fontSize: '0.8rem',
+        cursor: 'pointer',
+      }
+
+  return (
+    <button
+      onClick={handleCopy}
+      disabled={status === 'busy'}
+      data-testid="copy-diagnostics"
+      style={{ ...baseStyle, ...style }}
+    >
+      {text}
+    </button>
+  )
+}

--- a/apps/web/src/components/ErrorBoundary.tsx
+++ b/apps/web/src/components/ErrorBoundary.tsx
@@ -5,6 +5,7 @@
 // component because React does not support error boundary hooks.
 import { Component, type ErrorInfo, type ReactNode } from 'react'
 import { useTranslation, type TranslateFn } from '../i18n'
+import { CopyDiagnosticsButton } from './CopyDiagnosticsButton'
 
 const ISSUES_URL = 'https://github.com/outrightmental/ConversationSimulator/issues/new/choose'
 const DOCS_URL = 'https://docs.conversationsimulator.com/start/troubleshooting/'
@@ -36,6 +37,13 @@ class ErrorBoundaryInner extends Component<InnerProps, State> {
     const { error } = this.state
     const { t } = this.props
     if (error) {
+      const diagnosticsHeader = [
+        'ConversationSimulator diagnostics',
+        'kind: render-error',
+        `message: ${error.message}`,
+        ...(error.stack ? [`stack:\n${error.stack.split('\n').slice(0, 12).join('\n')}`] : []),
+        `time: ${new Date().toISOString()}`,
+      ].join('\n')
       return (
         <div
           role="alert"
@@ -98,6 +106,11 @@ class ErrorBoundaryInner extends Component<InnerProps, State> {
             >
               {t('error.goHome')}
             </button>
+            <CopyDiagnosticsButton
+              header={diagnosticsHeader}
+              context="render-error"
+              label={t('error.copyDiagnostics')}
+            />
           </div>
 
           <div style={{ marginTop: '1.25rem', display: 'flex', flexWrap: 'wrap', gap: '0.75rem', fontSize: '0.825rem' }}>

--- a/apps/web/src/components/LocalFilePicker.tsx
+++ b/apps/web/src/components/LocalFilePicker.tsx
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { useState } from 'react'
+import { CopyDiagnosticsButton } from './CopyDiagnosticsButton'
 
 type TauriInvoke = <T>(cmd: string, args?: unknown) => Promise<T>
 type TauriWindow = { __TAURI__?: { core?: { invoke?: TauriInvoke } } }
@@ -133,7 +134,12 @@ export function LocalFilePicker({
       </div>
       {dialogError && (
         <p role="alert" style={{ fontSize: '0.8rem', color: '#f87171', margin: '0.3rem 0 0' }}>
-          {dialogError}
+          {dialogError}{' '}
+          <CopyDiagnosticsButton
+            header={`ConversationSimulator diagnostics\nkind: file-dialog-error\nmessage: ${dialogError}\ntime: ${new Date().toISOString()}`}
+            context="file-picker"
+            compact
+          />
         </p>
       )}
     </div>

--- a/apps/web/src/components/RuntimeRecoveryCard.tsx
+++ b/apps/web/src/components/RuntimeRecoveryCard.tsx
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+import { CopyDiagnosticsButton } from './CopyDiagnosticsButton'
 
 export interface RecoveryAction {
   label: string
@@ -130,6 +131,13 @@ export default function RuntimeRecoveryCard({
   tertiaryAction,
   reportProblemHref,
 }: RuntimeRecoveryCardProps) {
+  const diagnosticsHeader = [
+    'ConversationSimulator diagnostics',
+    `title: ${title}`,
+    ...(errorDetail ? [`detail: ${errorDetail}`] : []),
+    `time: ${new Date().toISOString()}`,
+  ].join('\n')
+
   return (
     <div role="alert" style={cardStyle}>
       <p style={titleStyle}>{title}</p>
@@ -146,6 +154,7 @@ export default function RuntimeRecoveryCard({
         {primaryAction && <ActionButton action={primaryAction} />}
         {secondaryAction && <ActionButton action={secondaryAction} />}
         {tertiaryAction && <ActionButton action={tertiaryAction} />}
+        <CopyDiagnosticsButton header={diagnosticsHeader} context="runtime-recovery" />
         <a href={troubleshootingHref} target="_blank" rel="noreferrer" style={linkStyle}>
           {troubleshootingLabel}
         </a>

--- a/apps/web/src/components/RuntimeSettingsPanel.tsx
+++ b/apps/web/src/components/RuntimeSettingsPanel.tsx
@@ -4,6 +4,7 @@ import { api } from '../api/client'
 import type { ModelsResponse, RuntimeSettings } from '@convsim/shared'
 import type { ApiError } from '../api/errors'
 import { ApiErrorView } from './ApiErrorView'
+import { CopyDiagnosticsButton } from './CopyDiagnosticsButton'
 import { AI_ENGINE_DOCS_URL as DOCS_URL, UPDATE_DOCS_URL } from '../setup/docsUrls'
 
 const PROVIDER_NAMES: Record<string, string> = {
@@ -177,7 +178,16 @@ function FieldRow({
       <div>
         {children}
         {note && <div style={noteStyle}>{note}</div>}
-        {error && <div style={errorStyle} role="alert">{error}</div>}
+        {error && (
+          <div style={errorStyle} role="alert">
+            {error}{' '}
+            <CopyDiagnosticsButton
+              header={`ConversationSimulator diagnostics\nkind: runtime-settings-error\nmessage: ${error}\ntime: ${new Date().toISOString()}`}
+              context="runtime-settings"
+              compact
+            />
+          </div>
+        )}
       </div>
     </div>
   )

--- a/apps/web/src/components/VoiceInput.tsx
+++ b/apps/web/src/components/VoiceInput.tsx
@@ -8,6 +8,7 @@ import MicButton from './MicButton'
 import VadStatusIndicator from './VadStatusIndicator'
 import VadCalibration from './VadCalibration'
 import TranscriptReviewPanel from './TranscriptReviewPanel'
+import { CopyDiagnosticsButton } from './CopyDiagnosticsButton'
 
 const BACKCHANNEL_TRIGGER_MS = 3_500
 
@@ -334,7 +335,12 @@ export default function VoiceInput({ onSubmit, onRawStt, onSttLatency, onRecordi
         </p>
         {uploadError && (
           <p role="alert" style={{ ...noticeStyle, color: '#f87171' }}>
-            {uploadError}
+            {uploadError}{' '}
+            <CopyDiagnosticsButton
+              header={`ConversationSimulator diagnostics\nkind: voice-upload-error\nmessage: ${uploadError}\ntime: ${new Date().toISOString()}`}
+              context="voice-input:upload"
+              compact
+            />
           </p>
         )}
         <form onSubmit={handleTextSubmit} style={{ display: 'flex', flex: 1, gap: '0.5rem' }}>
@@ -374,12 +380,22 @@ export default function VoiceInput({ onSubmit, onRawStt, onSttLatency, onRecordi
       )}
       {error && !showDeniedNotice && (
         <p role="alert" style={{ ...noticeStyle, color: '#f87171' }}>
-          {error}
+          {error}{' '}
+          <CopyDiagnosticsButton
+            header={`ConversationSimulator diagnostics\nkind: voice-capture-error\nmessage: ${error}\ntime: ${new Date().toISOString()}`}
+            context="voice-input:capture"
+            compact
+          />
         </p>
       )}
       {uploadError && (
         <p role="alert" style={{ ...noticeStyle, color: '#f87171' }}>
-          {uploadError}
+          {uploadError}{' '}
+          <CopyDiagnosticsButton
+            header={`ConversationSimulator diagnostics\nkind: voice-upload-error\nmessage: ${uploadError}\ntime: ${new Date().toISOString()}`}
+            context="voice-input:upload"
+            compact
+          />
         </p>
       )}
 

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -28,6 +28,7 @@ export const de: LocaleMessages = {
     tryAgain: 'Erneut versuchen',
     goHome: 'Zur Startseite',
     reportIssue: 'Problem melden',
+    copyDiagnostics: 'Diagnose kopieren',
     documentation: 'Dokumentation',
     logsLabel: 'Protokolle:',
   },

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -23,6 +23,7 @@ export const en = {
     tryAgain: 'Try again',
     goHome: 'Go to home',
     reportIssue: 'Report this issue',
+    copyDiagnostics: 'Copy diagnostics',
     documentation: 'Documentation',
     logsLabel: 'Logs:',
   },

--- a/apps/web/src/screens/Logbook.tsx
+++ b/apps/web/src/screens/Logbook.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useLogbookProfile } from '../api/useLogbookProfile'
 import { api } from '../api/client'
+import { CopyDiagnosticsButton } from '../components/CopyDiagnosticsButton'
 import { useSteamAchievements, SteamAchievement } from '../hooks/useSteamAchievements'
 import { useEffect, useRef } from 'react'
 
@@ -114,8 +115,9 @@ export default function Logbook() {
     return (
       <div>
         <h1>Logbook</h1>
-        <p role="alert" style={{ color: '#f87171' }}>
-          Could not load logbook data. Check that the local runtime is running.
+        <p role="alert" style={{ color: '#f87171', display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' }}>
+          <span>Could not load logbook data. Check that the local runtime is running.</span>
+          <CopyDiagnosticsButton context="logbook:load" compact />
         </p>
       </div>
     )
@@ -362,7 +364,12 @@ export default function Logbook() {
         </button>
         {exportError && (
           <p role="alert" style={{ marginTop: '0.5rem', fontSize: '0.8rem', color: '#f87171' }}>
-            {exportError}
+            {exportError}{' '}
+            <CopyDiagnosticsButton
+              header={`ConversationSimulator diagnostics\nkind: logbook-export-error\nmessage: ${exportError}\ntime: ${new Date().toISOString()}`}
+              context="logbook:export"
+              compact
+            />
           </p>
         )}
       </section>

--- a/apps/web/src/screens/ScenarioLibrary.tsx
+++ b/apps/web/src/screens/ScenarioLibrary.tsx
@@ -7,6 +7,7 @@ import type { PackSummary, ImportPackResponse } from '../api/client'
 import type { ApiError } from '../api/errors'
 import { errorHeadline } from '../api/errors'
 import { ApiErrorView } from '../components/ApiErrorView'
+import { CopyDiagnosticsButton } from '../components/CopyDiagnosticsButton'
 import { useSteamStatus } from '../hooks/useSteamStatus'
 import { useSteamWorkshop } from '../hooks/useSteamWorkshop'
 
@@ -291,9 +292,14 @@ export default function ScenarioLibrary() {
                 <span
                   role="alert"
                   data-testid="workshop-sync-error"
-                  style={{ fontSize: '0.85rem', color: '#f87171' }}
+                  style={{ fontSize: '0.85rem', color: '#f87171', display: 'inline-flex', alignItems: 'center', gap: '0.4rem', flexWrap: 'wrap' }}
                 >
                   {workshopSyncSummary}
+                  <CopyDiagnosticsButton
+                    header={`ConversationSimulator diagnostics\nkind: workshop-sync-error\nmessage: ${workshopSyncSummary}\ntime: ${new Date().toISOString()}`}
+                    context="workshop-sync"
+                    compact
+                  />
                 </span>
               )}
               <button

--- a/apps/web/src/setup/RemediationCard.tsx
+++ b/apps/web/src/setup/RemediationCard.tsx
@@ -12,6 +12,8 @@
  */
 import { useState } from 'react'
 import type { PreflightCheck, PreflightFixAction } from '@convsim/shared'
+import { buildDiagnosticsReport } from '../api/diag'
+import { copyTextToClipboard } from '../components/CopyDiagnosticsButton'
 import { useTranslation } from '../i18n'
 
 export interface RemediationCardProps {
@@ -132,11 +134,18 @@ export function RemediationCard({ check, onAction, onTextOnly, coreVersion }: Re
   const [copied, setCopied] = useState(false)
 
   function handleCopy() {
-    const block = buildCopyBlock(check, coreVersion)
-    void navigator.clipboard.writeText(block).then(() => {
-      setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
-    })
+    // The copied report is the visible bug-report block plus the most relevant
+    // local log excerpts (fetched from the core service, redacted there), so a
+    // pasted issue carries the lines a maintainer actually needs.
+    void (async () => {
+      const block = buildCopyBlock(check, coreVersion)
+      const report = await buildDiagnosticsReport(block, `preflight:${check.id}`)
+      const ok = await copyTextToClipboard(report)
+      if (ok) {
+        setCopied(true)
+        setTimeout(() => setCopied(false), 2000)
+      }
+    })()
   }
 
   return (

--- a/apps/web/src/setup/steps/BenchmarkStep.tsx
+++ b/apps/web/src/setup/steps/BenchmarkStep.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { PrimaryButton } from '../primitives'
 import { errorMessage } from '../errorMessage'
+import { CopyDiagnosticsButton } from '../../components/CopyDiagnosticsButton'
 import type { UseSetupFlowReturn } from '../useSetupFlow'
 import { SETUP_DOCS_URL } from '../docsUrls'
 
@@ -74,7 +75,8 @@ export function BenchmarkStep({ flow, mode, onComplete }: BenchmarkStepProps) {
           style={{ marginTop: '1rem', padding: '0.75rem 1rem', background: 'rgba(239,68,68,0.08)', border: '1px solid rgba(239,68,68,0.3)', borderRadius: '6px' }}
         >
           <p style={{ margin: '0 0 0.4rem', color: '#f87171', fontSize: '0.875rem' }}>Benchmark failed: {errMsg}</p>
-          <p style={{ margin: 0, fontSize: '0.8rem', color: '#a1a1aa' }}>Your model is still selected and ready to use. The benchmark is optional.</p>
+          <p style={{ margin: '0 0 0.5rem', fontSize: '0.8rem', color: '#a1a1aa' }}>Your model is still selected and ready to use. The benchmark is optional.</p>
+          <CopyDiagnosticsButton error={flow.actionError} context="setup:benchmark" compact />
         </div>
       )}
 

--- a/apps/web/src/setup/steps/ConfirmInstallStep.tsx
+++ b/apps/web/src/setup/steps/ConfirmInstallStep.tsx
@@ -2,6 +2,7 @@
 import { ActionButton, PrimaryButton, DetailRow } from '../primitives'
 import { errorMessage } from '../errorMessage'
 import { ApiErrorView } from '../../components/ApiErrorView'
+import { CopyDiagnosticsButton } from '../../components/CopyDiagnosticsButton'
 import type { UseSetupFlowReturn } from '../useSetupFlow'
 import { SETUP_DOCS_URL } from '../docsUrls'
 
@@ -90,6 +91,9 @@ export function ConfirmInstallStep({ flow, mode }: ConfirmInstallStepProps) {
                   : 'If your hardware or runtime cannot install this model, try a smaller model or '}
                 check the <a href={SETUP_DOCS_URL} target="_blank" rel="noreferrer">setup docs</a>.
               </p>
+              <div style={{ marginTop: '0.5rem' }}>
+                <CopyDiagnosticsButton error={flow.actionError} context="setup-install:confirm" />
+              </div>
             </div>
           )
       )}

--- a/apps/web/src/setup/steps/GgufPathStep.tsx
+++ b/apps/web/src/setup/steps/GgufPathStep.tsx
@@ -2,6 +2,7 @@
 import { ActionButton, PrimaryButton } from '../primitives'
 import { errorMessage } from '../errorMessage'
 import { ApiErrorView } from '../../components/ApiErrorView'
+import { CopyDiagnosticsButton } from '../../components/CopyDiagnosticsButton'
 import { LocalFilePicker } from '../../components/LocalFilePicker'
 import type { UseSetupFlowReturn } from '../useSetupFlow'
 
@@ -50,7 +51,12 @@ export function GgufPathStep({ flow, mode }: GgufPathStepProps) {
       {flow.actionError && (
         mode === 'manager'
           ? <div style={{ marginTop: '0.75rem' }}><ApiErrorView error={flow.actionError} context="ModelManager" /></div>
-          : <p role="alert" style={{ color: '#f87171', marginTop: '0.75rem', fontSize: '0.875rem' }}>{errMsg}</p>
+          : (
+            <p role="alert" style={{ color: '#f87171', marginTop: '0.75rem', fontSize: '0.875rem', display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' }}>
+              <span>{errMsg}</span>
+              <CopyDiagnosticsButton error={flow.actionError} context="setup:gguf-path" compact />
+            </p>
+          )
       )}
 
       <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1.5rem' }}>

--- a/apps/web/src/setup/steps/InstallingStep.tsx
+++ b/apps/web/src/setup/steps/InstallingStep.tsx
@@ -2,6 +2,7 @@
 import { useEffect } from 'react'
 import { ActionButton, PrimaryButton } from '../primitives'
 import { errorMessage } from '../errorMessage'
+import { CopyDiagnosticsButton } from '../../components/CopyDiagnosticsButton'
 import { computeSetupInstallPct } from '../useSetupInstall'
 import type { UseSetupFlowReturn } from '../useSetupFlow'
 import type { SetupInstallStage } from '@convsim/shared'
@@ -105,6 +106,7 @@ export function InstallingStep({ flow, mode }: InstallingStepProps) {
               <div style={{ display: 'flex', gap: '0.5rem' }}>
                 <PrimaryButton onClick={() => { flow.resetAction(); flow.setStep('confirm-install') }}>Retry</PrimaryButton>
                 <ActionButton onClick={() => { flow.resetAction(); flow.setStep('choose') }}>Choose a different option</ActionButton>
+                <CopyDiagnosticsButton error={flow.actionError} context="setup-install:network" />
               </div>
             </div>
           )}
@@ -119,6 +121,7 @@ export function InstallingStep({ flow, mode }: InstallingStepProps) {
               <div style={{ display: 'flex', gap: '0.5rem' }}>
                 <PrimaryButton onClick={() => { flow.resetAction(); flow.setStep('confirm-install') }}>Try again</PrimaryButton>
                 <ActionButton onClick={() => { flow.resetAction(); flow.setStep('choose') }}>Choose a different option</ActionButton>
+                <CopyDiagnosticsButton error={flow.actionError} context="setup-install:disk" />
               </div>
             </div>
           )}
@@ -134,6 +137,7 @@ export function InstallingStep({ flow, mode }: InstallingStepProps) {
               </p>
               <div style={{ display: 'flex', gap: '0.5rem' }}>
                 <PrimaryButton onClick={() => { flow.resetAction(); flow.setStep('choose') }}>Choose a smaller model</PrimaryButton>
+                <CopyDiagnosticsButton error={flow.actionError} context="setup-install:warmup" />
               </div>
             </div>
           )}
@@ -147,6 +151,7 @@ export function InstallingStep({ flow, mode }: InstallingStepProps) {
               <div style={{ display: 'flex', gap: '0.5rem' }}>
                 <PrimaryButton onClick={() => { flow.resetAction(); flow.setStep('confirm-install') }}>Try again</PrimaryButton>
                 <ActionButton onClick={() => { flow.resetAction(); flow.setStep('choose') }}>Choose a different option</ActionButton>
+                <CopyDiagnosticsButton error={flow.actionError} context="setup-install" />
               </div>
             </div>
           )}

--- a/apps/web/src/setup/steps/LoadErrorStep.tsx
+++ b/apps/web/src/setup/steps/LoadErrorStep.tsx
@@ -2,6 +2,7 @@
 import { ActionButton } from '../primitives'
 import { errorMessage } from '../errorMessage'
 import { ApiErrorView } from '../../components/ApiErrorView'
+import { CopyDiagnosticsButton } from '../../components/CopyDiagnosticsButton'
 import type { UseSetupFlowReturn } from '../useSetupFlow'
 import { TROUBLESHOOTING_DOCS_URL } from '../docsUrls'
 
@@ -42,7 +43,10 @@ export function LoadErrorStep({ flow, mode }: LoadErrorStepProps) {
               <span style={{ color: '#52525b', fontSize: '0.825rem' }}>·</span>
               <a href={ISSUES_URL} target="_blank" rel="noreferrer" style={{ fontSize: '0.825rem', color: '#a1a1aa' }}>Report an issue</a>
             </div>
-            <ActionButton onClick={() => flow.setStep('welcome')}>Back to welcome</ActionButton>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
+              <ActionButton onClick={() => flow.setStep('welcome')}>Back to welcome</ActionButton>
+              <CopyDiagnosticsButton error={flow.loadError} context="setup:load" />
+            </div>
           </div>
         </>
       )}

--- a/apps/web/src/setup/steps/OllamaSelectStep.tsx
+++ b/apps/web/src/setup/steps/OllamaSelectStep.tsx
@@ -2,6 +2,7 @@
 import { ActionButton } from '../primitives'
 import { errorMessage } from '../errorMessage'
 import { ApiErrorView } from '../../components/ApiErrorView'
+import { CopyDiagnosticsButton } from '../../components/CopyDiagnosticsButton'
 import type { UseSetupFlowReturn } from '../useSetupFlow'
 
 interface OllamaSelectStepProps {
@@ -45,7 +46,12 @@ export function OllamaSelectStep({ flow, mode }: OllamaSelectStepProps) {
       {flow.actionError && (
         mode === 'manager'
           ? <div style={{ marginTop: '0.75rem' }}><ApiErrorView error={flow.actionError} context="ModelManager" /></div>
-          : <p role="alert" style={{ color: '#f87171', marginTop: '0.75rem', fontSize: '0.875rem' }}>{errMsg}</p>
+          : (
+            <p role="alert" style={{ color: '#f87171', marginTop: '0.75rem', fontSize: '0.875rem', display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' }}>
+              <span>{errMsg}</span>
+              <CopyDiagnosticsButton error={flow.actionError} context="setup:ollama" compact />
+            </p>
+          )
       )}
 
       <div style={{ marginTop: '1.5rem' }}>

--- a/services/convsim-core/convsim_core/log_excerpt.py
+++ b/services/convsim-core/convsim_core/log_excerpt.py
@@ -1,0 +1,243 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Assemble a compact, redacted excerpt of the most relevant local logs.
+
+Powers the "Copy diagnostics" action on the UI's error surfaces
+(``GET /api/diag/log-excerpt``). The excerpt is designed to be pasted into a
+GitHub issue by the user: small enough for a clipboard, redacted like the
+crash bundle, and focused on the most recent failure rather than the whole
+log history.
+
+Selection rules per file (most relevant first):
+
+  app.log     — the last WARNING/ERROR/CRITICAL entries (structured JSON
+                lines); falls back to a plain tail when no error-level entry
+                exists so the excerpt is never silently empty.
+  runtime.log — everything after the LAST ``--- llama-server start`` marker
+                (the most recent engine launch attempt — exactly the chunk
+                needed to triage "Model loaded but could not start"); falls
+                back to a plain tail when no marker is present.
+  kokoro.log  — plain tail, only when the file exists.
+
+Privacy: the excerpt is assembled locally and returned to the local UI only.
+It is never transmitted automatically — the user explicitly copies it. All
+text passes through :func:`redact_paths_in_text` so home-directory prefixes
+(which embed the OS username) appear as ``~``, matching the crash-bundle
+redaction promise.
+"""
+from __future__ import annotations
+
+import json
+import platform
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+from convsim_core import __version__
+from convsim_core.redaction import redact_paths_in_text
+
+# Marker written by LlamaCppSidecar.start() before each launch attempt.
+_RUNTIME_START_MARKER = "--- llama-server start"
+
+_ERROR_LEVELS: frozenset[str] = frozenset({"WARNING", "ERROR", "CRITICAL"})
+
+# Per-section line budgets. Tails matter most, so sections keep their newest
+# lines when over budget.
+_APP_LOG_MAX_LINES = 60
+_RUNTIME_LOG_MAX_LINES = 80
+_SIDECAR_LOG_MAX_LINES = 30
+# llama-server can emit very long single lines (tensor dumps); clamp so one
+# line cannot blow the clipboard budget.
+_MAX_LINE_CHARS = 400
+# Hard cap for the assembled excerpt body.
+_MAX_EXCERPT_BYTES = 16_000
+
+# Read at most this many bytes from the end of each log file. runtime.log in
+# particular receives raw llama-server stdout through the sidecar's file
+# handle, which the rotating logging handler cannot cap, so the file can grow
+# very large during long sessions. The most recent launch attempt lives at
+# the end, so a bounded tail read is both safe and sufficient.
+_MAX_READ_BYTES = 512 * 1024
+
+_TRUNCATION_NOTE = "[… earlier lines truncated …]"
+
+
+@dataclass
+class LogExcerpt:
+    """The assembled excerpt text plus the log files that contributed."""
+
+    text: str
+    sources: list[str] = field(default_factory=list)
+
+
+def _clamp_line(line: str) -> str:
+    if len(line) <= _MAX_LINE_CHARS:
+        return line
+    return line[:_MAX_LINE_CHARS] + " […]"
+
+
+def _read_lines(path: Path) -> list[str] | None:
+    """Return the tail of the file as lines, or None when it is unreadable.
+
+    Reads at most the last ``_MAX_READ_BYTES`` so an unbounded runtime.log
+    (raw sidecar stdout is not rotated) can never stall the endpoint or blow
+    memory. When the read is truncated the first, possibly partial, line is
+    dropped.
+    """
+    try:
+        size = path.stat().st_size
+        with path.open("rb") as fh:
+            truncated = size > _MAX_READ_BYTES
+            if truncated:
+                fh.seek(size - _MAX_READ_BYTES)
+            data = fh.read()
+        lines = data.decode("utf-8", errors="replace").splitlines()
+        if truncated and lines:
+            lines = lines[1:]
+        return lines
+    except OSError:
+        return None
+
+
+def _tail(lines: list[str], max_lines: int) -> list[str]:
+    if len(lines) <= max_lines:
+        return lines
+    return [_TRUNCATION_NOTE, *lines[-max_lines:]]
+
+
+def _app_log_excerpt(path: Path) -> list[str] | None:
+    """Last error-level entries from the structured app log.
+
+    Unparsable lines are kept verbatim so nothing is silently dropped when the
+    log format is unexpected (same policy as the crash bundle). When no
+    error-level entry exists, fall back to a short plain tail — an excerpt
+    that says "no errors" would hide the INFO lines leading up to a failure.
+    """
+    lines = _read_lines(path)
+    if lines is None:
+        return None
+    relevant: list[str] = []
+    for line in lines:
+        if not line.strip():
+            continue
+        try:
+            entry = json.loads(line)
+            if entry.get("level") in _ERROR_LEVELS:
+                relevant.append(line)
+        except (json.JSONDecodeError, AttributeError):
+            relevant.append(line)
+    if not relevant:
+        relevant = [ln for ln in lines if ln.strip()]
+    return _tail(relevant, _APP_LOG_MAX_LINES)
+
+
+def _runtime_log_excerpt(path: Path) -> list[str] | None:
+    """The chunk covering the most recent engine launch attempt.
+
+    Finds the last ``--- llama-server start`` marker and returns everything
+    from there to the end of the file. When the chunk is over budget the
+    marker and command lines are kept (they identify the model and flags) and
+    the middle is elided, because the crash reason is at the very end.
+    """
+    lines = _read_lines(path)
+    if lines is None:
+        return None
+
+    marker_idx = None
+    for i in range(len(lines) - 1, -1, -1):
+        if lines[i].startswith(_RUNTIME_START_MARKER):
+            marker_idx = i
+            break
+
+    if marker_idx is None:
+        return _tail(lines, _RUNTIME_LOG_MAX_LINES)
+
+    chunk = lines[marker_idx:]
+    if len(chunk) <= _RUNTIME_LOG_MAX_LINES:
+        return chunk
+
+    # Keep the marker + cmd header, elide the middle, keep the newest lines.
+    head = chunk[:2]
+    tail_budget = _RUNTIME_LOG_MAX_LINES - len(head)
+    omitted = len(chunk) - len(head) - tail_budget
+    return [*head, f"[… {omitted} lines omitted …]", *chunk[-tail_budget:]]
+
+
+def _plain_tail_excerpt(path: Path, max_lines: int) -> list[str] | None:
+    lines = _read_lines(path)
+    if lines is None:
+        return None
+    return _tail([ln for ln in lines if ln.strip()], max_lines)
+
+
+def _sanitize_context(context: str | None) -> str | None:
+    """Single-line, length-capped context tag safe to embed in the header."""
+    if context is None:
+        return None
+    cleaned = " ".join(context.split())
+    if not cleaned:
+        return None
+    return cleaned[:200]
+
+
+def build_log_excerpt(log_dir: str, *, context: str | None = None) -> LogExcerpt:
+    """Assemble the redacted log excerpt for the given log directory.
+
+    Never raises on missing or unreadable files — an error surface must be
+    able to call this while the system is unhealthy. Returns a header-only
+    excerpt when no log file exists.
+    """
+    log_root = Path(log_dir)
+
+    header = [
+        "ConversationSimulator log excerpt",
+        f"app: {__version__}",
+        f"platform: {platform.platform()}",
+        f"time: {datetime.now(timezone.utc).isoformat()}",
+    ]
+    ctx = _sanitize_context(context)
+    if ctx is not None:
+        header.append(f"context: {ctx}")
+
+    sections: list[tuple[str, str, list[str]]] = []
+
+    app_lines = _app_log_excerpt(log_root / "app.log")
+    if app_lines is not None:
+        sections.append(("app.log", "recent error-level entries", app_lines))
+
+    runtime_lines = _runtime_log_excerpt(log_root / "runtime.log")
+    if runtime_lines is not None:
+        sections.append(("runtime.log", "since last engine start", runtime_lines))
+
+    kokoro_lines = _plain_tail_excerpt(log_root / "kokoro.log", _SIDECAR_LOG_MAX_LINES)
+    if kokoro_lines is not None:
+        sections.append(("kokoro.log", "tail", kokoro_lines))
+
+    body_parts: list[str] = []
+    sources: list[str] = []
+    for name, label, lines in sections:
+        sources.append(name)
+        # Redact BEFORE clamping: a clamp cut through the middle of an
+        # absolute path could otherwise leave a partial home prefix (and a
+        # partial OS username) that the redaction pass no longer matches.
+        section_lines = [_clamp_line(redact_paths_in_text(ln)) for ln in lines]
+        body_parts.append(f"── {name} ({label}) ──")
+        body_parts.append("\n".join(section_lines) if section_lines else "(empty)")
+
+    if not sections:
+        body_parts.append("No log files found in the logs folder.")
+
+    body = "\n".join(body_parts)
+
+    # Hard cap: keep the header and the newest part of the body. The tail is
+    # where crash reasons live, so truncate from the front.
+    if len(body.encode("utf-8", errors="replace")) > _MAX_EXCERPT_BYTES:
+        encoded = body.encode("utf-8", errors="replace")
+        kept = encoded[-_MAX_EXCERPT_BYTES:].decode("utf-8", errors="replace")
+        # Cut at a line boundary so the excerpt does not open mid-line.
+        newline_idx = kept.find("\n")
+        if newline_idx != -1:
+            kept = kept[newline_idx + 1 :]
+        body = f"{_TRUNCATION_NOTE}\n{kept}"
+
+    text = "\n".join(header) + "\n\n" + body
+    return LogExcerpt(text=text, sources=sources)

--- a/services/convsim-core/convsim_core/routers/diag.py
+++ b/services/convsim-core/convsim_core/routers/diag.py
@@ -13,6 +13,7 @@ from convsim_core.beta_report import (
     latest_crash_bundle,
 )
 from convsim_core.crash_report import create_crash_bundle
+from convsim_core.log_excerpt import build_log_excerpt
 from convsim_core.redaction import redact_path
 
 logger = logging.getLogger(__name__)
@@ -28,6 +29,12 @@ _BETA_REPORT_NOTICE = (
     "Beta report bundle created locally. "
     "It is never transmitted automatically. "
     "Review the contents, then attach it to a GitHub issue manually."
+)
+
+_LOG_EXCERPT_NOTICE = (
+    "Log excerpt assembled locally. "
+    "It is never transmitted automatically. "
+    "Review it, then share it at your discretion (e.g. paste into a GitHub issue)."
 )
 
 
@@ -50,6 +57,12 @@ class _BetaReportResponse(BaseModel):
     notice: str
 
 
+class _LogExcerptResponse(BaseModel):
+    excerpt: str
+    sources: list[str]
+    notice: str
+
+
 @router.get("/logs-folder", response_model=_LogsFolderResponse)
 async def get_logs_folder(request: Request) -> _LogsFolderResponse:
     """Return the absolute path of the local logs folder.
@@ -58,6 +71,29 @@ async def get_logs_folder(request: Request) -> _LogsFolderResponse:
     """
     config = request.app.state.service_config
     return _LogsFolderResponse(logs_folder=str(Path(config.log_dir).resolve()))
+
+
+@router.get("/log-excerpt", response_model=_LogExcerptResponse)
+async def get_log_excerpt(
+    request: Request, context: str | None = None
+) -> _LogExcerptResponse:
+    """Return a compact, redacted excerpt of the most relevant local logs.
+
+    Backs the "Copy diagnostics" action on the UI's error surfaces, so a user
+    hitting any error can put the matching log lines on their clipboard in one
+    click.  The excerpt focuses on the most recent failure (error-level app
+    events plus the latest engine launch attempt), redacts home-directory
+    paths, and is returned to the local UI only — never transmitted.
+
+    ``context`` is an optional short tag describing which error surface asked
+    (e.g. ``setup-install:warmup``); it is embedded in the excerpt header so a
+    pasted report says where it came from.
+    """
+    config = request.app.state.service_config
+    result = build_log_excerpt(config.log_dir, context=context)
+    return _LogExcerptResponse(
+        excerpt=result.text, sources=result.sources, notice=_LOG_EXCERPT_NOTICE
+    )
 
 
 @router.post("/crash-bundle", response_model=_CrashBundleResponse)

--- a/services/convsim-core/tests/test_diag.py
+++ b/services/convsim-core/tests/test_diag.py
@@ -349,3 +349,53 @@ def test_latest_crash_bundle_picks_newest(tmp_path):
     latest = latest_crash_bundle(tmp_path)
     assert latest is not None
     assert latest.name == "crash-20260709T120000Z.zip"
+
+
+# ── GET /api/diag/log-excerpt ────────────────────────────────────────────────
+
+
+def test_log_excerpt_returns_200(client):
+    response = client.get("/api/diag/log-excerpt")
+    assert response.status_code == 200
+
+
+def test_log_excerpt_has_required_fields(client):
+    data = client.get("/api/diag/log-excerpt").json()
+    assert isinstance(data["excerpt"], str)
+    assert isinstance(data["sources"], list)
+    assert isinstance(data["notice"], str)
+
+
+def test_log_excerpt_notice_not_transmitted(client):
+    data = client.get("/api/diag/log-excerpt").json()
+    notice = data["notice"].lower()
+    assert "never" in notice or "not" in notice
+
+
+def test_log_excerpt_works_with_empty_log_dir(client):
+    data = client.get("/api/diag/log-excerpt").json()
+    assert "ConversationSimulator log excerpt" in data["excerpt"]
+
+
+def test_log_excerpt_includes_runtime_log_since_last_start(client, tmp_config):
+    log_dir = Path(tmp_config.log_dir)
+    log_dir.mkdir(parents=True, exist_ok=True)
+    (log_dir / "runtime.log").write_text(
+        "--- llama-server start old ---\n"
+        "stale line\n"
+        "--- llama-server start new ---\n"
+        "cmd: llama-server --model m.gguf\n"
+        "llama-server exited early (code 137)\n",
+        encoding="utf-8",
+    )
+    data = client.get("/api/diag/log-excerpt").json()
+    assert "llama-server exited early (code 137)" in data["excerpt"]
+    assert "stale line" not in data["excerpt"]
+    assert "runtime.log" in data["sources"]
+
+
+def test_log_excerpt_embeds_context_tag(client):
+    data = client.get(
+        "/api/diag/log-excerpt", params={"context": "setup-install:warmup"}
+    ).json()
+    assert "context: setup-install:warmup" in data["excerpt"]

--- a/services/convsim-core/tests/test_log_excerpt.py
+++ b/services/convsim-core/tests/test_log_excerpt.py
@@ -1,0 +1,221 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for convsim_core.log_excerpt — the copy-diagnostics excerpt builder."""
+import json
+from pathlib import Path
+
+from convsim_core.log_excerpt import (
+    _MAX_EXCERPT_BYTES,
+    build_log_excerpt,
+    LogExcerpt,
+)
+
+
+def _write(path: Path, lines: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _app_line(level: str, message: str) -> str:
+    return json.dumps({"level": level, "message": message})
+
+
+# ── Header and empty states ──────────────────────────────────────────────────
+
+
+def test_missing_log_dir_returns_header_only(tmp_path):
+    result = build_log_excerpt(str(tmp_path / "nope"))
+    assert isinstance(result, LogExcerpt)
+    assert "ConversationSimulator log excerpt" in result.text
+    assert "No log files found" in result.text
+    assert result.sources == []
+
+
+def test_header_contains_app_version_and_time(tmp_path):
+    result = build_log_excerpt(str(tmp_path))
+    assert "app: " in result.text
+    assert "platform: " in result.text
+    assert "time: " in result.text
+
+
+def test_context_is_included_in_header(tmp_path):
+    result = build_log_excerpt(str(tmp_path), context="setup-install:warmup")
+    assert "context: setup-install:warmup" in result.text
+
+
+def test_context_is_sanitized_to_single_line_and_capped(tmp_path):
+    nasty = "line one\nline two\t" + "x" * 500
+    result = build_log_excerpt(str(tmp_path), context=nasty)
+    context_lines = [l for l in result.text.splitlines() if l.startswith("context: ")]
+    assert len(context_lines) == 1
+    assert "\n" not in context_lines[0]
+    assert "line one line two" in context_lines[0]
+    assert len(context_lines[0]) <= len("context: ") + 200
+
+
+def test_blank_context_is_omitted(tmp_path):
+    result = build_log_excerpt(str(tmp_path), context="   ")
+    assert "context:" not in result.text
+
+
+# ── app.log selection ────────────────────────────────────────────────────────
+
+
+def test_app_log_keeps_only_error_level_entries(tmp_path):
+    _write(
+        tmp_path / "app.log",
+        [
+            _app_line("INFO", "routine startup"),
+            _app_line("ERROR", "something broke"),
+            _app_line("DEBUG", "noise"),
+            _app_line("CRITICAL", "very broken"),
+        ],
+    )
+    result = build_log_excerpt(str(tmp_path))
+    assert "something broke" in result.text
+    assert "very broken" in result.text
+    assert "routine startup" not in result.text
+    assert "app.log" in result.sources
+
+
+def test_app_log_unparsable_lines_kept_verbatim(tmp_path):
+    _write(tmp_path / "app.log", ["not json at all", _app_line("INFO", "fine")])
+    result = build_log_excerpt(str(tmp_path))
+    assert "not json at all" in result.text
+
+
+def test_app_log_falls_back_to_plain_tail_when_no_errors(tmp_path):
+    _write(tmp_path / "app.log", [_app_line("INFO", "only info here")])
+    result = build_log_excerpt(str(tmp_path))
+    assert "only info here" in result.text
+
+
+# ── runtime.log selection ────────────────────────────────────────────────────
+
+
+def test_runtime_log_slices_from_last_start_marker(tmp_path):
+    _write(
+        tmp_path / "runtime.log",
+        [
+            "--- llama-server start 2026-01-01T00:00:00Z ---",
+            "cmd: llama-server --model old.gguf",
+            "old attempt output",
+            "--- llama-server start 2026-01-02T00:00:00Z ---",
+            "cmd: llama-server --model new.gguf",
+            "ggml_metal buffer allocation failed",
+        ],
+    )
+    result = build_log_excerpt(str(tmp_path))
+    assert "new.gguf" in result.text
+    assert "ggml_metal buffer allocation failed" in result.text
+    assert "old attempt output" not in result.text
+    assert "runtime.log" in result.sources
+
+
+def test_runtime_log_without_marker_uses_plain_tail(tmp_path):
+    _write(tmp_path / "runtime.log", ["free-form line one", "free-form line two"])
+    result = build_log_excerpt(str(tmp_path))
+    assert "free-form line two" in result.text
+
+
+def test_runtime_log_long_chunk_keeps_marker_and_crash_tail(tmp_path):
+    lines = [
+        "--- llama-server start 2026-01-02T00:00:00Z ---",
+        "cmd: llama-server --model big.gguf",
+        *[f"loading tensor {i}" for i in range(500)],
+        "fatal: out of memory",
+    ]
+    _write(tmp_path / "runtime.log", lines)
+    result = build_log_excerpt(str(tmp_path))
+    assert "--- llama-server start" in result.text
+    assert "cmd: llama-server --model big.gguf" in result.text
+    assert "lines omitted" in result.text
+    assert "fatal: out of memory" in result.text
+    assert "loading tensor 0" not in result.text
+
+
+# ── kokoro.log ───────────────────────────────────────────────────────────────
+
+
+def test_kokoro_log_included_when_present(tmp_path):
+    _write(tmp_path / "kokoro.log", ["tts engine crashed"])
+    result = build_log_excerpt(str(tmp_path))
+    assert "tts engine crashed" in result.text
+    assert "kokoro.log" in result.sources
+
+
+def test_kokoro_log_absent_not_listed(tmp_path):
+    _write(tmp_path / "app.log", [_app_line("ERROR", "x")])
+    result = build_log_excerpt(str(tmp_path))
+    assert "kokoro.log" not in result.sources
+
+
+# ── Redaction and budgets ────────────────────────────────────────────────────
+
+
+def test_home_directory_is_redacted(tmp_path):
+    home = str(Path.home())
+    _write(
+        tmp_path / "runtime.log",
+        [f"error loading model at {home}/models/foo.gguf"],
+    )
+    result = build_log_excerpt(str(tmp_path))
+    assert home not in result.text
+    assert "~/models/foo.gguf" in result.text
+
+
+def test_very_long_lines_are_clamped(tmp_path):
+    _write(tmp_path / "runtime.log", ["x" * 5000])
+    result = build_log_excerpt(str(tmp_path))
+    assert "x" * 500 not in result.text
+    assert "[…]" in result.text
+
+
+def test_total_size_is_capped(tmp_path):
+    _write(
+        tmp_path / "app.log",
+        [_app_line("ERROR", f"padding {i} " + "y" * 300) for i in range(200)],
+    )
+    _write(
+        tmp_path / "runtime.log",
+        ["--- llama-server start now ---", "cmd: llama-server", *["z" * 300] * 200],
+    )
+    result = build_log_excerpt(str(tmp_path))
+    # Header (~5 short lines) plus capped body.
+    assert len(result.text.encode("utf-8")) < _MAX_EXCERPT_BYTES + 1000
+    assert "truncated" in result.text
+
+
+def test_excerpt_never_raises_on_directory_as_log_file(tmp_path):
+    (tmp_path / "app.log").mkdir(parents=True)
+    result = build_log_excerpt(str(tmp_path))
+    assert "ConversationSimulator log excerpt" in result.text
+
+
+def test_huge_runtime_log_reads_only_the_tail(tmp_path):
+    """A multi-megabyte runtime.log (unrotated sidecar stdout) must not be
+    read whole; the excerpt still carries the newest lines."""
+    from convsim_core.log_excerpt import _MAX_READ_BYTES
+
+    filler = ("spam " * 50).strip()
+    big = tmp_path / "runtime.log"
+    with big.open("w", encoding="utf-8") as fh:
+        fh.write("--- llama-server start ancient ---\n")
+        while fh.tell() < _MAX_READ_BYTES * 2:
+            fh.write(filler + "\n")
+        fh.write("final crash line at the very end\n")
+    result = build_log_excerpt(str(tmp_path))
+    assert "final crash line at the very end" in result.text
+    # The marker sits outside the bounded tail read, so it cannot appear.
+    assert "llama-server start ancient" not in result.text
+
+
+def test_redaction_survives_line_clamping(tmp_path):
+    """A long line whose home path would be cut by the clamp must not leak a
+    partial username: redaction happens before clamping."""
+    home = str(Path.home())
+    padding = "y" * 390  # pushes the path across the clamp boundary
+    _write(tmp_path / "runtime.log", [f"{padding} error at {home}/models/foo.gguf"])
+    result = build_log_excerpt(str(tmp_path))
+    assert home not in result.text
+    # No partial fragment of the home prefix beyond "~" appears.
+    assert home[: len(home) // 2] not in result.text.replace("~", "")


### PR DESCRIPTION
Closes #458

Every error surface in the app now offers a one-click **Copy diagnostics** action that puts the client-side error details **plus the most relevant local log excerpts** on the clipboard — so a bug report carries the lines a maintainer actually needs (llama-server's launch command and dying words, recent error-level app events) without the user hunting through platform data folders.

## Backend (convsim-core)

- New `GET /api/diag/log-excerpt?context=<tag>` (`routers/diag.py`) backed by `convsim_core/log_excerpt.py`:
  - `app.log` → last error-level structured entries (plain-tail fallback so the excerpt is never empty)
  - `runtime.log` → everything since the **last** `--- llama-server start` marker; marker + `cmd:` line always kept, middle elided when over budget (the crash reason is at the end)
  - `kokoro.log` → short tail when present
  - Bounded 512 KiB tail reads per file (raw sidecar stdout is not rotated and can grow unbounded), redaction of home paths **before** line clamping, per-line clamp, 16 KB total cap, never raises while the system is unhealthy
  - Same privacy posture as the crash bundle: assembled locally, never transmitted, `notice` field says so

## Frontend (web)

- New shared `CopyDiagnosticsButton` (+ `api/diag.ts`; raw fetch lives in `api/client.ts` per the lint rule): builds a header from the `ApiError` (or a custom header for non-API errors), appends the fetched excerpt, copies with a legacy-`execCommand` fallback, shows `Copied!` / `Copy failed`. Excerpt fetch is bounded (4 s) and degrades to a per-platform logs-folder pointer when the core is unreachable — the button keeps working when the backend is down.
- Wired into: `ApiErrorView` (both variants — covers every screen already using it), all setup wizard error cards (install network/disk/**warmup**/generic, confirm-install, GGUF path, Ollama, benchmark, load-error), `RuntimeRecoveryCard`, `RemediationCard` (its bug-report copy now appends the excerpt), app `ErrorBoundary` (i18n'd label, en+de), and the inline notices in VoiceInput, RuntimeSettingsPanel, LocalFilePicker, ScenarioLibrary (Workshop sync), and Logbook.

## Tests

- 22 new backend tests (`tests/test_log_excerpt.py`, `tests/test_diag.py`): marker slicing, elision, redaction (incl. redact-before-clamp regression), size caps, huge-file bounded reads, endpoint contract
- 11 new frontend tests (`CopyDiagnosticsButton.test.tsx`): copy flow, context propagation, core-unreachable fallback, header precedence, clipboard-failure state, payload validation
- One existing assertion updated (`RuntimeRecoveryCard.test.tsx`: `getByRole('button')` → named query, since the card now has two buttons)

Full local runs: web 1318/1318, core 2038 passed (the 3 `test_preflight` failures on my machine are root-container artifacts — chmod-unwritable dirs are writable as root — and fail identically on `main`), onboarding e2e fast trio 22/22, `tsc` clean, `check-i18n` clean, no new lint errors.
