### PR TITLE
Repo settings as code: Discussions off, squash-merge only, PR title + description default

### DIFF
--- a/infra/github.tf
+++ b/infra/github.tf
@@ -16,16 +16,20 @@ resource "github_repository" "this" {
   visibility = "public"
 
   has_issues      = true
-  has_discussions = true
+  has_discussions = false
   has_projects    = true
   # The docs site (docs.conversationsimulator.com) replaced the wiki; all
   # in-app and in-repo references now point there.
   has_wiki = false
 
-  allow_merge_commit     = true
+  allow_merge_commit     = false
   allow_squash_merge     = true
-  allow_rebase_merge     = true
+  allow_rebase_merge     = false
   delete_branch_on_merge = true
+
+  # Default squash commit = PR title + PR description (issue #460)
+  squash_merge_commit_title   = "PR_TITLE"
+  squash_merge_commit_message = "PR_BODY"
 
   topics = [
     "conversation-practice",


### PR DESCRIPTION
## What

Encodes the repository settings requested in #460 into `infra/github.tf`:

- `has_discussions = false`
- `allow_merge_commit = false`, `allow_rebase_merge = false` (squash only)
- `squash_merge_commit_title = "PR_TITLE"`, `squash_merge_commit_message = "PR_BODY"` — the provider spelling of *default to pull request title and description*

## Apply

Live settings are being flipped to match in the same session (owner-authorized), so this lands with **zero drift**: the next local `terraform plan` should show `github_repository.this` unchanged. HCL parse-validated; `terraform validate` was not runnable in the sandbox (registry egress blocked) — the local plan is the belt-and-suspenders check.

Closes #460