### PR TITLE
Pin llama.cpp to b9415 and gate macOS deployment target

### DIFF
--- a/.github/workflows/binary-health-check.yml
+++ b/.github/workflows/binary-health-check.yml
@@ -172,3 +172,50 @@ jobs:
 
           sys.exit(0)
           PYEOF
+
+  # ── macOS deployment-target gate (issue #469) ──────────────────────────────
+  # The Steam macOS depot once shipped an upstream llama.cpp build whose Metal
+  # backend was compiled for macOS 26; dyld killed llama-server at launch on
+  # every supported macOS, and the setup wizard misreported it as insufficient
+  # RAM.  This job downloads the pinned runtime exactly the way the release
+  # workflow does (release.yml's "Bundle llama-server" step calls
+  # download-runtime.sh, so it is protected transitively) and fails when any
+  # bundled Mach-O binary declares a minimum macOS newer than our floor.
+  llama-minos-gate:
+    name: macOS deployment-target gate
+    runs-on: macos-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Checker self-test
+        run: python3 scripts/check-macho-minos.py --self-test
+
+      # download-runtime.sh runs its own minos gate on Darwin before install,
+      # so a too-new pinned runtime fails right here.
+      - name: Download pinned runtime (arm64, self-gating)
+        run: bash runtimes/llama_cpp/download-runtime.sh --dest "$RUNNER_TEMP/llama-arm64"
+
+      - name: Verify installed arm64 binaries against the floor
+        run: |
+          FLOOR="${CONVSIM_MACOS_MINOS_FLOOR:-14.0}"
+          python3 scripts/check-macho-minos.py --max "$FLOOR" "$RUNNER_TEMP/llama-arm64"
+
+      # The x64 depot ships from the same pin; inspect that asset too (the
+      # checker parses Mach-O bytes directly, so the arm64 runner can verify
+      # x64 binaries without executing them).
+      - name: Verify x64 release asset against the floor
+        run: |
+          set -euo pipefail
+          FLOOR="${CONVSIM_MACOS_MINOS_FLOOR:-14.0}"
+          VERSION="$(sed -n 's/^LLAMA_CPP_PINNED_VERSION="\(.*\)"$/\1/p' runtimes/llama_cpp/download-runtime.sh)"
+          if [ -z "$VERSION" ]; then
+            echo "FAIL: could not read LLAMA_CPP_PINNED_VERSION from download-runtime.sh" >&2
+            exit 1
+          fi
+          echo "Pinned llama.cpp version: $VERSION"
+          URL="https://github.com/ggml-org/llama.cpp/releases/download/${VERSION}/llama-${VERSION}-bin-macos-x64.tar.gz"
+          curl -fSL --retry 3 -o "$RUNNER_TEMP/x64.tar.gz" "$URL"
+          mkdir -p "$RUNNER_TEMP/llama-x64"
+          tar -xzf "$RUNNER_TEMP/x64.tar.gz" -C "$RUNNER_TEMP/llama-x64"
+          python3 scripts/check-macho-minos.py --max "$FLOOR" "$RUNNER_TEMP/llama-x64"

--- a/docs/sidecar-bundling.md
+++ b/docs/sidecar-bundling.md
@@ -152,6 +152,43 @@ resolves `CONVSIM_LLAMA_CPP_EXECUTABLE` → `CONVSIM_BUNDLED_RUNTIME_DIR/llama-s
 
 ---
 
+## Pinned llama.cpp version and the macOS deployment-target gate
+
+The llama.cpp download scripts pin an exact upstream release
+(`LLAMA_CPP_PINNED_VERSION` in `runtimes/llama_cpp/download-runtime.sh` and
+`download-runtime.ps1`; keep the two in sync). Bumping the pin is a deliberate
+act, and on macOS it must clear one extra bar: **no bundled Mach-O binary may
+declare a minimum macOS newer than our supported floor** (14.0 by default,
+override with `CONVSIM_MACOS_MINOS_FLOOR`).
+
+Why: upstream llama.cpp prebuilts started targeting the newest macOS SDK
+(b9428+ declare macOS 26). Such a binary installs fine, but dyld kills it the
+instant it launches on any older macOS — in the Steam depot this surfaced as
+"Model loaded but could not start" with a misleading insufficient-RAM hint
+(issue #469). The breakage is statically visible in the Mach-O
+`LC_BUILD_VERSION` load command, so it is caught before shipping:
+
+- `scripts/check-macho-minos.py` parses the declared minimum-OS version of
+  Mach-O files (thin and universal; no dependencies; runs on any OS). Try
+  `--self-test`, or point it at a directory:
+  `python3 scripts/check-macho-minos.py --max 14.0 ~/.convsim/bin`.
+- `download-runtime.sh` runs the checker on Darwin after extracting and
+  refuses to install binaries that exceed the floor
+  (`CONVSIM_SKIP_MINOS_CHECK=1` bypasses it in an emergency).
+- The `llama-minos-gate` job in `.github/workflows/binary-health-check.yml`
+  verifies both macOS assets (arm64 and x64) of the pinned version on every
+  change under `runtimes/llama_cpp/**`. The release workflow bundles via
+  `download-runtime.sh`, so it inherits the same gate.
+
+Note the floor is currently 14.0 because upstream prebuilts have targeted
+macOS 14 for a long stretch of releases, while the Steam QA matrix
+([QA_STEAM_PLATFORM_MATRIX.md](QA_STEAM_PLATFORM_MATRIX.md)) lists macOS 13
+as the oldest supported release — closing that gap needs a source build with
+`MACOSX_DEPLOYMENT_TARGET=13` (or a matrix amendment) and is tracked
+separately.
+
+---
+
 ## Localhost enforcement in packaged builds
 
 `assert_localhost(host)` in `convsim_core/runtime/supervisor.py` is called at

--- a/runtimes/llama_cpp/download-runtime.ps1
+++ b/runtimes/llama_cpp/download-runtime.ps1
@@ -47,7 +47,11 @@ $REPO  = "ggml-org/llama.cpp"
 # leg of the release failed with a 403 doing exactly that).
 #
 # Pass -Version latest to resolve the newest release instead of the pin.
-$LLAMA_CPP_PINNED_VERSION = "b9996"
+# b9415 matches download-runtime.sh: newer upstream releases (b9428+) ship
+# macOS binaries built for macOS 26, which crash on every older macOS (issue
+# #469). Windows artifacts are unaffected, but the pins stay in sync so both
+# platforms ship the same inference engine.
+$LLAMA_CPP_PINNED_VERSION = "b9415"
 if (-not $Version) { $Version = $LLAMA_CPP_PINNED_VERSION }
 
 # ── Platform detection ────────────────────────────────────────────────────────

--- a/runtimes/llama_cpp/download-runtime.sh
+++ b/runtimes/llama_cpp/download-runtime.sh
@@ -44,7 +44,28 @@ done
 # To upgrade: bump this, re-run the script on each platform, and confirm
 # llama-server starts (`llama-server --version`) — that is what catches a
 # renamed asset or a changed archive layout.
-LLAMA_CPP_PINNED_VERSION="b9996"
+#
+# macOS deployment target (issue #469): upstream's prebuilt macOS binaries are
+# only usable on the macOS versions they declare via LC_BUILD_VERSION. From
+# b9428 onward the artifacts target macOS 26.0, so on any older macOS dyld
+# kills llama-server the instant it launches ("Symbol not found:
+# _OBJC_CLASS_$_MTLResidencySetDescriptor … built for macOS 26.0 which is
+# newer than running OS") — which the setup wizard used to misreport as
+# insufficient RAM. b9415 is the newest release targeting macOS 14.0. When
+# bumping the pin, the Darwin gate below (scripts/check-macho-minos.py) fails
+# the download if the new artifacts raise the declared minimum; verify the
+# candidate tag on every platform before raising the floor here.
+#
+# NOTE: no upstream prebuilt satisfies the documented macOS 13 (Ventura) floor
+# in docs/QA_STEAM_PLATFORM_MATRIX.md — every recent release targets 14.0+.
+# Supporting 13 requires building llama.cpp from source with
+# MACOSX_DEPLOYMENT_TARGET=13 (tracked separately from #469).
+LLAMA_CPP_PINNED_VERSION="b9415"
+
+# Highest macOS minimum the bundled binaries may declare (see above). Override
+# with CONVSIM_MACOS_MINOS_FLOOR, or set CONVSIM_SKIP_MINOS_CHECK=1 to bypass
+# the gate entirely (e.g. when deliberately building a newer-macOS-only depot).
+MACOS_MINOS_FLOOR="${CONVSIM_MACOS_MINOS_FLOOR:-14.0}"
 
 # Pass --version latest (or LLAMA_CPP_VERSION=latest) to resolve the newest
 # release instead of the pin.
@@ -210,6 +231,32 @@ SRC_DIR="$(dirname "$EXTRACTED_BIN")"
 # (@rpath/libllama-common.0.dylib). Copying only regular files drops all 18
 # symlinks and the binary still refuses to start; `cp -a` preserves them as links
 # rather than duplicating ~24 MB of libraries into the depot.
+# ── macOS deployment-target gate (issue #469) ─────────────────────────────────
+# Refuse to install binaries that declare a macOS minimum above the supported
+# floor: they would pass every download/extract step and then crash on launch
+# for every player below that version. Runs BEFORE anything is copied into
+# DEST_DIR so a failing gate can never clobber a working installation. The
+# checker is stdlib-only Python and lives in the repo; when it (or python3) is
+# unavailable — e.g. the script was copied out of the repo — warn instead of
+# failing the install.
+if [[ "$OS" == "Darwin" && "${CONVSIM_SKIP_MINOS_CHECK:-0}" != "1" ]]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  MINOS_CHECKER="${SCRIPT_DIR}/../../scripts/check-macho-minos.py"
+  if [[ -f "$MINOS_CHECKER" ]] && command -v python3 &>/dev/null; then
+    echo "Checking macOS deployment target (floor: ${MACOS_MINOS_FLOOR})..."
+    if ! python3 "$MINOS_CHECKER" --max "$MACOS_MINOS_FLOOR" "$SRC_DIR" > "$TMP_DIR/minos.log" 2>&1; then
+      grep '^FAIL' "$TMP_DIR/minos.log" >&2 || cat "$TMP_DIR/minos.log" >&2
+      echo "" >&2
+      echo "Release ${RELEASE_TAG} targets a macOS newer than ${MACOS_MINOS_FLOOR}," >&2
+      echo "so llama-server would be killed by dyld on supported systems (issue #469)." >&2
+      echo "Pick an older tag (--version), or set CONVSIM_SKIP_MINOS_CHECK=1 to force." >&2
+      exit 1
+    fi
+  else
+    echo "WARN: skipping macOS deployment-target check (checker or python3 unavailable)." >&2
+  fi
+fi
+
 echo "Installing shared libraries..."
 find "$SRC_DIR" -maxdepth 1 \( -type f -o -type l \) \
   \( -name '*.so' -o -name '*.so.*' -o -name '*.dylib' \) \

--- a/scripts/check-macho-minos.py
+++ b/scripts/check-macho-minos.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Fail when a Mach-O binary targets a macOS newer than the supported floor.
+
+Why this exists: the Steam macOS depot once shipped an upstream llama.cpp
+build whose Metal backend (libggml-metal.0.dylib) was compiled for macOS 26.
+On every supported macOS below that, dyld killed llama-server the instant it
+launched ("Symbol not found: _OBJC_CLASS_$_MTLResidencySetDescriptor …
+built for macOS 26.0 which is newer than running OS"), which the setup wizard
+misreported as insufficient RAM (issue #469). The breakage is statically
+visible in the Mach-O load commands, so it belongs in CI — not in a player's
+first-run experience.
+
+This script parses each file's LC_BUILD_VERSION (platform macOS) or legacy
+LC_VERSION_MIN_MACOSX load command — including universal/fat binaries — and
+reports the minimum-OS version the binary declares. With --max it exits
+non-zero when any inspected file exceeds the given floor.
+
+No dependencies beyond the standard library; runs anywhere (the bytes are
+parsed directly, so a Linux CI runner can inspect macOS artifacts).
+
+Usage:
+  check-macho-minos.py [--max X.Y] PATH...   # files or directories
+  check-macho-minos.py --self-test           # verify the parser on
+                                             # synthesized fixtures
+
+Exit codes: 0 = ok, 1 = a binary exceeds --max (or self-test failed),
+2 = usage / read error.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import struct
+import sys
+
+MH_MAGIC = 0xFEEDFACE
+MH_CIGAM = 0xCEFAEDFE
+MH_MAGIC_64 = 0xFEEDFACF
+MH_CIGAM_64 = 0xCFFAEDFE
+FAT_MAGIC = 0xCAFEBABE
+FAT_CIGAM = 0xBEBAFECA
+FAT_MAGIC_64 = 0xCAFEBABF
+FAT_CIGAM_64 = 0xBFBAFECA
+
+LC_VERSION_MIN_MACOSX = 0x24
+LC_BUILD_VERSION = 0x32
+PLATFORM_MACOS = 1
+
+
+def _decode_version(value: int) -> str:
+    """Decode the xxxx.yy.zz packed version used by Mach-O load commands."""
+    return f"{value >> 16}.{(value >> 8) & 0xFF}.{value & 0xFF}"
+
+
+def _version_tuple(text: str) -> tuple[int, int, int]:
+    """Parse X[.Y[.Z]] into a comparable 3-tuple.
+
+    Padding matters: naive tuples make "14.0.0" > "14.0" (longer tuple wins
+    on equal prefix), which would fail binaries that exactly match the floor.
+    """
+    parts = [int(part) for part in text.split(".")]
+    while len(parts) < 3:
+        parts.append(0)
+    return (parts[0], parts[1], parts[2])
+
+
+def _parse_thin(data: bytes) -> str | None:
+    """Return the declared macOS minimum of one thin Mach-O image, or None."""
+    if len(data) < 32:
+        return None
+    (magic,) = struct.unpack_from("<I", data, 0)
+    if magic in (MH_MAGIC_64, MH_MAGIC):
+        endian = "<"
+    elif magic in (MH_CIGAM_64, MH_CIGAM):
+        endian = ">"
+    else:
+        return None
+    is64 = magic in (MH_MAGIC_64, MH_CIGAM_64)
+    header_fmt = endian + ("7I" if not is64 else "8I")
+    header_size = struct.calcsize(header_fmt)
+    if len(data) < header_size:
+        return None
+    header = struct.unpack_from(header_fmt, data, 0)
+    ncmds = header[4]
+    offset = header_size
+    for _ in range(ncmds):
+        if offset + 8 > len(data):
+            return None
+        cmd, cmdsize = struct.unpack_from(endian + "II", data, offset)
+        if cmdsize < 8 or offset + cmdsize > len(data):
+            return None
+        if cmd == LC_BUILD_VERSION and cmdsize >= 24:
+            platform, minos = struct.unpack_from(endian + "II", data, offset + 8)
+            if platform == PLATFORM_MACOS:
+                return _decode_version(minos)
+        elif cmd == LC_VERSION_MIN_MACOSX and cmdsize >= 16:
+            (version,) = struct.unpack_from(endian + "I", data, offset + 8)
+            return _decode_version(version)
+        offset += cmdsize
+    return None
+
+
+def macho_minos(data: bytes) -> str | None:
+    """Return the highest declared macOS minimum across all slices, or None
+    when the bytes are not a Mach-O image (or declare no macOS target)."""
+    if len(data) < 8:
+        return None
+    (magic_be,) = struct.unpack_from(">I", data, 0)
+    if magic_be in (FAT_MAGIC, FAT_MAGIC_64):
+        is64 = magic_be == FAT_MAGIC_64
+        (nfat,) = struct.unpack_from(">I", data, 4)
+        arch_fmt = ">2I2Q2I" if is64 else ">5I"
+        arch_size = struct.calcsize(arch_fmt)
+        results: list[str] = []
+        for i in range(nfat):
+            base = 8 + i * arch_size
+            if base + arch_size > len(data):
+                break
+            fields = struct.unpack_from(arch_fmt, data, base)
+            slice_offset, slice_size = fields[2], fields[3]
+            if slice_offset + slice_size > len(data):
+                continue
+            found = _parse_thin(data[slice_offset : slice_offset + slice_size])
+            if found is not None:
+                results.append(found)
+        if not results:
+            return None
+        return max(results, key=_version_tuple)
+    return _parse_thin(data)
+
+
+def iter_candidate_files(paths: list[str]):
+    for path in paths:
+        if os.path.isdir(path):
+            for root, _dirs, files in os.walk(path):
+                for name in files:
+                    full = os.path.join(root, name)
+                    if not os.path.islink(full):
+                        yield full
+        elif not os.path.islink(path):
+            yield path
+
+
+def run_check(paths: list[str], max_minos: str | None) -> int:
+    limit = _version_tuple(max_minos) if max_minos else None
+    inspected = 0
+    violations = 0
+    for path in iter_candidate_files(paths):
+        try:
+            with open(path, "rb") as fh:
+                data = fh.read()
+        except OSError as exc:
+            print(f"error: cannot read {path}: {exc}", file=sys.stderr)
+            return 2
+        minos = macho_minos(data)
+        if minos is None:
+            continue
+        inspected += 1
+        if limit is not None and _version_tuple(minos) > limit:
+            violations += 1
+            print(f"FAIL {path}: targets macOS {minos} (> allowed {max_minos})")
+        else:
+            print(f"ok   {path}: targets macOS {minos}")
+    if inspected == 0:
+        print("error: no Mach-O files found under the given paths", file=sys.stderr)
+        return 2
+    if violations:
+        print(
+            f"\n{violations} binar{'y' if violations == 1 else 'ies'} exceed the "
+            f"macOS {max_minos} floor. Shipping these would crash on supported "
+            "systems the moment the engine launches (see issue #469).",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+# ── Self-test ────────────────────────────────────────────────────────────────
+
+
+def _synth_thin(minos: int, *, legacy: bool = False, big_endian: bool = False) -> bytes:
+    """Build a minimal 64-bit Mach-O with one version load command."""
+    endian = ">" if big_endian else "<"
+    if legacy:
+        cmd = struct.pack(endian + "4I", LC_VERSION_MIN_MACOSX, 16, minos, minos)
+    else:
+        cmd = struct.pack(
+            endian + "6I", LC_BUILD_VERSION, 24, PLATFORM_MACOS, minos, minos, 0
+        )
+    # The magic constant is always MH_MAGIC_64; writing every header field in
+    # the target byte order is what makes the on-disk image big-endian (a
+    # little-endian reader then sees MH_CIGAM_64 and swaps, as dyld would).
+    # magic, cputype, cpusubtype, filetype, ncmds, sizeofcmds, flags, reserved
+    header = struct.pack(endian + "8I", MH_MAGIC_64, 0, 0, 2, 1, len(cmd), 0, 0)
+    return header + cmd
+
+
+def _synth_fat(slices: list[bytes]) -> bytes:
+    header = struct.pack(">2I", FAT_MAGIC, len(slices))
+    arch_size = struct.calcsize(">5I")
+    offset = len(header) + arch_size * len(slices)
+    archs = b""
+    body = b""
+    for blob in slices:
+        archs += struct.pack(">5I", 0, 0, offset, len(blob), 0)
+        body += blob
+        offset += len(blob)
+    return header + archs + body
+
+
+def self_test() -> int:
+    v13 = (13 << 16) | (0 << 8)
+    v26 = (26 << 16) | (0 << 8)
+    v12_7_4 = (12 << 16) | (7 << 8) | 4
+    cases = [
+        ("LC_BUILD_VERSION 13.0", macho_minos(_synth_thin(v13)), "13.0.0"),
+        ("LC_BUILD_VERSION 26.0", macho_minos(_synth_thin(v26)), "26.0.0"),
+        ("legacy LC_VERSION_MIN 12.7.4", macho_minos(_synth_thin(v12_7_4, legacy=True)), "12.7.4"),
+        ("big-endian image", macho_minos(_synth_thin(v13, big_endian=True)), "13.0.0"),
+        ("fat: max of slices", macho_minos(_synth_fat([_synth_thin(v13), _synth_thin(v26)])), "26.0.0"),
+        ("not Mach-O", macho_minos(b"\x7fELF" + b"\x00" * 64), None),
+        ("truncated", macho_minos(b"\xcf\xfa\xed\xfe\x00"), None),
+    ]
+    failed = False
+    for name, got, want in cases:
+        status = "ok" if got == want else "FAIL"
+        if got != want:
+            failed = True
+        print(f"{status:4} self-test: {name}: got {got!r}, want {want!r}")
+    ordering = _version_tuple("26.0.0") > _version_tuple("13.0")
+    print(f"{'ok' if ordering else 'FAIL':4} self-test: version ordering 26.0.0 > 13.0")
+    failed = failed or not ordering
+    return 1 if failed else 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("paths", nargs="*", help="Mach-O files or directories to inspect")
+    parser.add_argument("--max", dest="max_minos", metavar="X.Y",
+                        help="fail when any binary targets a macOS newer than this")
+    parser.add_argument("--self-test", action="store_true",
+                        help="verify the parser against synthesized fixtures")
+    args = parser.parse_args()
+    if args.self_test:
+        return self_test()
+    if not args.paths:
+        parser.print_usage(sys.stderr)
+        return 2
+    return run_check(args.paths, args.max_minos)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Steam's macOS depot shipped upstream llama.cpp `b9996`, whose Metal backend (`libggml-metal.0.dylib`) declares a minimum of **macOS 26.0**. On every supported macOS, dyld killed `llama-server` the instant it launched — and the setup wizard misreported the crash as insufficient RAM. Fixes #469.

## Changes

- **Pin llama.cpp to `b9415`** in `download-runtime.sh` and `download-runtime.ps1` — the newest upstream release whose macOS binaries target 14.0 (`b9428`+ target 26.0). Windows/Linux are unaffected by the minos issue but the pins stay in sync so all platforms ship the same engine.
- **New `scripts/check-macho-minos.py`** — stdlib-only checker that parses the declared minimum macOS straight from Mach-O load commands (`LC_BUILD_VERSION` / legacy `LC_VERSION_MIN_MACOSX`, thin + universal/fat), so any OS can inspect macOS artifacts without executing them. Includes `--self-test` against synthesized fixtures.
- **Darwin install gate in `download-runtime.sh`** — refuses to install binaries above the floor (default `14.0`; `CONVSIM_MACOS_MINOS_FLOOR` overrides, `CONVSIM_SKIP_MINOS_CHECK=1` bypasses). Runs before anything is copied into the destination, so a failing gate never clobbers a working install.
- **New `llama-minos-gate` CI job** in `binary-health-check.yml` (runs on `runtimes/llama_cpp/**` changes): checker self-test, self-gating runtime download, explicit floor check of the installed arm64 runtime, plus the same check on the macos-x64 release asset. `release.yml` bundles via `download-runtime.sh`, so the release path inherits the gate transitively.
- **Docs**: new "Pinned llama.cpp version and the macOS deployment-target gate" section in `docs/sidecar-bundling.md`.

## Verification

- `check-macho-minos.py --self-test`: all green (modern + legacy load commands, big-endian, fat max-of-slices, non-Mach-O, truncated).
- Validated against real artifacts: `b9996` macos-arm64 → 42 binaries all FAIL at floor 14.0 (26.0.0); `b9415` → all pass (14.0.0).
- Gate simulated both directions with synthesized good/bad fixtures.
- `b9415` verified to have all 7 platform assets we ship; end-to-end `download-runtime.sh` run on Linux installs and `llama-server --version` reports 9415.
- `shellcheck` and `bash -n` clean; `actionlint` clean; `ruff check` clean; `scripts/smoke-check.sh` passes.

## Note

No upstream prebuilt satisfies the documented macOS 13 (Ventura) floor in `docs/QA_STEAM_PLATFORM_MATRIX.md` — upstream has targeted 14.0+ for a long stretch. Closing that gap needs a source build with `MACOSX_DEPLOYMENT_TARGET=13` or a QA-matrix amendment — filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C9WmcidRL3ABq7qhWHUsrG